### PR TITLE
Reenable border corner tessellation for monochromatic borders.

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -14,6 +14,7 @@ use internal_types::{TextureUpdateDetails, TextureUpdateList, PackedVertex, Rend
 use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePixel};
 use internal_types::{PackedVertexForTextureCacheUpdate, CompositionOp, ChildLayerIndex};
 use internal_types::{AxisDirection, LowLevelFilterOp, DrawCommand, DrawLayer, ANGLE_FLOAT_TO_FIXED};
+use internal_types::{BasicRotationAngle};
 use ipc_channel::ipc;
 use profiler::{Profiler, BackendProfileCounters};
 use profiler::{RendererProfileTimers, RendererProfileCounters};
@@ -26,7 +27,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
-//use tessellator::BorderCornerTessellation;
+use tessellator::BorderCornerTessellation;
 use texture_cache::{BorderType, TextureCache, TextureInsertOp};
 use time::precise_time_ns;
 use webrender_traits::{ColorF, Epoch, PipelineId, RenderNotifier};
@@ -661,7 +662,7 @@ impl Renderer {
                                                                outer_ry,
                                                                inner_rx,
                                                                inner_ry,
-                                                               _index,
+                                                               index,
                                                                inverted,
                                                                border_type) => {
                                 // From here on out everything is in device coordinates.
@@ -678,6 +679,8 @@ impl Renderer {
                                 let zero_point = Point2D::new(0.0, 0.0);
                                 let zero_size = Size2D::new(0.0, 0.0);
 
+                                let device_pixel_ratio = self.device_pixel_ratio;
+
                                 self.add_rect_to_raster_batch(update.id,
                                                               TextureId(0),
                                                               border_program_id,
@@ -686,8 +689,30 @@ impl Renderer {
                                                                          Size2D::new(width as u32, height as u32)),
                                                               border_type,
                                                               |texture_rect| {
-                                    let border_position = Point2D::new(texture_rect.origin.x + outer_rx.as_f32(),
-                                                                       texture_rect.origin.y + outer_ry.as_f32());
+                                    let border_radii_outer_size =
+                                        Size2D::new(border_radii_outer.x,
+                                                    border_radii_outer.y);
+                                    let border_radii_inner_size =
+                                        Size2D::new(border_radii_inner.x,
+                                                    border_radii_inner.y);
+                                    let untessellated_rect =
+                                        Rect::new(texture_rect.origin, border_radii_outer_size);
+                                    let tessellated_rect =
+                                        match index {
+                                            None => untessellated_rect,
+                                            Some(index) => {
+                                                untessellated_rect.tessellate_border_corner(
+                                                    &border_radii_outer_size,
+                                                    &border_radii_inner_size,
+                                                    1.0,
+                                                    BasicRotationAngle::Upright,
+                                                    index)
+                                            }
+                                        };
+
+                                    let border_position =
+                                        untessellated_rect.bottom_right() -
+                                        (tessellated_rect.origin - texture_rect.origin);
 
                                     [
                                         PackedVertexForTextureCacheUpdate::new(

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -232,7 +232,8 @@ impl ResourceCache {
             if !self.cached_rasters.contains_key(raster_item) {
                 let image_id = self.texture_cache.new_item_id();
                 self.texture_cache.insert_raster_op(image_id,
-                                                    raster_item);
+                                                    raster_item,
+                                                    self.device_pixel_ratio);
                 self.cached_rasters.insert(raster_item.clone(), image_id, frame_id);
             }
             self.cached_rasters.mark_as_needed(raster_item, frame_id);


### PR DESCRIPTION
Multicolored borders aren't tessellated for now; this can be a followup.

r? @glennw