### PR TITLE
Remove direct dependence on nightly features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ git = "https://github.com/ecoal95/rust-offscreen-rendering-context"
 [dependencies]
 gleam = "0.2"
 euclid = {version = "0.6.2", features = ["plugins"]}
-num = {version = "0.1.24", default-features = false}
+num = {version = "0.1.31", default-features = false}
 time = "0.1"
 fnv="1.0"
 scoped_threadpool = "0.1.6"

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -432,9 +432,9 @@ impl RasterBatch {
                                                          origin.y as f32),
                                             Size2D::new(dest_rect.size.width as f32,
                                                         dest_rect.size.height as f32)));
-
-                for i in (0..vertices.len()).step_by(4) {
-                    let index_offset = self.vertices.len();
+                let mut i = 0;
+                let index_offset = self.vertices.len();
+                while i < index_offset {
                     let index_base = (index_offset + i) as u16;
                     self.indices.push(index_base + 0);
                     self.indices.push(index_base + 1);
@@ -442,6 +442,7 @@ impl RasterBatch {
                     self.indices.push(index_base + 2);
                     self.indices.push(index_base + 3);
                     self.indices.push(index_base + 1);
+                    i += 4;
                 }
 
                 self.vertices.extend_from_slice(&vertices);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(step_by, zero_one)]
+#![feature(step_by)]
 //#![feature(mpsc_select)]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(step_by)]
 //#![feature(mpsc_select)]
 
 #[macro_use]

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@
 
 use euclid::{Matrix4, Point2D, Rect, Size2D};
 use internal_types::{RectColors};
-use std::num::Zero;
+use num::Zero;
 use time::precise_time_ns;
 use webrender_traits::ColorF;
 


### PR DESCRIPTION
wr_traits still depends on plugin based serde. This dependency could be made optional
so that webrender compiles on stable, though I'm not sure if this is necessary.

(should make it easier to hack on WR independently)