### PR TITLE
Fix loop count from 7b9c8e638

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -434,7 +434,7 @@ impl RasterBatch {
                                                         dest_rect.size.height as f32)));
                 let mut i = 0;
                 let index_offset = self.vertices.len();
-                while i < index_offset {
+                while i < vertices.len() {
                     let index_base = (index_offset + i) as u16;
                     self.indices.push(index_base + 0);
                     self.indices.push(index_base + 1);


### PR DESCRIPTION
After updating WebRender, [this box shadow](https://github.com/kevinmehall/webrender-experiments/blob/master/src/main.rs#L127) rendered incorrectly.
`git bisect` pointed to 7b9c8e638, where I noticed that the replacement
code wasn't quite equivalent -- `self.vertices` vs `vertices`

Before:
![](http://i.imgur.com/UPj8L7g.png)
After:
 ![](http://i.imgur.com/O37yAZA.png) 