### PR TITLE
Fix render target cache.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -142,7 +142,8 @@ impl RenderTarget {
                             width: f32,
                             height: f32,
                             device_pixel_ratio: f32,
-                            resource_cache: &mut ResourceCache) -> (Point2D<f32>, TextureId) {
+                            resource_cache: &mut ResourceCache,
+                            frame_id: FrameId) -> (Point2D<f32>, TextureId) {
         // If the target is more than 512x512 (an arbitrary choice), assign it
         // to an exact sized render target - assuming that there probably aren't
         // many of them. This minimises GPU memory wastage if there are just a small
@@ -156,7 +157,8 @@ impl RenderTarget {
 
                 let texture_id = resource_cache.allocate_render_target(device_pixel_size,
                                                                        device_pixel_size,
-                                                                       ImageFormat::RGBA8);
+                                                                       ImageFormat::RGBA8,
+                                                                       frame_id);
                 self.texture_id_list.push(texture_id);
                 self.page_allocator = Some(TexturePage::new(texture_id, texture_size));
             }
@@ -180,7 +182,8 @@ impl RenderTarget {
 
         let texture_id = resource_cache.allocate_render_target(device_pixel_width,
                                                                device_pixel_height,
-                                                               ImageFormat::RGBA8);
+                                                               ImageFormat::RGBA8,
+                                                               frame_id);
         self.texture_id_list.push(texture_id);
 
         (Point2D::zero(), texture_id)
@@ -1107,7 +1110,8 @@ impl Frame {
                         target.allocate_target_rect(target_rect.size.width,
                                                     target_rect.size.height,
                                                     context.device_pixel_ratio,
-                                                    context.resource_cache);
+                                                    context.resource_cache,
+                                                    self.id);
 
                     let mut new_target = RenderTarget::new(render_target_id,
                                                            origin,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -705,8 +705,6 @@ impl Renderer {
                                 let zero_point = Point2D::new(0.0, 0.0);
                                 let zero_size = Size2D::new(0.0, 0.0);
 
-                                let device_pixel_ratio = self.device_pixel_ratio;
-
                                 self.add_rect_to_raster_batch(update.id,
                                                               TextureId(0),
                                                               border_program_id,

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -381,9 +381,13 @@ impl ResourceCache {
     pub fn allocate_render_target(&mut self,
                                   width: u32,
                                   height: u32,
-                                  format: ImageFormat)
+                                  format: ImageFormat,
+                                  frame_id: FrameId)
                                   -> TextureId {
-        self.texture_cache.allocate_render_target(width, height, format)
+        self.texture_cache.allocate_render_target(width,
+                                                  height,
+                                                  format,
+                                                  frame_id)
     }
 
     pub fn free_old_render_targets(&mut self) {


### PR DESCRIPTION
Ensure that the render target cache doesn't return a render target that was allocated on this frame.

Fixes #184.