### PR TITLE
Make the desktop no longer show through when alpha blending is involved for borderless windows on the Mac.

### DIFF
--- a/src/debug_render.rs
+++ b/src/debug_render.rs
@@ -168,7 +168,8 @@ impl DebugRenderer {
             gl::disable(gl::DEPTH_TEST);
             gl::enable(gl::BLEND);
             gl::blend_equation(gl::FUNC_ADD);
-            gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+            gl::blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA,
+                                    gl::ONE, gl::ONE);
 
             let projection = Matrix4::ortho(0.0,
                                             viewport_size.width as f32,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1204,7 +1204,8 @@ impl Renderer {
                         gl::disable(gl::BLEND);
                     } else {
                         gl::enable(gl::BLEND);
-                        gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+                        gl::blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA,
+                                                gl::ONE, gl::ONE);
                         gl::blend_equation(gl::FUNC_ADD);
                     }
 
@@ -1417,8 +1418,8 @@ impl Renderer {
                                 program = self.blit_program_id;
                             }
                             CompositionOp::Filter(LowLevelFilterOp::Opacity(amount)) => {
-                                gl::blend_func(gl::SRC_ALPHA,
-                                               gl::ONE_MINUS_SRC_ALPHA);
+                                gl::blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA,
+                                                        gl::ONE, gl::ONE);
                                 gl::blend_equation(gl::FUNC_ADD);
                                 alpha = amount.to_f32_px();
                                 program = self.blit_program_id;
@@ -1430,7 +1431,10 @@ impl Renderer {
                                 let (opcode, amount, param0, param1) = match filter_op {
                                     LowLevelFilterOp::Blur(radius,
                                                            AxisDirection::Horizontal) => {
-                                        gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+                                        gl::blend_func_separate(gl::SRC_ALPHA,
+                                                                gl::ONE_MINUS_SRC_ALPHA,
+                                                                gl::ONE,
+                                                                gl::ONE);
                                         (0.0,
                                          radius.to_f32_px() * self.device_pixel_ratio,
                                          1.0,
@@ -1438,7 +1442,10 @@ impl Renderer {
                                     }
                                     LowLevelFilterOp::Blur(radius,
                                                            AxisDirection::Vertical) => {
-                                        gl::blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+                                        gl::blend_func_separate(gl::SRC_ALPHA,
+                                                                gl::ONE_MINUS_SRC_ALPHA,
+                                                                gl::ONE,
+                                                                gl::ONE);
                                         (0.0,
                                          radius.to_f32_px() * self.device_pixel_ratio,
                                          0.0,


### PR DESCRIPTION
This was because the blend function was
`GL_SRC_ALPHA`/`GL_ONE_MINUS_SRC_ALPHA` for both RGB and alpha, and that
was incorrect for alpha, since a destination alpha of 1.0 and a source
alpha < 1.0 should result in an alpha of 1.0.

r? @glennw