### PR TITLE
Use signed arithmetic to avoid underflow when shrinking window.

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1137,8 +1137,8 @@ impl Renderer {
         self.device.bind_render_target(layer.texture_id);
 
         // TODO(gw): This may not be needed in all cases...
-        let layer_origin = Point2D::new((layer.origin.x * self.device_pixel_ratio).round() as u32,
-                                        (layer.origin.y * self.device_pixel_ratio).round() as u32);
+        let layer_origin = Point2D::new((layer.origin.x * self.device_pixel_ratio).round() as gl::GLint,
+                                        (layer.origin.y * self.device_pixel_ratio).round() as gl::GLint);
 
         let layer_size = Size2D::new((layer.size.width * self.device_pixel_ratio).round() as u32,
                                      (layer.size.height * self.device_pixel_ratio).round() as u32);
@@ -1148,21 +1148,21 @@ impl Renderer {
                 layer_origin
             }
             None => {
-                let inverted_y0 = render_context.framebuffer_size.height -
-                                  layer_size.height -
+                let inverted_y0 = render_context.framebuffer_size.height as gl::GLint -
+                                  layer_size.height as gl::GLint -
                                   layer_origin.y;
 
                 Point2D::new(layer_origin.x, inverted_y0)
             }
         };
 
-        gl::scissor(layer_origin.x as gl::GLint,
-                    layer_origin.y as gl::GLint,
+        gl::scissor(layer_origin.x,
+                    layer_origin.y,
                     layer_size.width as gl::GLint,
                     layer_size.height as gl::GLint);
 
-        gl::viewport(layer_origin.x as gl::GLint,
-                     layer_origin.y as gl::GLint,
+        gl::viewport(layer_origin.x,
+                     layer_origin.y,
                      layer_size.width as gl::GLint,
                      layer_size.height as gl::GLint);
         let clear_color = if layer.texture_id.is_some() {


### PR DESCRIPTION
fixes #236 

The underflow occurs when the y co-ordinate of `viewport_size` in the last `render_api.set_root_stacking_context` call is bigger than the y co-ordinate of  `framebuffer_size` in a `renderer.render` call.

The problem is the calculated layer_origin y is negative, but we calculate it using unsigned ints, and then cast to signed just for the gl calls. The two places where this calculated value is used are `gl::scissor` and `gl::viewport`, both of these are perfectly happy with a negative origin point (as far as I know and can tell, but I don't have much experience with opengl), thus I've just changed it so we cast to signed integers early. 

The other options would be to require the above doesn't happen, either by using an outdated bigger framebuffer size (which results in the contents of the window moving upwards as the window shrinks), or recalling `set_root_stacking_context` (which is less efficient).