### PR TITLE
Handle nested transforms and clips when the transform consists solely of a translation.

### DIFF
--- a/src/node_compiler.rs
+++ b/src/node_compiler.rs
@@ -65,7 +65,14 @@ impl NodeCompiler for AABBTreeNode {
                     let StackingContextIndex(stacking_context_id) = draw_list.stacking_context_index.unwrap();
                     let context = &stacking_context_info[stacking_context_id];
 
-                    builder.set_current_clip_rect_offset(context.offset_from_layer);
+                    // FIXME(pcwalton): This is a not-great partial solution to servo/servo#10164.
+                    // A better solution would be to do this only if the transform consists of a
+                    // translation+scale only and fall back to stenciling if the object has a more
+                    // complex transform.
+                    let offset_from_layer = context.transform
+                                                   .invert()
+                                                   .transform_point(&context.offset_from_layer);
+                    builder.set_current_clip_rect_offset(offset_from_layer);
 
                     for index in &draw_list_index_buffer.indices {
                         let DrawListItemIndex(index) = *index;

--- a/tests/bug_servo_10164.html
+++ b/tests/bug_servo_10164.html
@@ -1,0 +1,19 @@
+<style>
+  .red {
+    width: 200px;
+    height: 200px;
+    overflow: hidden;
+    transform: scale(0.5);
+    background: red;
+  }
+  .green {
+    height: 100px;
+    width: 200px;
+    transform: translateX(-100px);
+    background-color: green;
+  }
+</style>
+
+<div class="red">
+  <div class="green"></div>
+</div>


### PR DESCRIPTION
This is a partial fix for the underlying issue, sufficient to address
servo/servo#10164.

r? @glennw