### PR TITLE
Do the texel-uv-to-pixel-uv conversion in floating point instead of in integers.

### DIFF
--- a/src/texture_cache.rs
+++ b/src/texture_cache.rs
@@ -538,8 +538,9 @@ impl TextureCacheItem {
                 Point2D::new(self.uv_rect().top_left.x, self.uv_rect().top_left.y),
                 Size2D::new(self.uv_rect().bottom_right.x - self.uv_rect().top_left.x,
                             self.uv_rect().bottom_right.y - self.uv_rect().top_left.y)),
-            pixel_uv: Point2D::new(self.uv_rect().top_left.x as u32 * texture_size.width,
-                                   self.uv_rect().top_left.y as u32 * texture_size.height),
+            pixel_uv:
+                Point2D::new((self.uv_rect().top_left.x * texture_size.width as f32) as u32,
+                             (self.uv_rect().top_left.y * texture_size.height as f32) as u32),
         }
     }
 

--- a/tests/bug_servo_10136.html
+++ b/tests/bug_servo_10136.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+body {
+    background: black;
+}
+div {
+    color: white;
+    text-shadow: 5px 5px 5px white;
+}
+</style>
+<div>whoa</div>


### PR DESCRIPTION
Before, the truncation rounded all texel uvs to zero, resulting in
unblurred glyphs overwriting whatever was at (0,0) in the texture cache!

Addresses servo/servo#10136.

r? @glennw 