### PR TITLE
Brand each payload message with the stacking context ID and epoch to avoid races.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ scoped_threadpool = "0.1.6"
 app_units = {version = "0.2.1", features = ["plugins"]}
 lazy_static = "0.1"
 log = "0.3"
+byteorder = "0.5"
 
 [target.x86_64-apple-darwin.dependencies]
 core-graphics = ">=0.2, <0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,5 +80,6 @@ extern crate scoped_threadpool;
 extern crate time;
 extern crate webrender_traits;
 extern crate offscreen_gl_context;
+extern crate byteorder;
 
 pub use renderer::{Renderer, RendererOptions};

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -259,9 +259,11 @@ impl Renderer {
         let context_handle = NativeGLContext::current_handle();
 
         let (device_pixel_ratio, enable_aa) = (options.device_pixel_ratio, options.enable_aa);
+        let payload_tx_for_backend = payload_tx.clone();
         thread::spawn(move || {
             let mut backend = RenderBackend::new(api_rx,
                                                  payload_rx,
+                                                 payload_tx_for_backend,
                                                  result_tx,
                                                  device_pixel_ratio,
                                                  white_image_id,


### PR DESCRIPTION
Addresses servo/servo#10256.

Needs servo/webrender_traits#31.

r? @glennw