### PR TITLE
Don't get stuck in overscroll

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -634,7 +634,8 @@ impl Frame {
         }
 
         let overscroll_amount = layer.overscroll_amount();
-        let overscrolling = overscroll_amount.width != 0.0 || overscroll_amount.height != 0.0;
+        let overscrolling = CAN_OVERSCROLL && (overscroll_amount.width != 0.0 ||
+                                               overscroll_amount.height != 0.0);
         if overscrolling {
             if overscroll_amount.width != 0.0 {
                 delta.x /= overscroll_amount.width.abs()
@@ -676,7 +677,9 @@ impl Frame {
         layer.scrolling.offset.x = layer.scrolling.offset.x.round();
         layer.scrolling.offset.y = layer.scrolling.offset.y.round();
 
-        layer.stretch_overscroll_spring();
+        if CAN_OVERSCROLL {
+            layer.stretch_overscroll_spring();
+        }
     }
 
     pub fn tick_scrolling_bounce_animations(&mut self) {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1301,10 +1301,7 @@ impl Frame {
         let mut layers_bouncing_back = HashSet::with_hasher(Default::default());
         for (scroll_layer_id, layer) in &self.layers {
             if layer.scrolling.started_bouncing_back {
-                let overscroll_amount = layer.overscroll_amount();
-                if overscroll_amount.width.abs() >= 0.1 || overscroll_amount.height.abs() >= 0.1 {
-                    layers_bouncing_back.insert(*scroll_layer_id);
-                }
+                layers_bouncing_back.insert(*scroll_layer_id);
             }
         }
         layers_bouncing_back

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -114,8 +114,11 @@ impl Layer {
     }
 
     pub fn tick_scrolling_bounce_animation(&mut self) {
-        self.scrolling.spring.animate();
+        let finished = self.scrolling.spring.animate();
         self.scrolling.offset = self.scrolling.spring.current();
+        if finished {
+            self.scrolling.started_bouncing_back = false;
+        }
     }
 }
 

--- a/src/spring.rs
+++ b/src/spring.rs
@@ -50,7 +50,8 @@ impl Spring {
         self.cur
     }
 
-    pub fn animate(&mut self) {
+    /// Run one tick of the spring animation. Return true if the animation is complete.
+    pub fn animate(&mut self) -> bool {
         if !is_resting(self.cur.x, self.prev.x, self.dest.x) ||
                 !is_resting(self.cur.y, self.prev.y, self.dest.y) {
             let next = Point2D::new(next(self.cur.x,
@@ -64,10 +65,12 @@ impl Spring {
                                          self.stiffness,
                                          self.damping));
             let (cur, dest) = (self.cur, self.dest);
-            self.coords(next, cur, dest)
+            self.coords(next, cur, dest);
+            false
         } else {
             let dest = self.dest;
-            self.coords(dest, dest, dest)
+            self.coords(dest, dest, dest);
+            true
         }
     }
 }


### PR DESCRIPTION
* Never trigger overscroll bounce when overscroll is disabled. This fixes a bug where rounding could cause a layer to enter overscroll even if CAN_OVERFLOW is false, and then get stuck.

* Run the overscroll animation all the way to the destination, then stop animating.  This fixes a bug where a layer could get "stuck" in overscroll because it gets within 0.1 of the edge and then stops.