### PR TITLE
Fold z-clears into the batches instead of having them be separate draw commands.

### DIFF
--- a/src/internal_types.rs
+++ b/src/internal_types.rs
@@ -603,6 +603,7 @@ pub struct StackingContextInfo {
     pub local_clip_rect: Rect<f32>,
     pub transform: Matrix4,
     pub perspective: Matrix4,
+    pub z_clear_needed: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This avoids doing z-clears if the batch is going to be entirely culled
out.

Dramatically improves scrolling performance on Twitter, Intel Iris.

r? @glennw