### PR TITLE
Use the new `webrender_traits` types to avoid copying buffers when new frames come in.

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -8,10 +8,9 @@ use internal_types::DrawListId;
 use resource_cache::ResourceCache;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use webrender_traits::{AuxiliaryLists, BuiltDisplayList, ItemRange, PipelineId, Epoch};
-use webrender_traits::{ColorF, DisplayListId, StackingContext, StackingContextId};
-use webrender_traits::{SpecificDisplayListItem};
-use webrender_traits::{IframeInfo};
+use webrender_traits::{AuxiliaryLists, BuiltDisplayList, BuiltDisplayListRef, ItemRange};
+use webrender_traits::{ColorF, DisplayListId, Epoch, PipelineId, StackingContext};
+use webrender_traits::{IframeInfo, StackingContextId, SpecificDisplayListItem};
 use webrender_traits::{RectangleDisplayItem, ClipRegion, DisplayItem, SpecificDisplayItem};
 
 #[derive(Debug)]
@@ -74,7 +73,7 @@ impl Scene {
                             id: DisplayListId,
                             pipeline_id: PipelineId,
                             epoch: Epoch,
-                            built_display_list: BuiltDisplayList,
+                            built_display_list: BuiltDisplayListRef,
                             resource_cache: &mut ResourceCache) {
         let items = built_display_list.display_list_items().iter().map(|item| {
             match item.specific {


### PR DESCRIPTION
This improves performance.

Depends on servo/webrender_traits#46.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/271)
<!-- Reviewable:end -->
