### PR TITLE
Expand viewports to consist of a rectangle and a transform.

### DIFF
--- a/src/aabbtree.rs
+++ b/src/aabbtree.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use euclid::{Point2D, Rect, Size2D};
-use internal_types::{CompiledNode, DrawListId, DrawListItemIndex, DrawListGroupId};
+use internal_types::{CompiledNode, DrawListId, DrawListItemIndex, DrawListGroupId, MAX_RECT};
 use resource_list::ResourceList;
 use util;
 


### PR DESCRIPTION
Further work should expand this to an entire rectangle/transform stack,
but this is an improvement over the current situation.

This was necessary to properly handle clipping in the presence of
nested iframes and `overflow: scroll` stacking contexts, while
simultaneously handling transformed and clipped iframes.

We still have some clipping issues when `overflow: scroll`, iframes, and
transforms are all nested together: this is visible in the browser.html
tab change animation on duckduckgo.com result pages. I wanted to get
this in now, though, because this significantly improves the current
situation.

Addresses servo/servo#11150.
Addresses servo/servo#11151.

r? @glennw 