### PR TITLE
Transform viewport rectangles if the current matrix can losslessly transform them.

### DIFF
--- a/tests/bug_servo_11358.html
+++ b/tests/bug_servo_11358.html
@@ -1,0 +1,12 @@
+<style>
+  body {
+    background: green;
+  }
+  iframe  {
+    width: 100vw;
+    height: 100vh;
+    border: 10px solid red;
+    transform: scale(.5);
+  }
+</style>
+<iframe src="data:text/html,<body style='overflow: hidden; overflow-y: auto;'><div style='background: blue; height: 2000px'>"></iframe>


### PR DESCRIPTION
This allows our current code to support a subset of nested clips and
transforms without actually having a full-blown clip/transform stack.

Closes servo/servo#11358.

r? @glennw