### PR TITLE
Add some simple optimizations to skip clears and stencil buffer operations.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1447,18 +1447,3 @@ impl Frame {
     }
 }
 
-trait Matrix4DUtils {
-    /// Returns true if this matrix transforms an axis-aligned 2D rectangle to another axis-aligned
-    /// 2D rectangle.
-    ///
-    /// This is used as part of `flatten()` above, as essentially a hack for browser.html.
-    fn can_losslessly_transform_a_2d_rect(&self) -> bool;
-}
-
-impl Matrix4DUtils for Matrix4D<f32> {
-    fn can_losslessly_transform_a_2d_rect(&self) -> bool {
-        self.m31 == 0.0 && self.m32 == 0.0 && self.m33 == 1.0 && self.m34 == 0.0 &&
-            self.m43 == 0.0 && self.m44 == 1.0
-    }
-}
-

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -208,7 +208,7 @@ impl RenderTarget {
         for item in &self.items {
             match item {
                 &FrameRenderItem::CompositeBatch(ref info, z_clear_needed) => {
-                    if z_clear_needed {
+                    if z_clear_needed && !commands.is_empty() {
                         commands.push(DrawCommand::Clear(ClearInfo {
                             clear_color: false,
                             clear_z: true,
@@ -310,7 +310,7 @@ impl RenderTarget {
 
                     if any_were_visible {
                         // Add a clear command if necessary.
-                        if z_clear_needed {
+                        if z_clear_needed && !commands.is_empty() {
                             commands.push(DrawCommand::Clear(ClearInfo {
                                 clear_color: false,
                                 clear_z: true,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -380,7 +380,6 @@ impl Renderer {
 
             gl::disable(gl::SCISSOR_TEST);
             gl::clear_color(1.0, 1.0, 1.0, 0.0);
-            gl::clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT | gl::STENCIL_BUFFER_BIT);
 
             self.update_shaders();
             self.update_texture_cache();

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,6 +38,12 @@ impl Drop for ProfileScope {
 // TODO: Implement these in euclid!
 pub trait MatrixHelpers {
     fn transform_rect(&self, rect: &Rect<f32>) -> Rect<f32>;
+
+    /// Returns true if this matrix transforms an axis-aligned 2D rectangle to another axis-aligned
+    /// 2D rectangle.
+    ///
+    /// This is used as part of `flatten()` above, as essentially a hack for browser.html.
+    fn can_losslessly_transform_a_2d_rect(&self) -> bool;
 }
 
 impl MatrixHelpers for Matrix4D<f32> {
@@ -65,6 +71,10 @@ impl MatrixHelpers for Matrix4D<f32> {
         }
         Rect::new(Point2D::new(min_x.clone(), min_y.clone()),
                   Size2D::new(max_x - min_x, max_y - min_y))
+    }
+
+    fn can_losslessly_transform_a_2d_rect(&self) -> bool {
+        self.m12 == 0.0 && self.m14 == 0.0 && self.m21 == 0.0 && self.m24 == 0.0 && self.m44 == 1.0
     }
 }
 


### PR DESCRIPTION
This series of optimizations speeds up painting of browser.html by 50% or more on my MacBook Pro/Intel Iris. It allows us to reach 60 FPS in some cases (though not reliably) even when YouTube is playing and visible and a transparent blurry Terminal is in the background.

r? @glennw