### PR TITLE
resource-cache: Allow deallocating images

### DIFF
--- a/src/render_backend.rs
+++ b/src/render_backend.rs
@@ -114,6 +114,9 @@ impl RenderBackend {
                                                                       format,
                                                                       bytes);
                         }
+                        ApiMsg::DeleteImage(id) => {
+                            self.resource_cache.delete_image_template(id);
+                        }
                         ApiMsg::CloneApi(sender) => {
                             let result = self.next_namespace_id;
 

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -221,6 +221,10 @@ impl ResourceCache {
         self.image_templates.insert(image_key, resource);
     }
 
+    pub fn delete_image_template(&mut self, image_key: ImageKey) {
+        self.image_templates.remove(&image_key);
+    }
+
     pub fn add_webgl_texture(&mut self, id: WebGLContextId, texture_id: TextureId, size: Size2D<i32>) {
         self.webgl_textures.insert(id, texture_id);
         self.texture_cache.add_raw_update(texture_id, size);

--- a/src/resource_list.rs
+++ b/src/resource_list.rs
@@ -46,16 +46,9 @@ impl ResourceList {
     }
 
     pub fn add_glyph(&mut self, font_key: FontKey, glyph: Glyph) {
-        match self.required_glyphs.entry(font_key) {
-            Occupied(entry) => {
-                entry.into_mut().insert(glyph);
-            }
-            Vacant(entry) => {
-                let mut hash_set = HashSet::new();
-                hash_set.insert(glyph);
-                entry.insert(hash_set);
-            }
-        }
+        self.required_glyphs.entry(font_key)
+                            .or_insert_with(HashSet::new)
+                            .insert(glyph);
     }
 
     pub fn add_radius_raster(&mut self,


### PR DESCRIPTION
This will allow us leaking a lot of canvas memory while using readback.

Also we should probably audit where are these used and when can they be
deallocated.

Depends on: https://github.com/servo/webrender_traits/pull/57

r? @glennw 