### PR TITLE
Bump euclid and reorder dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,21 +4,21 @@ version = "0.1.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 
 [dependencies]
-ipc-channel = {git = "https://github.com/servo/ipc-channel"}
-webrender_traits = {git = "https://github.com/servo/webrender_traits"}
-#notify = {git = "https://github.com/glennw/rsnotify.git", branch = "inotify-modify"}
-offscreen_gl_context = {version = "0.1.1", features = ["serde_serialization"]}
-gleam = "0.2"
-euclid = {version = "0.6.2", features = ["plugins"]}
-num-traits = "0.1.32"
-time = "0.1"
+app_units = "0.2.5"
+bit-set = "0.4"
+byteorder = "0.5"
+euclid = "0.7.1"
 fnv="1.0"
-scoped_threadpool = "0.1.6"
-app_units = {version = "0.2.1", features = ["plugins"]}
+gleam = "0.2"
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 lazy_static = "0.2"
 log = "0.3"
-byteorder = "0.5"
-bit-set = "0.4"
+#notify = {git = "https://github.com/glennw/rsnotify.git", branch = "inotify-modify"}
+num-traits = "0.1.32"
+offscreen_gl_context = {version = "0.1.9", features = ["serde_serialization"]}
+scoped_threadpool = "0.1.6"
+time = "0.1"
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 
 [target.'cfg(any(target_os = "android", target_os = "linux", target_os = "windows"))'.dependencies]
 freetype = {git = "https://github.com/servo/rust-freetype"}


### PR DESCRIPTION
This also is the first PR to rely on webrender_traits without serde_codegen,
but it doesn't appear in the diff since unfortunately we just depend on
a Git repository without even a tag or a commit hash.