### PR TITLE
 	Only send new scroll frames to the compositor if a scroll event actually resulted in motion, and fix some overscroll problems.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -768,7 +768,8 @@ impl Frame {
             layer.scrolling.started_bouncing_back = false
         } else if overscrolling &&
                 ((delta.x < 1.0 && delta.y < 1.0) || phase == ScrollEventPhase::End) {
-            layer.scrolling.started_bouncing_back = true
+            layer.scrolling.started_bouncing_back = true;
+            layer.scrolling.bouncing_back = true
         }
 
         layer.scrolling.offset.x = layer.scrolling.offset.x.round();
@@ -1479,7 +1480,7 @@ impl Frame {
                                     -> HashSet<ScrollLayerId, BuildHasherDefault<FnvHasher>> {
         let mut layers_bouncing_back = HashSet::with_hasher(Default::default());
         for (scroll_layer_id, layer) in &self.layers {
-            if layer.scrolling.started_bouncing_back {
+            if layer.scrolling.bouncing_back {
                 layers_bouncing_back.insert(*scroll_layer_id);
             }
         }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -138,7 +138,7 @@ impl Layer {
         let finished = self.scrolling.spring.animate();
         self.scrolling.offset = self.scrolling.spring.current();
         if finished {
-            self.scrolling.started_bouncing_back = false;
+            self.scrolling.bouncing_back = false
         }
     }
 }
@@ -148,6 +148,7 @@ pub struct ScrollingState {
     pub offset: Point2D<f32>,
     pub spring: Spring,
     pub started_bouncing_back: bool,
+    pub bouncing_back: bool,
 }
 
 impl ScrollingState {
@@ -156,6 +157,7 @@ impl ScrollingState {
             offset: Point2D::new(0.0, 0.0),
             spring: Spring::at(Point2D::new(0.0, 0.0), STIFFNESS, DAMPING),
             started_bouncing_back: false,
+            bouncing_back: false,
         }
     }
 }

--- a/src/spring.rs
+++ b/src/spring.rs
@@ -5,7 +5,7 @@
 use euclid::Point2D;
 
 /// Some arbitrarily small positive number used as threshold value.
-pub const EPSILON: f32 = 0.001;
+pub const EPSILON: f32 = 0.1;
 
 /// The default stiffness factor.
 pub const STIFFNESS: f32 = 0.2;


### PR DESCRIPTION
Requires servo/webrender_traits#64.

r? @glennw