### PR TITLE
Fixes allocating textures that use nearest sampling.

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use device::{ProgramId, TextureId, TextureFilter};
+use device::{ProgramId, TextureId};
 use euclid::{Point2D, Rect, Size2D};
 use internal_types::{MAX_RECT, AxisDirection, PackedVertexColorMode, PackedVertexForQuad};
 use internal_types::{PackedVertexForTextureCacheUpdate, RectUv, DevicePixel};
@@ -416,7 +416,7 @@ impl RasterBatch {
             dest_texture_id == self.dest_texture_id;
 
         if batch_ok {
-            let origin = self.page_allocator.allocate(&dest_rect.size, TextureFilter::Linear);
+            let origin = self.page_allocator.allocate(&dest_rect.size);
 
             if let Some(origin) = origin {
                 let vertices = f(&Rect::new(Point2D::new(origin.x as f32,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use batch::{MAX_MATRICES_PER_BATCH, OffsetParams};
-use device::{TextureId, TextureFilter};
+use device::{TextureId};
 use euclid::{Matrix4D, Point2D, Point3D, Point4D, Rect, Size2D};
 use fnv::FnvHasher;
 use geometry::ray_intersects_rect;
@@ -188,7 +188,7 @@ impl RenderTarget {
             let allocated_origin = self.page_allocator
                                        .as_mut()
                                        .unwrap()
-                                       .allocate(&size, TextureFilter::Linear);
+                                       .allocate(&size);
             if let Some(allocated_origin) = allocated_origin {
                 let origin = Point2D::new(allocated_origin.x as f32,
                                           allocated_origin.y as f32);


### PR DESCRIPTION
This code was accidentally removed during fixes for the tech preview demo.

Fixes an assert in the image_rendering_pixelated reftest.