### PR TITLE
clean up a compile error in the border fragment shader

### DIFF
--- a/res/ps_border.fs.glsl
+++ b/res/ps_border.fs.glsl
@@ -181,7 +181,6 @@ void main(void) {
     default:
     {
       discard;
-      break;
     }
   }
 }


### PR DESCRIPTION
This caused the shaders to fail to compile on windows.