### PR TITLE
Abstract the common transform related shader code into prim_shared.glsl.

### DIFF
--- a/res/ps_angle_gradient.vs.glsl
+++ b/res/ps_angle_gradient.vs.glsl
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 struct AngleGradient {
-	PrimitiveInfo info;
+    PrimitiveInfo info;
     vec4 start_end_point;
     uvec4 stop_count;
     vec4 colors[MAX_STOPS_PER_ANGLE_GRADIENT];

--- a/res/ps_image_transform.fs.glsl
+++ b/res/ps_image_transform.fs.glsl
@@ -3,11 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    vec2 pos = vPos.xy / vPos.z;
-
-    if (!point_in_rect(pos, vRect.xy, vRect.xy + vRect.zw)) {
-        discard;
-    }
-
-    oFragColor = texture(sDiffuse, vUv / vPos.z);
+    init_transform_fs(vLocalPos, vLocalRect);
+    oFragColor = texture(sDiffuse, vUv / vLocalPos.z);
 }

--- a/res/ps_image_transform.glsl
+++ b/res/ps_image_transform.glsl
@@ -4,5 +4,5 @@
 
 varying vec2 vUv;
 
-varying vec3 vPos;
-flat varying vec4 vRect;
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;

--- a/res/ps_image_transform.vs.glsl
+++ b/res/ps_image_transform.vs.glsl
@@ -15,51 +15,15 @@ layout(std140) uniform Items {
 
 void main(void) {
     Image image = images[gl_InstanceID];
-    Layer layer = layers[image.info.layer_tile_part.x];
-    Tile tile = tiles[image.info.layer_tile_part.y];
 
-    vec2 p0 = image.info.local_rect.xy;
-    vec2 p1 = image.info.local_rect.xy + vec2(image.info.local_rect.z, 0.0);
-    vec2 p2 = image.info.local_rect.xy + vec2(0.0, image.info.local_rect.w);
-    vec2 p3 = image.info.local_rect.xy + image.info.local_rect.zw;
+    TransformVertexInfo vi = write_transform_vertex(image.info);
 
-    vec4 t0 = layer.transform * vec4(p0, 0, 1);
-    vec4 t1 = layer.transform * vec4(p1, 0, 1);
-    vec4 t2 = layer.transform * vec4(p2, 0, 1);
-    vec4 t3 = layer.transform * vec4(p3, 0, 1);
+    vLocalRect = image.info.local_rect;
+    vLocalPos = vi.local_pos;
 
-    vec2 tp0 = t0.xy / t0.w;
-    vec2 tp1 = t1.xy / t1.w;
-    vec2 tp2 = t2.xy / t2.w;
-    vec2 tp3 = t3.xy / t3.w;
-
-    vec2 min_pos = min(tp0.xy, min(tp1.xy, min(tp2.xy, tp3.xy)));
-    vec2 max_pos = max(tp0.xy, max(tp1.xy, max(tp2.xy, tp3.xy)));
-
-    vec2 min_pos_clamped = clamp(min_pos * uDevicePixelRatio,
-                                 vec2(tile.actual_rect.xy),
-                                 vec2(tile.actual_rect.xy + tile.actual_rect.zw));
-
-    vec2 max_pos_clamped = clamp(max_pos * uDevicePixelRatio,
-                                 vec2(tile.actual_rect.xy),
-                                 vec2(tile.actual_rect.xy + tile.actual_rect.zw));
-
-    vec2 clamped_pos = mix(min_pos_clamped,
-                           max_pos_clamped,
-                           aPosition.xy);
-
-    vec3 layer_pos = get_layer_pos(clamped_pos / uDevicePixelRatio, image.info.layer_tile_part.x);
-
-    vRect = image.info.local_rect;
-    vPos = layer_pos;
-
-    vec2 f = (layer_pos.xy - image.info.local_rect.xy) / image.info.local_rect.zw;
+    vec2 f = (vi.local_pos.xy - image.info.local_rect.xy) / image.info.local_rect.zw;
 
     vUv = mix(image.st_rect.xy,
               image.st_rect.zw,
               f);
-
-    vec2 final_pos = clamped_pos + vec2(tile.target_rect.xy) - vec2(tile.actual_rect.xy);
-
-    gl_Position = uTransform * vec4(final_pos, 0, 1);
 }

--- a/res/ps_rectangle.vs.glsl
+++ b/res/ps_rectangle.vs.glsl
@@ -4,8 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 struct Rectangle {
-	PrimitiveInfo info;
-	vec4 color;
+    PrimitiveInfo info;
+    vec4 color;
 };
 
 layout(std140) uniform Items {

--- a/res/ps_rectangle_clip.vs.glsl
+++ b/res/ps_rectangle_clip.vs.glsl
@@ -4,8 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 struct Rectangle {
-  	PrimitiveInfo info;
-  	vec4 color;
+    PrimitiveInfo info;
+    vec4 color;
     Clip clip;
 };
 

--- a/res/ps_rectangle_transform.fs.glsl
+++ b/res/ps_rectangle_transform.fs.glsl
@@ -3,11 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    vec2 pos = vPos.xy / vPos.z;
-
-    if (!point_in_rect(pos, vRect.xy, vRect.xy + vRect.zw)) {
-	    discard;
-    }
-
-	oFragColor = vColor;
+    init_transform_fs(vLocalPos, vLocalRect);
+    oFragColor = vColor;
 }

--- a/res/ps_rectangle_transform.glsl
+++ b/res/ps_rectangle_transform.glsl
@@ -4,5 +4,5 @@
 
 varying vec4 vColor;
 
-varying vec3 vPos;
-flat varying vec4 vRect;
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;

--- a/res/ps_rectangle_transform.vs.glsl
+++ b/res/ps_rectangle_transform.vs.glsl
@@ -4,8 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 struct Rectangle {
-	PrimitiveInfo info;
-	vec4 color;
+    PrimitiveInfo info;
+    vec4 color;
 };
 
 layout(std140) uniform Items {
@@ -14,46 +14,11 @@ layout(std140) uniform Items {
 
 void main(void) {
     Rectangle rect = rects[gl_InstanceID];
-    Layer layer = layers[rect.info.layer_tile_part.x];
-    Tile tile = tiles[rect.info.layer_tile_part.y];
 
-    vec2 p0 = rect.info.local_rect.xy;
-    vec2 p1 = rect.info.local_rect.xy + vec2(rect.info.local_rect.z, 0.0);
-    vec2 p2 = rect.info.local_rect.xy + vec2(0.0, rect.info.local_rect.w);
-    vec2 p3 = rect.info.local_rect.xy + rect.info.local_rect.zw;
+    TransformVertexInfo vi = write_transform_vertex(rect.info);
 
-    vec4 t0 = layer.transform * vec4(p0, 0, 1);
-    vec4 t1 = layer.transform * vec4(p1, 0, 1);
-    vec4 t2 = layer.transform * vec4(p2, 0, 1);
-    vec4 t3 = layer.transform * vec4(p3, 0, 1);
+    vLocalRect = rect.info.local_rect;
+    vLocalPos = vi.local_pos;
 
-    vec2 tp0 = t0.xy / t0.w;
-    vec2 tp1 = t1.xy / t1.w;
-    vec2 tp2 = t2.xy / t2.w;
-    vec2 tp3 = t3.xy / t3.w;
-
-    vec2 min_pos = min(tp0.xy, min(tp1.xy, min(tp2.xy, tp3.xy)));
-    vec2 max_pos = max(tp0.xy, max(tp1.xy, max(tp2.xy, tp3.xy)));
-
-    vec2 min_pos_clamped = clamp(min_pos * uDevicePixelRatio,
-                                 vec2(tile.actual_rect.xy),
-                                 vec2(tile.actual_rect.xy + tile.actual_rect.zw));
-
-    vec2 max_pos_clamped = clamp(max_pos * uDevicePixelRatio,
-                                 vec2(tile.actual_rect.xy),
-                                 vec2(tile.actual_rect.xy + tile.actual_rect.zw));
-
-    vec2 clamped_pos = mix(min_pos_clamped,
-                           max_pos_clamped,
-                           aPosition.xy);
-
-    vec3 layer_pos = get_layer_pos(clamped_pos / uDevicePixelRatio, rect.info.layer_tile_part.x);
-
-    vRect = rect.info.local_rect;
-    vPos = layer_pos;
     vColor = rect.color;
-
-    vec2 final_pos = clamped_pos + vec2(tile.target_rect.xy) - vec2(tile.actual_rect.xy);
-
-    gl_Position = uTransform * vec4(final_pos, 0, 1);
 }


### PR DESCRIPTION
This is the first step in adding transform support for other primitive types,
as well as optimizing the performance of the 3d transform shader.