### PR TITLE
run glyph raster jobs in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.3"
 #notify = {git = "https://github.com/glennw/rsnotify.git", branch = "inotify-modify"}
 num-traits = "0.1.32"
 offscreen_gl_context = {version = "0.3", features = ["serde_serialization"]}
+rayon = "0.4.0"
 scoped_threadpool = "0.1.6"
 time = "0.1"
 webrender_traits = {git = "https://github.com/servo/webrender_traits", default-features = false}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,5 +106,6 @@ extern crate time;
 extern crate webrender_traits;
 extern crate offscreen_gl_context;
 extern crate byteorder;
+extern crate rayon;
 
 pub use renderer::{Renderer, RendererOptions};

--- a/src/resource_cache.rs
+++ b/src/resource_cache.rs
@@ -11,6 +11,7 @@ use freelist::FreeList;
 use internal_types::{FontTemplate, GlyphKey, RasterItem};
 use internal_types::{TextureUpdateList, DrawListId, DrawList};
 use platform::font::{FontContext, RasterizedGlyph};
+use rayon::prelude::*;
 use renderer::BLUR_INFLATION_FACTOR;
 use resource_list::ResourceList;
 use scoped_threadpool;
@@ -401,8 +402,7 @@ fn run_raster_jobs(pending_raster_jobs: &mut Vec<GlyphRasterJob>,
         return
     }
 
-    // TODO(gw): Run raster jobs in parallel again
-    for job in pending_raster_jobs {
+    pending_raster_jobs.par_iter_mut().weight_max().for_each(|job| {
         let font_template = &font_templates[&job.glyph_key.font_key];
         FONT_CONTEXT.with(move |font_context| {
             let mut font_context = font_context.borrow_mut();
@@ -421,7 +421,7 @@ fn run_raster_jobs(pending_raster_jobs: &mut Vec<GlyphRasterJob>,
                                                 device_pixel_ratio,
                                                 enable_aa);
         });
-    }
+    });
 }
 
 pub trait Resource {


### PR DESCRIPTION
preliminary tests show a ~31% improvement on glyph rasterization time of initial frames on wikipedia/nyt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/349)
<!-- Reviewable:end -->
