### PR TITLE
Add Api to access glyph dimensions

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -938,4 +938,9 @@ impl Frame {
             None
         }
     }
+
+    /// Returns the id which the next Frame would possess
+    pub fn next_frame_id(&self) -> FrameId {
+        FrameId(self.id.0 + 1)
+    }
 }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use texture_cache::BorderType;
 use tiling;
-use webrender_traits::{FontKey, Epoch, ColorF, PipelineId};
+use webrender_traits::{Epoch, ColorF, PipelineId};
 use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem, ScrollLayerId};
 
 #[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -691,25 +691,6 @@ impl BoxShadowRasterOp {
 pub enum BoxShadowPart {
     _Corner,
     _Edge,
-}
-
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub struct GlyphKey {
-    pub font_key: FontKey,
-    pub size: Au,
-    pub blur_radius: Au,
-    pub index: u32,
-}
-
-impl GlyphKey {
-    pub fn new(font_key: FontKey, size: Au, blur_radius: Au, index: u32) -> GlyphKey {
-        GlyphKey {
-            font_key: font_key,
-            size: size,
-            blur_radius: blur_radius,
-            index: index,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 use texture_cache::TextureCache;
 use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace};
-use webrender_traits::{PipelineId, RenderNotifier, WebGLContextId};
+use webrender_traits::{GlyphDimensions, PipelineId, RenderNotifier, WebGLContextId};
 use batch::new_id;
 use device::TextureId;
 use tiling::FrameBuilderConfig;
@@ -91,6 +91,18 @@ impl RenderBackend {
                         ApiMsg::AddNativeFont(id, native_font_handle) => {
                             self.resource_cache
                                 .add_font_template(id, FontTemplate::Native(native_font_handle));
+                        }
+                        ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
+                            let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
+                            for glyph_key in &glyph_keys {
+                                // Get the next frame id, so it'll remain in the texture cache.
+                                // This assumes that the glyph will be used in the next frame.
+                                let frame_id = self.frame.next_frame_id();
+                                let glyph_dim = self.resource_cache
+                                                    .get_glyph_dimensions(&glyph_key, frame_id);
+                                glyph_dimensions.push(glyph_dim);
+                            };
+                            tx.send(glyph_dimensions).unwrap();
                         }
                         ApiMsg::AddImage(id, width, height, format, bytes) => {
                             profile_counters.image_templates.inc(bytes.len());

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -8,7 +8,7 @@ use euclid::Size2D;
 use fnv::FnvHasher;
 use frame::FrameId;
 use freelist::FreeList;
-use internal_types::{FontTemplate, GlyphKey, RasterItem};
+use internal_types::{FontTemplate, RasterItem};
 use internal_types::{TextureUpdateList, DrawListId, DrawList};
 use platform::font::{FontContext, RasterizedGlyph};
 use rayon::prelude::*;
@@ -22,8 +22,8 @@ use std::hash::BuildHasherDefault;
 use std::hash::Hash;
 use texture_cache::{TextureCache, TextureCacheItem, TextureCacheItemId};
 use texture_cache::{BorderType, TextureInsertOp};
-use webrender_traits::{Epoch, FontKey, ImageKey, ImageFormat, DisplayItem, ImageRendering};
-use webrender_traits::{PipelineId, WebGLContextId};
+use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, DisplayItem, ImageRendering};
+use webrender_traits::{GlyphDimensions, PipelineId, WebGLContextId};
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
 
@@ -267,14 +267,19 @@ impl ResourceCache {
 
         // Update texture cache with any newly rasterized glyphs.
         resource_list.for_each_glyph(|glyph_key| {
-            if !self.cached_glyphs.contains_key(glyph_key) {
-                self.pending_raster_jobs.push(GlyphRasterJob {
-                    glyph_key: glyph_key.clone(),
-                    result: None,
-                });
-            }
-            self.cached_glyphs.mark_as_needed(glyph_key, frame_id);
+            self.create_raster_job(glyph_key, frame_id);
         });
+    }
+
+    #[inline]
+    fn create_raster_job(&mut self, glyph_key: &GlyphKey, frame_id: FrameId) {
+        if !self.cached_glyphs.contains_key(glyph_key) {
+            self.pending_raster_jobs.push(GlyphRasterJob {
+                glyph_key: glyph_key.clone(),
+                result: None,
+            });
+        }
+        self.cached_glyphs.mark_as_needed(glyph_key, frame_id);
     }
 
     pub fn raster_pending_glyphs(&mut self,
@@ -347,6 +352,22 @@ impl ResourceCache {
     pub fn get_glyph(&self, glyph_key: &GlyphKey, frame_id: FrameId) -> Option<&TextureCacheItem> {
         let image_id = self.cached_glyphs.get(glyph_key, frame_id);
         image_id.map(|image_id| self.texture_cache.get(image_id))
+    }
+
+    pub fn get_glyph_dimensions(&mut self,
+                                glyph_key: &GlyphKey,
+                                frame_id: FrameId)
+                                -> Option<GlyphDimensions> {
+        self.create_raster_job(&glyph_key, frame_id);
+        self.raster_pending_glyphs(frame_id);
+        self.get_glyph(&glyph_key, frame_id).map(|cached_glyph| {
+            GlyphDimensions {
+                left:   cached_glyph.user_data.x0,
+                top:    cached_glyph.user_data.y0,
+                width:  cached_glyph.requested_rect.size.width,
+                height: cached_glyph.requested_rect.size.height,
+            }
+        })
     }
 
     #[inline]

--- a/webrender/src/resource_list.rs
+++ b/webrender/src/resource_list.rs
@@ -4,10 +4,10 @@
 
 use app_units::Au;
 use fnv::FnvHasher;
-use internal_types::{Glyph, GlyphKey, RasterItem};
+use internal_types::{Glyph, RasterItem};
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use webrender_traits::{FontKey, ImageKey, ImageRendering};
+use webrender_traits::{FontKey, GlyphKey, ImageKey, ImageRendering};
 
 type RequiredImageSet = HashSet<(ImageKey, ImageRendering), BuildHasherDefault<FnvHasher>>;
 type RequiredGlyphMap = HashMap<FontKey,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -8,7 +8,7 @@ use device::{TextureId};
 use euclid::{Point2D, Rect, Matrix4D, Size2D, Point4D};
 use fnv::FnvHasher;
 use frame::FrameId;
-use internal_types::{Glyph, GlyphKey, DevicePixel, CompositionOp};
+use internal_types::{Glyph, DevicePixel, CompositionOp};
 use internal_types::{ANGLE_FLOAT_TO_FIXED, LowLevelFilterOp, RectUv};
 use layer::Layer;
 use renderer::{BLUR_INFLATION_FACTOR};
@@ -21,7 +21,7 @@ use std::mem;
 use std::hash::{BuildHasherDefault};
 use texture_cache::{TexturePage};
 use util::{self, rect_from_points, rect_from_points_f, MatrixHelpers, subtract_rect, RectHelpers};
-use webrender_traits::{ColorF, FontKey, ImageKey, ImageRendering, ComplexClipRegion};
+use webrender_traits::{ColorF, FontKey, GlyphKey, ImageKey, ImageRendering, ComplexClipRegion};
 use webrender_traits::{BorderDisplayItem, BorderStyle, ItemRange, AuxiliaryLists, BorderRadius, BorderSide};
 use webrender_traits::{BoxShadowClipMode, PipelineId, ScrollLayerId, WebGLContextId};
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -18,6 +18,8 @@ use offscreen_gl_context::{GLContextAttributes, GLLimits};
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
     AddNativeFont(FontKey, NativeFontHandle),
+    /// Gets the glyph dimensions
+    GetGlyphDimensions(Vec<GlyphKey>, IpcSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
     AddImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
     /// Updates the the resource cache with the new image data.
@@ -48,6 +50,14 @@ pub enum ApiMsg {
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
     RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct GlyphDimensions {
+    pub left: i32,
+    pub top: i32,
+    pub width: u32,
+    pub height: u32,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -215,6 +225,25 @@ pub enum FilterOp {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FontKey(u32, u32);
+
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct GlyphKey {
+    pub font_key: FontKey,
+    pub size: Au,
+    pub blur_radius: Au,
+    pub index: u32,
+}
+
+impl GlyphKey {
+    pub fn new(font_key: FontKey, size: Au, blur_radius: Au, index: u32) -> GlyphKey {
+        GlyphKey {
+            font_key: font_key,
+            size: size,
+            blur_radius: blur_radius,
+            index: index,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum FragmentType {


### PR DESCRIPTION
With this, standalone applications will be able to handle glyph spacing and/or positioning. Currently the workaround would be setting up a font renderer by yourself, but this would involve use of plattform dependent libraries and introduce overhead, since the texture cache already knows about the glyph dimensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/353)
<!-- Reviewable:end -->
