### PR TITLE
Switch the layer viewport rect to local space.

### DIFF
--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -37,17 +37,20 @@ void main(void) {
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(border.info);
     vLocalPos = vi.local_pos;
+
+    // Local space
+    vLocalRect = vi.clipped_local_rect;
 #else
     VertexInfo vi = write_vertex(border.info);
     vLocalPos = vi.local_clamped_pos.xy;
+
+    // Local space
+    vLocalRect = border.info.local_rect;
 #endif
 
     // This is what was currently sent.
     vVerticalColor = border.verticalColor;
     vHorizontalColor = border.horizontalColor;
-
-    // Local space
-    vLocalRect = border.info.local_rect;
 
     // Just our boring radius position.
     vRadii = border.radii;

--- a/webrender/res/ps_gradient.fs.glsl
+++ b/webrender/res/ps_gradient.fs.glsl
@@ -3,6 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    do_clip(vPos, vClipRect, vClipRadius);
+#ifdef WR_FEATURE_TRANSFORM
+    float alpha = 0;
+    vec2 local_pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
+#else
+    vec2 local_pos = vPos;
+#endif
+
+    do_clip(local_pos, vClipRect, vClipRadius);
+
     oFragColor = mix(vColor0, vColor1, vF);
+
+#ifdef WR_FEATURE_TRANSFORM
+    oFragColor.a *= alpha;
+#endif
 }

--- a/webrender/res/ps_gradient.glsl
+++ b/webrender/res/ps_gradient.glsl
@@ -2,9 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying float vF;
-varying vec2 vPos;
 flat varying vec4 vColor0;
 flat varying vec4 vColor1;
 flat varying vec4 vClipRect;
 flat varying vec4 vClipRadius;
+varying float vF;
+
+#ifdef WR_FEATURE_TRANSFORM
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;
+#else
+varying vec2 vPos;
+#endif

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -20,9 +20,17 @@ layout(std140) uniform Items {
 
 void main(void) {
     Gradient gradient = gradients[gl_InstanceID];
-    VertexInfo vi = write_vertex(gradient.info);
 
+#ifdef WR_FEATURE_TRANSFORM
+    TransformVertexInfo vi = write_transform_vertex(gradient.info);
+    vLocalRect = vi.clipped_local_rect;
+    vLocalPos = vi.local_pos;
+    vec2 f = (vi.local_pos.xy - gradient.info.local_rect.xy) / gradient.info.local_rect.zw;
+#else
+    VertexInfo vi = write_vertex(gradient.info);
     vec2 f = (vi.local_clamped_pos - gradient.info.local_rect.xy) / gradient.info.local_rect.zw;
+    vPos = vi.local_clamped_pos;
+#endif
 
     switch (gradient.dir.x) {
         case DIR_HORIZONTAL:
@@ -38,7 +46,6 @@ void main(void) {
                        gradient.clip.top_right.outer_inner_radius.x,
                        gradient.clip.bottom_right.outer_inner_radius.x,
                        gradient.clip.bottom_left.outer_inner_radius.x);
-    vPos = vi.local_clamped_pos;
 
     vColor0 = gradient.color0;
     vColor1 = gradient.color1;

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -18,7 +18,7 @@ void main(void) {
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(image.info);
-    vLocalRect = image.info.local_rect;
+    vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
     vStretchSize = image.stretch_size.xy;
 #else

--- a/webrender/res/ps_rectangle.vs.glsl
+++ b/webrender/res/ps_rectangle.vs.glsl
@@ -17,7 +17,7 @@ void main(void) {
     vColor = rect.color;
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(rect.info);
-    vLocalRect = rect.info.local_rect;
+    vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
 #else
     write_vertex(rect.info);

--- a/webrender/res/ps_text.fs.glsl
+++ b/webrender/res/ps_text.fs.glsl
@@ -4,5 +4,10 @@
 
 void main(void) {
     float a = texture(sDiffuse, vUv).a;
+#ifdef WR_FEATURE_TRANSFORM
+    float alpha = 0;
+    init_transform_fs(vLocalPos, vLocalRect, alpha);
+    a *= alpha;
+#endif
     oFragColor = vec4(vColor.rgb, vColor.a * a);
 }

--- a/webrender/res/ps_text.glsl
+++ b/webrender/res/ps_text.glsl
@@ -4,3 +4,8 @@
 
 flat varying vec4 vColor;
 varying vec2 vUv;
+
+#ifdef WR_FEATURE_TRANSFORM
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;
+#endif

--- a/webrender/res/ps_text.vs.glsl
+++ b/webrender/res/ps_text.vs.glsl
@@ -15,9 +15,16 @@ layout(std140) uniform Items {
 
 void main(void) {
     Glyph glyph = glyphs[gl_InstanceID];
-    VertexInfo vi = write_vertex(glyph.info);
 
+#ifdef WR_FEATURE_TRANSFORM
+    TransformVertexInfo vi = write_transform_vertex(glyph.info);
+    vLocalRect = vi.clipped_local_rect;
+    vLocalPos = vi.local_pos;
+    vec2 f = (vi.local_pos.xy - glyph.info.local_rect.xy) / glyph.info.local_rect.zw;
+#else
+    VertexInfo vi = write_vertex(glyph.info);
     vec2 f = (vi.local_clamped_pos - vi.local_rect.p0) / (vi.local_rect.p1 - vi.local_rect.p0);
+#endif
 
     vec2 texture_size = textureSize(sDiffuse, 0);
     vec2 st0 = glyph.uv_rect.xy / texture_size;

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -45,10 +45,6 @@ impl DevicePixel {
         let DevicePixel(value) = *self;
         value as u32
     }
-
-    pub fn max() -> DevicePixel {
-        DevicePixel(i32::MAX)
-    }
 }
 
 impl Add for DevicePixel {

--- a/webrender/src/layer.rs
+++ b/webrender/src/layer.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use euclid::{Matrix4D, Point2D, Rect, Size2D};
-use internal_types::DevicePixel;
 use spring::{DAMPING, STIFFNESS, Spring};
 use webrender_traits::{PipelineId, ScrollLayerId, ServoStackingContextId};
 
@@ -17,15 +16,14 @@ pub struct Layer {
     // Viewing rectangle
     pub local_viewport_rect: Rect<f32>,
 
+    // Viewing rectangle clipped against parent layer(s)
+    pub combined_local_viewport_rect: Rect<f32>,
+
     // World transform for the viewport rect itself.
     pub world_viewport_transform: Matrix4D<f32>,
 
     // World transform for content within this layer
     pub world_content_transform: Matrix4D<f32>,
-
-    // World space rectangle for the viewport.
-    // TODO(gw): Support non-rectangular viewports.
-    pub world_viewport_rect: Rect<DevicePixel>,
 
     // Transform for this layer, relative to parent layer.
     pub local_transform: Matrix4D<f32>,
@@ -52,9 +50,9 @@ impl Layer {
             scrolling: ScrollingState::new(),
             content_size: content_size,
             local_viewport_rect: *local_viewport_rect,
+            combined_local_viewport_rect: *local_viewport_rect,
             world_viewport_transform: Matrix4D::identity(),
             world_content_transform: Matrix4D::identity(),
-            world_viewport_rect: Rect::new(Point2D::zero(), Size2D::zero()),
             local_transform: *local_transform,
             children: Vec::new(),
             pipeline_id: pipeline_id,


### PR DESCRIPTION
This allows iframes and scroll roots to correctly clip to the viewport when they have
a 3d transform.

This still doesn't solve the nested transform within rotated
transform case, but it's a big improvement on the current situation.

Also add transform feature to various primitive shaders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/361)
<!-- Reviewable:end -->
