### PR TITLE
Edge-distance AA for transformed border corners

### DIFF
--- a/webrender/res/ps_border.glsl
+++ b/webrender/res/ps_border.glsl
@@ -19,12 +19,14 @@ flat varying uint vBorderPart; // Which part of the border we're drawing.
 // These are in device space
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;     // The clamped position in local space.
-flat varying vec4 vSizeInfo;
+flat varying vec4 vPieceRect;
+flat varying float vPieceRectHypotenuseLength;
 #else
 varying vec2 vLocalPos;     // The clamped position in local space.
 
 // These two are interpolated
-varying float vF;   // This is a weighting as we get closer to the bottom right corner?
+varying float vDistanceFromMixLine;  // This is the distance from the line where two colors
+                                     // meet in border corners.
 varying vec2 vDevicePos;    // The clamped position in device space.
 flat varying vec4 vBorders; // the rect of the border in (x, y, width, height) form
 #endif

--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -109,11 +109,17 @@ void main(void) {
     // x1 - x0 is the width of the corner / line.
     float width = x1 - x0;
     float height = y1 - y0;
+
+    // The fragment shader needs to calculate the distance from the bisecting line
+    // to properly mix border colors. For transformed borders, we calculate this distance
+    // in the fragment shader itself. For non-transformed borders, we can use the
+    // interpolator.
 #ifdef WR_FEATURE_TRANSFORM
-    vSizeInfo = vec4(x0, y0, width, height);
+    vPieceRect = vec4(x0, y0, width, height);
+    vPieceRectHypotenuseLength = sqrt(pow(width, 2) + pow(height, 2));
 #else
-    // This is just a weighting of the pixel colors it seems?
-    vF = (vi.local_clamped_pos.x - x0) * height - (vi.local_clamped_pos.y - y0) * width;
+    vDistanceFromMixLine = (vi.local_clamped_pos.x - x0) * height -
+                           (vi.local_clamped_pos.y - y0) * width;
 
     // These are in device space
     vDevicePos = vi.global_clamped_pos;


### PR DESCRIPTION
Extend edge-distance anti-aliasing to transformed border corner,
including border corner edges and color mixing areas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/366)
<!-- Reviewable:end -->
