### PR TITLE
Rewrite the alpha batcher to use a simple shortest-common-subsequence approximation algorithm.

### DIFF
--- a/webrender/res/ps_text_run.fs.glsl
+++ b/webrender/res/ps_text_run.fs.glsl
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void main(void) {
+    float a = texture(sDiffuse, vUv).a;
+    oFragColor = vec4(vColor.rgb, vColor.a * a);
+}

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+flat varying vec4 vColor;
+varying vec2 vUv;
+
+#ifdef WR_FEATURE_TRANSFORM
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;
+#endif

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -1,0 +1,43 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+struct TextRunGlyph {
+    vec4 local_rect;
+    ivec4 uv_rect;
+};
+
+struct TextRun {
+    PrimitiveInfo info;
+    TextRunGlyph glyphs[WR_GLYPHS_PER_TEXT_RUN];
+    vec4 color;
+};
+
+layout(std140) uniform Items {
+    TextRun text_runs[WR_MAX_PRIM_ITEMS];
+};
+
+void main(void) {
+    TextRun text_run = text_runs[gl_InstanceID / WR_GLYPHS_PER_TEXT_RUN];
+    TextRunGlyph glyph = text_run.glyphs[gl_InstanceID % WR_GLYPHS_PER_TEXT_RUN];
+    text_run.info.local_rect = glyph.local_rect;
+    ivec4 uv_rect = glyph.uv_rect;
+
+#ifdef WR_FEATURE_TRANSFORM
+    TransformVertexInfo vi = write_transform_vertex(text_run.info);
+    vLocalRect = vi.clipped_local_rect;
+    vLocalPos = vi.local_pos;
+    vec2 f = (vi.local_pos.xy - text_run.info.local_rect.xy) / text_run.info.local_rect.zw;
+#else
+    VertexInfo vi = write_vertex(text_run.info);
+    vec2 f = (vi.local_clamped_pos - vi.local_rect.p0) / (vi.local_rect.p1 - vi.local_rect.p0);
+#endif
+
+    vec2 texture_size = textureSize(sDiffuse, 0);
+    vec2 st0 = uv_rect.xy / texture_size;
+    vec2 st1 = uv_rect.zw / texture_size;
+
+    vColor = text_run.color;
+    vUv = mix(st0, st1, f);
+}

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -560,7 +560,7 @@ impl Drop for VAO {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Copy, Clone)]
 pub struct TextureId(pub gl::GLuint);       // TODO: HACK: Should not be public!
 
 #[derive(PartialEq, Eq, Hash, Debug, Copy, Clone)]


### PR DESCRIPTION
This makes the batcher simpler and more scalable and improves its output
at the cost of a small constant overhead. Because of the scalability
improvements, this patch lifts the cap on the number of alpha batches
per render phase to 4.

Before-and-after measurements on
http://en.wikipedia.org/wiki/Servomechanism:

* Draw calls: 161 → 77 (2.1x fewer)
* Backend CPU time: 3.15ms → 3.32ms (5.4% slower)
* CPU compositor time: 1.03ms → 0.53ms (94% faster)
* GPU time: 1.83ms → 1.80ms (1.7% faster)

Based on #364.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/367)
<!-- Reviewable:end -->
