### PR TITLE
Remove GPU clear of framebuffer.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1531,7 +1531,7 @@ impl Renderer {
                                          None);
             }
 
-            for (phase_index, phase) in frame.phases.iter().enumerate() {
+            for phase in &frame.phases {
                 let mut render_target_index = 0;
 
                 for target in &phase.targets {
@@ -1541,7 +1541,7 @@ impl Renderer {
                                          target,
                                          &Size2D::new(framebuffer_size.width as f32, framebuffer_size.height as f32),
                                          ct_index,
-                                         phase_index == 0);
+                                         false);
                     } else {
                         let rt_index = self.render_targets[render_target_index];
                         let ct_index = self.render_targets[1 - render_target_index];


### PR DESCRIPTION
Add a large white rectangle as the root display item. This is removed
by the occlusion culling for most tiles, and means that it's no longer
necessary to clear the framebuffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/371)
<!-- Reviewable:end -->
