### PR TITLE
webgl: Add vertexAttribPointer and disableVertexAttribArray support 

### DIFF
--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -548,6 +548,7 @@ pub enum WebGLCommand {
     UniformMatrix4fv(i32, bool, Vec<f32>),
     UseProgram(WebGLProgramId),
     VertexAttrib(u32, f32, f32, f32, f32),
+    VertexAttribPointer(u32, i32, u32, bool, i32, u32),
     VertexAttribPointer2f(u32, i32, bool, i32, u32),
     Viewport(i32, i32, i32, i32),
     TexImage2D(u32, i32, i32, i32, i32, u32, u32, Vec<u8>),

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -500,6 +500,7 @@ pub enum WebGLCommand {
     BindFramebuffer(u32, WebGLFramebufferBindingRequest),
     BindRenderbuffer(u32, Option<WebGLRenderbufferId>),
     BindTexture(u32, Option<WebGLTextureId>),
+    DisableVertexAttribArray(u32),
     DrawArrays(u32, i32, i32),
     DrawElements(u32, i32, u32, i64),
     EnableVertexAttribArray(u32),

--- a/webrender_traits/src/webgl.rs
+++ b/webrender_traits/src/webgl.rs
@@ -57,6 +57,7 @@ impl fmt::Debug for WebGLCommand {
             BindFramebuffer(..) => "BindFramebuffer",
             BindRenderbuffer(..) => "BindRenderbuffer",
             BindTexture(..) => "BindTexture",
+            DisableVertexAttribArray(..) => "DisableVertexAttribArray",
             DrawArrays(..) => "DrawArrays",
             DrawElements(..) => "DrawElements",
             EnableVertexAttribArray(..) => "EnableVertexAttribArray",
@@ -177,6 +178,8 @@ impl WebGLCommand {
                 gl::enable(cap),
             WebGLCommand::FrontFace(mode) =>
                 gl::front_face(mode),
+            WebGLCommand::DisableVertexAttribArray(attrib_id) =>
+                gl::disable_vertex_attrib_array(attrib_id),
             WebGLCommand::DrawArrays(mode, first, count) =>
                 gl::draw_arrays(mode, first, count),
             WebGLCommand::DrawElements(mode, count, type_, offset) =>

--- a/webrender_traits/src/webgl.rs
+++ b/webrender_traits/src/webgl.rs
@@ -106,6 +106,7 @@ impl fmt::Debug for WebGLCommand {
             UseProgram(..) => "UseProgram",
             VertexAttrib(..) => "VertexAttrib",
             VertexAttribPointer2f(..) => "VertexAttribPointer2f",
+            VertexAttribPointer(..) => "VertexAttribPointer",
             Viewport(..) => "Viewport",
             TexImage2D(..) => "TexImage2D",
             TexParameteri(..) => "TexParameteri",
@@ -310,6 +311,8 @@ impl WebGLCommand {
                 gl::vertex_attrib_4f(attrib_id, x, y, z, w),
             WebGLCommand::VertexAttribPointer2f(attrib_id, size, normalized, stride, offset) =>
                 gl::vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset),
+            WebGLCommand::VertexAttribPointer(attrib_id, size, data_type, normalized, stride, offset) =>
+                gl::vertex_attrib_pointer(attrib_id, size, data_type, normalized, stride, offset),
             WebGLCommand::Viewport(x, y, width, height) =>
                 gl::viewport(x, y, width, height),
             WebGLCommand::TexImage2D(target, level, internal, width, height, format, data_type, data) =>


### PR DESCRIPTION
I have a corresponding series to servo using these to reduce webgl-conformance failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/375)
<!-- Reviewable:end -->
