### PR TITLE
Bump wr_traits version, to pick the last PR.

### DIFF
--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"


### PR DESCRIPTION
I don't know if right now we're supposed to use it, though. Isn't it included
via path by WR?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/376)
<!-- Reviewable:end -->
