### PR TITLE
Switch primitives to make use of the caching available in prepare_render.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -12,6 +12,9 @@
 #define PST_BOTTOM       uint(6)
 #define PST_RIGHT        uint(7)
 
+#define UV_NORMALIZED    uint(0)
+#define UV_PIXEL         uint(1)
+
 // Border styles as defined in webrender_traits/types.rs
 #define BORDER_STYLE_NONE         uint(0)
 #define BORDER_STYLE_SOLID        uint(1)

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -5,8 +5,8 @@
 
 struct Image {
     PrimitiveInfo info;
-    vec4 st_rect;       // Location of the image texture in the texture atlas.
-    vec4 stretch_size;  // Size of the actual image.
+    vec4 st_rect;               // Location of the image texture in the texture atlas.
+    vec4 stretch_size_uvkind;   // Size of the actual image.
 };
 
 layout(std140) uniform Items {
@@ -20,13 +20,27 @@ void main(void) {
     TransformVertexInfo vi = write_transform_vertex(image.info);
     vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
-    vStretchSize = image.stretch_size.xy;
+    vStretchSize = image.stretch_size_uvkind.xy;
 #else
     VertexInfo vi = write_vertex(image.info);
-    vUv = (vi.local_clamped_pos - vi.local_rect.p0) / image.stretch_size.xy;
+    vUv = (vi.local_clamped_pos - vi.local_rect.p0) / image.stretch_size_uvkind.xy;
 #endif
 
     // vUv will contain how many times this image has wrapped around the image size.
-    vTextureSize = image.st_rect.zw - image.st_rect.xy;
-    vTextureOffset = image.st_rect.xy;
+    vec2 st0 = image.st_rect.xy;
+    vec2 st1 = image.st_rect.zw;
+
+    switch (uint(image.stretch_size_uvkind.z)) {
+        case UV_NORMALIZED:
+            break;
+        case UV_PIXEL: {
+                vec2 texture_size = textureSize(sDiffuse, 0);
+                st0 /= texture_size;
+                st1 /= texture_size;
+            }
+            break;
+    }
+
+    vTextureSize = st1 - st0;
+    vTextureOffset = st0;
 }

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -5,8 +5,8 @@
 
 struct Image {
     PrimitiveInfo info;
-    vec4 st_rect;       // Location of the image texture in the texture atlas.
-    vec4 stretch_size;  // Size of the actual image.
+    vec4 st_rect;               // Location of the image texture in the texture atlas.
+    vec4 stretch_size_uvkind;   // Size of the actual image.
     Clip clip;
 };
 
@@ -26,7 +26,22 @@ void main(void) {
     vPos = vi.local_clamped_pos;
 
     // vUv will contain how many times this image has wrapped around the image size.
-    vUv = (vi.local_clamped_pos - image.info.local_rect.xy) / image.stretch_size.xy;
-    vTextureSize = image.st_rect.zw - image.st_rect.xy;
-    vTextureOffset = image.st_rect.xy;
+    vUv = (vi.local_clamped_pos - image.info.local_rect.xy) / image.stretch_size_uvkind.xy;
+
+    vec2 st0 = image.st_rect.xy;
+    vec2 st1 = image.st_rect.zw;
+
+    switch (uint(image.stretch_size_uvkind.z)) {
+        case UV_NORMALIZED:
+            break;
+        case UV_PIXEL: {
+                vec2 texture_size = textureSize(sDiffuse, 0);
+                st0 /= texture_size;
+                st1 /= texture_size;
+            }
+            break;
+    }
+
+    vTextureSize = st1 - st0;
+    vTextureOffset = st0;
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1256,7 +1256,7 @@ impl Renderer {
     fn draw_ubo_batch<T>(&mut self,
                          ubo_data: &[T],
                          prim_shader: PrimitiveShader,
-                         quads_per_item: u32,
+                         quads_per_item: usize,
                          transform_kind: TransformedRectKind,
                          color_texture_id: TextureId,
                          projection: &Matrix4D<f32>) {
@@ -1276,7 +1276,7 @@ impl Renderer {
             gl::buffer_data(gl::UNIFORM_BUFFER, &chunk, gl::STATIC_DRAW);
             gl::bind_buffer_base(gl::UNIFORM_BUFFER, UBO_BIND_CACHE_ITEMS, ubo);
 
-            let quad_count = (chunk.len() as u32) * quads_per_item;
+            let quad_count = chunk.len() * quads_per_item;
             self.device.draw_indexed_triangles_instanced_u16(6, quad_count as gl::GLint);
             self.profile_counters.vertices.add(6 * (quad_count as usize));
             self.profile_counters.draw_calls.inc();

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -858,10 +858,188 @@ impl Primitive {
         match self.details {
             PrimitiveDetails::Rectangle(..) |
             PrimitiveDetails::Gradient(..) |
-            PrimitiveDetails::Border(..) |
             PrimitiveDetails::BoxShadow(..) |
             PrimitiveDetails::Image(..) => {
                 unreachable!();     // not currently supported from build_resource_list
+            }
+            PrimitiveDetails::Border(ref mut border) => {
+                let inner_radius = BorderRadius {
+                    top_left: Size2D::new(border.radius.top_left.width - border.left_width,
+                                          border.radius.top_left.height - border.top_width),
+                    top_right: Size2D::new(border.radius.top_right.width - border.right_width,
+                                           border.radius.top_right.height - border.top_width),
+                    bottom_left:
+                        Size2D::new(border.radius.bottom_left.width - border.left_width,
+                                    border.radius.bottom_left.height - border.bottom_width),
+                    bottom_right:
+                        Size2D::new(border.radius.bottom_right.width - border.right_width,
+                                    border.radius.bottom_right.height - border.bottom_width),
+                };
+
+                border.cache = Some(Box::new(BorderPrimitiveCache {
+                    elements: [
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.tl_outer.x,
+                                                               border.tl_outer.y,
+                                                               border.tl_inner.x,
+                                                               border.tl_inner.y),
+                            },
+                            vertical_color: border.top_color,
+                            horizontal_color: border.left_color,
+                            outer_radius_x: border.radius.top_left.width,
+                            outer_radius_y: border.radius.top_left.height,
+                            inner_radius_x: inner_radius.top_left.width,
+                            inner_radius_y: inner_radius.top_left.height,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::TopLeft as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.tr_inner.x,
+                                                               border.tr_outer.y,
+                                                               border.tr_outer.x,
+                                                               border.tr_inner.y),
+                            },
+                            vertical_color: border.right_color,
+                            horizontal_color: border.top_color,
+                            outer_radius_x: border.radius.top_right.width,
+                            outer_radius_y: border.radius.top_right.height,
+                            inner_radius_x: inner_radius.top_right.width,
+                            inner_radius_y: inner_radius.top_right.height,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::TopRight as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.bl_outer.x,
+                                                               border.bl_inner.y,
+                                                               border.bl_inner.x,
+                                                               border.bl_outer.y),
+                            },
+                            vertical_color: border.left_color,
+                            horizontal_color: border.bottom_color,
+                            outer_radius_x: border.radius.bottom_left.width,
+                            outer_radius_y: border.radius.bottom_left.height,
+                            inner_radius_x: inner_radius.bottom_left.width,
+                            inner_radius_y: inner_radius.bottom_left.height,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::BottomLeft as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.br_inner.x,
+                                                               border.br_inner.y,
+                                                               border.br_outer.x,
+                                                               border.br_outer.y),
+                            },
+                            vertical_color: border.right_color,
+                            horizontal_color: border.bottom_color,
+                            outer_radius_x: border.radius.bottom_right.width,
+                            outer_radius_y: border.radius.bottom_right.height,
+                            inner_radius_x: inner_radius.bottom_right.width,
+                            inner_radius_y: inner_radius.bottom_right.height,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::BottomRight as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.tl_outer.x,
+                                                               border.tl_inner.y,
+                                                               border.tl_outer.x + border.left_width,
+                                                               border.bl_inner.y),
+                            },
+                            vertical_color: border.left_color,
+                            horizontal_color: border.left_color,
+                            outer_radius_x: 0.0,
+                            outer_radius_y: 0.0,
+                            inner_radius_x: 0.0,
+                            inner_radius_y: 0.0,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::Left as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.tr_outer.x - border.right_width,
+                                                               border.tr_inner.y,
+                                                               border.br_outer.x,
+                                                               border.br_inner.y),
+                            },
+                            vertical_color: border.right_color,
+                            horizontal_color: border.right_color,
+                            outer_radius_x: 0.0,
+                            outer_radius_y: 0.0,
+                            inner_radius_x: 0.0,
+                            inner_radius_y: 0.0,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::Right as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.tl_inner.x,
+                                                               border.tl_outer.y,
+                                                               border.tr_inner.x,
+                                                               border.tr_outer.y + border.top_width),
+                            },
+                            vertical_color: border.top_color,
+                            horizontal_color: border.top_color,
+                            outer_radius_x: 0.0,
+                            outer_radius_y: 0.0,
+                            inner_radius_x: 0.0,
+                            inner_radius_y: 0.0,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::Top as u32), 0.0, 0.0, 0.0],
+                        },
+                        PackedBorderPrimitive {
+                            common: PackedPrimitiveInfo {
+                                padding: [0, 0],
+                                tile_index: 0,
+                                layer_index: 0,
+                                local_clip_rect: self.local_clip_rect,
+                                local_rect: rect_from_points_f(border.bl_inner.x,
+                                                               border.bl_outer.y - border.bottom_width,
+                                                               border.br_inner.x,
+                                                               border.br_outer.y),
+                            },
+                            vertical_color: border.bottom_color,
+                            horizontal_color: border.bottom_color,
+                            outer_radius_x: 0.0,
+                            outer_radius_y: 0.0,
+                            inner_radius_x: 0.0,
+                            inner_radius_y: 0.0,
+                            style: border.pack_style(),
+                            part: [pack_as_float(PrimitivePart::Bottom as u32), 0.0, 0.0, 0.0],
+                        },
+                    ],
+                }));
             }
             PrimitiveDetails::Text(ref mut text) => {
                 let mut cache = TextPrimitiveCache::new();
@@ -992,8 +1170,10 @@ impl Primitive {
         match self.details {
             PrimitiveDetails::Rectangle(..) => false,
             PrimitiveDetails::Gradient(..) => false,
-            PrimitiveDetails::Border(..) => false,
             PrimitiveDetails::BoxShadow(..) => false,
+            PrimitiveDetails::Border(ref details) => {
+                details.cache.is_none()
+            }
             PrimitiveDetails::Image(ref details) => {
                 match details.kind {
                     ImagePrimitiveKind::Image(image_key, image_rendering, _) => {
@@ -1166,186 +1346,14 @@ impl Primitive {
             (&mut PrimitiveBatchData::ImageClip(..), _) => return false,
             (&mut PrimitiveBatchData::Borders(ref mut data),
              &PrimitiveDetails::Border(ref border)) => {
-                let inner_radius = BorderRadius {
-                    top_left: Size2D::new(border.radius.top_left.width - border.left_width,
-                                          border.radius.top_left.height - border.top_width),
-                    top_right: Size2D::new(border.radius.top_right.width - border.right_width,
-                                           border.radius.top_right.height - border.top_width),
-                    bottom_left:
-                        Size2D::new(border.radius.bottom_left.width - border.left_width,
-                                    border.radius.bottom_left.height - border.bottom_width),
-                    bottom_right:
-                        Size2D::new(border.radius.bottom_right.width - border.right_width,
-                                    border.radius.bottom_right.height - border.bottom_width),
-                };
+                let cache = border.cache.as_ref().expect("No cache for border present!");
 
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.tl_outer.x,
-                                                       border.tl_outer.y,
-                                                       border.tl_inner.x,
-                                                       border.tl_inner.y),
-                    },
-                    vertical_color: border.top_color,
-                    horizontal_color: border.left_color,
-                    outer_radius_x: border.radius.top_left.width,
-                    outer_radius_y: border.radius.top_left.height,
-                    inner_radius_x: inner_radius.top_left.width,
-                    inner_radius_y: inner_radius.top_left.height,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::TopLeft as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.tr_inner.x,
-                                                       border.tr_outer.y,
-                                                       border.tr_outer.x,
-                                                       border.tr_inner.y),
-                    },
-                    vertical_color: border.right_color,
-                    horizontal_color: border.top_color,
-                    outer_radius_x: border.radius.top_right.width,
-                    outer_radius_y: border.radius.top_right.height,
-                    inner_radius_x: inner_radius.top_right.width,
-                    inner_radius_y: inner_radius.top_right.height,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::TopRight as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.bl_outer.x,
-                                                       border.bl_inner.y,
-                                                       border.bl_inner.x,
-                                                       border.bl_outer.y),
-                    },
-                    vertical_color: border.left_color,
-                    horizontal_color: border.bottom_color,
-                    outer_radius_x: border.radius.bottom_left.width,
-                    outer_radius_y: border.radius.bottom_left.height,
-                    inner_radius_x: inner_radius.bottom_left.width,
-                    inner_radius_y: inner_radius.bottom_left.height,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::BottomLeft as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.br_inner.x,
-                                                       border.br_inner.y,
-                                                       border.br_outer.x,
-                                                       border.br_outer.y),
-                    },
-                    vertical_color: border.right_color,
-                    horizontal_color: border.bottom_color,
-                    outer_radius_x: border.radius.bottom_right.width,
-                    outer_radius_y: border.radius.bottom_right.height,
-                    inner_radius_x: inner_radius.bottom_right.width,
-                    inner_radius_y: inner_radius.bottom_right.height,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::BottomRight as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.tl_outer.x,
-                                                       border.tl_inner.y,
-                                                       border.tl_outer.x + border.left_width,
-                                                       border.bl_inner.y),
-                    },
-                    vertical_color: border.left_color,
-                    horizontal_color: border.left_color,
-                    outer_radius_x: 0.0,
-                    outer_radius_y: 0.0,
-                    inner_radius_x: 0.0,
-                    inner_radius_y: 0.0,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::Left as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.tr_outer.x - border.right_width,
-                                                       border.tr_inner.y,
-                                                       border.br_outer.x,
-                                                       border.br_inner.y),
-                    },
-                    vertical_color: border.right_color,
-                    horizontal_color: border.right_color,
-                    outer_radius_x: 0.0,
-                    outer_radius_y: 0.0,
-                    inner_radius_x: 0.0,
-                    inner_radius_y: 0.0,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::Right as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.tl_inner.x,
-                                                       border.tl_outer.y,
-                                                       border.tr_inner.x,
-                                                       border.tr_outer.y + border.top_width),
-                    },
-                    vertical_color: border.top_color,
-                    horizontal_color: border.top_color,
-                    outer_radius_x: 0.0,
-                    outer_radius_y: 0.0,
-                    inner_radius_x: 0.0,
-                    inner_radius_y: 0.0,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::Top as u32), 0.0, 0.0, 0.0],
-                });
-
-                data.push(PackedBorderPrimitive {
-                    common: PackedPrimitiveInfo {
-                        padding: [0, 0],
-                        tile_index: tile_index_in_ubo,
-                        layer_index: layer_index_in_ubo,
-                        local_clip_rect: self.local_clip_rect,
-                        local_rect: rect_from_points_f(border.bl_inner.x,
-                                                       border.bl_outer.y - border.bottom_width,
-                                                       border.br_inner.x,
-                                                       border.br_outer.y),
-                    },
-                    vertical_color: border.bottom_color,
-                    horizontal_color: border.bottom_color,
-                    outer_radius_x: 0.0,
-                    outer_radius_y: 0.0,
-                    inner_radius_x: 0.0,
-                    inner_radius_y: 0.0,
-                    style: border.pack_style(),
-                    part: [pack_as_float(PrimitivePart::Bottom as u32), 0.0, 0.0, 0.0],
-                });
+                for element in &cache.elements {
+                    let mut element = element.clone();
+                    element.common.tile_index = tile_index_in_ubo;
+                    element.common.layer_index = layer_index_in_ubo;
+                    data.push(element);
+                }
             }
             (&mut PrimitiveBatchData::Borders(..), _) => return false,
             (&mut PrimitiveBatchData::AlignedGradient(ref mut data),


### PR DESCRIPTION
This is a slight performance win, but is mostly to make it easier to switch UBOs to SoA style. When this is done, these changes allow a much greater performance improvement (since primitives that hit multiple tiles are added only once).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/381)
<!-- Reviewable:end -->
