### PR TITLE
Early out for text runs with size <= 0.

### DIFF
--- a/webrender/src/resource_list.rs
+++ b/webrender/src/resource_list.rs
@@ -37,6 +37,7 @@ impl ResourceList {
     }
 
     pub fn add_glyph(&mut self, font_key: FontKey, glyph: Glyph) {
+        debug_assert!(glyph.size.0 > 0);
         self.required_glyphs.entry(font_key)
                             .or_insert_with(|| HashSet::with_hasher(Default::default()))
                             .insert(glyph);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2764,6 +2764,10 @@ impl FrameBuilder {
             return
         }
 
+        if size.0 <= 0 {
+            return
+        }
+
         let text_run_count = (glyph_range.length as u32) / GLYPHS_PER_TEXT_RUN;
         let text_count = (glyph_range.length as u32) % GLYPHS_PER_TEXT_RUN;
 


### PR DESCRIPTION
This fixes a few dozen css tests that provide negative font size.