### PR TITLE
3D transform and border-radius for dashed borders

### DIFF
--- a/webrender/res/ps_border.glsl
+++ b/webrender/res/ps_border.glsl
@@ -16,10 +16,11 @@ flat varying vec2 vRefPoint;
 flat varying uint vBorderStyle;
 flat varying uint vBorderPart; // Which part of the border we're drawing.
 
+flat varying vec4 vPieceRect;
+
 // These are in device space
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;     // The clamped position in local space.
-flat varying vec4 vPieceRect;
 flat varying float vPieceRectHypotenuseLength;
 #else
 varying vec2 vLocalPos;     // The clamped position in local space.

--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -111,12 +111,13 @@ void main(void) {
     float width = x1 - x0;
     float height = y1 - y0;
 
+    vPieceRect = vec4(x0, y0, width, height);
+
     // The fragment shader needs to calculate the distance from the bisecting line
     // to properly mix border colors. For transformed borders, we calculate this distance
     // in the fragment shader itself. For non-transformed borders, we can use the
     // interpolator.
 #ifdef WR_FEATURE_TRANSFORM
-    vPieceRect = vec4(x0, y0, width, height);
     vPieceRectHypotenuseLength = sqrt(pow(width, 2) + pow(height, 2));
 #else
     vDistanceFromMixLine = (vi.local_clamped_pos.x - x0) * height -


### PR DESCRIPTION
This adds 3D transforms and border-radius support for dashed borders.
The way that dashed borders are positioned has changed, but the results
still looks similar to what Gecko produces.

This also fixes an issue where the area between border dashes was
painted as white instead of transparent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/383)
<!-- Reviewable:end -->
