### PR TITLE
Switch the UBO data to be untyped.

### DIFF
--- a/webrender/res/ps_angle_gradient.glsl
+++ b/webrender/res/ps_angle_gradient.glsl
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define MAX_STOPS_PER_ANGLE_GRADIENT 8
-
 flat varying int vStopCount;
 flat varying float vAngle;
 flat varying vec2 vStartPoint;

--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -3,20 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct AngleGradient {
-    PrimitiveInfo info;
-    vec4 start_end_point;
-    vec4 stop_count;
-    vec4 colors[MAX_STOPS_PER_ANGLE_GRADIENT];
-    vec4 offsets[MAX_STOPS_PER_ANGLE_GRADIENT/4];
-};
-
-layout(std140) uniform Items {
-    AngleGradient gradients[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    AngleGradient gradient = gradients[gl_InstanceID];
+    AngleGradient gradient = fetch_angle_gradient(gl_InstanceID);
     VertexInfo vi = write_vertex(gradient.info);
 
     vStopCount = int(gradient.stop_count.x);

--- a/webrender/res/ps_blend.vs.glsl
+++ b/webrender/res/ps_blend.vs.glsl
@@ -3,18 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Blend {
-    vec4 target_rect;
-    vec4 src_rect;
-    vec4 opacity;
-};
-
-layout(std140) uniform Items {
-    Blend blends[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Blend blend = blends[gl_InstanceID];
+    Blend blend = fetch_blend(gl_InstanceID);
 
     vec2 local_pos = mix(vec2(blend.target_rect.xy),
                          vec2(blend.target_rect.xy + blend.target_rect.zw),

--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -3,19 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Border {
-    PrimitiveInfo info;
-    vec4 verticalColor;
-    vec4 horizontalColor;
-    vec4 radii;
-    vec4 border_style_trbl;
-    vec4 part;
-};
-
-layout(std140) uniform Items {
-    Border borders[WR_MAX_PRIM_ITEMS];
-};
-
 float get_border_style(Border a_border, uint a_edge) {
   switch (a_edge) {
     case PST_TOP:
@@ -34,7 +21,7 @@ float get_border_style(Border a_border, uint a_edge) {
 }
 
 void main(void) {
-    Border border = borders[gl_InstanceID];
+    Border border = fetch_border(gl_InstanceID);
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(border.info);
     vLocalPos = vi.local_pos;

--- a/webrender/res/ps_box_shadow.vs.glsl
+++ b/webrender/res/ps_box_shadow.vs.glsl
@@ -3,20 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct BoxShadow {
-    PrimitiveInfo info;
-    vec4 color;
-    vec4 border_radii_blur_radius_inverted;
-    vec4 bs_rect;
-    vec4 src_rect;
-};
-
-layout(std140) uniform Items {
-    BoxShadow boxshadows[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    BoxShadow bs = boxshadows[gl_InstanceID];
+    BoxShadow bs = fetch_boxshadow(gl_InstanceID);
     VertexInfo vi = write_vertex(bs.info);
 
     vPos = vi.local_clamped_pos;

--- a/webrender/res/ps_clear.vs.glsl
+++ b/webrender/res/ps_clear.vs.glsl
@@ -4,19 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct ClearTile {
-    uvec4 rect;
+layout(std140) uniform Data {
+    uvec4 data[WR_MAX_UBO_VECTORS];
 };
-
-layout(std140) uniform Tiles {
-    ClearTile tiles[WR_MAX_CLEAR_TILES];
-};
-
 
 void main() {
-    ClearTile tile = tiles[gl_InstanceID];
-
-    vec4 rect = vec4(tile.rect);
+    vec4 rect = vec4(data[gl_InstanceID]);
 
     vec4 pos = vec4(mix(rect.xy, rect.xy + rect.zw, aPosition.xy), 0, 1);
     gl_Position = uTransform * pos;

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -3,19 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Composite {
-    vec4 src0;
-    vec4 src1;
-    vec4 target_rect;
-    vec4 info_amount;
-};
-
-layout(std140) uniform Items {
-    Composite composites[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Composite composite = composites[gl_InstanceID];
+    Composite composite = fetch_composite(gl_InstanceID);
 
     vec2 local_pos = mix(vec2(composite.target_rect.xy),
                          vec2(composite.target_rect.xy + composite.target_rect.zw),

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -6,20 +6,8 @@
 #define DIR_HORIZONTAL      uint(0)
 #define DIR_VERTICAL        uint(1)
 
-struct Gradient {
-    PrimitiveInfo info;
-    vec4 color0;
-    vec4 color1;
-    vec4 dir;
-    Clip clip;
-};
-
-layout(std140) uniform Items {
-    Gradient gradients[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Gradient gradient = gradients[gl_InstanceID];
+    AlignedGradient gradient = fetch_aligned_gradient(gl_InstanceID);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(gradient.info);

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -3,18 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Image {
-    PrimitiveInfo info;
-    vec4 st_rect;               // Location of the image texture in the texture atlas.
-    vec4 stretch_size_uvkind;   // Size of the actual image.
-};
-
-layout(std140) uniform Items {
-    Image images[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Image image = images[gl_InstanceID];
+    Image image = fetch_image(gl_InstanceID);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(image.info);

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -3,19 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Image {
-    PrimitiveInfo info;
-    vec4 st_rect;               // Location of the image texture in the texture atlas.
-    vec4 stretch_size_uvkind;   // Size of the actual image.
-    Clip clip;
-};
-
-layout(std140) uniform Items {
-    Image images[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Image image = images[gl_InstanceID];
+    ImageClip image = fetch_image_clip(gl_InstanceID);
     VertexInfo vi = write_vertex(image.info);
 
     vClipRect = vec4(image.clip.rect.xy, image.clip.rect.xy + image.clip.rect.zw);

--- a/webrender/res/ps_rectangle.vs.glsl
+++ b/webrender/res/ps_rectangle.vs.glsl
@@ -3,17 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Rectangle {
-    PrimitiveInfo info;
-    vec4 color;
-};
-
-layout(std140) uniform Items {
-    Rectangle rects[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Rectangle rect = rects[gl_InstanceID];
+    Rectangle rect = fetch_rectangle(gl_InstanceID);
     vColor = rect.color;
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(rect.info);

--- a/webrender/res/ps_rectangle_clip.vs.glsl
+++ b/webrender/res/ps_rectangle_clip.vs.glsl
@@ -3,18 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Rectangle {
-    PrimitiveInfo info;
-    vec4 color;
-    Clip clip;
-};
-
-layout(std140) uniform Items {
-    Rectangle rects[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Rectangle rect = rects[gl_InstanceID];
+    RectangleClip rect = fetch_rectangle_clip(gl_InstanceID);
     VertexInfo vi = write_vertex(rect.info);
 
     vClipRect = vec4(rect.clip.rect.xy, rect.clip.rect.xy + rect.clip.rect.zw);

--- a/webrender/res/ps_text.vs.glsl
+++ b/webrender/res/ps_text.vs.glsl
@@ -3,18 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct Glyph {
-    PrimitiveInfo info;
-    vec4 color;
-    vec4 uv_rect;
-};
-
-layout(std140) uniform Items {
-    Glyph glyphs[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    Glyph glyph = glyphs[gl_InstanceID];
+    Glyph glyph = fetch_glyph(gl_InstanceID);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(glyph.info);

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -3,34 +3,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-struct TextRunGlyph {
-    vec4 local_rect;
-    vec4 uv_rect;
-};
-
-struct TextRun {
-    PrimitiveInfo info;
-    TextRunGlyph glyphs[WR_GLYPHS_PER_TEXT_RUN];
-    vec4 color;
-};
-
-layout(std140) uniform Items {
-    TextRun text_runs[WR_MAX_PRIM_ITEMS];
-};
-
 void main(void) {
-    TextRun text_run = text_runs[gl_InstanceID / WR_GLYPHS_PER_TEXT_RUN];
-    TextRunGlyph glyph = text_run.glyphs[gl_InstanceID % WR_GLYPHS_PER_TEXT_RUN];
-    text_run.info.local_rect = glyph.local_rect;
-    vec4 uv_rect = glyph.uv_rect;
+    vec4 color, uv_rect;
+    PrimitiveInfo info = fetch_text_run_glyph(gl_InstanceID, color, uv_rect);
 
 #ifdef WR_FEATURE_TRANSFORM
-    TransformVertexInfo vi = write_transform_vertex(text_run.info);
+    TransformVertexInfo vi = write_transform_vertex(info);
     vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
-    vec2 f = (vi.local_pos.xy - text_run.info.local_rect.xy) / text_run.info.local_rect.zw;
+    vec2 f = (vi.local_pos.xy - info.local_rect.xy) / info.local_rect.zw;
 #else
-    VertexInfo vi = write_vertex(text_run.info);
+    VertexInfo vi = write_vertex(info);
     vec2 f = (vi.local_clamped_pos - vi.local_rect.p0) / (vi.local_rect.p1 - vi.local_rect.p0);
 #endif
 
@@ -38,6 +21,6 @@ void main(void) {
     vec2 st0 = uv_rect.xy / texture_size;
     vec2 st1 = uv_rect.zw / texture_size;
 
-    vColor = text_run.color;
+    vColor = color;
     vUv = mix(st0, st1, f);
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -895,8 +895,8 @@ impl Primitive {
                     elements.push(PackedBoxShadowPrimitive {
                         common: PackedPrimitiveInfo {
                             padding: [0, 0],
-                            tile_index: 0,
-                            layer_index: 0,
+                            tile_index: 0.0,
+                            layer_index: 0.0,
                             local_clip_rect: self.local_clip_rect,
                             local_rect: rect,
                         },
@@ -929,8 +929,8 @@ impl Primitive {
                         let element = PackedImagePrimitiveClip {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: self.rect,
                             },
@@ -948,8 +948,8 @@ impl Primitive {
                         let element = PackedImagePrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: self.rect,
                             },
@@ -1052,8 +1052,8 @@ impl Primitive {
                             pieces.push(PackedAlignedGradientPrimitive {
                                 common: PackedPrimitiveInfo {
                                     padding: [0, 0],
-                                    tile_index: 0,
-                                    layer_index: 0,
+                                    tile_index: 0.0,
+                                    layer_index: 0.0,
                                     local_clip_rect: self.local_clip_rect,
                                     local_rect: piece_rect,
                                 },
@@ -1104,8 +1104,8 @@ impl Primitive {
                         let packed_prim = PackedAngleGradientPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: self.rect,
                             },
@@ -1140,8 +1140,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.tl_outer.x,
                                                                border.tl_outer.y,
@@ -1160,8 +1160,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.tr_inner.x,
                                                                border.tr_outer.y,
@@ -1180,8 +1180,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.bl_outer.x,
                                                                border.bl_inner.y,
@@ -1200,8 +1200,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.br_inner.x,
                                                                border.br_inner.y,
@@ -1220,8 +1220,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.tl_outer.x,
                                                                border.tl_inner.y,
@@ -1240,8 +1240,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.tr_outer.x - border.right_width,
                                                                border.tr_inner.y,
@@ -1260,8 +1260,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.tl_inner.x,
                                                                border.tl_outer.y,
@@ -1280,8 +1280,8 @@ impl Primitive {
                         PackedBorderPrimitive {
                             common: PackedPrimitiveInfo {
                                 padding: [0, 0],
-                                tile_index: 0,
-                                layer_index: 0,
+                                tile_index: 0.0,
+                                layer_index: 0.0,
                                 local_clip_rect: self.local_clip_rect,
                                 local_rect: rect_from_points_f(border.bl_inner.x,
                                                                border.bl_outer.y - border.bottom_width,
@@ -1335,8 +1335,8 @@ impl Primitive {
                 cache.glyph = Some(PackedGlyphPrimitive {
                     common: PackedPrimitiveInfo {
                         padding: [0, 0],
-                        tile_index: 0,
-                        layer_index: 0,
+                        tile_index: 0.0,
+                        layer_index: 0.0,
                         local_clip_rect: self.local_clip_rect,
                         local_rect: self.rect,
                     },
@@ -1404,8 +1404,8 @@ impl Primitive {
                 cache.glyphs = Some(PackedTextRunPrimitive {
                     common: PackedPrimitiveInfo {
                         padding: [0, 0],
-                        tile_index: 0,
-                        layer_index: 0,
+                        tile_index: 0.0,
+                        layer_index: 0.0,
                         local_clip_rect: self.local_clip_rect,
                         local_rect: self.rect,
                     },
@@ -1502,6 +1502,9 @@ impl Primitive {
            needs_blending != batch.blending_enabled {
             return false
         }
+
+        let layer_index_in_ubo = pack_as_float(layer_index_in_ubo);
+        let tile_index_in_ubo = pack_as_float(tile_index_in_ubo);
 
         match (&mut batch.data, &self.details) {
             (&mut PrimitiveBatchData::Blend(..), _) => return false,
@@ -1856,8 +1859,8 @@ pub struct PackedLayer {
 
 #[derive(Debug, Clone)]
 pub struct PackedPrimitiveInfo {
-    layer_index: u32,
-    tile_index: u32,
+    layer_index: f32,
+    tile_index: f32,
     padding: [u32; 2],
     local_clip_rect: Rect<f32>,
     local_rect: Rect<f32>,
@@ -1888,8 +1891,8 @@ pub struct PackedGlyphPrimitive {
 #[repr(C)]
 pub struct PackedTextRunPrimitive {
     common: PackedPrimitiveInfo,
-    glyphs: [PackedTextRunGlyph; GLYPHS_PER_TEXT_RUN],
     color: ColorF,
+    glyphs: [PackedTextRunGlyph; GLYPHS_PER_TEXT_RUN],
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This is an interim workaround for how slow shader compilation is on
Linux when using AoS style declarations. We need this change in order
to enable CI testing of WR, otherwise the test pass is too slow.

It brings the shader compile time on Linux down from around 1.8s to
around 0.2 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/385)
<!-- Reviewable:end -->
