### PR TITLE
Switch layers to use VTF instead of UBO.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -30,6 +30,8 @@
 #define MAX_STOPS_PER_ANGLE_GRADIENT 8
 
 #ifdef WR_VERTEX_SHADER
+uniform sampler2D sLayers;
+
 struct Layer {
     mat4 transform;
     mat4 inv_transform;
@@ -45,31 +47,27 @@ layout(std140) uniform Tiles {
     vec4 tiles[WR_MAX_UBO_VECTORS];
 };
 
-layout(std140) uniform Layers {
-    vec4 layers[WR_MAX_UBO_VECTORS];
-};
-
 Layer fetch_layer(int index) {
     Layer layer;
 
-    int offset = index * 13;
+    ivec2 uv = ivec2(0, index);
 
-    layer.transform[0] = layers[offset + 0];
-    layer.transform[1] = layers[offset + 1];
-    layer.transform[2] = layers[offset + 2];
-    layer.transform[3] = layers[offset + 3];
+    layer.transform[0] = texelFetchOffset(sLayers, uv, 0, ivec2(0, 0));
+    layer.transform[1] = texelFetchOffset(sLayers, uv, 0, ivec2(1, 0));
+    layer.transform[2] = texelFetchOffset(sLayers, uv, 0, ivec2(2, 0));
+    layer.transform[3] = texelFetchOffset(sLayers, uv, 0, ivec2(3, 0));
 
-    layer.inv_transform[0] = layers[offset + 4];
-    layer.inv_transform[1] = layers[offset + 5];
-    layer.inv_transform[2] = layers[offset + 6];
-    layer.inv_transform[3] = layers[offset + 7];
+    layer.inv_transform[0] = texelFetchOffset(sLayers, uv, 0, ivec2(4, 0));
+    layer.inv_transform[1] = texelFetchOffset(sLayers, uv, 0, ivec2(5, 0));
+    layer.inv_transform[2] = texelFetchOffset(sLayers, uv, 0, ivec2(6, 0));
+    layer.inv_transform[3] = texelFetchOffset(sLayers, uv, 0, ivec2(7, 0));
 
-    layer.local_clip_rect = layers[offset + 8];
+    layer.local_clip_rect = texelFetchOffset(sLayers, uv, 0, ivec2(8, 0));
 
-    layer.screen_vertices[0] = layers[offset + 9];
-    layer.screen_vertices[1] = layers[offset + 10];
-    layer.screen_vertices[2] = layers[offset + 11];
-    layer.screen_vertices[3] = layers[offset + 12];
+    layer.screen_vertices[0] = texelFetchOffset(sLayers, uv, 0, ivec2(9, 0));
+    layer.screen_vertices[1] = texelFetchOffset(sLayers, uv, 0, ivec2(10, 0));
+    layer.screen_vertices[2] = texelFetchOffset(sLayers, uv, 0, ivec2(11, 0));
+    layer.screen_vertices[3] = texelFetchOffset(sLayers, uv, 0, ivec2(12, 0));
 
     return layer;
 }

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -7,7 +7,7 @@ use device::{Device, ProgramId, VAOId, TextureId, VertexFormat};
 use device::{TextureFilter, VertexUsageHint};
 use euclid::{Matrix4D, Point2D, Size2D, Rect};
 use gleam::gl;
-use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePixel};
+use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePixel, TextureSampler};
 use internal_types::{DebugFontVertex, DebugColorVertex, RenderTargetMode, PackedColor};
 use std::f32;
 use webrender_traits::{ColorF, ImageFormat};
@@ -198,7 +198,7 @@ impl DebugRenderer {
 
             // Glyphs
             device.bind_program(self.font_program_id, &projection);
-            device.bind_color_texture(self.font_texture_id);
+            device.bind_texture(TextureSampler::Color, self.font_texture_id);
             device.bind_vao(self.font_vao);
             device.update_vao_indices(self.font_vao,
                                       &self.font_indices,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -94,17 +94,8 @@ pub type DrawListId = FreeListItemId;
 pub enum TextureSampler {
     Color,
     Mask,
-
     Cache,
-
-    CompositeLayer0,
-    CompositeLayer1,
-    CompositeLayer2,
-    CompositeLayer3,
-    CompositeLayer4,
-    CompositeLayer5,
-    CompositeLayer6,
-    CompositeLayer7,
+    Layers,
 }
 
 pub enum VertexAttribute {

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -705,6 +705,7 @@ impl TextureCache {
                 (&mut self.arena.pages_rgb8, RenderTargetMode::None)
             }
             (ImageFormat::Invalid, TextureCacheItemKind::Standard) |
+            (ImageFormat::RGBAF32, TextureCacheItemKind::Standard) |
             (_, TextureCacheItemKind::Alternate) => unreachable!(),
         };
 
@@ -902,7 +903,8 @@ impl TextureCache {
             }
             (&TextureInsertOp::Blit(..), ImageFormat::RGB8) => true,
             (&TextureInsertOp::Blit(..), ImageFormat::A8) => false,
-            (&TextureInsertOp::Blit(..), ImageFormat::Invalid) => unreachable!(),
+            (&TextureInsertOp::Blit(..), ImageFormat::Invalid) |
+            (&TextureInsertOp::Blit(..), ImageFormat::RGBAF32) => unreachable!(),
             (&TextureInsertOp::Blur(..), _) => false,
         };
 
@@ -927,7 +929,7 @@ impl TextureCache {
                             ImageFormat::A8 => 1,
                             ImageFormat::RGB8 => 3,
                             ImageFormat::RGBA8 => 4,
-                            ImageFormat::Invalid => unreachable!(),
+                            ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
                         };
 
                         let mut top_row_bytes = Vec::new();

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -295,6 +295,7 @@ pub enum ImageFormat {
     A8,
     RGB8,
     RGBA8,
+    RGBAF32,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
Using vertex texture fetch simplifies the CPU-side batching code,
and is also a performance win.

Also clean up the texture binding APIs / code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/390)
<!-- Reviewable:end -->
