### PR TITLE
Add anti-aliasing support for rounded rects

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -537,7 +537,7 @@ Composite fetch_composite(int index) {
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-void do_clip(vec2 pos, vec4 clip_rect, vec4 radius) {
+float do_clip(vec2 pos, vec4 clip_rect, vec4 radius) {
     vec2 ref_tl = clip_rect.xy + vec2( radius.x,  radius.x);
     vec2 ref_tr = clip_rect.zy + vec2(-radius.y,  radius.y);
     vec2 ref_br = clip_rect.zw + vec2(-radius.z, -radius.z);
@@ -548,15 +548,26 @@ void do_clip(vec2 pos, vec4 clip_rect, vec4 radius) {
     float d_br = distance(pos, ref_br);
     float d_bl = distance(pos, ref_bl);
 
-    bool out0 = pos.x < ref_tl.x && pos.y < ref_tl.y && d_tl > radius.x;
-    bool out1 = pos.x > ref_tr.x && pos.y < ref_tr.y && d_tr > radius.y;
-    bool out2 = pos.x > ref_br.x && pos.y > ref_br.y && d_br > radius.z;
-    bool out3 = pos.x < ref_bl.x && pos.y > ref_bl.y && d_bl > radius.w;
+    float pixels_per_fragment = length(fwidth(pos.xy));
+    float nudge = 0.5 * pixels_per_fragment;
 
-    // TODO(gw): Alpha anti-aliasing based on edge distance!
-    if (out0 || out1 || out2 || out3) {
-        discard;
-    }
+    bool out0 = pos.x < ref_tl.x && pos.y < ref_tl.y && d_tl > radius.x - nudge;
+    bool out1 = pos.x > ref_tr.x && pos.y < ref_tr.y && d_tr > radius.y - nudge;
+    bool out2 = pos.x > ref_br.x && pos.y > ref_br.y && d_br > radius.z - nudge;
+    bool out3 = pos.x < ref_bl.x && pos.y > ref_bl.y && d_bl > radius.w - nudge;
+
+    float distance_from_border = (float(out0) * (d_tl - radius.x + nudge)) +
+                                 (float(out1) * (d_tr - radius.y + nudge)) +
+                                 (float(out2) * (d_br - radius.z + nudge)) +
+                                 (float(out3) * (d_bl - radius.w + nudge));
+
+    // Move the distance back into pixels.
+    distance_from_border /= pixels_per_fragment;
+
+    // Apply a more gradual fade out to transparent.
+    //distance_from_border -= 0.5;
+
+    return smoothstep(1.0, 0, distance_from_border);
 }
 
 float squared_distance_from_rect(vec2 p, vec2 origin, vec2 size) {

--- a/webrender/res/ps_gradient.fs.glsl
+++ b/webrender/res/ps_gradient.fs.glsl
@@ -7,12 +7,12 @@ void main(void) {
     float alpha = 0;
     vec2 local_pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
 #else
+    float alpha = 1;
     vec2 local_pos = vPos;
 #endif
 
-    do_clip(local_pos, vClipRect, vClipRadius);
-
-    oFragColor = mix(vColor0, vColor1, vF);
+    alpha = min(alpha, do_clip(local_pos, vClipRect, vClipRadius));
+    oFragColor = mix(vColor0, vColor1, vF) * vec4(1, 1, 1, alpha);
 
 #ifdef WR_FEATURE_TRANSFORM
     oFragColor.a *= alpha;

--- a/webrender/res/ps_image_clip.fs.glsl
+++ b/webrender/res/ps_image_clip.fs.glsl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    do_clip(vPos, vClipRect, vClipRadius);
+    float alpha = do_clip(vPos, vClipRect, vClipRadius);
     vec2 st = vTextureOffset + vTextureSize * fract(vUv);
-    oFragColor = texture(sDiffuse, st);
+    oFragColor = texture(sDiffuse, st) * vec4(1, 1, 1, alpha);
 }

--- a/webrender/res/ps_rectangle_clip.fs.glsl
+++ b/webrender/res/ps_rectangle_clip.fs.glsl
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    do_clip(vPos, vClipRect, vClipRadius);
-
-    oFragColor = vColor;
+    float alpha = do_clip(vPos, vClipRect, vClipRadius);
+    oFragColor = vColor * vec4(1, 1, 1, alpha);
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -799,6 +799,10 @@ struct Primitive {
 
 impl Primitive {
     fn is_opaque(&self, resource_cache: &ResourceCache, frame_id: FrameId) -> bool {
+        if self.complex_clip.is_some() {
+            return false;
+        }
+
         match self.details {
             PrimitiveDetails::Rectangle(ref primitive) => primitive.color.a == 1.0,
             PrimitiveDetails::Image(ImagePrimitive {


### PR DESCRIPTION
Do edge distance anti-aliasing on rectangles (solid color, images, and
gradients) with clips that are rounded rects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/395)
<!-- Reviewable:end -->
