### PR TITLE
Add basic overlay scrollbar support.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -15,7 +15,7 @@ use resource_cache::ResourceCache;
 use scene::{SceneStackingContext, ScenePipeline, Scene, SceneItem, SpecificSceneItem};
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use tiling::{Clip, FrameBuilder, FrameBuilderConfig, InsideTest};
+use tiling::{Clip, FrameBuilder, FrameBuilderConfig, InsideTest, PrimitiveFlags};
 use util::MatrixHelpers;
 use webrender_traits::{AuxiliaryLists, PipelineId, Epoch, ScrollPolicy, ScrollLayerId};
 use webrender_traits::{ColorF, StackingContext, FilterOp, MixBlendMode};
@@ -29,6 +29,8 @@ const CAN_OVERSCROLL: bool = false;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct FrameId(pub u32);
+
+static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF { r: 0.3, g: 0.3, b: 0.3, a: 0.6 };
 
 struct FlattenContext<'a> {
     resource_cache: &'a mut ResourceCache,
@@ -523,7 +525,8 @@ impl Frame {
             context.builder.add_solid_rectangle(&stacking_context.bounds,
                                                 &stacking_context.bounds,
                                                 None,
-                                                &ColorF::new(1.0, 1.0, 1.0, 1.0));
+                                                &ColorF::new(1.0, 1.0, 1.0, 1.0),
+                                                PrimitiveFlags::None);
         }
 
         for item in scene_items {
@@ -582,7 +585,8 @@ impl Frame {
                                 builder.add_solid_rectangle(&item.rect,
                                                             &item.clip.main,
                                                             clip,
-                                                            &info.color);
+                                                            &info.color,
+                                                            PrimitiveFlags::None);
                             }
                             SpecificDisplayItem::Gradient(ref info) => {
                                 builder.add_gradient(item.rect,
@@ -722,6 +726,17 @@ impl Frame {
                     }
                 }
             }
+        }
+
+        if level == 0 && self.frame_builder_config.enable_scrollbars {
+            let scrollbar_rect = Rect::new(Point2D::zero(),
+                                           Size2D::new(10.0, 70.0));
+            context.builder.add_solid_rectangle(&scrollbar_rect,
+                                                &scrollbar_rect,
+                                                None,
+                                                &DEFAULT_SCROLLBAR_COLOR,
+                                                PrimitiveFlags::Scrollbar(self.root_scroll_layer_id.unwrap(),
+                                                                          4.0));
         }
 
         context.builder.pop_layer();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -491,7 +491,7 @@ impl Renderer {
         // texture ids
         let context_handle = NativeGLContext::current_handle();
 
-        let config = FrameBuilderConfig::new();
+        let config = FrameBuilderConfig::new(options.enable_scrollbars);
 
         let debug = options.debug;
         let (device_pixel_ratio, enable_aa) = (options.device_pixel_ratio, options.enable_aa);
@@ -1643,4 +1643,5 @@ pub struct RendererOptions {
     pub enable_profiler: bool,
     pub debug: bool,
     pub enable_recording: bool,
+    pub enable_scrollbars: bool,
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -34,6 +34,13 @@ const ALPHA_BATCHERS_PER_RENDER_TARGET: usize = 4;
 const MIN_TASKS_PER_ALPHA_BATCHER: usize = 64;
 const FLOATS_PER_RENDER_TASK_INFO: usize = 8;
 
+#[derive(Debug)]
+struct ScrollbarPrimitive {
+    scroll_layer_id: ScrollLayerId,
+    prim_index: PrimitiveIndex,
+    border_radius: f32,
+}
+
 #[inline(always)]
 fn pack_as_float(value: u32) -> f32 {
     value as f32 + 0.5
@@ -56,6 +63,12 @@ enum PrimitiveRunCmd {
     PushStackingContext(StackingContextIndex),
     PrimitiveRun(PrimitiveIndex, usize),
     PopStackingContext,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum PrimitiveFlags {
+    None,
+    Scrollbar(ScrollLayerId, f32)
 }
 
 #[repr(u32)]
@@ -2213,6 +2226,16 @@ impl ClipCorner {
             inner_radius_y: 0.0,
         }
     }
+
+    fn uniform(rect: Rect<f32>, outer_radius: f32, inner_radius: f32) -> ClipCorner {
+        ClipCorner {
+            rect: rect,
+            outer_radius_x: outer_radius,
+            outer_radius_y: outer_radius,
+            inner_radius_x: inner_radius,
+            inner_radius_y: inner_radius,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2231,11 +2254,13 @@ pub struct ClearTile {
 
 #[derive(Clone, Copy)]
 pub struct FrameBuilderConfig {
+    pub enable_scrollbars: bool,
 }
 
 impl FrameBuilderConfig {
-    pub fn new() -> FrameBuilderConfig {
+    pub fn new(enable_scrollbars: bool) -> FrameBuilderConfig {
         FrameBuilderConfig {
+            enable_scrollbars: enable_scrollbars,
         }
     }
 }
@@ -2249,6 +2274,8 @@ pub struct FrameBuilder {
 
     layer_store: Vec<StackingContext>,
     packed_layers: Vec<PackedStackingContext>,
+
+    scrollbar_prims: Vec<ScrollbarPrimitive>,
 }
 
 pub struct Frame {
@@ -2311,6 +2338,32 @@ impl Clip {
             top_right: ClipCorner::invalid(rect),
             bottom_left: ClipCorner::invalid(rect),
             bottom_right: ClipCorner::invalid(rect),
+        }
+    }
+
+    pub fn uniform(rect: Rect<f32>, radius: f32) -> Clip {
+        Clip {
+            rect: rect,
+            top_left: ClipCorner::uniform(Rect::new(Point2D::new(rect.origin.x,
+                                                                 rect.origin.y),
+                                                    Size2D::new(radius, radius)),
+                                          radius,
+                                          0.0),
+            top_right: ClipCorner::uniform(Rect::new(Point2D::new(rect.origin.x + rect.size.width - radius,
+                                                                  rect.origin.y),
+                                                    Size2D::new(radius, radius)),
+                                           radius,
+                                           0.0),
+            bottom_left: ClipCorner::uniform(Rect::new(Point2D::new(rect.origin.x,
+                                                                    rect.origin.y + rect.size.height - radius),
+                                                       Size2D::new(radius, radius)),
+                                             radius,
+                                             0.0),
+            bottom_right: ClipCorner::uniform(Rect::new(Point2D::new(rect.origin.x + rect.size.width - radius,
+                                                                     rect.origin.y + rect.size.height - radius),
+                                                        Size2D::new(radius, radius)),
+                                              radius,
+                                              0.0),
         }
     }
 }
@@ -2552,6 +2605,7 @@ impl FrameBuilder {
             device_pixel_ratio: device_pixel_ratio,
             debug: debug,
             packed_layers: Vec::new(),
+            scrollbar_prims: Vec::new(),
         }
     }
 
@@ -2559,7 +2613,7 @@ impl FrameBuilder {
                      rect: &Rect<f32>,
                      clip_rect: &Rect<f32>,
                      clip: Option<Box<Clip>>,
-                     details: PrimitiveDetails) {
+                     details: PrimitiveDetails) -> PrimitiveIndex {
         let prim = Primitive {
             rect: *rect,
             complex_clip: clip,
@@ -2574,13 +2628,15 @@ impl FrameBuilder {
             &mut PrimitiveRunCmd::PrimitiveRun(_run_prim_index, ref mut count) => {
                 debug_assert!(_run_prim_index.0 + *count == prim_index.0);
                 *count += 1;
-                return;
+                return prim_index;
             }
             &mut PrimitiveRunCmd::PushStackingContext(..) |
             &mut PrimitiveRunCmd::PopStackingContext => {}
         }
 
         self.cmds.push(PrimitiveRunCmd::PrimitiveRun(prim_index, 1));
+
+        prim_index
     }
 
     pub fn push_layer(&mut self,
@@ -2624,7 +2680,8 @@ impl FrameBuilder {
                                rect: &Rect<f32>,
                                clip_rect: &Rect<f32>,
                                clip: Option<Box<Clip>>,
-                               color: &ColorF) {
+                               color: &ColorF,
+                               flags: PrimitiveFlags) {
         if color.a == 0.0 {
             return;
         }
@@ -2633,10 +2690,21 @@ impl FrameBuilder {
             color: *color,
         };
 
-        self.add_primitive(rect,
-                           clip_rect,
-                           clip,
-                           PrimitiveDetails::Rectangle(prim));
+        let prim_index = self.add_primitive(rect,
+                                            clip_rect,
+                                            clip,
+                                            PrimitiveDetails::Rectangle(prim));
+
+        match flags {
+            PrimitiveFlags::None => {}
+            PrimitiveFlags::Scrollbar(scroll_layer_id, border_radius) => {
+                self.scrollbar_prims.push(ScrollbarPrimitive {
+                    prim_index: prim_index,
+                    scroll_layer_id: scroll_layer_id,
+                    border_radius: border_radius,
+                });
+            }
+        }
     }
 
     pub fn supported_style(&mut self, border: &BorderSide) -> bool {
@@ -2846,7 +2914,8 @@ impl FrameBuilder {
             self.add_solid_rectangle(&box_bounds,
                                      clip_rect,
                                      None,
-                                     color);
+                                     color,
+                                     PrimitiveFlags::None);
             return;
         }
 
@@ -3189,6 +3258,50 @@ impl FrameBuilder {
         }
     }
 
+    fn update_scroll_bars(&mut self,
+                          layer_map: &HashMap<ScrollLayerId, Layer, BuildHasherDefault<FnvHasher>>) {
+        let distance_from_edge = 8.0;
+
+        for scrollbar_prim in &self.scrollbar_prims {
+            let prim = &mut self.prim_store[scrollbar_prim.prim_index.0];
+            let scroll_layer = &layer_map[&scrollbar_prim.scroll_layer_id];
+
+            let scrollable_distance = scroll_layer.content_size.height - scroll_layer.local_viewport_rect.size.height;
+
+            if scrollable_distance <= 0.0 {
+                prim.local_clip_rect.size = Size2D::zero();
+                continue;
+            }
+
+            let f = -scroll_layer.scrolling.offset.y / scrollable_distance;
+
+            let min_y = scroll_layer.local_viewport_rect.origin.y -
+                        scroll_layer.scrolling.offset.y +
+                        distance_from_edge;
+
+            let max_y = scroll_layer.local_viewport_rect.origin.y +
+                        scroll_layer.local_viewport_rect.size.height -
+                        scroll_layer.scrolling.offset.y -
+                        prim.rect.size.height -
+                        distance_from_edge;
+
+            prim.rect.origin.x = scroll_layer.local_viewport_rect.origin.x +
+                                 scroll_layer.local_viewport_rect.size.width -
+                                 prim.rect.size.width -
+                                 distance_from_edge;
+
+            prim.rect.origin.y = util::lerp(min_y, max_y, f);
+            prim.local_clip_rect = prim.rect;
+
+            if scrollbar_prim.border_radius == 0.0 {
+                prim.complex_clip = None;
+            } else {
+                prim.complex_clip = Some(Box::new(Clip::uniform(prim.rect,
+                                                                scrollbar_prim.border_radius)));
+            }
+        }
+    }
+
     pub fn build(&mut self,
                  resource_cache: &mut ResourceCache,
                  frame_id: FrameId,
@@ -3205,6 +3318,8 @@ impl FrameBuilder {
         let mut debug_rects = Vec::new();
 
         let (x_tile_count, y_tile_count, mut screen_tiles) = self.create_screen_tiles();
+
+        self.update_scroll_bars(layer_map);
 
         self.cull_layers(&screen_rect,
                          layer_map,


### PR DESCRIPTION
This adds the infrastructure for adding scrollbars to any scroll root,
however for now it only draws a scrollbar for the root frame. Once we
are happy with the implementation and design, we can easily enable it
for iframes and other scroll roots.

The idea is to insert a primitive of any kind into the primitive tree
and tag it as being a scroll bar primitive for a given layer. This
means we can allow styling of the scrollbar in the future, making use
of any of the display item features that are supported (e.g. border
corners, gradients, images, anti-aliasing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/397)
<!-- Reviewable:end -->
