### PR TITLE
Transformation support for rounded rectangles

### DIFF
--- a/webrender/res/ps_image_clip.fs.glsl
+++ b/webrender/res/ps_image_clip.fs.glsl
@@ -1,9 +1,22 @@
+#line 1
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    float alpha = do_clip(vPos, vClipRect, vClipRadius);
-    vec2 st = vTextureOffset + vTextureSize * fract(vUv);
+#ifdef WR_FEATURE_TRANSFORM
+    float alpha = 1;
+    vec2 local_pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
+    vec2 uv = (local_pos - vLocalRect.xy) / vStretchSize;
+#else
+    float alpha = 1;
+    vec2 local_pos = vLocalPos;
+    vec2 uv = vUv;
+#endif
+
+    vec2 st = vTextureOffset + vTextureSize * fract(uv);
+
+    alpha = min(alpha, do_clip(local_pos, vClipRect, vClipRadius));
     oFragColor = texture(sDiffuse, st) * vec4(1, 1, 1, alpha);
 }

--- a/webrender/res/ps_image_clip.glsl
+++ b/webrender/res/ps_image_clip.glsl
@@ -2,9 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying vec2 vUv;                 // Location within the CSS box to draw.
-varying vec2 vPos;
 flat varying vec2 vTextureOffset; // Offset of this image into the texture atlas.
 flat varying vec2 vTextureSize;   // Size of the image in the texture atlas.
 flat varying vec4 vClipRect;
 flat varying vec4 vClipRadius;
+
+#ifdef WR_FEATURE_TRANSFORM
+varying vec3 vLocalPos;
+flat varying vec4 vLocalRect;
+flat varying vec2 vStretchSize;
+#else
+varying vec2 vLocalPos;
+varying vec2 vUv;                 // Location within the CSS box to draw.
+#endif

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -5,17 +5,23 @@
 
 void main(void) {
     ImageClip image = fetch_image_clip(gl_InstanceID);
+
+#ifdef WR_FEATURE_TRANSFORM
+    TransformVertexInfo vi = write_transform_vertex(image.info);
+    vLocalRect = vi.clipped_local_rect;
+    vLocalPos = vi.local_pos;
+    vStretchSize = image.stretch_size_uvkind.xy;
+#else
     VertexInfo vi = write_vertex(image.info);
+    vUv = (vi.local_clamped_pos - vi.local_rect.p0) / image.stretch_size_uvkind.xy;
+    vLocalPos = vi.local_clamped_pos;
+#endif
 
     vClipRect = vec4(image.clip.rect.xy, image.clip.rect.xy + image.clip.rect.zw);
     vClipRadius = vec4(image.clip.top_left.outer_inner_radius.x,
                        image.clip.top_right.outer_inner_radius.x,
                        image.clip.bottom_right.outer_inner_radius.x,
                        image.clip.bottom_left.outer_inner_radius.x);
-    vPos = vi.local_clamped_pos;
-
-    // vUv will contain how many times this image has wrapped around the image size.
-    vUv = (vi.local_clamped_pos - image.info.local_rect.xy) / image.stretch_size_uvkind.xy;
 
     vec2 st0 = image.st_rect.xy;
     vec2 st1 = image.st_rect.zw;

--- a/webrender/res/ps_rectangle_clip.fs.glsl
+++ b/webrender/res/ps_rectangle_clip.fs.glsl
@@ -3,6 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    float alpha = do_clip(vPos, vClipRect, vClipRadius);
+#ifdef WR_FEATURE_TRANSFORM
+    float alpha = 1;
+    vec2 local_pos = init_transform_fs(vPos, vLocalRect, alpha);
+#else
+    float alpha = 1;
+    vec2 local_pos = vPos;
+#endif
+
+    alpha = min(alpha, do_clip(local_pos, vClipRect, vClipRadius));
     oFragColor = vColor * vec4(1, 1, 1, alpha);
 }

--- a/webrender/res/ps_rectangle_clip.glsl
+++ b/webrender/res/ps_rectangle_clip.glsl
@@ -5,6 +5,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec4 vColor;
-varying vec2 vPos;
 flat varying vec4 vClipRect;
 flat varying vec4 vClipRadius;
+
+#ifdef WR_FEATURE_TRANSFORM
+varying vec3 vPos;
+flat varying vec4 vLocalRect;
+#else
+varying vec2 vPos;
+#endif

--- a/webrender/res/ps_rectangle_clip.vs.glsl
+++ b/webrender/res/ps_rectangle_clip.vs.glsl
@@ -5,14 +5,21 @@
 
 void main(void) {
     RectangleClip rect = fetch_rectangle_clip(gl_InstanceID);
+
+#ifdef WR_FEATURE_TRANSFORM
+    TransformVertexInfo vi = write_transform_vertex(rect.info);
+    vPos = vi.local_pos;
+    vLocalRect = vi.clipped_local_rect;
+#else
     VertexInfo vi = write_vertex(rect.info);
+    vPos = vi.local_clamped_pos;
+#endif
 
     vClipRect = vec4(rect.clip.rect.xy, rect.clip.rect.xy + rect.clip.rect.zw);
     vClipRadius = vec4(rect.clip.top_left.outer_inner_radius.x,
                        rect.clip.top_right.outer_inner_radius.x,
                        rect.clip.bottom_right.outer_inner_radius.x,
                        rect.clip.bottom_left.outer_inner_radius.x);
-    vPos = vi.local_clamped_pos;
 
     vColor = rect.color;
 }


### PR DESCRIPTION
Add transformation support for rounded solid color and image
rectangles. This already exists for gradients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/399)
<!-- Reviewable:end -->
