### PR TITLE
Do not repeat textures in transformed image rects

### DIFF
--- a/webrender/res/ps_image.fs.glsl
+++ b/webrender/res/ps_image.fs.glsl
@@ -8,7 +8,12 @@ void main(void) {
 #ifdef WR_FEATURE_TRANSFORM
     float alpha = 0;
     vec2 pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
-    vec2 uv = (pos - vLocalRect.xy) / vStretchSize;
+
+    // We clamp the texture coordinate calculation here to the local rectangle boundaries,
+    // which makes the edge of the texture stretch instead of repeat.
+    vec2 uv = clamp(pos, vLocalRect.xy, vLocalRect.xy + vLocalRect.zw);
+
+    uv = (uv - vLocalRect.xy) / vStretchSize;
 #else
     vec2 uv = vUv;
 #endif

--- a/webrender/res/ps_image_clip.fs.glsl
+++ b/webrender/res/ps_image_clip.fs.glsl
@@ -8,7 +8,12 @@ void main(void) {
 #ifdef WR_FEATURE_TRANSFORM
     float alpha = 1;
     vec2 local_pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
-    vec2 uv = (local_pos - vLocalRect.xy) / vStretchSize;
+
+    // We clamp the texture coordinate calculation here to the local rectangle boundaries,
+    // which makes the edge of the texture stretch instead of repeat.
+    vec2 uv = clamp(local_pos.xy, vLocalRect.xy, vLocalRect.xy + vLocalRect.zw);
+
+    uv = (uv - vLocalRect.xy) / vStretchSize;
 #else
     float alpha = 1;
     vec2 local_pos = vLocalPos;


### PR DESCRIPTION
The way that texture coordinates were calculated meant that textures
were repeated outside the bounds of transformed image primitives. Clamp
to local rect boundaries in order to simulate texture clamping here.
This is important for anti-aliased edges, which have subpixels
outside texture boundaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/400)
<!-- Reviewable:end -->
