### PR TITLE
Show the name of the failing file on shader compile error

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -829,7 +829,8 @@ impl Device {
         gl::shader_source(id, &[&source[..]]);
         gl::compile_shader(id);
         if gl::get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
-            println!("Failed to compile shader: {}", gl::get_shader_info_log(id));
+            println!("Failed to compile shader: {:?}", path);
+            println!("{}", gl::get_shader_info_log(id));
             if panic_on_fail {
                 panic!("-- Shader compile failed - exiting --");
             }


### PR DESCRIPTION
If compiling of a shader fails for some reason in a release build, there is no information about which file caused the error (only in debug build). Consider printing the filename on errors:

Before:
```
Failed to compile shader: 0:25(2): error: initializer of type int cannot be assigned to variable of type float
0:29(2): error: value of type float cannot be assigned to variable of type int
```

After:
```
Failed to compile shader: "/home/odroid/servo/resources/shaders/ps_rectangle_clip.fs.glsl"
0:25(2): error: initializer of type int cannot be assigned to variable of type float
0:29(2): error: value of type float cannot be assigned to variable of type int
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/406)
<!-- Reviewable:end -->
