### PR TITLE
Add ARM support

### DIFF
--- a/webrender/res/ps_image_clip.fs.glsl
+++ b/webrender/res/ps_image_clip.fs.glsl
@@ -6,7 +6,7 @@
 
 void main(void) {
 #ifdef WR_FEATURE_TRANSFORM
-    float alpha = 1;
+    float alpha = 1.f;
     vec2 local_pos = init_transform_fs(vLocalPos, vLocalRect, alpha);
 
     // We clamp the texture coordinate calculation here to the local rectangle boundaries,
@@ -14,7 +14,7 @@ void main(void) {
     vec2 pos_for_texture =
          clamp(pos, vLocalRect.xy, vLocalRect.xy + vLocalRect.zw) - vLocalRect.xy;
 #else
-    float alpha = 1;
+    float alpha = 1.f;
     vec2 local_pos = vLocalPos;
     vec2 relative_pos_in_rect = vLocalPos - vLocalRect.xy;
 #endif

--- a/webrender/res/ps_rectangle_clip.fs.glsl
+++ b/webrender/res/ps_rectangle_clip.fs.glsl
@@ -4,10 +4,10 @@
 
 void main(void) {
 #ifdef WR_FEATURE_TRANSFORM
-    float alpha = 1;
+    float alpha = 1.f;
     vec2 local_pos = init_transform_fs(vPos, vLocalRect, alpha);
 #else
-    float alpha = 1;
+    float alpha = 1.f;
     vec2 local_pos = vPos;
 #endif
 

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -19,10 +19,10 @@ use std::mem;
 //use std::thread;
 use webrender_traits::ImageFormat;
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 const GL_FORMAT_A: gl::GLuint = gl::RED;
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 const GL_FORMAT_A: gl::GLuint = gl::ALPHA;
 
 #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
@@ -31,16 +31,10 @@ const GL_FORMAT_BGRA: gl::GLuint = gl::BGRA;
 #[cfg(target_os = "android")]
 const GL_FORMAT_BGRA: gl::GLuint = gl::BGRA_EXT;
 
-#[cfg(target_os = "linux")]
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 const SHADER_VERSION: &'static str = "#version 150\n";
 
-#[cfg(target_os = "macos")]
-const SHADER_VERSION: &'static str = "#version 150\n";
-
-#[cfg(target_os = "windows")]
-const SHADER_VERSION: &'static str = "#version 150\n";
-
-#[cfg(target_os = "android")]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 const SHADER_VERSION: &'static str = "#version 300 es\n";
 
 static SHADER_PREAMBLE: &'static str = "shared.glsl";
@@ -578,19 +572,19 @@ pub struct VBOId(gl::GLuint);
 #[derive(PartialEq, Eq, Hash, Debug, Copy, Clone)]
 struct IBOId(gl::GLuint);
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 pub struct GpuProfile {
     next_query: usize,
     qids: Vec<gl::GLuint>,
 }
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 pub struct GpuProfile;
 
 const QUERY_COUNT: i32 = 4;
 
 impl GpuProfile {
-    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn new() -> GpuProfile {
         let queries = gl::gen_queries(QUERY_COUNT);
 
@@ -605,41 +599,41 @@ impl GpuProfile {
         }
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn new() -> GpuProfile {
         GpuProfile
     }
 
-    #[cfg(any(target_os = "android", target_os = "gonk"))]
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn get(&mut self) -> u64 {
         0
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn get(&mut self) -> u64 {
         let qi = self.next_query;
         gl::get_query_object_ui64v(self.qids[qi], gl::QUERY_RESULT)
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn begin(&mut self) {
         gl::begin_query(gl::TIME_ELAPSED, self.qids[self.next_query]);
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn begin(&mut self) {}
 
-    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn end(&mut self) {
         gl::end_query(gl::TIME_ELAPSED);
         self.next_query = (self.next_query + 1) % QUERY_COUNT as usize;
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     pub fn end(&mut self) -> u64 { 0 }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 impl Drop for GpuProfile {
     fn drop(&mut self) {
         gl::delete_queries(&self.qids);
@@ -1412,7 +1406,7 @@ impl Device {
 
         let (gl_format, bpp, data) = match self.textures.get(&texture_id).unwrap().format {
             ImageFormat::A8 => {
-                if cfg!(target_os="android") {
+                if cfg!(any(target_arch="arm", target_arch="aarch64")) {
                     for byte in data {
                         expanded_data.push(*byte);
                         expanded_data.push(*byte);
@@ -1620,7 +1614,7 @@ impl Drop for Device {
 fn gl_texture_formats_for_image_format(format: ImageFormat) -> (gl::GLint, gl::GLuint) {
     match format {
         ImageFormat::A8 => {
-            if cfg!(target_os="android") {
+            if cfg!(any(target_arch="arm", target_arch="aarch64")) {
                 (GL_FORMAT_BGRA as gl::GLint, GL_FORMAT_BGRA)
             } else {
                 (GL_FORMAT_A as gl::GLint, GL_FORMAT_A)
@@ -1628,7 +1622,7 @@ fn gl_texture_formats_for_image_format(format: ImageFormat) -> (gl::GLint, gl::G
         },
         ImageFormat::RGB8 => (gl::RGB as gl::GLint, gl::RGB),
         ImageFormat::RGBA8 => {
-            if cfg!(target_os="android") {
+            if cfg!(any(target_arch="arm", target_arch="aarch64")) {
                 (GL_FORMAT_BGRA as gl::GLint, GL_FORMAT_BGRA)
             } else {
                 (gl::RGBA as gl::GLint, GL_FORMAT_BGRA)


### PR DESCRIPTION
This PR adds ARM support to Webrender:

- Fixes int-to-float conversions, causing shader compile errors
- Instead of using OS name/`android` to determine OpenGL/GLES version, uses the architecture; use GLES if the target arch is ARM or AArch64

A screenshot of Servo running on Odroid XU3:

![servo-wr2-arm](https://cloud.githubusercontent.com/assets/4354863/18553633/6f8ddc7a-7b61-11e6-8c96-7a95525fc66f.png)

(running as `./servo -G es2 -w -Z wr-stats https://en.wikipedia.org/wiki/Rust`)

As you can see, there are still some bugs, eg. missing hover effects or font drawing problems of `wr-stats`, but the rendering itself seems ok, and the performance is really good.
Also I'm not 100% sure about the GL parameters like `GL_FORMAT_A` and the `GpuProfile`, I'd be happy if someone could review them.

CC @glennw, @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/408)
<!-- Reviewable:end -->
