### PR TITLE
Don't deinit textures each frame.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1604,9 +1604,6 @@ impl Renderer {
                     }
                 }
             }
-
-            self.layer_texture.deinit(&mut self.device);
-            self.render_task_texture.deinit(&mut self.device);
         }
 
         // Clear tiles with no items


### PR DESCRIPTION
The calls to `glTexImage2D()` cause driver stalls on Mac.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/410)
<!-- Reviewable:end -->
