### PR TITLE
Remove unused deinit() function.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -88,10 +88,6 @@ impl VertexDataTexture {
                             RenderTargetMode::None,
                             Some(unsafe { mem::transmute(data.as_slice()) } ));
     }
-
-    fn deinit(&mut self, device: &mut Device) {
-        device.deinit_texture(self.id);
-    }
 }
 
 const TRANSFORM_FEATURE: &'static [&'static str] = &["TRANSFORM"];


### PR DESCRIPTION
This is unused since 7bd2fb3026e23ef4e5a2e9295165065824476ac8 ("Don't
deinit textures each frame.") and was causing compiler warnings in
servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/413)
<!-- Reviewable:end -->
