### PR TITLE
Add a number of changes to support running tests on OSMesa.

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -21,7 +21,7 @@ ipc-channel = "0.5"
 lazy_static = "0.2"
 log = "0.3"
 num-traits = "0.1.32"
-offscreen_gl_context = {version = "0.4", features = ["serde_serialization"]}
+offscreen_gl_context = {version = "0.4", features = ["serde_serialization", "osmesa"]}
 rayon = "0.4.0"
 time = "0.1"
 webrender_traits = {path = "../webrender_traits", default-features = false}

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -43,33 +43,20 @@ impl GLContextHandleWrapper {
 
     pub fn new_context(&self,
                        size: Size2D<i32>,
-                       attributes: GLContextAttributes,
-                       shared: bool) -> Result<GLContextWrapper, &'static str> {
+                       attributes: GLContextAttributes) -> Result<GLContextWrapper, &'static str> {
         match *self {
             GLContextHandleWrapper::Native(ref handle) => {
-                let shared_handle = if shared {
-                    Some(handle)
-                } else {
-                    None
-                };
-
                 let ctx = GLContext::<NativeGLContext>::new(size,
                                                             attributes,
                                                             ColorAttachmentType::Texture,
-                                                            shared_handle);
+                                                            Some(handle));
                 ctx.map(GLContextWrapper::Native)
             }
             GLContextHandleWrapper::OSMesa(ref handle) => {
-                let shared_handle = if shared {
-                    Some(handle)
-                } else {
-                    None
-                };
-
                 let ctx = GLContext::<OSMesaContext>::new(size,
                                                           attributes,
                                                           ColorAttachmentType::Texture,
-                                                          shared_handle);
+                                                          Some(handle));
                 ctx.map(GLContextWrapper::OSMesa)
             }
         }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -9,6 +9,10 @@ use euclid::{Matrix4D, Point2D, Rect, Size2D};
 use fnv::FnvHasher;
 use freelist::{FreeListItem, FreeListItemId};
 use num_traits::Zero;
+use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle};
+use offscreen_gl_context::{GLContext, NativeGLContextMethods};
+use offscreen_gl_context::{OSMesaContext, OSMesaContextHandle};
+use offscreen_gl_context::{ColorAttachmentType, GLContextAttributes, GLLimits};
 use profiler::BackendProfileCounters;
 use std::collections::{HashMap, HashSet};
 use std::f32;
@@ -20,7 +24,130 @@ use std::sync::Arc;
 use texture_cache::BorderType;
 use tiling;
 use webrender_traits::{Epoch, ColorF, PipelineId};
-use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem, ScrollLayerId};
+use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
+use webrender_traits::{ScrollLayerId, WebGLCommand};
+
+pub enum GLContextHandleWrapper {
+    Native(NativeGLContextHandle),
+    OSMesa(OSMesaContextHandle),
+}
+
+impl GLContextHandleWrapper {
+    pub fn current_native_handle() -> Option<GLContextHandleWrapper> {
+        NativeGLContext::current_handle().map(|handle| {
+            GLContextHandleWrapper::Native(handle)
+        })
+    }
+
+    pub fn current_osmesa_handle() -> Option<GLContextHandleWrapper> {
+        OSMesaContext::current_handle().map(|handle| {
+            GLContextHandleWrapper::OSMesa(handle)
+        })
+    }
+
+    pub fn new_context(&self,
+                       size: Size2D<i32>,
+                       attributes: GLContextAttributes,
+                       shared: bool) -> Result<GLContextWrapper, &'static str> {
+        match self {
+            &GLContextHandleWrapper::Native(ref handle) => {
+                let shared_handle = if shared {
+                    Some(handle)
+                } else {
+                    None
+                };
+
+                let ctx = GLContext::<NativeGLContext>::new(size,
+                                                            attributes,
+                                                            ColorAttachmentType::Texture,
+                                                            shared_handle);
+                ctx.map(|ctx| {
+                    GLContextWrapper::Native(ctx)
+                })
+            }
+            &GLContextHandleWrapper::OSMesa(ref handle) => {
+                let shared_handle = if shared {
+                    Some(handle)
+                } else {
+                    None
+                };
+
+                let ctx = GLContext::<OSMesaContext>::new(size,
+                                                          attributes,
+                                                          ColorAttachmentType::Texture,
+                                                          shared_handle);
+                ctx.map(|ctx| {
+                    GLContextWrapper::OSMesa(ctx)
+                })
+            }
+        }
+    }
+}
+
+pub enum GLContextWrapper {
+    Native(GLContext<NativeGLContext>),
+    OSMesa(GLContext<OSMesaContext>),
+}
+
+impl GLContextWrapper {
+    pub fn make_current(&self) {
+        match self {
+            &GLContextWrapper::Native(ref ctx) => {
+                ctx.make_current().unwrap();
+            }
+            &GLContextWrapper::OSMesa(ref ctx) => {
+                ctx.make_current().unwrap();
+            }
+        }
+    }
+
+    pub fn unbind(&self) {
+        match self {
+            &GLContextWrapper::Native(ref ctx) => {
+                ctx.unbind().unwrap();
+            }
+            &GLContextWrapper::OSMesa(ref ctx) => {
+                ctx.unbind().unwrap();
+            }
+        }
+    }
+
+    pub fn apply_command(&self, cmd: WebGLCommand) {
+        match self {
+            &GLContextWrapper::Native(ref ctx) => {
+                cmd.apply(ctx);
+            }
+            &GLContextWrapper::OSMesa(ref ctx) => {
+                cmd.apply(ctx);
+            }
+        }
+    }
+
+    pub fn get_info(&self) -> (Size2D<i32>, u32, GLLimits) {
+        match self {
+            &GLContextWrapper::Native(ref ctx) => {
+                let (real_size, texture_id) = {
+                    let draw_buffer = ctx.borrow_draw_buffer().unwrap();
+                    (draw_buffer.size(), draw_buffer.get_bound_texture_id().unwrap())
+                };
+
+                let limits = ctx.borrow_limits().clone();
+
+                (real_size, texture_id, limits)
+            }
+            &GLContextWrapper::OSMesa(ref ctx) => {
+                let (real_size, texture_id) = {
+                    let draw_buffer = ctx.borrow_draw_buffer().unwrap();
+                    (draw_buffer.size(), draw_buffer.get_bound_texture_id().unwrap())
+                };
+
+                let limits = ctx.borrow_limits().clone();
+
+                (real_size, texture_id, limits)
+            }
+        }
+    }
+}
 
 #[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DevicePixel(pub i32);

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -34,23 +34,19 @@ pub enum GLContextHandleWrapper {
 
 impl GLContextHandleWrapper {
     pub fn current_native_handle() -> Option<GLContextHandleWrapper> {
-        NativeGLContext::current_handle().map(|handle| {
-            GLContextHandleWrapper::Native(handle)
-        })
+        NativeGLContext::current_handle().map(GLContextHandleWrapper::Native)
     }
 
     pub fn current_osmesa_handle() -> Option<GLContextHandleWrapper> {
-        OSMesaContext::current_handle().map(|handle| {
-            GLContextHandleWrapper::OSMesa(handle)
-        })
+        OSMesaContext::current_handle().map(GLContextHandleWrapper::OSMesa)
     }
 
     pub fn new_context(&self,
                        size: Size2D<i32>,
                        attributes: GLContextAttributes,
                        shared: bool) -> Result<GLContextWrapper, &'static str> {
-        match self {
-            &GLContextHandleWrapper::Native(ref handle) => {
+        match *self {
+            GLContextHandleWrapper::Native(ref handle) => {
                 let shared_handle = if shared {
                     Some(handle)
                 } else {
@@ -61,11 +57,9 @@ impl GLContextHandleWrapper {
                                                             attributes,
                                                             ColorAttachmentType::Texture,
                                                             shared_handle);
-                ctx.map(|ctx| {
-                    GLContextWrapper::Native(ctx)
-                })
+                ctx.map(GLContextWrapper::Native)
             }
-            &GLContextHandleWrapper::OSMesa(ref handle) => {
+            GLContextHandleWrapper::OSMesa(ref handle) => {
                 let shared_handle = if shared {
                     Some(handle)
                 } else {
@@ -76,9 +70,7 @@ impl GLContextHandleWrapper {
                                                           attributes,
                                                           ColorAttachmentType::Texture,
                                                           shared_handle);
-                ctx.map(|ctx| {
-                    GLContextWrapper::OSMesa(ctx)
-                })
+                ctx.map(GLContextWrapper::OSMesa)
             }
         }
     }
@@ -91,41 +83,41 @@ pub enum GLContextWrapper {
 
 impl GLContextWrapper {
     pub fn make_current(&self) {
-        match self {
-            &GLContextWrapper::Native(ref ctx) => {
+        match *self {
+            GLContextWrapper::Native(ref ctx) => {
                 ctx.make_current().unwrap();
             }
-            &GLContextWrapper::OSMesa(ref ctx) => {
+            GLContextWrapper::OSMesa(ref ctx) => {
                 ctx.make_current().unwrap();
             }
         }
     }
 
     pub fn unbind(&self) {
-        match self {
-            &GLContextWrapper::Native(ref ctx) => {
+        match *self {
+            GLContextWrapper::Native(ref ctx) => {
                 ctx.unbind().unwrap();
             }
-            &GLContextWrapper::OSMesa(ref ctx) => {
+            GLContextWrapper::OSMesa(ref ctx) => {
                 ctx.unbind().unwrap();
             }
         }
     }
 
     pub fn apply_command(&self, cmd: WebGLCommand) {
-        match self {
-            &GLContextWrapper::Native(ref ctx) => {
+        match *self {
+            GLContextWrapper::Native(ref ctx) => {
                 cmd.apply(ctx);
             }
-            &GLContextWrapper::OSMesa(ref ctx) => {
+            GLContextWrapper::OSMesa(ref ctx) => {
                 cmd.apply(ctx);
             }
         }
     }
 
     pub fn get_info(&self) -> (Size2D<i32>, u32, GLLimits) {
-        match self {
-            &GLContextWrapper::Native(ref ctx) => {
+        match *self {
+            GLContextWrapper::Native(ref ctx) => {
                 let (real_size, texture_id) = {
                     let draw_buffer = ctx.borrow_draw_buffer().unwrap();
                     (draw_buffer.size(), draw_buffer.get_bound_texture_id().unwrap())
@@ -135,7 +127,7 @@ impl GLContextWrapper {
 
                 (real_size, texture_id, limits)
             }
-            &GLContextWrapper::OSMesa(ref ctx) => {
+            GLContextWrapper::OSMesa(ref ctx) => {
                 let (real_size, texture_id) = {
                     let draw_buffer = ctx.borrow_draw_buffer().unwrap();
                     (draw_buffer.size(), draw_buffer.get_bound_texture_id().unwrap())

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -11,7 +11,7 @@ use {ApiMsg, AuxiliaryLists, BuiltDisplayList, ColorF, DisplayListId, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState};
 use {StackingContext, StackingContextId, WebGLContextId, WebGLCommand};
-use {GlyphKey, GlyphDimensions};
+use {GlyphKey, GlyphDimensions, ContextSharing};
 
 impl RenderApiSender {
     pub fn new(api_sender: IpcSender<ApiMsg>,
@@ -222,7 +222,7 @@ impl RenderApi {
     }
 
     pub fn request_webgl_context(&self, size: &Size2D<i32>, attributes: GLContextAttributes)
-                                 -> Result<(WebGLContextId, GLLimits, bool), String> {
+                                 -> Result<(WebGLContextId, GLLimits, ContextSharing), String> {
         let (tx, rx) = ipc::channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
         self.api_sender.send(msg).unwrap();

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -222,7 +222,7 @@ impl RenderApi {
     }
 
     pub fn request_webgl_context(&self, size: &Size2D<i32>, attributes: GLContextAttributes)
-                                 -> Result<(WebGLContextId, GLLimits), String> {
+                                 -> Result<(WebGLContextId, GLLimits, bool), String> {
         let (tx, rx) = ipc::channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
         self.api_sender.send(msg).unwrap();

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -11,7 +11,7 @@ use {ApiMsg, AuxiliaryLists, BuiltDisplayList, ColorF, DisplayListId, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState};
 use {StackingContext, StackingContextId, WebGLContextId, WebGLCommand};
-use {GlyphKey, GlyphDimensions, ContextSharing};
+use {GlyphKey, GlyphDimensions};
 
 impl RenderApiSender {
     pub fn new(api_sender: IpcSender<ApiMsg>,
@@ -222,7 +222,7 @@ impl RenderApi {
     }
 
     pub fn request_webgl_context(&self, size: &Size2D<i32>, attributes: GLContextAttributes)
-                                 -> Result<(WebGLContextId, GLLimits, ContextSharing), String> {
+                                 -> Result<(WebGLContextId, GLLimits), String> {
         let (tx, rx) = ipc::channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
         self.api_sender.send(msg).unwrap();

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -14,6 +14,12 @@ use offscreen_gl_context::{GLContextAttributes, GLLimits};
 
 #[cfg(target_os = "macos")] use core_graphics::font::CGFont;
 
+#[derive(Debug, Copy, Clone)]
+pub enum RendererKind {
+    Native,
+    OSMesa,
+}
+
 #[derive(Deserialize, Serialize)]
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
@@ -48,7 +54,7 @@ pub enum ApiMsg {
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<(Point2D<f32>, PipelineId)>),
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
-    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
+    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits, bool), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
 }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -20,12 +20,6 @@ pub enum RendererKind {
     OSMesa,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-pub enum ContextSharing {
-    Shared,
-    NotShared,
-}
-
 #[derive(Deserialize, Serialize)]
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
@@ -60,7 +54,7 @@ pub enum ApiMsg {
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<(Point2D<f32>, PipelineId)>),
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
-    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits, ContextSharing), String>>),
+    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
 }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -20,6 +20,12 @@ pub enum RendererKind {
     OSMesa,
 }
 
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub enum ContextSharing {
+    Shared,
+    NotShared,
+}
+
 #[derive(Deserialize, Serialize)]
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
@@ -54,7 +60,7 @@ pub enum ApiMsg {
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<(Point2D<f32>, PipelineId)>),
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
-    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits, bool), String>>),
+    RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits, ContextSharing), String>>),
     WebGLCommand(WebGLContextId, WebGLCommand),
 }
 


### PR DESCRIPTION
* Add a wrapper type for webgl contexts that allows selectinng
  between a native (hw accel) or osmesa (software) context at
  runtime.

* Change request_webgl_context behaviour to try creating a readback
  (non-shared) context if shared context creation fails. This means
  that the webgl code in servo doesn't have to be aware of whether
  it should be creating native or osmesa contexts in fallback mode.

* Flush each webgl context at the start of the frame to ensure
  contexts are painted correctly when sharing osmesa contexts.

* Add init option to specify what kind of renderering context
  is being used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/417)
<!-- Reviewable:end -->
