### PR TITLE
Fix upside down WebGL

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -3503,8 +3503,8 @@ impl ImagePrimitive {
             ImagePrimitiveKind::WebGL(context_id) => {
                 ImageInfo {
                     color_texture_id: resource_cache.get_webgl_texture(&context_id),
-                    uv0: Point2D::zero(),
-                    uv1: Point2D::new(1.0, 1.0),
+                    uv0: Point2D::new(0.0, 1.0),
+                    uv1: Point2D::new(1.0, 0.0),
                     stretch_size: None,
                     uv_kind: TextureCoordKind::Normalized,
                     tile_spacing: Size2D::zero(),


### PR DESCRIPTION
Fix WebGL texture UVs: WebGL canvas is renderered upside down in servo when webrender is enabled. glReadPixels is returning the correct image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/420)
<!-- Reviewable:end -->
