### PR TITLE
Stop using step_by, which is unstable.

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(step_by)]
 //#![feature(mpsc_select)]
 
 //! A GPU based Webrender.

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -893,8 +893,8 @@ impl TextureCache {
         let is_opaque = match (&insert_op, format) {
             (&TextureInsertOp::Blit(ref bytes), ImageFormat::RGBA8) => {
                 let mut is_opaque = true;
-                for i in (0..bytes.len()).step_by(4) {
-                    if bytes[i + 3] != 255 {
+                for i in 0..(bytes.len() / 4) {
+                    if bytes[i * 4 + 3] != 255 {
                         is_opaque = false;
                         break;
                     }


### PR DESCRIPTION
step_by on ranges isn't currently stable (see rust-lang/rust#27741), so stop using that function.

This is enough for webrender to compile on stable rust (1.12) on my machine, so it probably closes issue #336.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/438)
<!-- Reviewable:end -->
