### PR TITLE
Bring the border radius back on Linux.

### DIFF
--- a/webrender/res/ps_border.fs.glsl
+++ b/webrender/res/ps_border.fs.glsl
@@ -39,7 +39,7 @@ float alpha_for_solid_border(float distance_from_ref,
   distance_from_border /= pixels_per_fragment;
 
   // Apply a more gradual fade out to transparent.
-  distance_from_border -= 0.5;
+  // distance_from_border -= 0.5;
 
   return smoothstep(1.0, 0.0, distance_from_border);
 }

--- a/webrender/res/ps_border.fs.glsl
+++ b/webrender/res/ps_border.fs.glsl
@@ -28,7 +28,7 @@ float alpha_for_solid_border(float distance_from_ref,
   inner_radius += nudge;
   outer_radius -= nudge;
 
-  if ((distance_from_ref < outer_radius && distance_from_ref > inner_radius)) {
+  if (distance_from_ref < outer_radius && distance_from_ref > inner_radius) {
     return 1.0;
   }
 

--- a/webrender/res/ps_rectangle_clip.fs.glsl
+++ b/webrender/res/ps_rectangle_clip.fs.glsl
@@ -3,11 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-#ifdef WR_FEATURE_TRANSFORM
     float alpha = 1.f;
+#ifdef WR_FEATURE_TRANSFORM
     vec2 local_pos = init_transform_fs(vPos, vLocalRect, alpha);
 #else
-    float alpha = 1.f;
     vec2 local_pos = vPos;
 #endif
 


### PR DESCRIPTION
I just noticed while reading over #444 that this same line is commented for
clipping. This was making the alpha component of the border radius being always
zero.

This brings back the border radius on Linux. I didn't notice any other issue.
Not totally sure why this only happens on Intel cards though, probably is a
floating point math issue?

Also, this improves the appearance with `LIBGL_ALWAYS_SOFTWARE=1` too, which I guess is the canonical representation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/446)
<!-- Reviewable:end -->
