### PR TITLE
Ensure that RGB8 texture cache pages are backed by an FBO.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -698,11 +698,8 @@ impl TextureCache {
             (ImageFormat::RGBA8, TextureCacheItemKind::Alternate) => {
                 (&mut self.arena.alternate_pages_rgba8, RenderTargetMode::RenderTarget)
             }
-            //(ImageFormat::RGBA8, TextureCacheItemKind::RenderTarget) => {
-            //    (&mut self.arena.render_target_pages, RenderTargetMode::RenderTarget)
-            //}
             (ImageFormat::RGB8, TextureCacheItemKind::Standard) => {
-                (&mut self.arena.pages_rgb8, RenderTargetMode::None)
+                (&mut self.arena.pages_rgb8, RenderTargetMode::RenderTarget)
             }
             (ImageFormat::Invalid, TextureCacheItemKind::Standard) |
             (ImageFormat::RGBAF32, TextureCacheItemKind::Standard) |


### PR DESCRIPTION
Previously, only RGBA8 and A8 atlas pages were backed by FBO, since
they are the only formats that are blitted to by dynamic resources.
However, texture cache resize makes use of FBO, so ensure that RGB8
pages have an FBO attached too.

In the future, it might make sense to consider only creating the
backing FBO when/as it's needed for resize operations, since they are
very rarely used (we should profile to see if this makes any difference).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/449)
<!-- Reviewable:end -->
