### PR TITLE
Optimizations to filter effects, blend targets, and batching.

### DIFF
--- a/webrender/res/ps_blend.fs.glsl
+++ b/webrender/res/ps_blend.fs.glsl
@@ -37,22 +37,25 @@ vec3 hsvToRgb(vec3 c) {
     float residualHue = hue - float(sector);
 
     vec3 pqt = c.z * vec3(1.0 - c.y, 1.0 - c.y * residualHue, 1.0 - c.y * (1.0 - residualHue));
-    if (sector == 0)
-        return vec3(c.z, pqt.z, pqt.x);
-    if (sector == 1)
-        return vec3(pqt.y, c.z, pqt.x);
-    if (sector == 2)
-        return vec3(pqt.x, c.z, pqt.z);
-    if (sector == 3)
-        return vec3(pqt.x, pqt.y, c.z);
-    if (sector == 4)
-        return vec3(pqt.z, pqt.x, c.z);
-    return vec3(c.z, pqt.x, pqt.y);
+    switch (sector) {
+        case 0:
+            return vec3(c.z, pqt.z, pqt.x);
+        case 1:
+            return vec3(pqt.y, c.z, pqt.x);
+        case 2:
+            return vec3(pqt.x, c.z, pqt.z);
+        case 3:
+            return vec3(pqt.x, pqt.y, c.z);
+        case 4:
+            return vec3(pqt.z, pqt.x, c.z);
+        default:
+            return vec3(c.z, pqt.x, pqt.y);
+    }
 }
 
 vec4 Blur(float radius, vec2 direction) {
     // TODO(gw): Support blur in WR2!
-    return vec4(1, 1, 1, 1);
+    return vec4(1.0);
 }
 
 vec4 Contrast(vec4 Cs, float amount) {

--- a/webrender/res/ps_blend.fs.glsl
+++ b/webrender/res/ps_blend.fs.glsl
@@ -4,7 +4,134 @@
 
 uniform sampler2D sCache;
 
+vec3 rgbToHsv(vec3 c) {
+    float value = max(max(c.r, c.g), c.b);
+
+    float chroma = value - min(min(c.r, c.g), c.b);
+    if (chroma == 0.0) {
+        return vec3(0.0);
+    }
+    float saturation = chroma / value;
+
+    float hue;
+    if (c.r == value)
+        hue = (c.g - c.b) / chroma;
+    else if (c.g == value)
+        hue = 2.0 + (c.b - c.r) / chroma;
+    else // if (c.b == value)
+        hue = 4.0 + (c.r - c.g) / chroma;
+
+    hue *= 1.0/6.0;
+    if (hue < 0.0)
+        hue += 1.0;
+    return vec3(hue, saturation, value);
+}
+
+vec3 hsvToRgb(vec3 c) {
+    if (c.s == 0.0) {
+        return vec3(c.z);
+    }
+
+    float hue = c.x * 6.0;
+    int sector = int(hue);
+    float residualHue = hue - float(sector);
+
+    vec3 pqt = c.z * vec3(1.0 - c.y, 1.0 - c.y * residualHue, 1.0 - c.y * (1.0 - residualHue));
+    if (sector == 0)
+        return vec3(c.z, pqt.z, pqt.x);
+    if (sector == 1)
+        return vec3(pqt.y, c.z, pqt.x);
+    if (sector == 2)
+        return vec3(pqt.x, c.z, pqt.z);
+    if (sector == 3)
+        return vec3(pqt.x, pqt.y, c.z);
+    if (sector == 4)
+        return vec3(pqt.z, pqt.x, c.z);
+    return vec3(c.z, pqt.x, pqt.y);
+}
+
+vec4 Blur(float radius, vec2 direction) {
+    // TODO(gw): Support blur in WR2!
+    return vec4(1, 1, 1, 1);
+}
+
+vec4 Contrast(vec4 Cs, float amount) {
+    return vec4(Cs.rgb * amount - 0.5 * amount + 0.5, 1.0);
+}
+
+vec4 Grayscale(vec4 Cs, float amount) {
+    float ia = 1.0 - amount;
+    return mat4(vec4(0.2126 + 0.7874 * ia, 0.2126 - 0.2126 * ia, 0.2126 - 0.2126 * ia, 0.0),
+                vec4(0.7152 - 0.7152 * ia, 0.7152 + 0.2848 * ia, 0.7152 - 0.7152 * ia, 0.0),
+                vec4(0.0722 - 0.0722 * ia, 0.0722 - 0.0722 * ia, 0.0722 + 0.9278 * ia, 0.0),
+                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
+}
+
+vec4 HueRotate(vec4 Cs, float amount) {
+    vec3 CsHsv = rgbToHsv(Cs.rgb);
+    CsHsv.x = mod(CsHsv.x + amount / 6.283185307179586, 1.0);
+    return vec4(hsvToRgb(CsHsv), Cs.a);
+}
+
+vec4 Invert(vec4 Cs, float amount) {
+    return mix(Cs, vec4(1.0, 1.0, 1.0, Cs.a) - vec4(Cs.rgb, 0.0), amount);
+}
+
+vec4 Saturate(vec4 Cs, float amount) {
+    return vec4(hsvToRgb(min(vec3(1.0, amount, 1.0) * rgbToHsv(Cs.rgb), vec3(1.0))), Cs.a);
+}
+
+vec4 Sepia(vec4 Cs, float amount) {
+    float ia = 1.0 - amount;
+    return mat4(vec4(0.393 + 0.607 * ia, 0.349 - 0.349 * ia, 0.272 - 0.272 * ia, 0.0),
+                vec4(0.769 - 0.769 * ia, 0.686 + 0.314 * ia, 0.534 - 0.534 * ia, 0.0),
+                vec4(0.189 - 0.189 * ia, 0.168 - 0.168 * ia, 0.131 + 0.869 * ia, 0.0),
+                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
+}
+
+vec4 Brightness(vec4 Cs, float amount) {
+    return vec4(Cs.rgb * amount, Cs.a);
+}
+
+vec4 Opacity(vec4 Cs, float amount) {
+    return vec4(Cs.rgb, Cs.a * amount);
+}
+
 void main(void) {
-    vec4 color = texture(sCache, vUv);
-    oFragColor = vec4(color.rgb * vBrightnessOpacity.x, color.a * vBrightnessOpacity.y);
+    vec4 Cs = texture(sCache, vUv);
+
+    if (Cs.a == 0.0) {
+        discard;
+    }
+
+    switch (vOp) {
+        case 0:
+            // Gaussian blur is specially handled:
+            oFragColor = Cs;// Blur(vAmount, vec2(0,0));
+            break;
+        case 1:
+            oFragColor = Contrast(Cs, vAmount);
+            break;
+        case 2:
+            oFragColor = Grayscale(Cs, vAmount);
+            break;
+        case 3:
+            oFragColor = HueRotate(Cs, vAmount);
+            break;
+        case 4:
+            oFragColor = Invert(Cs, vAmount);
+            break;
+        case 5:
+            oFragColor = Saturate(Cs, vAmount);
+            break;
+        case 6:
+            oFragColor = Sepia(Cs, vAmount);
+            break;
+        case 7:
+            oFragColor = Brightness(Cs, vAmount);
+            break;
+        case 8:
+            oFragColor = Opacity(Cs, vAmount);
+            break;
+    }
 }

--- a/webrender/res/ps_blend.glsl
+++ b/webrender/res/ps_blend.glsl
@@ -3,4 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec2 vUv;
-varying vec2 vBrightnessOpacity;
+flat varying float vAmount;
+flat varying int vOp;

--- a/webrender/res/ps_blend.vs.glsl
+++ b/webrender/res/ps_blend.vs.glsl
@@ -5,17 +5,23 @@
 
 void main(void) {
     Blend blend = fetch_blend(gl_InstanceID);
-    Tile src = fetch_tile(blend.src_id_target_id_opacity.x);
-    Tile dest = fetch_tile(blend.src_id_target_id_opacity.y);
+    Tile src = fetch_tile(blend.src_id_target_id_op_amount.x);
+    Tile dest = fetch_tile(blend.src_id_target_id_op_amount.y);
 
-    vec2 local_pos = mix(vec2(dest.target_rect.xy),
-                         vec2(dest.target_rect.xy + dest.target_rect.zw),
+    vec2 dest_origin = dest.screen_origin_task_origin.zw -
+                       dest.screen_origin_task_origin.xy +
+                       src.screen_origin_task_origin.xy;
+
+    vec2 local_pos = mix(dest_origin,
+                         dest_origin + src.size.xy,
                          aPosition.xy);
 
-    vec2 st0 = vec2(src.target_rect.xy) / 2048.0;
-    vec2 st1 = vec2(src.target_rect.xy + src.target_rect.zw) / 2048.0;
+    vec2 st0 = vec2(src.screen_origin_task_origin.zw) / 2048.0;
+    vec2 st1 = vec2(src.screen_origin_task_origin.zw + src.size.xy) / 2048.0;
     vUv = mix(st0, st1, aPosition.xy);
-    vBrightnessOpacity = blend.src_id_target_id_opacity.zw / 65535.0;
+
+    vOp = blend.src_id_target_id_op_amount.z;
+    vAmount = blend.src_id_target_id_op_amount.w / 65535.0;
 
     gl_Position = uTransform * vec4(local_pos, 0, 1);
 }

--- a/webrender/res/ps_composite.fs.glsl
+++ b/webrender/res/ps_composite.fs.glsl
@@ -4,100 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define COMPOSITE_KIND_MIX_BLEND_MODE   0
-#define COMPOSITE_KIND_FILTER           1
-
 uniform sampler2D sCache;
-
-vec3 rgbToHsv(vec3 c) {
-    float value = max(max(c.r, c.g), c.b);
-
-    float chroma = value - min(min(c.r, c.g), c.b);
-    if (chroma == 0.0) {
-        return vec3(0.0);
-    }
-    float saturation = chroma / value;
-
-    float hue;
-    if (c.r == value)
-        hue = (c.g - c.b) / chroma;
-    else if (c.g == value)
-        hue = 2.0 + (c.b - c.r) / chroma;
-    else // if (c.b == value)
-        hue = 4.0 + (c.r - c.g) / chroma;
-
-    hue *= 1.0/6.0;
-    if (hue < 0.0)
-        hue += 1.0;
-    return vec3(hue, saturation, value);
-}
-
-vec3 hsvToRgb(vec3 c) {
-    if (c.s == 0.0) {
-        return vec3(c.z);
-    }
-
-    float hue = c.x * 6.0;
-    int sector = int(hue);
-    float residualHue = hue - float(sector);
-
-    vec3 pqt = c.z * vec3(1.0 - c.y, 1.0 - c.y * residualHue, 1.0 - c.y * (1.0 - residualHue));
-    if (sector == 0)
-        return vec3(c.z, pqt.z, pqt.x);
-    if (sector == 1)
-        return vec3(pqt.y, c.z, pqt.x);
-    if (sector == 2)
-        return vec3(pqt.x, c.z, pqt.z);
-    if (sector == 3)
-        return vec3(pqt.x, pqt.y, c.z);
-    if (sector == 4)
-        return vec3(pqt.z, pqt.x, c.z);
-    return vec3(c.z, pqt.x, pqt.y);
-}
 
 float gauss(float x, float sigma) {
     if (sigma == 0.0)
         return 1.0;
     return (1.0 / sqrt(6.283185307179586 * sigma * sigma)) * exp(-(x * x) / (2.0 * sigma * sigma));
-}
-
-vec4 Blur(float radius, vec2 direction) {
-    // TODO(gw): Support blur in WR2!
-    return vec4(1, 1, 1, 1);
-}
-
-vec4 Contrast(vec4 Cs, float amount) {
-    return vec4(Cs.rgb * amount - 0.5 * amount + 0.5, 1.0);
-}
-
-vec4 Grayscale(vec4 Cs, float amount) {
-    float ia = 1.0 - amount;
-    return mat4(vec4(0.2126 + 0.7874 * ia, 0.2126 - 0.2126 * ia, 0.2126 - 0.2126 * ia, 0.0),
-                vec4(0.7152 - 0.7152 * ia, 0.7152 + 0.2848 * ia, 0.7152 - 0.7152 * ia, 0.0),
-                vec4(0.0722 - 0.0722 * ia, 0.0722 - 0.0722 * ia, 0.0722 + 0.9278 * ia, 0.0),
-                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
-}
-
-vec4 HueRotate(vec4 Cs, float amount) {
-    vec3 CsHsv = rgbToHsv(Cs.rgb);
-    CsHsv.x = mod(CsHsv.x + amount / 6.283185307179586, 1.0);
-    return vec4(hsvToRgb(CsHsv), Cs.a);
-}
-
-vec4 Invert(vec4 Cs, float amount) {
-    return mix(Cs, vec4(1.0, 1.0, 1.0, Cs.a) - vec4(Cs.rgb, 0.0), amount);
-}
-
-vec4 Saturate(vec4 Cs, float amount) {
-    return vec4(hsvToRgb(min(vec3(1.0, amount, 1.0) * rgbToHsv(Cs.rgb), vec3(1.0))), Cs.a);
-}
-
-vec4 Sepia(vec4 Cs, float amount) {
-    float ia = 1.0 - amount;
-    return mat4(vec4(0.393 + 0.607 * ia, 0.349 - 0.349 * ia, 0.272 - 0.272 * ia, 0.0),
-                vec4(0.769 - 0.769 * ia, 0.686 + 0.314 * ia, 0.534 - 0.534 * ia, 0.0),
-                vec4(0.189 - 0.189 * ia, 0.168 - 0.168 * ia, 0.131 + 0.869 * ia, 0.0),
-                vec4(0.0, 0.0, 0.0, 1.0)) * Cs;
 }
 
 vec3 Multiply(vec3 Cb, vec3 Cs) {
@@ -242,77 +154,63 @@ vec3 Luminosity(vec3 Cb, vec3 Cs) {
 }
 
 void main(void) {
-    vec4 Cs = texture(sCache, vUv1);
     vec4 Cb = texture(sCache, vUv0);
 
-    // TODO(gw): This is a hack that's (probably) wrong.
-    //           Instead of drawing the tile rect, draw the
-    //           stacking context bounds instead?
-    if (Cs.a == 0.0) {
+    if (vUv1.x < vUv1Rect.x ||
+        vUv1.x > vUv1Rect.z ||
+        vUv1.y < vUv1Rect.y ||
+        vUv1.y > vUv1Rect.w) {
         oFragColor = Cb;
         return;
     }
 
-    int kind = vInfo.x;
-    int op = vInfo.y;
-    float amount = vAmount;
+    vec4 Cs = texture(sCache, vUv1);
 
     // Return yellow if none of the branches match (shouldn't happen).
     vec4 result = vec4(1.0, 1.0, 0.0, 1.0);
 
-    switch (kind) {
-        case COMPOSITE_KIND_MIX_BLEND_MODE:
-            if (op == 2) {
-                result.rgb = Screen(Cb.rgb, Cs.rgb);
-            } else if (op == 3) {
-                result.rgb = HardLight(Cs.rgb, Cb.rgb);        // Overlay is inverse of Hardlight
-            } else if (op == 6) {
-                result.r = ColorDodge(Cb.r, Cs.r);
-                result.g = ColorDodge(Cb.g, Cs.g);
-                result.b = ColorDodge(Cb.b, Cs.b);
-            } else if (op == 7) {
-                result.r = ColorBurn(Cb.r, Cs.r);
-                result.g = ColorBurn(Cb.g, Cs.g);
-                result.b = ColorBurn(Cb.b, Cs.b);
-            } else if (op == 8) {
-                result.rgb = HardLight(Cb.rgb, Cs.rgb);
-            } else if (op == 9) {
-                result.r = SoftLight(Cb.r, Cs.r);
-                result.g = SoftLight(Cb.g, Cs.g);
-                result.b = SoftLight(Cb.b, Cs.b);
-            } else if (op == 10) {
-                result.rgb = Difference(Cb.rgb, Cs.rgb);
-            } else if (op == 11) {
-                result.rgb = Exclusion(Cb.rgb, Cs.rgb);
-            } else if (op == 12) {
-                result.rgb = Hue(Cb.rgb, Cs.rgb);
-            } else if (op == 13) {
-                result.rgb = Saturation(Cb.rgb, Cs.rgb);
-            } else if (op == 14) {
-                result.rgb = Color(Cb.rgb, Cs.rgb);
-            } else if (op == 15) {
-                result.rgb = Luminosity(Cb.rgb, Cs.rgb);
-            }
+    switch (vOp) {
+        case 2:
+            result.rgb = Screen(Cb.rgb, Cs.rgb);
             break;
-        case COMPOSITE_KIND_FILTER:
-            if (op == 0) {
-                // Gaussian blur is specially handled:
-                result = Cs;// Blur(amount, vec2(0,0));
-            } else {
-                if (op == 1) {
-                    result = Contrast(Cs, amount);
-                } else if (op == 2) {
-                    result = Grayscale(Cs, amount);
-                } else if (op == 3) {
-                    result = HueRotate(Cs, amount);
-                } else if (op == 4) {
-                    result = Invert(Cs, amount);
-                } else if (op == 5) {
-                    result = Saturate(Cs, amount);
-                } else if (op == 6) {
-                    result = Sepia(Cs, amount);
-                }
-            }
+        case 3:
+            result.rgb = HardLight(Cs.rgb, Cb.rgb);        // Overlay is inverse of Hardlight
+            break;
+        case 6:
+            result.r = ColorDodge(Cb.r, Cs.r);
+            result.g = ColorDodge(Cb.g, Cs.g);
+            result.b = ColorDodge(Cb.b, Cs.b);
+            break;
+        case 7:
+            result.r = ColorBurn(Cb.r, Cs.r);
+            result.g = ColorBurn(Cb.g, Cs.g);
+            result.b = ColorBurn(Cb.b, Cs.b);
+            break;
+        case 8:
+            result.rgb = HardLight(Cb.rgb, Cs.rgb);
+            break;
+        case 9:
+            result.r = SoftLight(Cb.r, Cs.r);
+            result.g = SoftLight(Cb.g, Cs.g);
+            result.b = SoftLight(Cb.b, Cs.b);
+            break;
+        case 10:
+            result.rgb = Difference(Cb.rgb, Cs.rgb);
+            break;
+        case 11:
+            result.rgb = Exclusion(Cb.rgb, Cs.rgb);
+            break;
+        case 12:
+            result.rgb = Hue(Cb.rgb, Cs.rgb);
+            break;
+        case 13:
+            result.rgb = Saturation(Cb.rgb, Cs.rgb);
+            break;
+        case 14:
+            result.rgb = Color(Cb.rgb, Cs.rgb);
+            break;
+        case 15:
+            result.rgb = Luminosity(Cb.rgb, Cs.rgb);
             break;
     }
 

--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -4,5 +4,5 @@
 
 varying vec2 vUv0;
 varying vec2 vUv1;
-flat varying ivec2 vInfo;
-flat varying float vAmount;
+flat varying vec4 vUv1Rect;
+flat varying int vOp;

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -5,24 +5,28 @@
 
 void main(void) {
     Composite composite = fetch_composite(gl_InstanceID);
-    Tile src0 = fetch_tile(composite.src0_src1_target_id.x);
-    Tile src1 = fetch_tile(composite.src0_src1_target_id.y);
-    Tile dest = fetch_tile(composite.src0_src1_target_id.z);
+    Tile src0 = fetch_tile(composite.src0_src1_target_id_op.x);
+    Tile src1 = fetch_tile(composite.src0_src1_target_id_op.y);
+    Tile dest = fetch_tile(composite.src0_src1_target_id_op.z);
 
-    vec2 local_pos = mix(vec2(dest.target_rect.xy),
-                         vec2(dest.target_rect.xy + dest.target_rect.zw),
+    vec2 local_pos = mix(dest.screen_origin_task_origin.zw,
+                         dest.screen_origin_task_origin.zw + dest.size.xy,
                          aPosition.xy);
 
-    vec2 st0 = vec2(src0.target_rect.xy) / 2048.0;
-    vec2 st1 = vec2(src0.target_rect.xy + src0.target_rect.zw) / 2048.0;
+    vec2 st0 = vec2(src0.screen_origin_task_origin.zw) / 2048.0;
+    vec2 st1 = vec2(src0.screen_origin_task_origin.zw + src0.size.xy) / 2048.0;
     vUv0 = mix(st0, st1, aPosition.xy);
 
-    st0 = vec2(src1.target_rect.xy) / 2048.0;
-    st1 = vec2(src1.target_rect.xy + src1.target_rect.zw) / 2048.0;
-    vUv1 = mix(st0, st1, aPosition.xy);
+    st0 = vec2(src1.screen_origin_task_origin.zw) / 2048.0;
+    st1 = vec2(src1.screen_origin_task_origin.zw + src1.size.xy) / 2048.0;
+    vec2 local_virtual_pos = mix(dest.screen_origin_task_origin.xy,
+                                 dest.screen_origin_task_origin.xy + dest.size.xy,
+                                 aPosition.xy);
+    vec2 f = (local_virtual_pos - src1.screen_origin_task_origin.xy) / src1.size.xy;
+    vUv1 = mix(st0, st1, f);
+    vUv1Rect = vec4(st0, st1);
 
-    vInfo = composite.info_amount.xy;
-    vAmount = composite.info_amount.z / 65535.0;
+    vOp = composite.src0_src1_target_id_op.w;
 
     gl_Position = uTransform * vec4(local_pos, 0, 1);
 }


### PR DESCRIPTION
* Switch all filter effects to run through the single source blend shader, instead of composite shader.
* Each render target uses a single alpha batcher now that the batching algorithm is reasonably efficient.
* Change tile size to 256x256. This seems to be a better tradeoff for GPU vs CPU time on all sites I tried.
* Switch blend targets to only allocate the used rect, rather than the entire tile size rect.

Closes #423.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/461)
<!-- Reviewable:end -->
