### PR TITLE
Convert webrender from euclid's old to new unit system.

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -7,7 +7,7 @@ use device::{Device, ProgramId, VAOId, TextureId, VertexFormat};
 use device::{TextureFilter, VertexUsageHint};
 use euclid::{Matrix4D, Point2D, Size2D, Rect};
 use gleam::gl;
-use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePixel, TextureSampler};
+use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, TextureSampler};
 use internal_types::{DebugFontVertex, DebugColorVertex, RenderTargetMode, PackedColor};
 use std::f32;
 use webrender_traits::{ColorF, ImageFormat};
@@ -147,16 +147,16 @@ impl DebugRenderer {
 
     #[allow(dead_code)]
     pub fn add_line(&mut self,
-                    x0: DevicePixel,
-                    y0: DevicePixel,
+                    x0: i32,
+                    y0: i32,
                     color0: &ColorF,
-                    x1: DevicePixel,
-                    y1: DevicePixel,
+                    x1: i32,
+                    y1: i32,
                     color1: &ColorF) {
         let color0 = PackedColor::from_color(color0);
         let color1 = PackedColor::from_color(color1);
-        self.line_vertices.push(DebugColorVertex::new(x0.0 as f32, y0.0 as f32, color0));
-        self.line_vertices.push(DebugColorVertex::new(x1.0 as f32, y1.0 as f32, color1));
+        self.line_vertices.push(DebugColorVertex::new(x0 as f32, y0 as f32, color0));
+        self.line_vertices.push(DebugColorVertex::new(x1 as f32, y1 as f32, color1));
     }
 
     pub fn render(&mut self,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -4,10 +4,9 @@
 
 use app_units::Au;
 use device::{TextureId, TextureFilter};
-use euclid::{Point2D, Rect, Size2D};
+use euclid::{Point2D, Rect, Size2D, TypedRect, TypedPoint2D, TypedSize2D, Length, UnknownUnit};
 use fnv::FnvHasher;
 use freelist::{FreeListItem, FreeListItemId};
-use num_traits::Zero;
 use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle};
 use offscreen_gl_context::{GLContext, NativeGLContextMethods, GLContextDispatcher};
 use offscreen_gl_context::{OSMesaContext, OSMesaContextHandle};
@@ -17,7 +16,6 @@ use std::collections::{HashMap, HashSet};
 use std::f32;
 use std::hash::BuildHasherDefault;
 use std::i32;
-use std::ops::{Add, Sub};
 use std::path::PathBuf;
 use std::sync::Arc;
 use texture_cache::BorderType;
@@ -130,51 +128,16 @@ impl GLContextWrapper {
     }
 }
 
+pub type DeviceRect = TypedRect<i32, DevicePixel>;
+pub type DevicePoint = TypedPoint2D<i32, DevicePixel>;
+pub type DeviceSize = TypedSize2D<i32, DevicePixel>;
+pub type DeviceLength = Length<i32, DevicePixel>;
+
 #[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct DevicePixel(pub i32);
+pub struct DevicePixel;
 
-impl DevicePixel {
-    pub fn new(value: f32, device_pixel_ratio: f32) -> DevicePixel {
-        DevicePixel((value * device_pixel_ratio).round() as i32)
-    }
-
-    pub fn from_u32(value: u32) -> DevicePixel {
-        DevicePixel(value as i32)
-    }
-
-    // TODO(gw): Remove eventually...
-    pub fn as_f32(&self) -> f32 {
-        let DevicePixel(value) = *self;
-        value as f32
-    }
-}
-
-impl Add for DevicePixel {
-    type Output = DevicePixel;
-
-    #[inline]
-    fn add(self, other: DevicePixel) -> DevicePixel {
-        DevicePixel(self.0 + other.0)
-    }
-}
-
-impl Sub for DevicePixel {
-    type Output = DevicePixel;
-
-    fn sub(self, other: DevicePixel) -> DevicePixel {
-        DevicePixel(self.0 - other.0)
-    }
-}
-
-impl Zero for DevicePixel {
-    fn zero() -> DevicePixel {
-        DevicePixel(0)
-    }
-
-    fn is_zero(&self) -> bool {
-        let DevicePixel(value) = *self;
-        value == 0
-    }
+pub fn device_pixel(value: f32, device_pixel_ratio: f32) -> DeviceLength {
+    DeviceLength::new((value * device_pixel_ratio).round() as i32)
 }
 
 const UV_FLOAT_TO_FIXED: f32 = 65535.0;
@@ -473,11 +436,11 @@ pub struct RectColors {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct RectUv<T> {
-    pub top_left: Point2D<T>,
-    pub top_right: Point2D<T>,
-    pub bottom_left: Point2D<T>,
-    pub bottom_right: Point2D<T>,
+pub struct RectUv<T, U = UnknownUnit> {
+    pub top_left: TypedPoint2D<T, U>,
+    pub top_right: TypedPoint2D<T, U>,
+    pub bottom_left: TypedPoint2D<T, U>,
+    pub bottom_right: TypedPoint2D<T, U>,
 }
 
 #[derive(Clone, Debug)]

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -7,7 +7,7 @@ use device::TextureId;
 use euclid::{Point2D, Matrix4D, Rect, Size2D};
 use frame::FrameId;
 use gpu_store::{GpuStore, GpuStoreAddress};
-use internal_types::{DevicePixel, Glyph};
+use internal_types::{DeviceRect, Glyph};
 use renderer::BLUR_INFLATION_FACTOR;
 use resource_cache::ResourceCache;
 use resource_list::ResourceList;
@@ -314,7 +314,7 @@ pub enum PrimitiveContainer {
 
 pub struct PrimitiveStore {
     // CPU side information only
-    pub cpu_bounding_rects: Vec<Option<Rect<DevicePixel>>>,
+    pub cpu_bounding_rects: Vec<Option<DeviceRect>>,
     pub cpu_text_runs: Vec<TextRunPrimitiveCpu>,
     pub cpu_images: Vec<ImagePrimitiveCpu>,
     pub cpu_gradients: Vec<GradientPrimitiveCpu>,
@@ -499,7 +499,7 @@ impl PrimitiveStore {
         PrimitiveIndex(prim_index)
     }
 
-    pub fn get_bounding_rect(&self, index: PrimitiveIndex) -> &Option<Rect<DevicePixel>> {
+    pub fn get_bounding_rect(&self, index: PrimitiveIndex) -> &Option<DeviceRect> {
         &self.cpu_bounding_rects[index.0]
     }
 
@@ -578,7 +578,7 @@ impl PrimitiveStore {
 
     pub fn build_bounding_rect(&mut self,
                                prim_index: PrimitiveIndex,
-                               screen_rect: &Rect<DevicePixel>,
+                               screen_rect: &DeviceRect,
                                layer_transform: &Matrix4D<f32>,
                                layer_combined_local_clip_rect: &Rect<f32>,
                                device_pixel_ratio: f32) -> bool {
@@ -660,10 +660,10 @@ impl PrimitiveStore {
 
                     dest_glyphs[actual_glyph_count] = GpuBlock32::from(GlyphPrimitive {
                         offset: local_glyph_rect.origin,
-                        uv0: Point2D::new(image_info.pixel_rect.top_left.x.0 as f32,
-                                          image_info.pixel_rect.top_left.y.0 as f32),
-                        uv1: Point2D::new(image_info.pixel_rect.bottom_right.x.0 as f32,
-                                          image_info.pixel_rect.bottom_right.y.0 as f32),
+                        uv0: Point2D::new(image_info.pixel_rect.top_left.x as f32,
+                                          image_info.pixel_rect.top_left.y as f32),
+                        uv1: Point2D::new(image_info.pixel_rect.bottom_right.x as f32,
+                                          image_info.pixel_rect.bottom_right.y as f32),
                         padding: Point2D::zero(),
                     });
 
@@ -898,10 +898,10 @@ impl ImagePrimitiveCpu {
                 let info = resource_cache.get_image(image_key, image_rendering, frame_id);
                 ImageInfo {
                     color_texture_id: info.texture_id,
-                    uv0: Point2D::new(info.pixel_rect.top_left.x.0 as f32,
-                                      info.pixel_rect.top_left.y.0 as f32),
-                    uv1: Point2D::new(info.pixel_rect.bottom_right.x.0 as f32,
-                                      info.pixel_rect.bottom_right.y.0 as f32),
+                    uv0: Point2D::new(info.pixel_rect.top_left.x as f32,
+                                      info.pixel_rect.top_left.y as f32),
+                    uv1: Point2D::new(info.pixel_rect.bottom_right.x as f32,
+                                      info.pixel_rect.bottom_right.y as f32),
                     stretch_size: Some(stretch_size),
                     uv_kind: TextureCoordKind::Pixel,
                     tile_spacing: tile_spacing,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -18,7 +18,7 @@ use fnv::FnvHasher;
 use gleam::gl;
 use internal_types::{RendererFrame, ResultMsg, TextureUpdateOp};
 use internal_types::{TextureUpdateDetails, TextureUpdateList, PackedVertex, RenderTargetMode};
-use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePixel};
+use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, DevicePoint};
 use internal_types::{PackedVertexForTextureCacheUpdate};
 use internal_types::{AxisDirection, TextureSampler, GLContextHandleWrapper};
 use ipc_channel::ipc;
@@ -1257,8 +1257,8 @@ impl Renderer {
     }
 
     fn add_debug_rect(&mut self,
-                      p0: Point2D<DevicePixel>,
-                      p1: Point2D<DevicePixel>,
+                      p0: DevicePoint,
+                      p1: DevicePoint,
                       label: &str,
                       c: &ColorF) {
         let tile_x0 = p0.x;
@@ -1291,8 +1291,8 @@ impl Renderer {
                             tile_y1,
                             c);
         if label.len() > 0 {
-            self.debug.add_text((tile_x0.0 as f32 + tile_x1.0 as f32) * 0.5,
-                                (tile_y0.0 as f32 + tile_y1.0 as f32) * 0.5,
+            self.debug.add_text((tile_x0 as f32 + tile_x1 as f32) * 0.5,
+                                (tile_y0 as f32 + tile_y1 as f32) * 0.5,
                                 label,
                                 c);
         }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -10,7 +10,7 @@ use frame::FrameId;
 use freelist::{FreeList, FreeListItem, FreeListItemId};
 use internal_types::{TextureUpdate, TextureUpdateOp, TextureUpdateDetails};
 use internal_types::{RenderTargetMode, TextureImage, TextureUpdateList};
-use internal_types::{RectUv, DevicePixel};
+use internal_types::{RectUv, DevicePixel, DevicePoint};
 use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -444,7 +444,7 @@ pub struct TextureCacheItem {
     pub user_data: TextureCacheItemUserData,
 
     // The texture coordinates for this item
-    pub pixel_rect: RectUv<DevicePixel>,
+    pub pixel_rect: RectUv<i32, DevicePixel>,
 
     // The size of the entire texture (not just the allocated rectangle)
     pub texture_size: Size2D<u32>,
@@ -498,14 +498,14 @@ impl TextureCacheItem {
             texture_id: texture_id,
             texture_size: *texture_size,
             pixel_rect: RectUv {
-                top_left: Point2D::new(DevicePixel::from_u32(requested_rect.origin.x),
-                                       DevicePixel::from_u32(requested_rect.origin.y)),
-                top_right: Point2D::new(DevicePixel::from_u32(requested_rect.origin.x + requested_rect.size.width),
-                                        DevicePixel::from_u32(requested_rect.origin.y)),
-                bottom_left: Point2D::new(DevicePixel::from_u32(requested_rect.origin.x),
-                                          DevicePixel::from_u32(requested_rect.origin.y + requested_rect.size.height)),
-                bottom_right: Point2D::new(DevicePixel::from_u32(requested_rect.origin.x + requested_rect.size.width),
-                                           DevicePixel::from_u32(requested_rect.origin.y + requested_rect.size.height))
+                top_left: DevicePoint::new(requested_rect.origin.x as i32,
+                                           requested_rect.origin.y as i32),
+                top_right: DevicePoint::new((requested_rect.origin.x + requested_rect.size.width) as i32,
+                                            requested_rect.origin.y as i32),
+                bottom_left: DevicePoint::new(requested_rect.origin.x as i32,
+                                              (requested_rect.origin.y + requested_rect.size.height) as i32),
+                bottom_right: DevicePoint::new((requested_rect.origin.x + requested_rect.size.width) as i32,
+                                               (requested_rect.origin.y + requested_rect.size.height) as i32)
             },
             user_data: TextureCacheItemUserData {
                 x0: user_x0,
@@ -534,14 +534,14 @@ impl TextureCacheItem {
     pub fn uv_rect(&self) -> RectUv<f32> {
         let (width, height) = (self.texture_size.width as f32, self.texture_size.height as f32);
         RectUv {
-            top_left: Point2D::new(self.pixel_rect.top_left.x.as_f32() / width,
-                                   self.pixel_rect.top_left.y.as_f32() / height),
-            top_right: Point2D::new(self.pixel_rect.top_right.x.as_f32() / width,
-                                    self.pixel_rect.top_right.y.as_f32() / height),
-            bottom_left: Point2D::new(self.pixel_rect.bottom_left.x.as_f32() / width,
-                                      self.pixel_rect.bottom_left.y.as_f32() / height),
-            bottom_right: Point2D::new(self.pixel_rect.bottom_right.x.as_f32() / width,
-                                       self.pixel_rect.bottom_right.y.as_f32() / height),
+            top_left: Point2D::new(self.pixel_rect.top_left.x as f32 / width,
+                                   self.pixel_rect.top_left.y as f32 / height),
+            top_right: Point2D::new(self.pixel_rect.top_right.x as f32 / width,
+                                    self.pixel_rect.top_right.y as f32 / height),
+            bottom_left: Point2D::new(self.pixel_rect.bottom_left.x as f32 / width,
+                                      self.pixel_rect.bottom_left.y as f32 / height),
+            bottom_right: Point2D::new(self.pixel_rect.bottom_right.x as f32 / width,
+                                       self.pixel_rect.bottom_right.y as f32 / height),
         }
     }
 }
@@ -632,10 +632,10 @@ impl TextureCache {
                 y0: 0,
             },
             pixel_rect: RectUv {
-                top_left: Point2D::zero(),
-                top_right: Point2D::zero(),
-                bottom_left: Point2D::zero(),
-                bottom_right: Point2D::zero(),
+                top_left: DevicePoint::zero(),
+                top_right: DevicePoint::zero(),
+                bottom_left: DevicePoint::zero(),
+                bottom_right: DevicePoint::zero(),
             },
             allocated_rect: Rect::zero(),
             requested_rect: Rect::zero(),


### PR DESCRIPTION
This PR introduces some type aliases such as ```DeviceRect = TypedRect<i32, DevicePixel>``` replacing ```Rect<DevicePixel(i32)>``` (euclid's built-in way to deal with units), and uses them in webrender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/463)
<!-- Reviewable:end -->
