### PR TITLE
Add runtime profiler toggle and expose DebugRenderer

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1635,6 +1635,14 @@ impl Renderer {
             }
         }
     }
+
+    pub fn debug_renderer<'a>(&'a mut self) -> &'a mut DebugRenderer {
+        &mut self.debug
+    }
+
+    pub fn set_profiler_enabled(&mut self, enabled: bool) {
+        self.enable_profiler = enabled;
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This is a bit of a hack, so let me know if you'd prefer me to not do this, or do this a different way.  I'm using this in https://github.com/vvuk/wrench/commit/0747956617902b0ea5c1cb14463c07cd5004bb7c to provide on-screen help and toggle the profiler at runtime.    Toggling the profiler seems to work well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/472)
<!-- Reviewable:end -->
