### PR TITLE
Fix Android build

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -25,7 +25,7 @@ const GL_FORMAT_A: gl::GLuint = gl::RED;
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 const GL_FORMAT_A: gl::GLuint = gl::ALPHA;
 
-#[cfg(any(target_os = "windows", unix))]
+#[cfg(any(target_os = "windows", all(unix, not(target_os = "android"))))]
 const GL_FORMAT_BGRA: gl::GLuint = gl::BGRA;
 
 #[cfg(target_os = "android")]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -676,7 +676,7 @@ impl Renderer {
     fn enable_msaa(&self, _: bool) {
     }
 
-    #[cfg(any(target_os = "windows", unix))]
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "android"))))]
     fn enable_msaa(&self, enable_msaa: bool) {
         if self.enable_msaa {
             if enable_msaa {


### PR DESCRIPTION
#466 (c0b0ac08f4c829a979814cb1733262288a30e844) breaks the Android build, because both `unix` and `target_os = "android"` becomes true, so you get duplicate definition errors.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/473)
<!-- Reviewable:end -->
