### PR TITLE
Fixed a number of smoothstep() UB cases in the shaders

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -578,7 +578,7 @@ Composite fetch_composite(int index) {
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-float squared_distance_from_rect(vec2 p, vec2 origin, vec2 size) {
+float distance_from_rect(vec2 p, vec2 origin, vec2 size) {
     vec2 clamped = clamp(p, origin, origin + size);
     return distance(clamped, p);
 }
@@ -587,10 +587,10 @@ vec2 init_transform_fs(vec3 local_pos, vec4 local_rect, out float fragment_alpha
     fragment_alpha = 1.0;
     vec2 pos = local_pos.xy / local_pos.z;
 
-    float squared_distance = squared_distance_from_rect(pos, local_rect.xy, local_rect.zw);
-    if (squared_distance != 0.0) {
+    float border_distance = distance_from_rect(pos, local_rect.xy, local_rect.zw);
+    if (border_distance != 0.0) {
         float delta = length(fwidth(local_pos.xy));
-        fragment_alpha = smoothstep(1.0, 0.0, squared_distance / delta * 2.0);
+        fragment_alpha = 1.0 - smoothstep(0.0, 1.0, border_distance / delta * 2.0);
     }
 
     return pos;

--- a/webrender/res/ps_border.fs.glsl
+++ b/webrender/res/ps_border.fs.glsl
@@ -41,7 +41,7 @@ float alpha_for_solid_border(float distance_from_ref,
   // Apply a more gradual fade out to transparent.
   // distance_from_border -= 0.5;
 
-  return smoothstep(1.0, 0.0, distance_from_border);
+  return 1.0 - smoothstep(0.0, 1.0, distance_from_border);
 }
 
 float alpha_for_solid_border_corner(vec2 local_pos,
@@ -97,7 +97,7 @@ vec4 draw_dotted_edge(vec2 local_pos, vec4 piece_rect, float pixels_per_fragment
   // Move the distance back into pixels.
   distance_from_circle_edge /= pixels_per_fragment;
 
-  float alpha = smoothstep(1.0, 0.0, min(1.0, max(0.0, distance_from_circle_edge)));
+  float alpha = 1.0 - smoothstep(0.0, 1.0, min(1.0, max(0.0, distance_from_circle_edge)));
   return vHorizontalColor * vec4(1.0, 1.0, 1.0, alpha);
 }
 


### PR DESCRIPTION
Fixed the red rectangle in #427, but the text is still broken (to be addressed later).
The change is similar to https://github.com/servo/webrender/pull/444/commits/b89ecd1746c5b4fe8ef84bcfc72b61e563a42bc4, now all `smoothstep` calls should be correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/474)
<!-- Reviewable:end -->
