### PR TITLE
Use texture layers for render target allocations, remove render phases.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -34,6 +34,8 @@
 
 #define MAX_STOPS_PER_ANGLE_GRADIENT 8
 
+uniform sampler2DArray sCache;
+
 #ifdef WR_VERTEX_SHADER
 
 #define VECS_PER_LAYER             13
@@ -121,7 +123,7 @@ Layer fetch_layer(int index) {
 
 struct Tile {
     vec4 screen_origin_task_origin;
-    vec4 size;
+    vec4 size_target_index;
 };
 
 Tile fetch_tile(int index) {
@@ -130,7 +132,7 @@ Tile fetch_tile(int index) {
     ivec2 uv = get_fetch_uv(index, VECS_PER_TILE);
 
     tile.screen_origin_task_origin = texelFetchOffset(sRenderTasks, uv, 0, ivec2(0, 0));
-    tile.size = texelFetchOffset(sRenderTasks, uv, 0, ivec2(1, 0));
+    tile.size_target_index = texelFetchOffset(sRenderTasks, uv, 0, ivec2(1, 0));
 
     return tile;
 }
@@ -425,7 +427,7 @@ VertexInfo write_vertex(vec4 instance_rect,
 
     vec2 clamped_pos = clamp(device_pos,
                              vec2(tile.screen_origin_task_origin.xy),
-                             vec2(tile.screen_origin_task_origin.xy + tile.size.xy));
+                             vec2(tile.screen_origin_task_origin.xy + tile.size_target_index.xy));
 
     vec4 local_clamped_pos = layer.inv_transform * vec4(clamped_pos / uDevicePixelRatio, world_pos.z, 1);
     local_clamped_pos.xyz /= local_clamped_pos.w;
@@ -479,11 +481,11 @@ TransformVertexInfo write_transform_vertex(vec4 instance_rect,
 
     vec2 min_pos_clamped = clamp(min_pos * uDevicePixelRatio,
                                  vec2(tile.screen_origin_task_origin.xy),
-                                 vec2(tile.screen_origin_task_origin.xy + tile.size.xy));
+                                 vec2(tile.screen_origin_task_origin.xy + tile.size_target_index.xy));
 
     vec2 max_pos_clamped = clamp(max_pos * uDevicePixelRatio,
                                  vec2(tile.screen_origin_task_origin.xy),
-                                 vec2(tile.screen_origin_task_origin.xy + tile.size.xy));
+                                 vec2(tile.screen_origin_task_origin.xy + tile.size_target_index.xy));
 
     vec2 clamped_pos = mix(min_pos_clamped,
                            max_pos_clamped,

--- a/webrender/res/ps_blend.fs.glsl
+++ b/webrender/res/ps_blend.fs.glsl
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-uniform sampler2D sCache;
-
 vec3 rgbToHsv(vec3 c) {
     float value = max(max(c.r, c.g), c.b);
 

--- a/webrender/res/ps_blend.glsl
+++ b/webrender/res/ps_blend.glsl
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying vec2 vUv;
+varying vec3 vUv;
 flat varying float vAmount;
 flat varying int vOp;

--- a/webrender/res/ps_blend.vs.glsl
+++ b/webrender/res/ps_blend.vs.glsl
@@ -13,12 +13,13 @@ void main(void) {
                        src.screen_origin_task_origin.xy;
 
     vec2 local_pos = mix(dest_origin,
-                         dest_origin + src.size.xy,
+                         dest_origin + src.size_target_index.xy,
                          aPosition.xy);
 
-    vec2 st0 = vec2(src.screen_origin_task_origin.zw) / 2048.0;
-    vec2 st1 = vec2(src.screen_origin_task_origin.zw + src.size.xy) / 2048.0;
-    vUv = mix(st0, st1, aPosition.xy);
+    vec2 texture_size = vec2(textureSize(sCache, 0));
+    vec2 st0 = src.screen_origin_task_origin.zw / texture_size;
+    vec2 st1 = (src.screen_origin_task_origin.zw + src.size_target_index.xy) / texture_size;
+    vUv = vec3(mix(st0, st1, aPosition.xy), src.size_target_index.z);
 
     vOp = blend.src_id_target_id_op_amount.z;
     vAmount = blend.src_id_target_id_op_amount.w / 65535.0;

--- a/webrender/res/ps_composite.fs.glsl
+++ b/webrender/res/ps_composite.fs.glsl
@@ -4,8 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-uniform sampler2D sCache;
-
 float gauss(float x, float sigma) {
     if (sigma == 0.0)
         return 1.0;

--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying vec2 vUv0;
-varying vec2 vUv1;
+varying vec3 vUv0;
+varying vec3 vUv1;
 flat varying vec4 vUv1Rect;
 flat varying int vOp;

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -10,20 +10,21 @@ void main(void) {
     Tile dest = fetch_tile(composite.src0_src1_target_id_op.z);
 
     vec2 local_pos = mix(dest.screen_origin_task_origin.zw,
-                         dest.screen_origin_task_origin.zw + dest.size.xy,
+                         dest.screen_origin_task_origin.zw + dest.size_target_index.xy,
                          aPosition.xy);
 
-    vec2 st0 = vec2(src0.screen_origin_task_origin.zw) / 2048.0;
-    vec2 st1 = vec2(src0.screen_origin_task_origin.zw + src0.size.xy) / 2048.0;
-    vUv0 = mix(st0, st1, aPosition.xy);
+    vec2 texture_size = vec2(textureSize(sCache, 0));
+    vec2 st0 = src0.screen_origin_task_origin.zw / texture_size;
+    vec2 st1 = (src0.screen_origin_task_origin.zw + src0.size_target_index.xy) / texture_size;
+    vUv0 = vec3(mix(st0, st1, aPosition.xy), src0.size_target_index.z);
 
-    st0 = vec2(src1.screen_origin_task_origin.zw) / 2048.0;
-    st1 = vec2(src1.screen_origin_task_origin.zw + src1.size.xy) / 2048.0;
+    st0 = vec2(src1.screen_origin_task_origin.zw) / texture_size;
+    st1 = vec2(src1.screen_origin_task_origin.zw + src1.size_target_index.xy) / texture_size;
     vec2 local_virtual_pos = mix(dest.screen_origin_task_origin.xy,
-                                 dest.screen_origin_task_origin.xy + dest.size.xy,
+                                 dest.screen_origin_task_origin.xy + dest.size_target_index.xy,
                                  aPosition.xy);
-    vec2 f = (local_virtual_pos - src1.screen_origin_task_origin.xy) / src1.size.xy;
-    vUv1 = mix(st0, st1, f);
+    vec2 f = (local_virtual_pos - src1.screen_origin_task_origin.xy) / src1.size_target_index.xy;
+    vUv1 = vec3(mix(st0, st1, f), src1.size_target_index.z);
     vUv1Rect = vec4(st0, st1);
 
     vOp = composite.src0_src1_target_id_op.w;

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -4,7 +4,7 @@
 
 use debug_font_data;
 use device::{Device, ProgramId, VAOId, TextureId, VertexFormat};
-use device::{TextureFilter, VertexUsageHint};
+use device::{TextureFilter, VertexUsageHint, TextureTarget};
 use euclid::{Matrix4D, Point2D, Size2D, Rect};
 use gleam::gl;
 use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, TextureSampler};
@@ -36,7 +36,7 @@ impl DebugRenderer {
         let line_vao = device.create_vao(VertexFormat::DebugColor, None);
         let tri_vao = device.create_vao(VertexFormat::DebugColor, None);
 
-        let font_texture_id = device.create_texture_ids(1)[0];
+        let font_texture_id = device.create_texture_ids(1, TextureTarget::Default)[0];
         device.init_texture(font_texture_id,
                             debug_font_data::BMP_WIDTH,
                             debug_font_data::BMP_HEIGHT,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -308,7 +308,8 @@ impl DebugColorVertex {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RenderTargetMode {
     None,
-    RenderTarget,
+    SimpleRenderTarget,
+    LayerRenderTarget(i32),      // Number of texture layers
 }
 
 #[derive(Debug)]

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -383,12 +383,12 @@ impl PrimitiveStore {
             let gpu_address = self.gpu_data32.alloc(6);
             self.populate_clip_data(gpu_address, clip);
             let mask = match masked.mask {
-                MaskImageSource::User(image_key) => (Some(image_key), TextureId(0)),
+                MaskImageSource::User(image_key) => (Some(image_key), TextureId::invalid()),
                 MaskImageSource::Renderer(texture_id) => (None, texture_id),
             };
             (Some(gpu_address), mask)
         } else {
-            (None, (None, TextureId(0)))
+            (None, (None, TextureId::invalid()))
         };
 
         let metadata = match container {
@@ -399,7 +399,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: is_opaque,
                     need_to_build_cache: mask_image.is_some(),
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -419,7 +419,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     need_to_build_cache: true,
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -439,7 +439,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     need_to_build_cache: true,
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -459,7 +459,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     need_to_build_cache: mask_image.is_some(),
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -480,7 +480,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     need_to_build_cache: true,
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -501,7 +501,7 @@ impl PrimitiveStore {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     need_to_build_cache: mask_image.is_some(),
-                    color_texture_id: TextureId(0),
+                    color_texture_id: TextureId::invalid(),
                     mask_texture_id: mask_texture_id,
                     mask_image: mask_image,
                     clip_index: clip_index,
@@ -678,7 +678,7 @@ impl PrimitiveStore {
                         Some(image_info) => image_info,
                     };
 
-                    debug_assert!(metadata.color_texture_id == TextureId(0) ||
+                    debug_assert!(metadata.color_texture_id == TextureId::invalid() ||
                                   metadata.color_texture_id == image_info.texture_id);
                     metadata.color_texture_id = image_info.texture_id;
 

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -231,7 +231,7 @@ impl ProfileCounter for AverageTimeProfileCounter {
 pub struct FrameProfileCounters {
     pub total_primitives: IntProfileCounter,
     pub visible_primitives: IntProfileCounter,
-    pub phases: IntProfileCounter,
+    pub passes: IntProfileCounter,
     pub targets: IntProfileCounter,
 }
 
@@ -240,8 +240,8 @@ impl FrameProfileCounters {
         FrameProfileCounters {
             total_primitives: IntProfileCounter::new("Total Primitives"),
             visible_primitives: IntProfileCounter::new("Visible Primitives"),
-            phases: IntProfileCounter::new("Phases"),
-            targets: IntProfileCounter::new("Target switches"),
+            passes: IntProfileCounter::new("Passes"),
+            targets: IntProfileCounter::new("Render Targets"),
         }
     }
 }
@@ -620,7 +620,7 @@ impl Profiler {
         self.draw_counters(&[
             &frame_profile.total_primitives,
             &frame_profile.visible_primitives,
-            &frame_profile.phases,
+            &frame_profile.passes,
             &frame_profile.targets,
         ], debug_renderer, true);
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -288,7 +288,7 @@ impl RenderBackend {
                                         self.webgl_contexts.insert(id, ctx);
 
                                         self.resource_cache
-                                            .add_webgl_texture(id, TextureId(texture_id), real_size);
+                                            .add_webgl_texture(id, TextureId::new(texture_id), real_size);
 
                                         tx.send(Ok((id, limits))).unwrap();
                                     },

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -691,19 +691,19 @@ impl TextureCache {
 
         let (page_list, mode) = match (format, kind) {
             (ImageFormat::A8, TextureCacheItemKind::Standard) => {
-                (&mut self.arena.pages_a8, RenderTargetMode::RenderTarget)
+                (&mut self.arena.pages_a8, RenderTargetMode::SimpleRenderTarget)
             }
             (ImageFormat::A8, TextureCacheItemKind::Alternate) => {
-                (&mut self.arena.alternate_pages_a8, RenderTargetMode::RenderTarget)
+                (&mut self.arena.alternate_pages_a8, RenderTargetMode::SimpleRenderTarget)
             }
             (ImageFormat::RGBA8, TextureCacheItemKind::Standard) => {
-                (&mut self.arena.pages_rgba8, RenderTargetMode::RenderTarget)
+                (&mut self.arena.pages_rgba8, RenderTargetMode::SimpleRenderTarget)
             }
             (ImageFormat::RGBA8, TextureCacheItemKind::Alternate) => {
-                (&mut self.arena.alternate_pages_rgba8, RenderTargetMode::RenderTarget)
+                (&mut self.arena.alternate_pages_rgba8, RenderTargetMode::SimpleRenderTarget)
             }
             (ImageFormat::RGB8, TextureCacheItemKind::Standard) => {
-                (&mut self.arena.pages_rgb8, RenderTargetMode::RenderTarget)
+                (&mut self.arena.pages_rgb8, RenderTargetMode::SimpleRenderTarget)
             }
             (ImageFormat::Invalid, TextureCacheItemKind::Standard) |
             (ImageFormat::RGBAF32, TextureCacheItemKind::Standard) |

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -234,6 +234,9 @@ pub enum PrimitiveFlags {
 }
 
 #[derive(Debug, Copy, Clone)]
+struct RenderTargetIndex(usize);
+
+#[derive(Debug, Copy, Clone)]
 struct RenderTaskIndex(usize);
 
 #[derive(Debug, Copy, Clone)]
@@ -427,19 +430,48 @@ struct RenderTargetContext<'a> {
 }
 
 pub struct RenderTarget {
-    pub is_framebuffer: bool,
-    page_allocator: TexturePage,
-    tasks: Vec<RenderTask>,
     pub alpha_batcher: AlphaBatcher,
+    page_allocator: TexturePage,
 }
 
 impl RenderTarget {
-    fn new(is_framebuffer: bool) -> RenderTarget {
+    fn new() -> RenderTarget {
         RenderTarget {
-            is_framebuffer: is_framebuffer,
-            page_allocator: TexturePage::new(TextureId(0), RENDERABLE_CACHE_SIZE as u32),
-            tasks: Vec::new(),
             alpha_batcher: AlphaBatcher::new(),
+            page_allocator: TexturePage::new(TextureId::invalid(), RENDERABLE_CACHE_SIZE as u32),
+        }
+    }
+
+    fn build(&mut self,
+             ctx: &RenderTargetContext,
+             render_tasks: &mut RenderTaskCollection) {
+        self.alpha_batcher.build(ctx, render_tasks);
+    }
+
+    fn add_task(&mut self, task: RenderTask) {
+        match task.kind {
+            RenderTaskKind::Alpha(info) => {
+                self.alpha_batcher.add_task(AlphaBatchTask {
+                    task_id: task.id,
+                    items: info.items,
+                });
+            }
+        }
+    }
+}
+
+pub struct RenderPass {
+    pub is_framebuffer: bool,
+    tasks: Vec<RenderTask>,
+    pub targets: Vec<RenderTarget>,
+}
+
+impl RenderPass {
+    fn new(is_framebuffer: bool) -> RenderPass {
+        RenderPass {
+            is_framebuffer: is_framebuffer,
+            targets: vec![ RenderTarget::new() ],
+            tasks: Vec::new(),
         }
     }
 
@@ -451,59 +483,42 @@ impl RenderTarget {
              ctx: &RenderTargetContext,
              render_tasks: &mut RenderTaskCollection) {
         // Step through each task, adding to batches as appropriate.
-        for task in self.tasks.drain(..) {
-            match task.kind {
-                RenderTaskKind::Alpha(info) => {
-                    self.alpha_batcher.add_task(AlphaBatchTask {
-                        task_id: task.id,
-                        items: info.items,
-                    });
+        for mut task in self.tasks.drain(..) {
+            // Find a target to assign this task to, or create a new
+            // one if required.
+            match task.location {
+                RenderTaskLocation::Fixed(..) => {}
+                RenderTaskLocation::Dynamic(ref mut origin, ref size) => {
+                    let alloc_size = Size2D::new(size.width as u32,
+                                                 size.height as u32);
+
+                    let alloc_origin = self.targets
+                                           .last_mut()
+                                           .unwrap()
+                                           .page_allocator.allocate(&alloc_size);
+
+                    let alloc_origin = match alloc_origin {
+                        Some(alloc_origin) => alloc_origin,
+                        None => {
+                            let mut new_target = RenderTarget::new();
+                            let origin = new_target.page_allocator
+                                                   .allocate(&alloc_size)
+                                                   .expect("Each render task must allocate <= size of one target!");
+                            self.targets.push(new_target);
+                            origin
+                        }
+                    };
+
+                    let alloc_origin = DevicePoint::new(alloc_origin.x as i32,
+                                                        alloc_origin.y as i32);
+                    *origin = Some((alloc_origin, RenderTargetIndex(self.targets.len() - 1)));
                 }
             }
+
+            render_tasks.add(&task);
+            self.targets.last_mut().unwrap().add_task(task);
         }
 
-        self.alpha_batcher.build(ctx, render_tasks);
-    }
-}
-
-pub struct RenderPhase {
-    pub targets: Vec<RenderTarget>,
-}
-
-impl RenderPhase {
-    fn new(max_target_count: usize) -> RenderPhase {
-        //println!("+ start render phase: targets={}", max_target_count);
-        let mut targets = Vec::with_capacity(max_target_count);
-        for index in 0..max_target_count {
-            targets.push(RenderTarget::new(index == max_target_count-1));
-        }
-
-        RenderPhase {
-            targets: targets,
-        }
-    }
-
-    fn add_compiled_screen_tile(&mut self,
-                                mut tile: CompiledScreenTile,
-                                render_tasks: &mut RenderTaskCollection) -> Option<CompiledScreenTile> {
-        debug_assert!(tile.required_target_count <= self.targets.len());
-
-        let ok = tile.main_render_task.alloc_if_required(self.targets.len() - 1,
-                                                         &mut self.targets);
-
-        if ok {
-            tile.main_render_task.assign_to_targets(self.targets.len() - 1,
-                                                    &mut self.targets,
-                                                    render_tasks);
-            None
-        } else {
-            Some(tile)
-        }
-    }
-
-    fn build(&mut self,
-             ctx: &RenderTargetContext,
-             render_tasks: &mut RenderTaskCollection) {
         for target in &mut self.targets {
             target.build(ctx, render_tasks);
         }
@@ -513,7 +528,7 @@ impl RenderPhase {
 #[derive(Debug)]
 enum RenderTaskLocation {
     Fixed(DeviceRect),
-    Dynamic(Option<DevicePoint>, DeviceSize),
+    Dynamic(Option<(DevicePoint, RenderTargetIndex)>, DeviceSize),
 }
 
 #[derive(Debug)]
@@ -566,7 +581,7 @@ impl RenderTask {
     fn write_task_data(&self) -> RenderTaskData {
         match self.kind {
             RenderTaskKind::Alpha(ref task) => {
-                let target_rect = self.get_target_rect();
+                let (target_rect, target_index) = self.get_target_rect();
                 debug_assert!(target_rect.size.width == task.actual_rect.size.width);
                 debug_assert!(target_rect.size.height == task.actual_rect.size.height);
 
@@ -578,7 +593,7 @@ impl RenderTask {
                         target_rect.origin.y as f32,
                         task.actual_rect.size.width as f32,
                         task.actual_rect.size.height as f32,
-                        0.0,
+                        target_index.0 as f32,
                         0.0,
                     ],
                 }
@@ -597,75 +612,36 @@ impl RenderTask {
         }
     }
 
-    fn get_target_rect(&self) -> DeviceRect {
+    fn get_target_rect(&self) -> (DeviceRect, RenderTargetIndex) {
         match self.location {
-            RenderTaskLocation::Fixed(rect) => rect,
-            RenderTaskLocation::Dynamic(origin, size) => {
-                DeviceRect::new(origin.expect("Should have been allocated by now!"),
-                                size)
+            RenderTaskLocation::Fixed(rect) => (rect, RenderTargetIndex(0)),
+            RenderTaskLocation::Dynamic(origin_and_target_index, size) => {
+                let (origin, target_index) = origin_and_target_index.expect("Should have been allocated by now!");
+                (DeviceRect::new(origin, size), target_index)
             }
         }
     }
 
-    fn assign_to_targets(mut self,
-                         target_index: usize,
-                         targets: &mut Vec<RenderTarget>,
-                         render_tasks: &mut RenderTaskCollection) {
+    fn assign_to_passes(mut self,
+                        pass_index: usize,
+                        passes: &mut Vec<RenderPass>) {
         for child in self.children.drain(..) {
-            child.assign_to_targets(target_index - 1,
-                                    targets,
-                                    render_tasks);
+            child.assign_to_passes(pass_index - 1,
+                                   passes);
         }
-
-        render_tasks.add(&self);
 
         // Sanity check - can be relaxed if needed
         match self.location {
             RenderTaskLocation::Fixed(..) => {
-                debug_assert!(target_index == targets.len() - 1);
+                debug_assert!(pass_index == passes.len() - 1);
             }
             RenderTaskLocation::Dynamic(..) => {
-                debug_assert!(target_index < targets.len() - 1);
+                debug_assert!(pass_index < passes.len() - 1);
             }
         }
 
-        let target = &mut targets[target_index];
-        target.add_render_task(self);
-    }
-
-    fn alloc_if_required(&mut self,
-                         target_index: usize,
-                         targets: &mut Vec<RenderTarget>) -> bool {
-        match self.location {
-            RenderTaskLocation::Fixed(..) => {}
-            RenderTaskLocation::Dynamic(ref mut origin, ref size) => {
-                let target = &mut targets[target_index];
-
-                let alloc_size = Size2D::new(size.width as u32,
-                                             size.height as u32);
-
-                let alloc_origin = target.page_allocator.allocate(&alloc_size);
-
-                match alloc_origin {
-                    Some(alloc_origin) => {
-                        *origin = Some(DevicePoint::new(alloc_origin.x as i32,
-                                                        alloc_origin.y as i32));
-                    }
-                    None => {
-                        return false;
-                    }
-                }
-            }
-        }
-
-        for child in &mut self.children {
-            if !child.alloc_if_required(target_index - 1,
-                                        targets) {
-                return false;
-            }
-        }
-
-        true
+        let pass = &mut passes[pass_index];
+        pass.add_render_task(self);
     }
 
     fn max_depth(&self,
@@ -739,8 +715,8 @@ impl AlphaBatchKey {
         AlphaBatchKey {
             kind: AlphaBatchKind::Blend,
             flags: AlphaBatchKeyFlags(0),
-            color_texture_id: TextureId(0),
-            mask_texture_id: TextureId(0),
+            color_texture_id: TextureId::invalid(),
+            mask_texture_id: TextureId::invalid(),
         }
     }
 
@@ -748,8 +724,8 @@ impl AlphaBatchKey {
         AlphaBatchKey {
             kind: AlphaBatchKind::Composite,
             flags: AlphaBatchKeyFlags(0),
-            color_texture_id: TextureId(0),
-            mask_texture_id: TextureId(0),
+            color_texture_id: TextureId::invalid(),
+            mask_texture_id: TextureId::invalid(),
         }
     }
 
@@ -769,9 +745,9 @@ impl AlphaBatchKey {
     fn is_compatible_with(&self, other: &AlphaBatchKey) -> bool {
         self.kind == other.kind &&
             self.flags == other.flags &&
-            (self.color_texture_id == TextureId(0) || other.color_texture_id == TextureId(0) ||
+        (self.color_texture_id == TextureId::invalid() || other.color_texture_id == TextureId::invalid() ||
              self.color_texture_id == other.color_texture_id) &&
-            (self.mask_texture_id == TextureId(0) || other.mask_texture_id == TextureId(0) ||
+            (self.mask_texture_id == TextureId::invalid() || other.mask_texture_id == TextureId::invalid() ||
              self.mask_texture_id == other.mask_texture_id)
     }
 }
@@ -860,8 +836,8 @@ pub struct PrimitiveBatch {
 impl PrimitiveBatch {
     fn blend() -> PrimitiveBatch {
         PrimitiveBatch {
-            color_texture_id: TextureId(0),
-            mask_texture_id: TextureId(0),
+            color_texture_id: TextureId::invalid(),
+            mask_texture_id: TextureId::invalid(),
             transform_kind: TransformedRectKind::AxisAligned,
             has_complex_clip: false,
             blending_enabled: true,
@@ -871,8 +847,8 @@ impl PrimitiveBatch {
 
     fn composite() -> PrimitiveBatch {
         PrimitiveBatch {
-            color_texture_id: TextureId(0),
-            mask_texture_id: TextureId(0),
+            color_texture_id: TextureId::invalid(),
+            mask_texture_id: TextureId::invalid(),
             transform_kind: TransformedRectKind::AxisAligned,
             has_complex_clip: false,
             blending_enabled: true,
@@ -1089,7 +1065,7 @@ pub struct Frame {
     pub viewport_size: Size2D<i32>,
     pub debug_rects: Vec<DebugRect>,
     pub cache_size: Size2D<f32>,
-    pub phases: Vec<RenderPhase>,
+    pub passes: Vec<RenderPass>,
     pub clear_tiles: Vec<ClearTile>,
     pub profile_counters: FrameProfileCounters,
 
@@ -1114,21 +1090,26 @@ enum CompiledScreenTileInfo {
 #[derive(Debug)]
 struct CompiledScreenTile {
     main_render_task: RenderTask,
-    required_target_count: usize,
+    required_pass_count: usize,
     info: CompiledScreenTileInfo,
 }
 
 impl CompiledScreenTile {
     fn new(main_render_task: RenderTask,
            info: CompiledScreenTileInfo) -> CompiledScreenTile {
-        let mut required_target_count = 0;
-        main_render_task.max_depth(0, &mut required_target_count);
+        let mut required_pass_count = 0;
+        main_render_task.max_depth(0, &mut required_pass_count);
 
         CompiledScreenTile {
             main_render_task: main_render_task,
-            required_target_count: required_target_count,
+            required_pass_count: required_pass_count,
             info: info,
         }
+    }
+
+    fn build(self, passes: &mut Vec<RenderPass>) {
+        self.main_render_task.assign_to_passes(passes.len() - 1,
+                                               passes);
     }
 }
 
@@ -2045,10 +2026,13 @@ impl FrameBuilder {
 
         // Build list of passes, target allocs that each tile needs.
         let mut compiled_screen_tiles = Vec::new();
+        let mut max_passes_needed = 0;
         for screen_tile in screen_tiles {
             let rect = screen_tile.rect;        // TODO(gw): Remove clone here
             match screen_tile.compile(&ctx) {
                 Some(compiled_screen_tile) => {
+                    max_passes_needed = cmp::max(max_passes_needed,
+                                                 compiled_screen_tile.required_pass_count);
                     if self.debug {
                         let (label, color) = match &compiled_screen_tile.info {
                             &CompiledScreenTileInfo::SimpleAlpha(prim_count) => {
@@ -2074,44 +2058,26 @@ impl FrameBuilder {
             }
         }
 
-        let mut phases = Vec::new();
+        let mut passes = Vec::new();
         let static_render_task_count = ctx.render_task_id_counter.load(Ordering::SeqCst);
         let mut render_tasks = RenderTaskCollection::new(static_render_task_count);
 
         if !compiled_screen_tiles.is_empty() {
-            // Sort by pass count to minimize render target switches.
-            compiled_screen_tiles.sort_by(|a, b| {
-                let a_passes = a.required_target_count;
-                let b_passes = b.required_target_count;
-                b_passes.cmp(&a_passes)
-            });
-
-            // Do the allocations now, assigning each tile to a render
-            // phase as required.
-
-            let mut current_phase = RenderPhase::new(compiled_screen_tiles[0].required_target_count);
-
-            for compiled_screen_tile in compiled_screen_tiles {
-                if let Some(failed_tile) = current_phase.add_compiled_screen_tile(compiled_screen_tile,
-                                                                                  &mut render_tasks) {
-                    let full_phase = mem::replace(&mut current_phase,
-                                                  RenderPhase::new(failed_tile.required_target_count));
-                    phases.push(full_phase);
-
-                    let result = current_phase.add_compiled_screen_tile(failed_tile,
-                                                                        &mut render_tasks);
-                    assert!(result.is_none(), "TODO: Handle single tile not fitting in render phase.");
-                }
+            // Do the allocations now, assigning each tile's tasks to a render
+            // pass and target as required.
+            for index in 0..max_passes_needed {
+                passes.push(RenderPass::new(index == max_passes_needed-1));
             }
 
-            phases.push(current_phase);
+            for compiled_screen_tile in compiled_screen_tiles {
+                compiled_screen_tile.build(&mut passes);
+            }
 
-            //println!("rendering: phase count={}", phases.len());
-            for phase in &mut phases {
-                phase.build(&ctx, &mut render_tasks);
+            for pass in passes.iter_mut().rev() {
+                pass.build(&ctx, &mut render_tasks);
 
-                profile_counters.phases.inc();
-                profile_counters.targets.add(phase.targets.len());
+                profile_counters.passes.inc();
+                profile_counters.targets.add(pass.targets.len());
             }
         }
 
@@ -2119,7 +2085,7 @@ impl FrameBuilder {
             viewport_size: self.screen_rect.size,
             debug_rects: debug_rects,
             profile_counters: profile_counters,
-            phases: phases,
+            passes: passes,
             clear_tiles: clear_tiles,
             cache_size: Size2D::new(RENDERABLE_CACHE_SIZE as f32,
                                     RENDERABLE_CACHE_SIZE as f32),


### PR DESCRIPTION
Instead of splitting the scene into multiple phases, use texture
layers to allocate slices as needed for each pass of the render
frame. These are pooled and only allocated when the frame render
target configuration changes.

Previously, the code asserted if it was unable to fit the render
tasks into a single render target for a single tile. Now, this
(pathological) case is handled correctly.

This makes the upcoming dynamic primitive cache support a lot
simpler to add. It also means that we don't use a ping-pong
allocation style, which typically performs badly on mobile / tiled
rendering architectures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/478)
<!-- Reviewable:end -->
