### PR TITLE
Improved/fixed the command recording

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -11,7 +11,7 @@ serde_derive = ["webrender_traits/serde_derive"]
 
 [dependencies]
 app_units = "0.3"
-bincode = "0.6.0"
+bincode = "0.6"
 bit-set = "0.4"
 byteorder = "0.5"
 euclid = "0.10"

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -5,28 +5,33 @@ use std::io::Write;
 use webrender_traits::ApiMsg;
 use byteorder::{LittleEndian, WriteBytesExt};
 
-pub fn write_data(frame:u32, data: &Vec<u8>){
-       let filename = format!("record/frame_{}.bin", frame);
-       let mut file = OpenOptions::new().append(true).create(true).open(filename).unwrap();
-       file.write_u32::<LittleEndian>(data.len() as u32).ok();
-       file.write(data).ok(); 
+fn write_data(frame: u32, data: &[u8]) {
+    let filename = format!("record/frame_{}.bin", frame);
+    let mut file = OpenOptions::new().append(true).create(true).open(filename).unwrap();
+    file.write_u32::<LittleEndian>(data.len() as u32).ok();
+    file.write(data).ok();
 }
 
-pub fn write_msg(frame:u32, msg: &ApiMsg){
-   match msg{
-               ref msg @ &ApiMsg::AddRawFont(..) | 
-               ref msg @ &ApiMsg::AddNativeFont(..) |
-               ref msg @ &ApiMsg::AddImage(..) |
-               ref msg @ &ApiMsg::SetRootPipeline(..) |
-               ref msg @ &ApiMsg::UpdateImage(..) |
-               ref msg @ &ApiMsg::Scroll(..)|
-               ref msg @ &ApiMsg::TickScrollingBounce|
-               ref msg @ &ApiMsg::DeleteImage(..)|
-               ref msg @ &ApiMsg::SetRootStackingContext(..) =>{
-                       let buff = serialize(msg, bincode::SizeLimit::Infinite).unwrap();
-                       write_data(frame, &buff)
-               }
-               _ => {}
+pub fn write_msg(frame: u32, msg: &ApiMsg) {
+    match msg {
+        &ApiMsg::AddRawFont(..) |
+        &ApiMsg::AddNativeFont(..) |
+        &ApiMsg::AddImage(..) |
+        &ApiMsg::UpdateImage(..) |
+        &ApiMsg::DeleteImage(..)|
+        &ApiMsg::SetRootStackingContext(..) |
+        &ApiMsg::SetRootPipeline(..) |
+        &ApiMsg::Scroll(..)|
+        &ApiMsg::TickScrollingBounce |
+        &ApiMsg::WebGLCommand(..) => {
+            let buff = serialize(msg, bincode::SizeLimit::Infinite).unwrap();
+            write_data(frame, &buff);
        }
+       _ => {}
+    }
 }
 
+pub fn write_payload(frame: u32, data: &[u8]) {
+    write_data(frame, &[]); //signal the payload
+    write_data(frame, data);
+}

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -89,15 +89,15 @@ impl RenderBackend {
 
     pub fn run(&mut self) {
         let mut profile_counters = BackendProfileCounters::new();
-        let mut frame_counter:u32 = 0;
-        if self.enable_recording{
-                fs::create_dir("record").ok();
+        let mut frame_counter: u32 = 0;
+        if self.enable_recording {
+            fs::create_dir("record").ok();
         }
         loop {
             let msg = self.api_rx.recv();
             match msg {
                 Ok(msg) => {
-                    if self.enable_recording{
+                    if self.enable_recording {
                         record::write_msg(frame_counter, &msg);
                     }
                     match msg {
@@ -183,9 +183,8 @@ impl RenderBackend {
                             for leftover_auxiliary_data in leftover_auxiliary_data {
                                 self.payload_tx.send(&leftover_auxiliary_data[..]).unwrap()
                             }
-                            if self.enable_recording{
-                                record::write_data(frame_counter, &auxiliary_data);
-                                frame_counter += 1;
+                            if self.enable_recording {
+                                record::write_payload(frame_counter, &auxiliary_data);
                             }
                             let mut auxiliary_data = Cursor::new(&mut auxiliary_data[8..]);
                             for (display_list_id,
@@ -223,7 +222,10 @@ impl RenderBackend {
                                 self.render()
                             });
 
-                            self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
+                            if self.scene.root_pipeline_id.is_some() {
+                                self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
+                                frame_counter += 1;
+                            }
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
                             let frame = profile_counters.total_time.profile(|| {
@@ -233,7 +235,9 @@ impl RenderBackend {
                                 self.render()
                             });
 
-                            self.publish_frame(frame, &mut profile_counters);
+                            // the root pipeline is guaranteed to be Some() at this point
+                            self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
+                            frame_counter += 1;
                         }
                         ApiMsg::Scroll(delta, cursor, move_phase) => {
                             let frame = profile_counters.total_time.profile(|| {


### PR DESCRIPTION
This PR changes the recorded data stream. Instead of relying on the `deserialize` to fail for the payload data, I'm sending the message of size 0, followed by an actual payload size to disambiguate it.
A PR to update the [wr-replay](https://github.com/alanamramjit/replay) tool will follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/484)
<!-- Reviewable:end -->
