### PR TITLE
Fix Android build

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1752,6 +1752,11 @@ impl Device {
         gl::delete_buffers(&[buffer.0]);
     }
 
+    #[cfg(target_os = "android")]
+    pub fn set_multisample(&self, enable: bool) {
+    }
+
+    #[cfg(not(target_os = "android"))]
     pub fn set_multisample(&self, enable: bool) {
         if self.capabilities.supports_multisampling {
             if enable {


### PR DESCRIPTION
`gl::MULTISAMPLE` is not defined on Android.

Related: servo/servo#13154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/492)
<!-- Reviewable:end -->
