### PR TITLE
Text transformation fixes

### DIFF
--- a/webrender/res/ps_text.vs.glsl
+++ b/webrender/res/ps_text.vs.glsl
@@ -10,7 +10,7 @@ void main(void) {
     TransformVertexInfo vi = write_transform_vertex(glyph.info);
     vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
-    vec2 f = (vi.local_pos.xy - glyph.info.local_rect.xy) / glyph.info.local_rect.zw;
+    vec2 f = (vi.local_pos.xy / vi.local_pos.z - glyph.info.local_rect.xy) / glyph.info.local_rect.zw;
 #else
     VertexInfo vi = write_vertex(glyph.info);
     vec2 f = (vi.local_clamped_pos - vi.local_rect.p0) / (vi.local_rect.p1 - vi.local_rect.p0);

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -16,7 +16,7 @@ void main(void) {
                                                     prim.tile);
     vLocalRect = vi.clipped_local_rect;
     vLocalPos = vi.local_pos;
-    vec2 f = (vi.local_pos.xy - prim.local_rect.xy) / prim.local_rect.zw;
+    vec2 f = (vi.local_pos.xy / vi.local_pos.z - local_rect.xy) / local_rect.zw;
 #else
     VertexInfo vi = write_vertex(local_rect,
                                  prim.local_clip_rect,

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -884,16 +884,18 @@ impl Device {
         source.extend_from_slice(s.as_bytes());
         gl::shader_source(id, &[&source[..]]);
         gl::compile_shader(id);
+        let log = gl::get_shader_info_log(id);
         if gl::get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
-            println!("Failed to compile shader: {:?}", path);
-            println!("{}", gl::get_shader_info_log(id));
+            println!("Failed to compile shader: {:?}\n{}", path, log);
             if panic_on_fail {
                 panic!("-- Shader compile failed - exiting --");
             }
 
             None
         } else {
-            //println!("{}", gl::get_shader_info_log(id));
+            if !log.is_empty() {
+                println!("Warnings detected on shader: {:?}\n{}", path, log);
+            }
             Some(id)
         }
     }


### PR DESCRIPTION
Fixes #427  well, mostly...
Looks like the transformed clips (#498) need to be implemented for this to work fully correct.

Also adds a bit of comments to GLSL code to understand what's going on (please check if I misunderstood stuff and documented it wrong!).

The errors spotted:
  1. `layer.screen_vertices` was fetched with wrong indices
  2. `untransform` would use undefined value of `t` if the layer plane is perpendicular to the view
  3. text vertex shaders were missing a division by `vi.local_pos.z` for the layer coordinates
  4. `prim.local_rect` was used for the text_run local rectangle, instead of `local_rect`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/497)
<!-- Reviewable:end -->
