### PR TITLE
Fix GL stencil state

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1781,7 +1781,7 @@ impl Device {
     }
 
     pub fn disable_stencil(&self) {
-        gl::disable(gl::STENCIL);
+        gl::disable(gl::STENCIL_TEST);
     }
 
     pub fn disable_scissor(&self) {


### PR DESCRIPTION
This was a typo from #480 
Found out by qApitrace log:
> major api error 14: GL_INVALID_ENUM in glDisable(GL_STENCIL)

Perhaps, we should check for gl errors in the code too. We seem to only do that for WebGL commands at this point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/500)
<!-- Reviewable:end -->
