### PR TITLE
Add get_image_properties() to resource cache.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -986,6 +986,7 @@ impl ImagePrimitiveCpu {
         match self.kind {
             ImagePrimitiveKind::Image(image_key, image_rendering, stretch_size, tile_spacing) => {
                 let info = resource_cache.get_image(image_key, image_rendering, frame_id);
+                let image_properties = resource_cache.get_image_properties(image_key);
                 ImageInfo {
                     color_texture_id: info.texture_id,
                     uv0: Point2D::new(info.pixel_rect.top_left.x as f32,
@@ -995,7 +996,7 @@ impl ImagePrimitiveCpu {
                     stretch_size: Some(stretch_size),
                     uv_kind: TextureCoordKind::Pixel,
                     tile_spacing: tile_spacing,
-                    is_opaque: info.is_opaque,
+                    is_opaque: image_properties.is_opaque,
                 }
             }
             ImagePrimitiveKind::WebGL(context_id) => {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -27,6 +27,11 @@ use webrender_traits::{GlyphDimensions, PipelineId, WebGLContextId};
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
 
+pub struct ImageProperties {
+    pub format: ImageFormat,
+    pub is_opaque: bool,
+}
+
 pub struct DummyResources {
     pub white_image_id: TextureCacheItemId,
     pub opaque_mask_image_id: TextureCacheItemId,
@@ -38,6 +43,7 @@ struct ImageResource {
     height: u32,
     format: ImageFormat,
     epoch: Epoch,
+    is_opaque: bool,
 }
 
 struct GlyphRasterJob {
@@ -158,6 +164,7 @@ impl ResourceCache {
                               format: ImageFormat,
                               bytes: Vec<u8>) {
         let resource = ImageResource {
+            is_opaque: is_image_opaque(format, &bytes),
             width: width,
             height: height,
             format: format,
@@ -185,6 +192,7 @@ impl ResourceCache {
         };
 
         let resource = ImageResource {
+            is_opaque: is_image_opaque(format, &bytes),
             width: width,
             height: height,
             format: format,
@@ -371,6 +379,15 @@ impl ResourceCache {
         self.texture_cache.get(image_info.texture_cache_id)
     }
 
+    pub fn get_image_properties(&self, image_key: ImageKey) -> ImageProperties {
+        let image_template = &self.image_templates[&image_key];
+
+        ImageProperties {
+            format: image_template.format,
+            is_opaque: image_template.is_opaque,
+        }
+    }
+
     #[inline]
     pub fn get_image_by_cache_id(&self, texture_cache_id: TextureCacheItemId)
                                  -> &TextureCacheItem {
@@ -440,3 +457,26 @@ impl Resource for CachedImageInfo {
     }
 }
 
+// TODO(gw): If this ever shows up in profiles, consider calculating
+// this lazily on demand, possibly via the resource cache thread.
+// It can probably be made a lot faster with SIMD too!
+// This assumes that A8 textures are never opaque, since they are
+// typically used for alpha masks. We could revisit that if it
+// ever becomes an issue in real world usage.
+fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
+    match format {
+        ImageFormat::RGBA8 => {
+            let mut is_opaque = true;
+            for i in 0..(bytes.len() / 4) {
+                if bytes[i * 4 + 3] != 255 {
+                    is_opaque = false;
+                    break;
+                }
+            }
+            is_opaque
+        }
+        ImageFormat::RGB8 => true,
+        ImageFormat::A8 => false,
+        ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
+    }
+}


### PR DESCRIPTION
This allows querying image opacity before an image is added to
the texture cache.

This doesn't change functionality, but it's prep work for some
of the upcoming interface changes in the resource cache that are
needed for subpixel glyph functionality.

This is arguably a much cleaner interface as well, it never really
made sense to have this accessible only via the texture cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/511)
<!-- Reviewable:end -->
