### PR TITLE
Major refactoring of how clips are processed down the pipeline

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -9,7 +9,7 @@ flat varying vec4 vClipMaskUvRect;
 flat varying vec4 vClipMaskLocalRect;
 
 #ifdef WR_VERTEX_SHADER
-void write_clip(ClipInfo clip) {
+void write_clip(ClipData clip) {
     vClipRect = vec4(clip.rect.rect.xy, clip.rect.rect.xy + clip.rect.rect.zw);
     vClipRadius = vec4(clip.top_left.outer_inner_radius.x,
                        clip.top_right.outer_inner_radius.x,
@@ -17,8 +17,8 @@ void write_clip(ClipInfo clip) {
                        clip.bottom_left.outer_inner_radius.x);
     //TODO: interpolate the final mask UV
     vec2 texture_size = textureSize(sMask, 0);
-    vClipMaskUvRect = clip.mask_info.uv_rect / texture_size.xyxy;
-    vClipMaskLocalRect = clip.mask_info.local_rect; //TODO: transform
+    vClipMaskUvRect = clip.mask_data.uv_rect / texture_size.xyxy;
+    vClipMaskLocalRect = clip.mask_data.local_rect; //TODO: transform
 }
 #endif
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -347,13 +347,13 @@ ClipRect fetch_clip_rect(int index) {
     return rect;
 }
 
-struct ImageMaskInfo {
+struct ImageMaskData {
     vec4 uv_rect;
     vec4 local_rect;
 };
 
-ImageMaskInfo fetch_mask_info(int index) {
-    ImageMaskInfo info;
+ImageMaskData fetch_mask_data(int index) {
+    ImageMaskData info;
 
     ivec2 uv = get_fetch_uv_2(index);
 
@@ -379,24 +379,24 @@ ClipCorner fetch_clip_corner(int index) {
     return corner;
 }
 
-struct ClipInfo {
+struct ClipData {
     ClipRect rect;
     ClipCorner top_left;
     ClipCorner top_right;
     ClipCorner bottom_left;
     ClipCorner bottom_right;
-    ImageMaskInfo mask_info;
+    ImageMaskData mask_data;
 };
 
-ClipInfo fetch_clip(int index) {
-    ClipInfo clip;
+ClipData fetch_clip(int index) {
+    ClipData clip;
 
     clip.rect = fetch_clip_rect(index + 0);
     clip.top_left = fetch_clip_corner(index + 1);
     clip.top_right = fetch_clip_corner(index + 2);
     clip.bottom_left = fetch_clip_corner(index + 3);
     clip.bottom_right = fetch_clip_corner(index + 4);
-    clip.mask_info = fetch_mask_info(index + 5);
+    clip.mask_data = fetch_mask_data(index + 5);
 
     return clip;
 }

--- a/webrender/res/ps_gradient_clip.vs.glsl
+++ b/webrender/res/ps_gradient_clip.vs.glsl
@@ -66,6 +66,6 @@ void main(void) {
             break;
     }
 
-    ClipInfo clip = fetch_clip(prim.clip_index);
+    ClipData clip = fetch_clip(prim.clip_index);
     write_clip(clip);
 }

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -23,7 +23,7 @@ void main(void) {
     vLocalPos = vi.local_clamped_pos;
 #endif
 
-    ClipInfo clip = fetch_clip(prim.clip_index);
+    ClipData clip = fetch_clip(prim.clip_index);
     write_clip(clip);
 
     // vUv will contain how many times this image has wrapped around the image size.

--- a/webrender/res/ps_rectangle_clip.vs.glsl
+++ b/webrender/res/ps_rectangle_clip.vs.glsl
@@ -22,6 +22,6 @@ void main(void) {
     vPos = vi.local_clamped_pos;
 #endif
 
-    ClipInfo clip = fetch_clip(prim.clip_index);
+    ClipData clip = fetch_clip(prim.clip_index);
     write_clip(clip);
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -411,6 +411,7 @@ impl RenderBackend {
 
     fn render(&mut self) -> RendererFrame {
         let frame = self.frame.build(&mut self.resource_cache,
+                                     &self.scene.pipeline_auxiliary_lists,
                                      self.device_pixel_ratio);
 
         let pending_update = self.resource_cache.pending_updates();

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -53,6 +53,7 @@ enum State {
     QueryResources,
 }
 
+#[derive(Clone, Debug)]
 pub struct DummyResources {
     pub white_image_id: TextureCacheItemId,
     pub opaque_mask_image_id: TextureCacheItemId,

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -8,7 +8,8 @@ use internal_types::DrawListId;
 use resource_cache::ResourceCache;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use webrender_traits::{AuxiliaryLists, BuiltDisplayList, ItemRange, PipelineId, Epoch};
+use tiling::AuxiliaryListsMap;
+use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch};
 use webrender_traits::{ColorF, DisplayListId, StackingContext, StackingContextId};
 use webrender_traits::{SpecificDisplayListItem};
 use webrender_traits::{IframeInfo};
@@ -29,9 +30,7 @@ pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipeline_map: HashMap<PipelineId, ScenePipeline, BuildHasherDefault<FnvHasher>>,
     pub pipeline_sizes: HashMap<PipelineId, Size2D<f32>>,
-    pub pipeline_auxiliary_lists: HashMap<PipelineId,
-                                          AuxiliaryLists,
-                                          BuildHasherDefault<FnvHasher>>,
+    pub pipeline_auxiliary_lists: AuxiliaryListsMap,
     pub display_list_map: HashMap<DisplayListId, SceneDisplayList, BuildHasherDefault<FnvHasher>>,
     pub stacking_context_map: HashMap<StackingContextId, SceneStackingContext, BuildHasherDefault<FnvHasher>>,
 }
@@ -185,15 +184,10 @@ impl Scene {
             let rectangle_item = RectangleDisplayItem {
                 color: background_color,
             };
-            let clip = ClipRegion {
-                main: overflow,
-                complex: ItemRange::empty(),
-                image_mask: None,
-            };
             let root_bg_color_item = DisplayItem {
                 item: SpecificDisplayItem::Rectangle(rectangle_item),
                 rect: overflow,
-                clip: clip,
+                clip: ClipRegion::simple(&overflow),
             };
 
             let draw_list_id = resource_cache.add_draw_list(vec![root_bg_color_item], pipeline_id);

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -6,7 +6,7 @@ use display_list::AuxiliaryListsBuilder;
 use euclid::{Rect, Size2D};
 use {BorderRadius, BorderDisplayItem, ClipRegion, ColorF, ComplexClipRegion};
 use {FontKey, ImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
-use {ImageMask};
+use {ImageMask, ItemRange};
 
 impl BorderDisplayItem {
     pub fn top_left_inner_radius(&self) -> Size2D<f32> {
@@ -60,6 +60,14 @@ impl ClipRegion {
             main: *rect,
             complex: auxiliary_lists_builder.add_complex_clip_regions(&complex),
             image_mask: image_mask,
+        }
+    }
+
+    pub fn simple(rect: &Rect<f32>) -> ClipRegion {
+        ClipRegion {
+            main: *rect,
+            complex: ItemRange::empty(),
+            image_mask: None,
         }
     }
 }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -187,6 +187,12 @@ pub struct ClipRegion {
     pub image_mask: Option<ImageMask>,
 }
 
+impl ClipRegion {
+    pub fn is_complex(&self) -> bool {
+        self.complex.length !=0 || self.image_mask.is_some()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.


### PR DESCRIPTION
This moves the clipping hack down the road (from `Frame` to `FrameBuilder`), allowing to eventually implement multiple transformed clips properly (#498), as discussed on IRC with @glennw .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/512)
<!-- Reviewable:end -->
