### PR TITLE
Fix regression in WPT color tests.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -857,6 +857,7 @@ impl AlphaBatchKey {
     fn is_compatible_with(&self, other: &AlphaBatchKey) -> bool {
         self.kind == other.kind &&
             self.flags == other.flags &&
+            self.blend_mode == other.blend_mode &&
         (self.color_texture_id == TextureId::invalid() || other.color_texture_id == TextureId::invalid() ||
              self.color_texture_id == other.color_texture_id) &&
             (self.mask_texture_id == TextureId::invalid() || other.mask_texture_id == TextureId::invalid() ||


### PR DESCRIPTION
I forgot to add the new blend mode field to the batch
compatibility check function. Oops!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/513)
<!-- Reviewable:end -->
