### PR TITLE
Use glyph metrics to calculate text run bounds and offsets.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -879,9 +879,4 @@ impl Frame {
         }
         layers_bouncing_back
     }
-
-    /// Returns the id which the next Frame would possess
-    pub fn next_frame_id(&self) -> FrameId {
-        FrameId(self.id.0 + 1)
-    }
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -116,11 +116,7 @@ impl RenderBackend {
                         ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
                             let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
                             for glyph_key in &glyph_keys {
-                                // Get the next frame id, so it'll remain in the texture cache.
-                                // This assumes that the glyph will be used in the next frame.
-                                let frame_id = self.frame.next_frame_id();
-                                let glyph_dim = self.resource_cache
-                                                    .get_glyph_dimensions(&glyph_key, frame_id);
+                                let glyph_dim = self.resource_cache.get_glyph_dimensions(glyph_key);
                                 glyph_dimensions.push(glyph_dim);
                             };
                             tx.send(glyph_dimensions).unwrap();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -529,8 +529,6 @@ impl Renderer {
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
         let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
-                             0,
-                             0,
                              2,
                              2,
                              ImageFormat::RGBA8,
@@ -540,8 +538,6 @@ impl Renderer {
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
-                             0,
-                             0,
                              2,
                              2,
                              ImageFormat::A8,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2002,7 +2002,7 @@ impl FrameBuilder {
 
     fn prepare_primitives(&mut self,
                           screen_rect: &DeviceRect,
-                          resource_cache: &ResourceCache,
+                          resource_cache: &mut ResourceCache,
                           frame_id: FrameId,
                           pipeline_auxiliary_lists: &HashMap<PipelineId, AuxiliaryLists, BuildHasherDefault<FnvHasher>>) {
         for (layer, packed_layer) in self.layer_store

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -58,7 +58,7 @@ pub enum ApiMsg {
     WebGLCommand(WebGLContextId, WebGLCommand),
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
 pub struct GlyphDimensions {
     pub left: i32,
     pub top: i32,


### PR DESCRIPTION
Instead of rasterizing glyphs, and using that to calculate the
bounding box of text runs, use glyph metrics instead.

This is important, since it allows us to delay rasterization of
glyphs until later in the frame, which means we can delay the
decision on whether to rasterize a glyph with subpixel
antialising or not.

It also removes the concept of "user data" in the texture cache
since the resource cache is now used to extract glyph metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/514)
<!-- Reviewable:end -->
