### PR TITLE
Remove the unused StackingContext has_stacking_contexts field

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -71,8 +71,6 @@ impl WebRenderFrameBuilder {
                             stacking_context: &mut webrender_traits::StackingContext)
                             -> DisplayListId {
         let id = api.next_display_list_id();
-        stacking_context.has_stacking_contexts = stacking_context.has_stacking_contexts ||
-                                                 display_list.descriptor().has_stacking_contexts;
         stacking_context.display_lists.push(id);
         self.display_lists.push((id, display_list));
         id

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -53,7 +53,6 @@ impl BuiltDisplayList {
 
 pub struct DisplayListBuilder {
     pub mode: DisplayListMode,
-    pub has_stacking_contexts: bool,
 
     pub work_list: Vec<DisplayItem>,
 
@@ -65,7 +64,6 @@ impl DisplayListBuilder {
     pub fn new() -> DisplayListBuilder {
         DisplayListBuilder {
             mode: DisplayListMode::Default,
-            has_stacking_contexts: false,
             work_list: Vec::new(),
             display_list_items: Vec::new(),
             display_items: Vec::new(),
@@ -218,7 +216,6 @@ impl DisplayListBuilder {
     }
 
     pub fn push_stacking_context(&mut self, stacking_context_id: StackingContextId) {
-        self.has_stacking_contexts = true;
         self.flush();
         let info = StackingContextInfo {
             id: stacking_context_id,
@@ -296,7 +293,6 @@ impl DisplayListBuilder {
             BuiltDisplayList {
                 descriptor: BuiltDisplayListDescriptor {
                     mode: self.mode,
-                    has_stacking_contexts: self.has_stacking_contexts,
                     display_list_items_size: display_list_items_size,
                     display_items_size: display_items_size,
                 },

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -31,7 +31,6 @@ impl StackingContext {
             establishes_3d_context: establishes_3d_context,
             mix_blend_mode: mix_blend_mode,
             filters: auxiliary_lists_builder.add_filters(&filters),
-            has_stacking_contexts: false,
         }
     }
 }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -156,7 +156,6 @@ pub struct BuiltDisplayList {
 #[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct BuiltDisplayListDescriptor {
     pub mode: DisplayListMode,
-    pub has_stacking_contexts: bool,
 
     /// The size in bytes of the display list items in this display list.
     display_list_items_size: usize,
@@ -455,7 +454,6 @@ pub struct StackingContext {
     pub establishes_3d_context: bool,
     pub mix_blend_mode: MixBlendMode,
     pub filters: ItemRange,
-    pub has_stacking_contexts: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
It seems that this field has been unused since the switch to WR2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/518)
<!-- Reviewable:end -->
