### PR TITLE
Add basic subpixel AA text support on Linux.

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -99,6 +99,7 @@ fn main() {
         precache_shaders: false,
         renderer_kind: webrender_traits::RendererKind::Native,
         debug: false,
+        enable_subpixel_aa: false,
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -140,6 +140,7 @@ fn main() {
         debug: true,
         precache_shaders: false,
         renderer_kind: RendererKind::Native,
+        enable_subpixel_aa: false,
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/webrender/res/ps_text_run.fs.glsl
+++ b/webrender/res/ps_text_run.fs.glsl
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
+#ifdef WR_FEATURE_SUBPIXEL_AA
+    oFragColor = texture(sDiffuse, vUv);
+#else
     float a = texture(sDiffuse, vUv).a;
 #ifdef WR_FEATURE_TRANSFORM
     float alpha = 0.0;
@@ -10,4 +13,5 @@ void main(void) {
     a *= alpha;
 #endif
     oFragColor = vec4(vColor.rgb, vColor.a * a);
+#endif
 }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::mem;
 //use std::sync::mpsc::{channel, Sender};
 //use std::thread;
-use webrender_traits::ImageFormat;
+use webrender_traits::{ColorF, ImageFormat};
 
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 const GL_FORMAT_A: gl::GLuint = gl::RED;
@@ -1812,6 +1812,11 @@ impl Device {
         gl::blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA,
                                 gl::ONE, gl::ONE);
         gl::blend_equation(gl::FUNC_ADD);
+    }
+
+    pub fn set_blend_mode_subpixel(&self, color: ColorF) {
+        gl::blend_color(color.r, color.g, color.b, color.a);
+        gl::blend_func(gl::CONSTANT_COLOR, gl::ONE_MINUS_SRC_COLOR);
     }
 }
 

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -24,14 +24,6 @@ use webrender_traits::{Epoch, ColorF, PipelineId};
 use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
 use webrender_traits::{ScrollLayerId, WebGLCommand};
 
-#[allow(dead_code)]     // TODO(gw): Make use of the subpixel render mode!
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-pub enum FontRenderMode {
-    Mono,
-    Alpha,
-    Subpixel,
-}
-
 pub enum GLContextHandleWrapper {
     Native(NativeGLContextHandle),
     OSMesa(OSMesaContextHandle),

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -12,10 +12,9 @@ use core_graphics::geometry::CGPoint;
 use core_text::font::CTFont;
 use core_text::font_descriptor::kCTFontDefaultOrientation;
 use core_text;
-use internal_types::FontRenderMode;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use webrender_traits::{FontKey, GlyphDimensions};
+use webrender_traits::{FontKey, FontRenderMode, GlyphDimensions};
 
 pub type NativeFontHandle = CGFont;
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -92,6 +92,8 @@ const GPU_TAG_PRIM_BORDER: GpuProfileTag = GpuProfileTag { label: "Border", colo
 pub enum BlendMode {
     None,
     Alpha,
+    // Use the color of the text itself as a constant color blend factor.
+    Subpixel(ColorF),
 }
 
 struct VertexDataTexture {
@@ -140,7 +142,8 @@ impl VertexDataTexture {
     }
 }
 
-const TRANSFORM_FEATURE: &'static [&'static str] = &["TRANSFORM"];
+const TRANSFORM_FEATURE: &'static str = "TRANSFORM";
+const SUBPIXEL_AA_FEATURE: &'static str = "SUBPIXEL_AA";
 
 enum ShaderKind {
     Primitive,
@@ -153,14 +156,14 @@ struct LazilyCompiledShader {
     name: &'static str,
     kind: ShaderKind,
     max_ubo_vectors: usize,
-    features: &'static [&'static str],
+    features: Vec<&'static str>,
 }
 
 impl LazilyCompiledShader {
     fn new(kind: ShaderKind,
            name: &'static str,
            max_ubo_vectors: usize,
-           features: &'static [&'static str],
+           features: &[&'static str],
            device: &mut Device,
            precache: bool) -> LazilyCompiledShader {
         let mut shader = LazilyCompiledShader {
@@ -168,7 +171,7 @@ impl LazilyCompiledShader {
             name: name,
             kind: kind,
             max_ubo_vectors: max_ubo_vectors,
-            features: features,
+            features: features.to_vec(),
         };
 
         if precache {
@@ -190,7 +193,7 @@ impl LazilyCompiledShader {
                     create_prim_shader(self.name,
                                        device,
                                        self.max_ubo_vectors,
-                                       self.features)
+                                       &self.features)
                 }
             };
             self.id = Some(id);
@@ -235,18 +238,22 @@ impl PrimitiveShader {
            max_ubo_vectors: usize,
            max_prim_items: usize,
            device: &mut Device,
+           features: &[&'static str],
            precache: bool) -> PrimitiveShader {
         let simple = LazilyCompiledShader::new(ShaderKind::Primitive,
                                                name,
                                                max_ubo_vectors,
-                                               &[],
+                                               features,
                                                device,
                                                precache);
+
+        let mut transform_features = features.to_vec();
+        transform_features.push(TRANSFORM_FEATURE);
 
         let transform = LazilyCompiledShader::new(ShaderKind::Primitive,
                                                   name,
                                                   max_ubo_vectors,
-                                                  TRANSFORM_FEATURE,
+                                                  &transform_features,
                                                   device,
                                                   precache);
 
@@ -335,6 +342,7 @@ pub struct Renderer {
 
     ps_rectangle: PrimitiveShader,
     ps_text_run: PrimitiveShader,
+    ps_text_run_subpixel: PrimitiveShader,
     ps_image: PrimitiveShader,
     ps_border: PrimitiveShader,
     ps_gradient: PrimitiveShader,
@@ -443,53 +451,69 @@ impl Renderer {
                                                 max_ubo_vectors,
                                                 max_prim_instances,
                                                 &mut device,
+                                                &[],
                                                 options.precache_shaders);
         let ps_text_run = PrimitiveShader::new("ps_text_run",
                                                max_ubo_vectors,
                                                max_prim_instances,
                                                &mut device,
+                                               &[],
                                                options.precache_shaders);
+        let ps_text_run_subpixel = PrimitiveShader::new("ps_text_run",
+                                                        max_ubo_vectors,
+                                                        max_prim_instances,
+                                                        &mut device,
+                                                        &[ SUBPIXEL_AA_FEATURE ],
+                                                        options.precache_shaders);
         let ps_image = PrimitiveShader::new("ps_image",
                                             max_ubo_vectors,
                                             max_prim_instances,
                                             &mut device,
+                                            &[],
                                             options.precache_shaders);
         let ps_border = PrimitiveShader::new("ps_border",
                                              max_ubo_vectors,
                                              max_prim_instances,
                                              &mut device,
+                                             &[],
                                              options.precache_shaders);
         let ps_rectangle_clip = PrimitiveShader::new("ps_rectangle_clip",
                                                      max_ubo_vectors,
                                                      max_prim_instances,
                                                      &mut device,
+                                                     &[],
                                                      options.precache_shaders);
         let ps_image_clip = PrimitiveShader::new("ps_image_clip",
                                                  max_ubo_vectors,
                                                  max_prim_instances,
                                                  &mut device,
+                                                 &[],
                                                  options.precache_shaders);
 
         let ps_box_shadow = PrimitiveShader::new("ps_box_shadow",
                                                  max_ubo_vectors,
                                                  max_prim_instances,
                                                  &mut device,
+                                                 &[],
                                                  options.precache_shaders);
 
         let ps_gradient = PrimitiveShader::new("ps_gradient",
                                                max_ubo_vectors,
                                                max_prim_instances,
                                                &mut device,
+                                               &[],
                                                options.precache_shaders);
         let ps_gradient_clip = PrimitiveShader::new("ps_gradient_clip",
                                                     max_ubo_vectors,
                                                     max_prim_instances,
                                                     &mut device,
+                                                    &[],
                                                     options.precache_shaders);
         let ps_angle_gradient = PrimitiveShader::new("ps_angle_gradient",
                                                      max_ubo_vectors,
                                                      max_prim_instances,
                                                      &mut device,
+                                                     &[],
                                                      options.precache_shaders);
 
         let ps_blend = LazilyCompiledShader::new(ShaderKind::Primitive,
@@ -619,7 +643,8 @@ impl Renderer {
             RendererKind::OSMesa => GLContextHandleWrapper::current_osmesa_handle(),
         };
 
-        let config = FrameBuilderConfig::new(options.enable_scrollbars);
+        let config = FrameBuilderConfig::new(options.enable_scrollbars,
+                                             options.enable_subpixel_aa);
 
         let debug = options.debug;
         let (device_pixel_ratio, enable_aa) = (options.device_pixel_ratio, options.enable_aa);
@@ -657,6 +682,7 @@ impl Renderer {
             cs_box_shadow: cs_box_shadow,
             ps_rectangle: ps_rectangle,
             ps_text_run: ps_text_run,
+            ps_text_run_subpixel: ps_text_run_subpixel,
             ps_image: ps_image,
             ps_border: ps_border,
             ps_rectangle_clip: ps_rectangle_clip,
@@ -1405,9 +1431,13 @@ impl Renderer {
 
             if batch.key.blend_mode != prev_blend_mode {
                 match batch.key.blend_mode {
-                    // TODO(gw): More blend modes to come with subpixel aa work.
                     BlendMode::None | BlendMode::Alpha => {
                         self.device.set_blend(batch.key.blend_mode == BlendMode::Alpha);
+                        self.device.set_blend_mode_alpha();
+                    }
+                    BlendMode::Subpixel(color) => {
+                        self.device.set_blend(true);
+                        self.device.set_blend_mode_subpixel(color);
                     }
                 }
                 prev_blend_mode = batch.key.blend_mode;
@@ -1502,7 +1532,10 @@ impl Renderer {
                 }
                 &PrimitiveBatchData::TextRun(ref ubo_data) => {
                     self.gpu_profile.add_marker(GPU_TAG_PRIM_TEXT_RUN);
-                    let (shader, max_prim_items) = self.ps_text_run.get(&mut self.device, transform_kind);
+                    let (shader, max_prim_items) = match batch.key.blend_mode {
+                        BlendMode::Subpixel(..) => self.ps_text_run_subpixel.get(&mut self.device, transform_kind),
+                        BlendMode::Alpha | BlendMode::None => self.ps_text_run.get(&mut self.device, transform_kind),
+                    };
                     self.draw_ubo_batch(ubo_data,
                                         shader,
                                         1,
@@ -1686,4 +1719,5 @@ pub struct RendererOptions {
     pub enable_scrollbars: bool,
     pub precache_shaders: bool,
     pub renderer_kind: RendererKind,
+    pub enable_subpixel_aa: bool,
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -8,7 +8,7 @@ use euclid::{Point2D, Size2D};
 use fnv::FnvHasher;
 use frame::FrameId;
 use freelist::FreeList;
-use internal_types::{FontTemplate, FontRenderMode};
+use internal_types::FontTemplate;
 use internal_types::{TextureUpdateList, DrawListId, DrawList};
 use platform::font::{FontContext, RasterizedGlyph};
 use rayon::prelude::*;
@@ -22,7 +22,7 @@ use std::hash::Hash;
 use texture_cache::{TextureCache, TextureCacheItem, TextureCacheItemId};
 use texture_cache::{BorderType, TextureInsertOp};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, DisplayItem, ImageRendering};
-use webrender_traits::{GlyphDimensions, PipelineId, WebGLContextId};
+use webrender_traits::{FontRenderMode, GlyphDimensions, PipelineId, WebGLContextId};
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
 
@@ -39,6 +39,25 @@ pub struct CacheItem {
     pub texture_id: TextureId,
     pub uv0: Point2D<f32>,
     pub uv1: Point2D<f32>,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+pub struct RenderedGlyphKey {
+    pub key: GlyphKey,
+    pub render_mode: FontRenderMode,
+}
+
+impl RenderedGlyphKey {
+    pub fn new(font_key: FontKey,
+               size: Au,
+               blur_radius: Au,
+               index: u32,
+               render_mode: FontRenderMode) -> RenderedGlyphKey {
+        RenderedGlyphKey {
+            key: GlyphKey::new(font_key, size, blur_radius, index),
+            render_mode: render_mode,
+        }
+    }
 }
 
 pub struct ImageProperties {
@@ -69,7 +88,7 @@ struct ImageResource {
 }
 
 struct GlyphRasterJob {
-    glyph_key: GlyphKey,
+    glyph_key: RenderedGlyphKey,
     result: Option<RasterizedGlyph>,
 }
 
@@ -144,6 +163,7 @@ struct TextRunResourceRequest {
     size: Au,
     blur_radius: Au,
     glyph_indices: Vec<u32>,
+    render_mode: FontRenderMode,
 }
 
 enum ResourceRequest {
@@ -157,7 +177,7 @@ struct WebGLTexture {
 }
 
 pub struct ResourceCache {
-    cached_glyphs: ResourceClassCache<GlyphKey, Option<TextureCacheItemId>>,
+    cached_glyphs: ResourceClassCache<RenderedGlyphKey, Option<TextureCacheItemId>>,
     cached_images: ResourceClassCache<(ImageKey, ImageRendering), CachedImageInfo>,
 
     // TODO(pcwalton): Figure out the lifecycle of these.
@@ -288,13 +308,15 @@ impl ResourceCache {
                           key: FontKey,
                           size: Au,
                           blur_radius: Au,
-                          glyph_indices: &[u32]) {
+                          glyph_indices: &[u32],
+                          render_mode: FontRenderMode) {
         debug_assert!(self.state == State::AddResources);
         self.pending_requests.push(ResourceRequest::TextRun(TextRunResourceRequest {
             key: key,
             size: size,
             blur_radius: blur_radius,
             glyph_indices: glyph_indices.to_vec(),
+            render_mode: render_mode,
         }));
     }
 
@@ -313,7 +335,7 @@ impl ResourceCache {
                 let texture_width;
                 let texture_height;
                 let insert_op;
-                match job.glyph_key.blur_radius {
+                match job.glyph_key.key.blur_radius {
                     Au(0) => {
                         texture_width = result.width;
                         texture_height = result.height;
@@ -366,15 +388,17 @@ impl ResourceCache {
                          size: Au,
                          blur_radius: Au,
                          glyph_indices: &[u32],
+                         render_mode: FontRenderMode,
                          mut f: F) -> TextureId where F: FnMut(usize, Point2D<f32>, Point2D<f32>) {
         debug_assert!(self.state == State::QueryResources);
-        let mut glyph_key = GlyphKey::new(font_key,
-                                          size,
-                                          blur_radius,
-                                          0);
+        let mut glyph_key = RenderedGlyphKey::new(font_key,
+                                                  size,
+                                                  blur_radius,
+                                                  0,
+                                                  render_mode);
         let mut texture_id = TextureId::invalid();
         for (loop_index, glyph_index) in glyph_indices.iter().enumerate() {
-            glyph_key.index = *glyph_index;
+            glyph_key.key.index = *glyph_index;
             let image_id = self.cached_glyphs.get(&glyph_key, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
@@ -530,10 +554,11 @@ impl ResourceCache {
                 }
                 ResourceRequest::TextRun(ref text_run) => {
                     for glyph_index in &text_run.glyph_indices {
-                        let glyph_key = GlyphKey::new(text_run.key,
-                                                      text_run.size,
-                                                      text_run.blur_radius,
-                                                      *glyph_index);
+                        let glyph_key = RenderedGlyphKey::new(text_run.key,
+                                                              text_run.size,
+                                                              text_run.blur_radius,
+                                                              *glyph_index,
+                                                              text_run.render_mode);
 
                         self.cached_glyphs.mark_as_needed(&glyph_key, self.current_frame_id);
                         if !self.cached_glyphs.contains_key(&glyph_key) {
@@ -564,28 +589,27 @@ fn run_raster_jobs(pending_raster_jobs: &mut Vec<GlyphRasterJob>,
         return
     }
 
-    let render_mode = if enable_aa {
-        FontRenderMode::Alpha
-    } else {
-        FontRenderMode::Mono
-    };
-
     pending_raster_jobs.par_iter_mut().weight_max().for_each(|job| {
-        let font_template = &font_templates[&job.glyph_key.font_key];
+        let font_template = &font_templates[&job.glyph_key.key.font_key];
         FONT_CONTEXT.with(move |font_context| {
             let mut font_context = font_context.borrow_mut();
             match *font_template {
                 FontTemplate::Raw(ref bytes) => {
-                    font_context.add_raw_font(&job.glyph_key.font_key, &**bytes);
+                    font_context.add_raw_font(&job.glyph_key.key.font_key, &**bytes);
                 }
                 FontTemplate::Native(ref native_font_handle) => {
-                    font_context.add_native_font(&job.glyph_key.font_key,
+                    font_context.add_native_font(&job.glyph_key.key.font_key,
                                                  (*native_font_handle).clone());
                 }
             }
-            job.result = font_context.rasterize_glyph(job.glyph_key.font_key,
-                                                      job.glyph_key.size,
-                                                      job.glyph_key.index,
+            let render_mode = if enable_aa {
+                job.glyph_key.render_mode
+            } else {
+                FontRenderMode::Mono
+            };
+            job.result = font_context.rasterize_glyph(job.glyph_key.key.font_key,
+                                                      job.glyph_key.key.size,
+                                                      job.glyph_key.key.index,
                                                       device_pixel_ratio,
                                                       render_mode);
         });

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -247,6 +247,13 @@ pub enum FilterOp {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FontKey(u32, u32);
 
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum FontRenderMode {
+    Mono,
+    Alpha,
+    Subpixel,
+}
+
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GlyphKey {
     pub font_key: FontKey,
@@ -256,7 +263,10 @@ pub struct GlyphKey {
 }
 
 impl GlyphKey {
-    pub fn new(font_key: FontKey, size: Au, blur_radius: Au, index: u32) -> GlyphKey {
+    pub fn new(font_key: FontKey,
+               size: Au,
+               blur_radius: Au,
+               index: u32) -> GlyphKey {
         GlyphKey {
             font_key: font_key,
             size: size,


### PR DESCRIPTION
This is some preliminary support for subpixel AA. Specifically:
 * Only on Linux for now.
 * No gamma correction.
 * Disabled by default (use -Z subpixel-aa to test).
 * Doesn't deal with rotations, subpixel positioning etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/527)
<!-- Reviewable:end -->
