### PR TITLE
Fixed shader error in ps_image_clip

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
         enable_recording: false,
         enable_scrollbars: false,
         debug: true,
-        precache_shaders: false,
+        precache_shaders: true,
         renderer_kind: RendererKind::Native,
     };
 

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -27,14 +27,9 @@ void main(void) {
     write_clip(clip);
 
     // vUv will contain how many times this image has wrapped around the image size.
-    vec2 st0 = image.st_rect.xy;
-    vec2 st1 = image.st_rect.zw;
-
-    if (image.has_pixel_coords) {
-        vec2 texture_size = vec2(textureSize(sDiffuse, 0));
-        st0 /= texture_size;
-        st1 /= texture_size;
-    }
+    vec2 texture_size = vec2(textureSize(sDiffuse, 0));
+    vec2 st0 = image.st_rect.xy / texture_size;
+    vec2 st1 = image.st_rect.zw / texture_size;
 
     vTextureSize = st1 - st0;
     vTextureOffset = st0;


### PR DESCRIPTION
>Failed to compile shader: "../webrender/res/ps_image_clip.vs.glsl"
>0:33(6): error: cannot access field `has_pixel_coords' of structure
>0:33(6): error: type mismatch
>0:33(6): error: if-statement condition must be scalar boolean

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/529)
<!-- Reviewable:end -->
