### PR TITLE
[WIP] Image masked screen rectangle

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
         enable_recording: false,
         enable_scrollbars: false,
         debug: true,
-        precache_shaders: false,
+        precache_shaders: true,
         renderer_kind: RendererKind::Native,
     };
 

--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -6,7 +6,7 @@
 flat varying vec4 vClipRect;
 flat varying vec4 vClipRadius;
 flat varying vec4 vClipMaskUvRect;
-flat varying vec4 vClipMaskLocalRect;
+flat varying vec4 vClipMaskScreenRect;
 
 #ifdef WR_VERTEX_SHADER
 void write_clip(ClipData clip) {
@@ -18,7 +18,7 @@ void write_clip(ClipData clip) {
     //TODO: interpolate the final mask UV
     vec2 texture_size = textureSize(sMask, 0);
     vClipMaskUvRect = clip.mask_data.uv_rect / texture_size.xyxy;
-    vClipMaskLocalRect = clip.mask_data.local_rect; //TODO: transform
+    vClipMaskScreenRect = clip.mask_data.screen_rect;
 }
 #endif
 
@@ -54,7 +54,7 @@ float do_clip(vec2 pos) {
     float border_alpha = 1.0 - smoothstep(0.0, 1.0, distance_from_border);
 
     bool repeat_mask = false; //TODO
-    vec2 vMaskUv = (pos - vClipMaskLocalRect.xy) / vClipMaskLocalRect.zw;
+    vec2 vMaskUv = (pos - vClipMaskScreenRect.xy) / vClipMaskScreenRect.zw;
     vec2 clamped_mask_uv = repeat_mask ? fract(vMaskUv) :
         clamp(vMaskUv, vec2(0.0, 0.0), vec2(1.0, 1.0));
     vec2 source_uv = clamped_mask_uv * vClipMaskUvRect.zw + vClipMaskUvRect.xy;

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -349,7 +349,7 @@ ClipRect fetch_clip_rect(int index) {
 
 struct ImageMaskData {
     vec4 uv_rect;
-    vec4 local_rect;
+    vec4 screen_rect;
 };
 
 ImageMaskData fetch_mask_data(int index) {
@@ -358,7 +358,7 @@ ImageMaskData fetch_mask_data(int index) {
     ivec2 uv = get_fetch_uv_2(index);
 
     info.uv_rect = texelFetchOffset(sData32, uv, 0, ivec2(0, 0));
-    info.local_rect = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
+    info.screen_rect = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
 
     return info;
 }

--- a/webrender/res/ps_image_clip.vs.glsl
+++ b/webrender/res/ps_image_clip.vs.glsl
@@ -27,14 +27,9 @@ void main(void) {
     write_clip(clip);
 
     // vUv will contain how many times this image has wrapped around the image size.
-    vec2 st0 = image.st_rect.xy;
-    vec2 st1 = image.st_rect.zw;
-
-    if (image.has_pixel_coords) {
-        vec2 texture_size = vec2(textureSize(sDiffuse, 0));
-        st0 /= texture_size;
-        st1 /= texture_size;
-    }
+    vec2 texture_size = vec2(textureSize(sDiffuse, 0));
+    vec2 st0 = image.st_rect.xy / texture_size;
+    vec2 st1 = image.st_rect.zw / texture_size;
 
     vTextureSize = st1 - st0;
     vTextureOffset = st0;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -226,7 +226,7 @@ impl ClipCorner {
 #[derive(Debug, Clone)]
 struct ImageMaskData {
     uv_rect: Rect<f32>,
-    local_rect: Rect<f32>,
+    screen_rect: Rect<f32>,
 }
 
 #[derive(Debug, Clone)]
@@ -283,7 +283,7 @@ impl ClipData {
             },
             mask_data: ImageMaskData {
                 uv_rect: Rect::zero(),
-                local_rect: Rect::zero(),
+                screen_rect: Rect::zero(),
             },
         }
     }
@@ -316,7 +316,7 @@ impl ClipData {
                                               0.0),
             mask_data: ImageMaskData {
                 uv_rect: Rect::zero(),
-                local_rect: Rect::zero(),
+                screen_rect: Rect::zero(),
             },
         }
     }
@@ -564,7 +564,7 @@ impl PrimitiveStore {
                         uv_rect: Rect::new(tex_cache.uv0,
                                            Size2D::new(tex_cache.uv1.x - tex_cache.uv0.x,
                                                        tex_cache.uv1.y - tex_cache.uv0.y)),
-                        local_rect: mask.rect,
+                        screen_rect: mask.rect,
                     });
                 }
             }


### PR DESCRIPTION
Includes #529
Renames `local_rect` -> `screen_rect` for the `ImageMaskData`, since the idea now is that the mask is always screen-aligned, and we are baking anything non-aligned into the off-screen textures (#498).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/530)
<!-- Reviewable:end -->
