### PR TITLE
Add stride data to add image

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -335,6 +335,7 @@ pub enum RenderTargetMode {
 pub enum TextureUpdateDetails {
     Raw,
     Blit(Vec<u8>),
+    BlitWithStride(Vec<u8>, u32),
     Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage, BorderType),
 }
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -121,11 +121,12 @@ impl RenderBackend {
                             };
                             tx.send(glyph_dimensions).unwrap();
                         }
-                        ApiMsg::AddImage(id, width, height, format, bytes) => {
+                        ApiMsg::AddImage(id, width, height, stride, format, bytes) => {
                             profile_counters.image_templates.inc(bytes.len());
                             self.resource_cache.add_image_template(id,
                                                                    width,
                                                                    height,
+                                                                   stride,
                                                                    format,
                                                                    bytes);
                         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -531,6 +531,7 @@ impl Renderer {
         texture_cache.insert(white_image_id,
                              2,
                              2,
+                             2 * 4, // 4 bytes per pixel because RGBA8
                              ImageFormat::RGBA8,
                              TextureFilter::Linear,
                              TextureInsertOp::Blit(white_pixels),
@@ -540,6 +541,7 @@ impl Renderer {
         texture_cache.insert(dummy_mask_image_id,
                              2,
                              2,
+                             2, // Stride is 2 because 1 byte per pixel A8
                              ImageFormat::A8,
                              TextureFilter::Linear,
                              TextureInsertOp::Blit(mask_pixels),
@@ -888,6 +890,15 @@ impl Renderer {
                                     x,
                                     y,
                                     width, height,
+                                    bytes.as_slice());
+                            }
+                            TextureUpdateDetails::BlitWithStride(bytes, stride) => {
+                                //println!("Updating with stride {:?} and width: {:?}", stride, width);
+                                self.device.update_texture_with_stride(
+                                    update.id,
+                                    x,
+                                    y,
+                                    width, height, stride,
                                     bytes.as_slice());
                             }
                             TextureUpdateDetails::Blur(bytes,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -63,6 +63,7 @@ struct ImageResource {
     bytes: Vec<u8>,
     width: u32,
     height: u32,
+    stride: u32,
     format: ImageFormat,
     epoch: Epoch,
     is_opaque: bool,
@@ -209,12 +210,14 @@ impl ResourceCache {
                               image_key: ImageKey,
                               width: u32,
                               height: u32,
+                              stride: u32,
                               format: ImageFormat,
                               bytes: Vec<u8>) {
         let resource = ImageResource {
             is_opaque: is_image_opaque(format, &bytes),
             width: width,
             height: height,
+            stride: width, // This is an invalid stride for now, fixup
             format: format,
             bytes: bytes,
             epoch: Epoch(0),
@@ -243,6 +246,7 @@ impl ResourceCache {
             is_opaque: is_image_opaque(format, &bytes),
             width: width,
             height: height,
+            stride: width, // This is an invalid stride for now, fixup
             format: format,
             bytes: bytes,
             epoch: next_epoch,
@@ -332,6 +336,7 @@ impl ResourceCache {
                 self.texture_cache.insert(image_id,
                                           texture_width,
                                           texture_height,
+                                          texture_width,
                                           ImageFormat::RGBA8,
                                           TextureFilter::Linear,
                                           insert_op,
@@ -494,6 +499,7 @@ impl ResourceCache {
                                 self.texture_cache.update(image_id,
                                                           image_template.width,
                                                           image_template.height,
+                                                          image_template.stride,
                                                           image_template.format,
                                                           image_template.bytes.clone());
 
@@ -516,6 +522,7 @@ impl ResourceCache {
                             self.texture_cache.insert(image_id,
                                                       image_template.width,
                                                       image_template.height,
+                                                      image_template.stride,
                                                       image_template.format,
                                                       filter,
                                                       TextureInsertOp::Blit(image_template.bytes.clone()),

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -790,6 +790,7 @@ impl TextureCache {
                   image_id: TextureCacheItemId,
                   width: u32,
                   height: u32,
+                  stride: u32, // TODO (mchang) Handle strides
                   _format: ImageFormat,
                   bytes: Vec<u8>) {
         let existing_item = self.items.get(image_id);
@@ -816,6 +817,7 @@ impl TextureCache {
                   image_id: TextureCacheItemId,
                   width: u32,
                   height: u32,
+                  stride: u32,
                   format: ImageFormat,
                   filter: TextureFilter,
                   insert_op: TextureInsertOp,
@@ -909,7 +911,7 @@ impl TextureCache {
                                         result.item.requested_rect.origin.y,
                                         width,
                                         height,
-                                        TextureUpdateDetails::Blit(bytes))
+                                        TextureUpdateDetails::BlitWithStride(bytes, stride))
             }
             (AllocationKind::TexturePage,
              TextureInsertOp::Blur(bytes, glyph_size, blur_radius)) => {

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -91,11 +91,12 @@ impl RenderApi {
     pub fn add_image(&self,
                      width: u32,
                      height: u32,
+                     stride: u32,
                      format: ImageFormat,
                      bytes: Vec<u8>) -> ImageKey {
         let new_id = self.next_unique_id();
         let key = ImageKey::new(new_id.0, new_id.1);
-        let msg = ApiMsg::AddImage(key, width, height, format, bytes);
+        let msg = ApiMsg::AddImage(key, width, height, stride, format, bytes);
         self.api_sender.send(msg).unwrap();
         key
     }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -27,7 +27,7 @@ pub enum ApiMsg {
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, IpcSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
-    AddImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
+    AddImage(ImageKey, u32, u32, u32, ImageFormat, Vec<u8>),
     /// Updates the the resource cache with the new image data.
     UpdateImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
     /// Drops an image from the resource cache.


### PR DESCRIPTION
This adds support for a custom stride versus tightly packed image data. A couple of questions though:

1) In get_texture_info, please review this carefully. I want to make sure I used Cow right and got the lifetimes right.
2) The current iteration requires stride data on ApiMsg::AddImage. I'm not sure this will break Servo, a second patch for the gecko-wr integration fixes this up. Alternatively, we can add an ApiMsg::AddImageWithStride if you'd prefer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/535)
<!-- Reviewable:end -->
