### PR TITLE
Implement Home end key scroll

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -19,7 +19,7 @@ use tiling::{AuxiliaryListsMap, FrameBuilder, FrameBuilderConfig, PrimitiveFlags
 use util::MatrixHelpers;
 use webrender_traits::{AuxiliaryLists, PipelineId, Epoch, ScrollPolicy, ScrollLayerId};
 use webrender_traits::{ClipRegion, ColorF, DisplayItem, StackingContext, FilterOp, MixBlendMode};
-use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, SpecificDisplayItem, ScrollLayerState};
+use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, ScrollLocation, SpecificDisplayItem, ScrollLayerState};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
 use webrender_traits::{ServoScrollRootId, ScrollLayerRect, as_scroll_parent_rect, ScrollLayerPixel};
 use webrender_traits::WorldPoint4D;
@@ -331,10 +331,11 @@ impl Frame {
 
     /// Returns true if any layers actually changed position or false otherwise.
     pub fn scroll(&mut self,
-                  mut delta: Point2D<f32>,
+                  scroll_location: ScrollLocation,
                   cursor: Point2D<f32>,
                   phase: ScrollEventPhase)
                   -> bool {
+
         let root_scroll_layer_id = match self.root_scroll_layer_id {
             Some(root_scroll_layer_id) => root_scroll_layer_id,
             None => return false,
@@ -350,6 +351,37 @@ impl Frame {
             ScrollLayerInfo::Fixed => unreachable!("Tried to scroll a fixed position layer."),
         };
 
+        let mut delta:Point2D<f32> = match scroll_location {
+            ScrollLocation::Delta(delta) => delta,
+            ScrollLocation::Start => {
+                if layer.scrolling.offset.y.round() == 0.0 {
+                    // Nothing to do.
+                    return false;
+                }
+
+                layer.scrolling.offset.y = 0.0;
+                return true;
+            },
+            ScrollLocation::End => {
+                let end_pos = -layer.content_size.height +
+                                                 (layer.local_viewport_rect.size.height);
+
+                if layer.scrolling.offset.y.round() == end_pos {
+                    // Nothing to do.
+                    return false;
+                }
+                
+                layer.scrolling.offset.y = end_pos;
+                return true;
+            },
+        };
+
+        let overscroll_amount = layer.overscroll_amount();
+        let overscrolling = CAN_OVERSCROLL && (overscroll_amount.width != 0.0 ||
+                                               overscroll_amount.height != 0.0);
+        if overscrolling {
+            if overscroll_amount.width != 0.0 {
+                delta.x /= overscroll_amount.width.abs()
         let mut scrolled_a_layer = false;
         for (layer_id, layer) in self.layers.iter_mut() {
             if layer_id.pipeline_id != scroll_layer_id.pipeline_id {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -19,15 +19,11 @@ use tiling::{AuxiliaryListsMap, FrameBuilder, FrameBuilderConfig, PrimitiveFlags
 use util::MatrixHelpers;
 use webrender_traits::{AuxiliaryLists, PipelineId, Epoch, ScrollPolicy, ScrollLayerId};
 use webrender_traits::{ClipRegion, ColorF, DisplayItem, StackingContext, FilterOp, MixBlendMode};
-<<<<<<< 22aefa1b9daa4ae0b8e8d161d9d0173bb2117c9b
 use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, ScrollLocation, SpecificDisplayItem, ScrollLayerState};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
 use webrender_traits::{ServoScrollRootId, ScrollLayerRect, as_scroll_parent_rect, ScrollLayerPixel};
 use webrender_traits::WorldPoint4D;
 use webrender_traits::{LayerTransform, LayerToScrollTransform, ScrollToWorldTransform};
-=======
-use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, SpecificDisplayItem, ScrollLayerState, ScrollLocation};
->>>>>>> Implement home end key scrolling support.
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -302,6 +298,7 @@ impl Frame {
     }
 
     /// Returns true if any layers actually changed position or false otherwise.
+<<<<<<< efdaeb1c18aea2be3172aea2af309298b2f54402
     pub fn scroll_layers(&mut self,
                          origin: Point2D<f32>,
                          pipeline_id: PipelineId,

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -367,28 +367,30 @@ impl Frame {
                 continue;
             }
 
-            let mut delta:Point2D<f32> = match scroll_location {
+            let mut delta = match scroll_location {
                 ScrollLocation::Delta(delta) => delta,
                 ScrollLocation::Start => {
-                    if layer.scrolling.offset.y.round() == 0.0 {
-                        // Nothing to do.
-                        return false;
+                    if layer.scrolling.offset.y.round() <= 0.0 {
+                        // Nothing to do on this layer.
+                        continue;
                     }
 
                     layer.scrolling.offset.y = 0.0;
-                    return true;
+                    scrolled_a_layer = true;
+                    continue;
                 },
                 ScrollLocation::End => {
                     let end_pos = -layer.content_size.height +
                                   layer.local_viewport_rect.size.height;
 
-                    if layer.scrolling.offset.y.round() == end_pos {
-                        // Nothing to do.
-                        return false;
+                    if layer.scrolling.offset.y.round() >= end_pos {
+                        // Nothing to do on this layer.
+                        continue;
                     }
                 
                     layer.scrolling.offset.y = end_pos;
-                    return true;
+                    scrolled_a_layer = true;
+                    continue;
                 },
             };
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -298,7 +298,6 @@ impl Frame {
     }
 
     /// Returns true if any layers actually changed position or false otherwise.
-<<<<<<< efdaeb1c18aea2be3172aea2af309298b2f54402
     pub fn scroll_layers(&mut self,
                          origin: Point2D<f32>,
                          pipeline_id: PipelineId,

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -380,8 +380,8 @@ impl Frame {
                     continue;
                 },
                 ScrollLocation::End => {
-                    let end_pos = -layer.content_size.height +
-                                  layer.local_viewport_rect.size.height;
+                    let end_pos = layer.local_viewport_rect.size.height
+                                  - layer.content_size.height;
 
                     if layer.scrolling.offset.y.round() >= end_pos {
                         // Nothing to do on this layer.
@@ -391,7 +391,7 @@ impl Frame {
                     layer.scrolling.offset.y = end_pos;
                     scrolled_a_layer = true;
                     continue;
-                },
+                }
             };
 
             let overscroll_amount = layer.overscroll_amount();

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -9,7 +9,7 @@ use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::cell::Cell;
 use {ApiMsg, ColorF, DisplayListBuilder, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
-use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ServoScrollRootId};
+use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLocation, ServoScrollRootId};
 use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
 
 impl RenderApiSender {
@@ -188,8 +188,8 @@ impl RenderApi {
     ///
     /// Webrender looks for the layer closest to the user
     /// which has `ScrollPolicy::Scrollable` set.
-    pub fn scroll(&self, delta: Point2D<f32>, cursor: Point2D<f32>, phase: ScrollEventPhase) {
-        let msg = ApiMsg::Scroll(delta, cursor, phase);
+    pub fn scroll(&self, scroll_location: ScrollLocation, cursor: Point2D<f32>, phase: ScrollEventPhase) {
+        let msg = ApiMsg::Scroll(scroll_location, cursor, phase);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -493,9 +493,12 @@ pub enum ScrollPolicy {
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum ScrollLocation {
-    Delta(Point2D<f32>), // Scroll by a certain amount.
-    Start, // Scroll to very top of element.
-    End // Scroll to very bottom of element.
+    /// Scroll by a certain amount.
+    Delta(Point2D<f32>), 
+    /// Scroll to very top of element.
+    Start,
+    /// Scroll to very bottom of element. 
+    End 
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -48,7 +48,6 @@ pub enum ApiMsg {
                        BuiltDisplayListDescriptor,
                        AuxiliaryListsDescriptor),
     SetRootPipeline(PipelineId),
-    Scroll(Point2D<f32>, Point2D<f32>, ScrollEventPhase),
     ScrollLayersWithScrollId(Point2D<f32>, PipelineId, ServoScrollRootId),
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, MsgSender<(Point2D<f32>, PipelineId)>),
@@ -490,6 +489,13 @@ pub struct ScrollLayerState {
 pub enum ScrollPolicy {
     Scrollable,
     Fixed,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum ScrollLocation {
+    Delta(Point2D<f32>), // Scroll by a certain amount.
+    Start, // Scroll to very top of element.
+    End // Scroll to very bottom of element.
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -48,6 +48,7 @@ pub enum ApiMsg {
                        BuiltDisplayListDescriptor,
                        AuxiliaryListsDescriptor),
     SetRootPipeline(PipelineId),
+    Scroll(ScrollLocation, Point2D<f32>, ScrollEventPhase),
     ScrollLayersWithScrollId(Point2D<f32>, PipelineId, ServoScrollRootId),
     TickScrollingBounce,
     TranslatePointToLayerSpace(Point2D<f32>, MsgSender<(Point2D<f32>, PipelineId)>),


### PR DESCRIPTION
Addressing issue https://github.com/servo/servo/issues/13082.
Supporting https://github.com/servo/servo/pull/14141.

* Adds `ScrollLocation` type in `webrender_traits`.
* Refactor api to use new `ScrollLocation`
* Implement home/end scrolling in `webrender/src/frame.rs` `fn scroll(...)` using new `ScrollLocation` struct passed in.



<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/540)
<!-- Reviewable:end -->
