### PR TITLE
Change text-shadow to blur entire text run, and clean up texture cache.

### DIFF
--- a/webrender/res/cs_blur.fs.glsl
+++ b/webrender/res/cs_blur.fs.glsl
@@ -1,0 +1,39 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// TODO(gw): Write a fast path blur that handles smaller blur radii
+//           with a offset / weight uniform table and a constant
+//           loop iteration count!
+
+// TODO(gw): Make use of the bilinear sampling trick to reduce
+//           the number of texture fetches needed for a gaussian blur.
+
+float gauss(float x, float sigma) {
+    return (1.0 / sqrt(6.283185307179586 * sigma * sigma)) * exp(-(x * x) / (2.0 * sigma * sigma));
+}
+
+void main(void) {
+    vec4 color = texture(sCache, vUv) * gauss(0.0, vSigma);
+
+    for (int i=1 ; i < vBlurRadius ; ++i) {
+        vec2 offset = vec2(float(i)) * vOffsetScale;
+
+        vec2 st0 = clamp(vUv.xy + offset, vUvRect.xy, vUvRect.zw);
+        vec4 color0 = texture(sCache, vec3(st0, vUv.z));
+
+        vec2 st1 = clamp(vUv.xy - offset, vUvRect.xy, vUvRect.zw);
+        vec4 color1 = texture(sCache, vec3(st1, vUv.z));
+
+        // Alpha must be premultiplied in order to properly blur the alpha channel.
+        float weight = gauss(float(i), vSigma);
+        color += vec4(color0.rgb * color0.a, color0.a) * weight;
+        color += vec4(color1.rgb * color1.a, color1.a) * weight;
+    }
+
+    // Unpremultiply the alpha.
+    color = vec4(color.rgb / color.a, color.a);
+
+    oFragColor = color;
+}

--- a/webrender/res/cs_blur.fs.glsl
+++ b/webrender/res/cs_blur.fs.glsl
@@ -15,7 +15,8 @@ float gauss(float x, float sigma) {
 }
 
 void main(void) {
-    vec4 color = texture(sCache, vUv) * gauss(0.0, vSigma);
+    vec4 sample = texture(sCache, vUv);
+    vec4 color = vec4(sample.rgb * sample.a, sample.a) * gauss(0.0, vSigma);
 
     for (int i=1 ; i < vBlurRadius ; ++i) {
         vec2 offset = vec2(float(i)) * vOffsetScale;
@@ -33,7 +34,7 @@ void main(void) {
     }
 
     // Unpremultiply the alpha.
-    color = vec4(color.rgb / color.a, color.a);
+    color.rgb /= color.a;
 
     oFragColor = color;
 }

--- a/webrender/res/cs_blur.glsl
+++ b/webrender/res/cs_blur.glsl
@@ -1,0 +1,10 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+varying vec3 vUv;
+flat varying vec4 vUvRect;
+flat varying vec2 vOffsetScale;
+flat varying float vSigma;
+flat varying int vBlurRadius;

--- a/webrender/res/cs_blur.vs.glsl
+++ b/webrender/res/cs_blur.vs.glsl
@@ -17,35 +17,28 @@ void main(void) {
     vec4 local_rect = task.data0;
 
     vec2 pos = mix(local_rect.xy,
-    			   local_rect.xy + local_rect.zw,
-    			   aPosition.xy);
+                   local_rect.xy + local_rect.zw,
+                   aPosition.xy);
 
     vec2 texture_size = textureSize(sCache, 0).xy;
     vUv.z = src_task.data1.x;
     vBlurRadius = int(task.data1.y);
     vSigma = task.data1.y * 0.5;
 
-    vec4 src_rect;
-    vec2 uv0, uv1;
-
     switch (cmd.dir) {
         case DIR_HORIZONTAL:
             vOffsetScale = vec2(1.0 / texture_size.x, 0.0);
-            vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
-            uv0 = src_task.data0.xy;
-            uv1 = src_task.data0.xy + src_task.data0.zw;
             break;
         case DIR_VERTICAL:
             vOffsetScale = vec2(0.0, 1.0 / texture_size.y);
-            vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
-            uv0 = src_task.data0.xy;
-            uv1 = src_task.data0.xy + src_task.data0.zw;
             break;
     }
 
-    uv0 /= texture_size;
-    uv1 /= texture_size;
+    vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
     vUvRect /= texture_size.xyxy;
+
+    vec2 uv0 = src_task.data0.xy / texture_size;
+    vec2 uv1 = (src_task.data0.xy + src_task.data0.zw) / texture_size;
     vUv.xy = mix(uv0, uv1, aPosition.xy);
 
     gl_Position = uTransform * vec4(pos, 0.0, 1.0);

--- a/webrender/res/cs_blur.vs.glsl
+++ b/webrender/res/cs_blur.vs.glsl
@@ -1,0 +1,52 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Applies a separable gaussian blur in one direction, as specified
+// by the dir field in the blur command.
+
+#define DIR_HORIZONTAL  0
+#define DIR_VERTICAL    1
+
+void main(void) {
+    BlurCommand cmd = fetch_blur(gl_InstanceID);
+    RenderTaskData task = fetch_render_task(cmd.task_id);
+    RenderTaskData src_task = fetch_render_task(cmd.src_task_id);
+
+    vec4 local_rect = task.data0;
+
+    vec2 pos = mix(local_rect.xy,
+    			   local_rect.xy + local_rect.zw,
+    			   aPosition.xy);
+
+    vec2 texture_size = textureSize(sCache, 0).xy;
+    vUv.z = src_task.data1.x;
+    vBlurRadius = int(task.data1.y);
+    vSigma = task.data1.y * 0.5;
+
+    vec4 src_rect;
+    vec2 uv0, uv1;
+
+    switch (cmd.dir) {
+        case DIR_HORIZONTAL:
+            vOffsetScale = vec2(1.0 / texture_size.x, 0.0);
+            vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
+            uv0 = src_task.data0.xy;
+            uv1 = src_task.data0.xy + src_task.data0.zw;
+            break;
+        case DIR_VERTICAL:
+            vOffsetScale = vec2(0.0, 1.0 / texture_size.y);
+            vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
+            uv0 = src_task.data0.xy;
+            uv1 = src_task.data0.xy + src_task.data0.zw;
+            break;
+    }
+
+    uv0 /= texture_size;
+    uv1 /= texture_size;
+    vUvRect /= texture_size.xyxy;
+    vUv.xy = mix(uv0, uv1, aPosition.xy);
+
+    gl_Position = uTransform * vec4(pos, 0.0, 1.0);
+}

--- a/webrender/res/cs_text_run.fs.glsl
+++ b/webrender/res/cs_text_run.fs.glsl
@@ -1,0 +1,9 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void main(void) {
+    float a = texture(sDiffuse, vUv).a;
+    oFragColor = vec4(vColor.rgb, vColor.a * a);
+}

--- a/webrender/res/cs_text_run.glsl
+++ b/webrender/res/cs_text_run.glsl
@@ -1,0 +1,7 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+varying vec2 vUv;
+flat varying vec4 vColor;

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -1,0 +1,35 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Draw a text run to a cache target. These are always
+// drawn un-transformed. These are used for effects such
+// as text-shadow.
+
+void main(void) {
+    CachePrimitiveInstance cpi = fetch_cache_instance(gl_InstanceID);
+    RenderTaskData task = fetch_render_task(cpi.render_task_index);
+    TextRun text = fetch_text_run(cpi.specific_prim_index);
+    Glyph glyph = fetch_glyph(cpi.sub_index);
+    PrimitiveGeometry pg = fetch_prim_geometry(cpi.global_prim_index);
+
+    // Glyphs size is already in device-pixels.
+    // The render task origin is in device-pixels. Offset that by
+    // the glyph offset, relative to its primitive bounding rect.
+    vec2 size = glyph.uv_rect.zw - glyph.uv_rect.xy;
+    vec2 origin = task.data0.xy + uDevicePixelRatio * (glyph.offset.xy - pg.local_rect.xy);
+    vec4 local_rect = vec4(origin, size);
+
+    vec2 texture_size = vec2(textureSize(sDiffuse, 0));
+    vec2 st0 = glyph.uv_rect.xy / texture_size;
+    vec2 st1 = glyph.uv_rect.zw / texture_size;
+
+    vec2 pos = mix(local_rect.xy,
+    			   local_rect.xy + local_rect.zw,
+    			   aPosition.xy);
+	vUv = mix(st0, st1, aPosition.xy);
+	vColor = text.color;
+
+    gl_Position = uTransform * vec4(pos, 0.0, 1.0);
+}

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -26,8 +26,8 @@ void main(void) {
     vec2 st1 = glyph.uv_rect.zw / texture_size;
 
     vec2 pos = mix(local_rect.xy,
-    			   local_rect.xy + local_rect.zw,
-    			   aPosition.xy);
+                   local_rect.xy + local_rect.zw,
+                   aPosition.xy);
 	vUv = mix(st0, st1, aPosition.xy);
 	vColor = text.color;
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -277,10 +277,31 @@ PrimitiveInstance fetch_instance(int index) {
     return pi;
 }
 
+struct BlurCommand {
+    int task_id;
+    int src_task_id;
+    int dir;
+};
+
+BlurCommand fetch_blur(int index) {
+    BlurCommand blur;
+
+    int offset = index * 1;
+
+    ivec4 data0 = int_data[offset + 0];
+
+    blur.task_id = data0.x;
+    blur.src_task_id = data0.y;
+    blur.dir = data0.z;
+
+    return blur;
+}
+
 struct CachePrimitiveInstance {
     int global_prim_index;
     int specific_prim_index;
     int render_task_index;
+    int sub_index;
 };
 
 CachePrimitiveInstance fetch_cache_instance(int index) {
@@ -293,6 +314,7 @@ CachePrimitiveInstance fetch_cache_instance(int index) {
     cpi.global_prim_index = data0.x;
     cpi.specific_prim_index = data0.y;
     cpi.render_task_index = data0.z;
+    cpi.sub_index = data0.w;
 
     return cpi;
 }

--- a/webrender/res/ps_cache_image.fs.glsl
+++ b/webrender/res/ps_cache_image.fs.glsl
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void main(void) {
+    oFragColor = texture(sCache, vUv);
+}

--- a/webrender/res/ps_cache_image.glsl
+++ b/webrender/res/ps_cache_image.glsl
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+varying vec3 vUv;

--- a/webrender/res/ps_cache_image.vs.glsl
+++ b/webrender/res/ps_cache_image.vs.glsl
@@ -1,0 +1,27 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Draw a cached primitive (e.g. a blurred text run) from the
+// target cache to the framebuffer, applying tile clip boundaries.
+
+void main(void) {
+    Primitive prim = load_primitive(gl_InstanceID);
+
+    VertexInfo vi = write_vertex(prim.local_rect,
+                                 prim.local_clip_rect,
+                                 prim.layer,
+                                 prim.tile);
+
+    RenderTaskData child_task = fetch_render_task(prim.user_data.x);
+    vUv.z = child_task.data1.x;
+
+    vec2 texture_size = vec2(textureSize(sCache, 0));
+    vec2 uv0 = child_task.data0.xy / texture_size;
+    vec2 uv1 = (child_task.data0.xy + child_task.data0.zw) / texture_size;
+
+    vec2 f = (vi.local_clamped_pos - prim.local_rect.xy) / prim.local_rect.zw;
+
+    vUv.xy = mix(uv0, uv1, f);
+}

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -6,7 +6,7 @@ use euclid::Matrix4D;
 use fnv::FnvHasher;
 use gleam::gl;
 use internal_types::{PackedVertex, PackedVertexForQuad};
-use internal_types::{PackedVertexForTextureCacheUpdate, RenderTargetMode, TextureSampler};
+use internal_types::{RenderTargetMode, TextureSampler};
 use internal_types::{VertexAttribute, DebugFontVertex, DebugColorVertex};
 //use notify::{self, Watcher};
 use std::collections::HashMap;
@@ -65,7 +65,6 @@ pub enum VertexFormat {
     Rectangles,
     DebugFont,
     DebugColor,
-    RasterOp,
 }
 
 pub trait FileWatcherHandler : Send {
@@ -233,78 +232,6 @@ impl VertexFormat {
                                           false,
                                           vertex_stride as gl::GLint,
                                           0 + vertex_stride * offset);
-            }
-            VertexFormat::RasterOp => {
-                gl::enable_vertex_attrib_array(VertexAttribute::Position as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::ColorRectTL as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::ColorTexCoordRectTop as
-                                               gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::BorderRadii as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::BorderPosition as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::BlurRadius as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::DestTextureSize as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::SourceTextureSize as gl::GLuint);
-                gl::enable_vertex_attrib_array(VertexAttribute::Misc as gl::GLuint);
-
-                self.set_divisors(0);
-
-                let vertex_stride = mem::size_of::<PackedVertexForTextureCacheUpdate>() as
-                    gl::GLuint;
-
-                gl::vertex_attrib_pointer(VertexAttribute::Position as gl::GLuint,
-                                          2,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          0);
-                gl::vertex_attrib_pointer(VertexAttribute::ColorRectTL as gl::GLuint,
-                                          4,
-                                          gl::UNSIGNED_BYTE,
-                                          true,
-                                          vertex_stride as gl::GLint,
-                                          8);
-                gl::vertex_attrib_pointer(VertexAttribute::ColorTexCoordRectTop as gl::GLuint,
-                                          2,
-                                          gl::UNSIGNED_SHORT,
-                                          true,
-                                          vertex_stride as gl::GLint,
-                                          12);
-                gl::vertex_attrib_pointer(VertexAttribute::BorderRadii as gl::GLuint,
-                                          4,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          16);
-                gl::vertex_attrib_pointer(VertexAttribute::BorderPosition as gl::GLuint,
-                                          4,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          32);
-                gl::vertex_attrib_pointer(VertexAttribute::DestTextureSize as gl::GLuint,
-                                          2,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          48);
-                gl::vertex_attrib_pointer(VertexAttribute::SourceTextureSize as gl::GLuint,
-                                          2,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          56);
-                gl::vertex_attrib_pointer(VertexAttribute::BlurRadius as gl::GLuint,
-                                          1,
-                                          gl::FLOAT,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          64);
-                gl::vertex_attrib_pointer(VertexAttribute::Misc as gl::GLuint,
-                                          4,
-                                          gl::UNSIGNED_BYTE,
-                                          false,
-                                          vertex_stride as gl::GLint,
-                                          68);
             }
         }
     }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -150,7 +150,6 @@ pub fn device_pixel(value: f32, device_pixel_ratio: f32) -> DeviceLength {
     DeviceLength::new((value * device_pixel_ratio).round() as i32)
 }
 
-const UV_FLOAT_TO_FIXED: f32 = 65535.0;
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;
 pub const ANGLE_FLOAT_TO_FIXED: f32 = 65535.0;
 
@@ -305,7 +304,6 @@ pub enum RenderTargetMode {
 pub enum TextureUpdateDetails {
     Raw,
     Blit(Vec<u8>, Option<u32>),
-    Blur(Vec<u8>, Size2D<u32>, Au, TextureImage, TextureImage),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -421,72 +419,6 @@ pub struct RectUv<T, U = UnknownUnit> {
     pub top_right: TypedPoint2D<T, U>,
     pub bottom_left: TypedPoint2D<T, U>,
     pub bottom_right: TypedPoint2D<T, U>,
-}
-
-#[derive(Debug, Clone)]
-#[repr(C)]
-pub struct PackedVertexForTextureCacheUpdate {
-    pub x: f32,
-    pub y: f32,
-    pub color: PackedColor,
-    pub u: u16,
-    pub v: u16,
-    pub border_radii_outer_rx: f32,
-    pub border_radii_outer_ry: f32,
-    pub border_radii_inner_rx: f32,
-    pub border_radii_inner_ry: f32,
-    pub border_position_x: f32,
-    pub border_position_y: f32,
-    pub border_position_arc_center_x: f32,
-    pub border_position_arc_center_y: f32,
-    pub dest_texture_size_x: f32,
-    pub dest_texture_size_y: f32,
-    pub source_texture_size_x: f32,
-    pub source_texture_size_y: f32,
-    pub blur_radius: f32,
-    pub misc0: u8,
-    pub misc1: u8,
-    pub misc2: u8,
-    pub misc3: u8,
-}
-
-impl PackedVertexForTextureCacheUpdate {
-    pub fn new(position: &Point2D<f32>,
-               color: &ColorF,
-               uv: &Point2D<f32>,
-               border_radii_outer: &Point2D<f32>,
-               border_radii_inner: &Point2D<f32>,
-               border_position: &Point2D<f32>,
-               border_position_arc_center: &Point2D<f32>,
-               dest_texture_size: &Size2D<f32>,
-               source_texture_size: &Size2D<f32>,
-               blur_radius: f32)
-               -> PackedVertexForTextureCacheUpdate {
-        PackedVertexForTextureCacheUpdate {
-            x: position.x,
-            y: position.y,
-            color: PackedColor::from_color(color),
-            u: (uv.x * UV_FLOAT_TO_FIXED).round() as u16,
-            v: (uv.y * UV_FLOAT_TO_FIXED).round() as u16,
-            border_radii_outer_rx: border_radii_outer.x,
-            border_radii_outer_ry: border_radii_outer.y,
-            border_radii_inner_rx: border_radii_inner.x,
-            border_radii_inner_ry: border_radii_inner.y,
-            border_position_x: border_position.x,
-            border_position_y: border_position.y,
-            border_position_arc_center_x: border_position_arc_center.x,
-            border_position_arc_center_y: border_position_arc_center.y,
-            dest_texture_size_x: dest_texture_size.width,
-            dest_texture_size_y: dest_texture_size.height,
-            source_texture_size_x: source_texture_size.width,
-            source_texture_size_y: source_texture_size.height,
-            blur_radius: blur_radius,
-            misc0: 0,
-            misc1: 0,
-            misc2: 0,
-            misc3: 0,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -49,7 +49,6 @@ extern crate log;
 #[macro_use]
 extern crate bitflags;
 
-mod batch;
 mod batch_builder;
 mod debug_colors;
 mod debug_font_data;

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -258,19 +258,16 @@ pub enum FontRenderMode {
 pub struct GlyphKey {
     pub font_key: FontKey,
     pub size: Au,
-    pub blur_radius: Au,
     pub index: u32,
 }
 
 impl GlyphKey {
     pub fn new(font_key: FontKey,
                size: Au,
-               blur_radius: Au,
                index: u32) -> GlyphKey {
         GlyphKey {
             font_key: font_key,
             size: size,
-            blur_radius: blur_radius,
             index: index,
         }
     }


### PR DESCRIPTION
* Add support for text-shadow to be drawn via render tasks on text runs.
* Add support for blur render tasks. Uses standard 2 pass separable technique.
* Remove a large amount of code that was used only for old glyph blur support.
* Remove blur_radius from GlyphKey, resource cache, texture cache etc.
* Add gaussian blur shader (cs_blur).
* Add text run cache shader (cs_text_run).
* Add generic primitive shader for drawing cache items (ps_cache_image).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/546)
<!-- Reviewable:end -->
