### PR TITLE
Support external image texture/buffer

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -42,6 +42,7 @@ use time::precise_time_ns;
 use util::TransformedRectKind;
 use webrender_traits::{ColorF, Epoch, PipelineId, RenderNotifier, RenderDispatcher};
 use webrender_traits::{ImageFormat, RenderApiSender, RendererKind};
+use webrender_traits::{ExternalImage, ExternalImageCallback, ExternalImageKey};
 
 pub const BLUR_INFLATION_FACTOR: u32 = 3;
 pub const MAX_RASTER_OP_SIZE: u32 = 2048;
@@ -368,6 +369,10 @@ pub struct Renderer {
     /// Used to dispatch functions to the main thread's event loop.
     /// Required to allow GLContext sharing in some implementations like WGL.
     main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
+
+    // Used for accessing the external texture/buffer through FFI.
+    // E.g. We could use this callback function to access the texture/buffer in C++.
+    external_image_callback: Option<ExternalImageCallback>,
 }
 
 impl Renderer {
@@ -698,6 +703,7 @@ impl Renderer {
             data128_texture: data128_texture,
             pipeline_epoch_map: HashMap::with_hasher(Default::default()),
             main_thread_dispatcher: main_thread_dispatcher,
+            external_image_callback: options.external_image_callback
         };
 
         renderer.update_uniform_locations();
@@ -1687,4 +1693,5 @@ pub struct RendererOptions {
     pub precache_shaders: bool,
     pub renderer_kind: RendererKind,
     pub enable_subpixel_aa: bool,
+    pub external_image_callback: Option<ExternalImageCallback>,
 }

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -94,8 +94,7 @@ impl RenderApi {
                      stride: Option<u32>,
                      format: ImageFormat,
                      bytes: Vec<u8>) -> ImageKey {
-        let new_id = self.next_unique_id();
-        let key = ImageKey::new(new_id.0, new_id.1);
+        let key = self.alloc_image();
         let msg = ApiMsg::AddImage(key, width, height, stride, format, bytes);
         self.api_sender.send(msg).unwrap();
         key

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -743,3 +743,55 @@ pub enum WebGLShaderParameter {
     Bool(bool),
     Invalid,
 }
+
+#[repr(C)]
+pub struct ExternalImageKey(pub u32);
+
+pub enum ExternalImage<'i> {
+    TextureHandle {
+        handle: u32,
+    },
+    MemoryBuff {
+        buff: &'i [u8],
+    }
+}
+
+#[repr(C)]
+pub enum ExternalImageType {
+    TEXTURE_HANDLE,
+    MEM_OR_SHMEM,
+}
+
+#[repr(C)]
+pub struct ExternalImageStruct {
+    image_type: ExternalImageType,
+
+    // external buffer handle
+    handle: u32,
+
+    // shmem or memory buffer
+    buff: *const u8,
+    size: usize,
+}
+
+impl ExternalImageStruct {
+    pub fn get_image(&self) -> ExternalImage {
+        match self.image_type {
+            ExternalImageType::TEXTURE_HANDLE =>
+                ExternalImage::TextureHandle { handle: self.handle },
+            ExternalImageType::MEM_OR_SHMEM =>
+                ExternalImage::MemoryBuff { buff: unsafe { std::slice::from_raw_parts(self.buff, self.size)} },
+        }
+    }
+}
+
+pub type GetExternalImageCallback = fn(ExternalImageKey) -> ExternalImageStruct;
+
+pub type ReleaseExternalImageCallback = fn(ExternalImageKey);
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct ExternalImageCallback {
+    pub get_func: GetExternalImageCallback,
+    pub release_func: ReleaseExternalImageCallback,
+}


### PR DESCRIPTION
This patch try to support external image in WR (#524).

Then, we could use these two callback function to get/release the external buffer/image from c++.
```
pub get_func: GetExternalImageCallback
pub release_func: ReleaseExternalImageCallback
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/547)
<!-- Reviewable:end -->
