### PR TITLE
[WIP] Add support for externally allocated images in the render backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -595,6 +595,15 @@ impl Frame {
                                                   info.image_key,
                                                   info.image_rendering);
                             }
+                            SpecificDisplayItem::ExternalImage(ref info) => {
+                                builder.add_external_image(item.rect,
+                                                           &item.clip,
+                                                           &info.stretch_size,
+                                                           &info.tile_spacing,
+                                                           info.image_key,
+                                                           info.uv_rect,
+                                                           info.image_rendering);
+                            }
                             SpecificDisplayItem::Text(ref text_info) => {
                                 builder.add_text(item.rect,
                                                  &item.clip,

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -595,15 +595,6 @@ impl Frame {
                                                   info.image_key,
                                                   info.image_rendering);
                             }
-                            SpecificDisplayItem::ExternalImage(ref info) => {
-                                builder.add_external_image(item.rect,
-                                                           &item.clip,
-                                                           &info.stretch_size,
-                                                           &info.tile_spacing,
-                                                           info.image_key,
-                                                           info.uv_rect,
-                                                           info.image_rendering);
-                            }
                             SpecificDisplayItem::Text(ref text_info) => {
                                 builder.add_text(item.rect,
                                                  &item.clip,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -220,6 +220,13 @@ impl SourceTexture {
             SourceTexture::Id(_) => { false }
         }
     }
+
+    pub fn to_external(&self) -> Option<ExternalImageKey> {
+        match *self {
+            SourceTexture::External(key) => Some(key),
+            SourceTexture::Id(_) => None,
+        }
+    }
 }
 
 /// Optional textures that can be used as a source in the shaders.

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tiling;
 use webrender_traits::{Epoch, ColorF, PipelineId};
-use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
+use webrender_traits::{ExternalImageKey, ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
 use webrender_traits::{ScrollLayerId, WebGLCommand};
 
 pub enum GLContextHandleWrapper {
@@ -193,19 +193,48 @@ impl TextureSampler {
     }
 }
 
+/// A reference to a texture, either an id assigned by the render backend or an
+/// indirect key resolved to an id later by the renderer.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SourceTexture {
+    Id(TextureId),
+    External(ExternalImageKey),
+    // TODO(nical): should this have a None variant to better separate the cases
+    // where the batch does not use all its texture slots and cases where a slot
+    // will be used but the texture hasn't been assigned yet?
+}
+
+impl SourceTexture {
+    pub fn invalid() -> SourceTexture { SourceTexture::Id(TextureId::invalid()) }
+
+    pub fn is_valid(&self) -> bool {
+        match *self {
+            SourceTexture::Id(id) => { id.is_valid() }
+            SourceTexture::External(_) => { true }
+        }
+    }
+
+    pub fn is_external(&self) -> bool {
+        match *self {
+            SourceTexture::External(_) => { true }
+            SourceTexture::Id(_) => { false }
+        }
+    }
+}
+
 /// Optional textures that can be used as a source in the shaders.
-/// Textures that are not used by the batch are equal to TextureId::invalid().
+/// Textures that are not used by the batch are equal to SourceTexture::invalid().
 #[derive(Copy, Clone, Debug)]
 pub struct BatchTextures {
-    pub colors: [TextureId; 3],
-    pub mask: TextureId,
+    pub colors: [SourceTexture; 3],
+    pub mask: SourceTexture,
 }
 
 impl BatchTextures {
     pub fn no_texture() -> Self {
         BatchTextures {
-            colors: [TextureId::invalid(); 3],
-            mask: TextureId::invalid(),
+            colors: [SourceTexture::invalid(); 3],
+            mask: SourceTexture::invalid(),
         }
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -11,7 +11,7 @@ use frame::FrameId;
 use gpu_store::GpuStoreAddress;
 use internal_types::{DeviceRect, DevicePoint, DeviceSize, DeviceLength, device_pixel, CompositionOp};
 use internal_types::{ANGLE_FLOAT_TO_FIXED, LowLevelFilterOp};
-use internal_types::{BatchTextures};
+use internal_types::{SourceTexture, BatchTextures};
 use layer::Layer;
 use prim_store::{PrimitiveGeometry, RectanglePrimitive, PrimitiveContainer};
 use prim_store::{BorderPrimitiveCpu, BorderPrimitiveGpu, BoxShadowPrimitiveGpu};
@@ -34,7 +34,7 @@ use std::usize;
 use texture_cache::TexturePage;
 use util::{self, rect_from_points, MatrixHelpers, rect_from_points_f};
 use util::{TransformedRect, TransformedRectKind, subtract_rect, pack_as_float};
-use webrender_traits::{ColorF, FontKey, ImageKey, ImageRendering, MixBlendMode};
+use webrender_traits::{ColorF, FontKey, ImageKey, ExternalImageKey, ImageRendering, MixBlendMode};
 use webrender_traits::{BorderDisplayItem, BorderSide, BorderStyle};
 use webrender_traits::{AuxiliaryLists, ItemRange, BoxShadowClipMode, ClipRegion};
 use webrender_traits::{PipelineId, ScrollLayerId, WebGLContextId, FontRenderMode};
@@ -50,7 +50,7 @@ pub type AuxiliaryListsMap = HashMap<PipelineId,
 
 trait AlphaBatchHelpers {
     fn get_batch_kind(&self, metadata: &PrimitiveMetadata) -> AlphaBatchKind;
-    fn get_color_textures(&self, metadata: &PrimitiveMetadata) -> [TextureId; 3];
+    fn get_color_textures(&self, metadata: &PrimitiveMetadata) -> [SourceTexture; 3];
     fn get_blend_mode(&self, needs_blending: bool, metadata: &PrimitiveMetadata) -> BlendMode;
     fn prim_affects_tile(&self,
                          prim_index: PrimitiveIndex,
@@ -100,8 +100,8 @@ impl AlphaBatchHelpers for PrimitiveStore {
         batch_kind
     }
 
-    fn get_color_textures(&self, metadata: &PrimitiveMetadata) -> [TextureId; 3] {
-        let invalid = TextureId::invalid();
+    fn get_color_textures(&self, metadata: &PrimitiveMetadata) -> [SourceTexture; 3] {
+        let invalid = SourceTexture::invalid();
         match metadata.prim_kind {
             PrimitiveKind::Border |
             PrimitiveKind::BoxShadow |
@@ -113,7 +113,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
             }
             PrimitiveKind::TextRun => {
                 let text_run_cpu = &self.cpu_text_runs[metadata.cpu_prim_index.0];
-                [text_run_cpu.color_texture_id, invalid, invalid]
+                [SourceTexture::Id(text_run_cpu.color_texture_id), invalid, invalid]
             }
             // TODO(nical): YuvImage will return 3 textures.
         }
@@ -494,7 +494,7 @@ impl AlphaBatcher {
 
                         let textures = BatchTextures {
                             colors: ctx.prim_store.get_color_textures(prim_metadata),
-                            mask: prim_metadata.mask_texture_id,
+                            mask: SourceTexture::Id(prim_metadata.mask_texture_id),
                         };
 
                         batch_key = AlphaBatchKey::primitive(batch_kind,
@@ -673,11 +673,11 @@ impl RenderTarget {
                         // we switch the texture atlas to use texture layers!
                         let textures = BatchTextures {
                             colors: ctx.prim_store.get_color_textures(prim_metadata),
-                            mask: prim_metadata.mask_texture_id,
+                            mask: SourceTexture::Id(prim_metadata.mask_texture_id),
                         };
 
-                        debug_assert!(textures.colors[0] != TextureId::invalid());
-                        debug_assert!(self.text_run_textures.colors[0] == TextureId::invalid() ||
+                        debug_assert!(textures.colors[0] != SourceTexture::invalid());
+                        debug_assert!(self.text_run_textures.colors[0] == SourceTexture::invalid() ||
                                       self.text_run_textures.colors[0] == textures.colors[0]);
                         self.text_run_textures = textures;
 
@@ -1117,7 +1117,7 @@ pub enum BlurDirection {
 }
 
 #[inline]
-fn textures_compatible(t1: TextureId, t2: TextureId) -> bool {
+fn textures_compatible(t1: SourceTexture, t2: SourceTexture) -> bool {
     !t1.is_valid() || !t2.is_valid() || t1 == t2
 }
 
@@ -1995,7 +1995,7 @@ impl FrameBuilder {
                                context_id: WebGLContextId) {
         let prim_cpu = ImagePrimitiveCpu {
             kind: ImagePrimitiveKind::WebGL(context_id),
-            color_texture_id: TextureId::invalid(),
+            color_texture_id: SourceTexture::invalid(),
         };
 
         let prim_gpu = ImagePrimitiveGpu {
@@ -2021,12 +2021,45 @@ impl FrameBuilder {
             kind: ImagePrimitiveKind::Image(image_key,
                                             image_rendering,
                                             *tile_spacing),
-            color_texture_id: TextureId::invalid(),
+            color_texture_id: SourceTexture::invalid(),
         };
 
         let prim_gpu = ImagePrimitiveGpu {
             uv0: Point2D::zero(),
             uv1: Point2D::zero(),
+            stretch_size: *stretch_size,
+            tile_spacing: *tile_spacing,
+        };
+
+        self.add_primitive(&rect,
+                           clip_region,
+                           PrimitiveContainer::Image(prim_cpu, prim_gpu));
+    }
+
+    pub fn add_external_image(&mut self,
+                              rect: Rect<f32>,
+                              clip_region: &ClipRegion,
+                              stretch_size: &Size2D<f32>,
+                              tile_spacing: &Size2D<f32>,
+                              key: ExternalImageKey,
+                              uv_rect: Rect<f32>,
+                              image_rendering: ImageRendering) {
+        // The external image primitve works like a regular image where
+        // most of the information is already resolved, except the texture
+        // which is resolved later in the renderer instead of using the resource
+        // cache.
+
+        let prim_cpu = ImagePrimitiveCpu {
+            kind: ImagePrimitiveKind::ExternalImage(image_rendering,
+                                                    *tile_spacing),
+            color_texture_id: SourceTexture::External(key),
+        };
+
+        // TODO(nical): check that we don't need to invert y or whatnot, and look into
+        // where we are supposed to compute the tiled texture coordinates.
+        let prim_gpu = ImagePrimitiveGpu {
+            uv0: uv_rect.origin,
+            uv1: uv_rect.bottom_right(),
             stretch_size: *stretch_size,
             tile_spacing: *tile_spacing,
         };

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -5,7 +5,7 @@
 use display_list::AuxiliaryListsBuilder;
 use euclid::{Rect, Size2D};
 use {BorderRadius, BorderDisplayItem, ClipRegion, ColorF, ComplexClipRegion};
-use {FontKey, ImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
+use {FontKey, ImageKey, ExternalImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
 use {ImageMask, ItemRange};
 
 impl BorderDisplayItem {
@@ -107,9 +107,23 @@ impl FontKey {
     }
 }
 
+// hijack the last highest bit of the namespace to store whether or not the key
+// is external.
+const IMAGE_KEY_EXTERNAL_BIT: u32 = 0x80000000;
+
 impl ImageKey {
-    pub fn new(key0: u32, key1: u32) -> ImageKey {
-        ImageKey(key0, key1)
+    pub fn new(namespace: u32, key: u32) -> ImageKey {
+        assert!(namespace & IMAGE_KEY_EXTERNAL_BIT == 0);
+        ImageKey(namespace, key)
+    }
+
+    pub fn new_external(namespace: u32, key: u32) -> ExternalImageKey {
+        assert!(namespace & IMAGE_KEY_EXTERNAL_BIT == 0);
+        ImageKey(namespace | IMAGE_KEY_EXTERNAL_BIT, key)
+    }
+
+    pub fn is_external(&self) -> bool {
+        self.0 & IMAGE_KEY_EXTERNAL_BIT != 0
     }
 }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -319,28 +319,6 @@ pub struct ImageDisplayItem {
     pub image_rendering: ImageRendering,
 }
 
-// TODO(nical): The only differences with the image item is that we provide a
-// different type of key but more importantly we provide the uv rectangle.
-// It would look nicer if the ImageDisplayItem was doing both external and
-// regular images, but it may not make sense to have an uv_rect specified for
-// regular images.
-// The reason I think we should have uv_rect for external images is that I would
-// like gecko to pack several of the externally rendered items (for example all
-// native widgets like buttons, check boxes and the like) in the same texture, and
-// in some cases we just don't have a choice because the GPU will round up the
-// texture size to 32 if the image is smaller.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExternalImageDisplayItem {
-    pub image_key: ExternalImageKey,
-    pub stretch_size: Size2D<f32>,
-    pub tile_spacing: Size2D<f32>,
-    // TODO(nical) Decide what unit to use!
-    // Should it be in texels or [0..1] texture space?
-    // I'd say in texels...
-    pub uv_rect: Rect<f32>,
-    pub image_rendering: ImageRendering,
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageFormat {
     Invalid,
@@ -353,8 +331,10 @@ pub enum ImageFormat {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ImageKey(u32, u32);
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ExternalImageKey(u32, u32);
+// TODO(nical) in order to not split the API, ExternalImageKey is just an alias
+// for ImageKey. The downside is that in places where we expect only one of the
+// two types, we have to check at runtime.
+pub type ExternalImageKey = ImageKey;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageRendering {
@@ -469,7 +449,6 @@ pub enum SpecificDisplayItem {
     Rectangle(RectangleDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),
-    ExternalImage(ExternalImageDisplayItem),
     WebGL(WebGLDisplayItem),
     Border(BorderDisplayItem),
     BoxShadow(BoxShadowDisplayItem),

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -319,6 +319,28 @@ pub struct ImageDisplayItem {
     pub image_rendering: ImageRendering,
 }
 
+// TODO(nical): The only differences with the image item is that we provide a
+// different type of key but more importantly we provide the uv rectangle.
+// It would look nicer if the ImageDisplayItem was doing both external and
+// regular images, but it may not make sense to have an uv_rect specified for
+// regular images.
+// The reason I think we should have uv_rect for external images is that I would
+// like gecko to pack several of the externally rendered items (for example all
+// native widgets like buttons, check boxes and the like) in the same texture, and
+// in some cases we just don't have a choice because the GPU will round up the
+// texture size to 32 if the image is smaller.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExternalImageDisplayItem {
+    pub image_key: ExternalImageKey,
+    pub stretch_size: Size2D<f32>,
+    pub tile_spacing: Size2D<f32>,
+    // TODO(nical) Decide what unit to use!
+    // Should it be in texels or [0..1] texture space?
+    // I'd say in texels...
+    pub uv_rect: Rect<f32>,
+    pub image_rendering: ImageRendering,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageFormat {
     Invalid,
@@ -330,6 +352,9 @@ pub enum ImageFormat {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ImageKey(u32, u32);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ExternalImageKey(u32, u32);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageRendering {
@@ -444,6 +469,7 @@ pub enum SpecificDisplayItem {
     Rectangle(RectangleDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),
+    ExternalImage(ExternalImageDisplayItem),
     WebGL(WebGLDisplayItem),
     Border(BorderDisplayItem),
     BoxShadow(BoxShadowDisplayItem),


### PR DESCRIPTION
Although there is some overlap with PR #547, the latter currently focuses on the API aspect while the work I have here is a proof-of-concept implementation of how to get the indirection layer set up in the various bits that happen in the render backend thread. I'd love to have the two PRs on the same ticket to group the discussions and reviews but it looks like github doesn't work that way).

Since this is rebased on top of PR #534, you currently see a lot more change than you need to in the diff view, so for now just ignore the commit "Refactor texture names and support more than two textures in the shaders."

The basic idea here is to add an image item which does not use the resource cache to generate the texture id and uv coordinates. UVs are specified upfront and the texture id is resolved at the last moment by the renderer from an ExternalmageKey (introdoced in PR #547). The render backend thread only sees the ExternalImageKey so there is some plumbing done, in particular in the primitive store, in order to not use the resource cache in this particular case.

UVs are provided up front because I want to be able to store several images in the same texture (basically have something that would work like webrender's texture cache for content that is not supported by webrender, and is rendered from a different thread). Also we sometimes have to fiddle with the texture size because the texture is too small or the driver is too buggy, so we can't assume that the UVs are going to cover the entire image.

It's currently in a rough and unfinished state (UVs are passed through without considering the tiling, etc.) but the basic infrastructure is here (for the render backend side of things, refer to PR #547 for the renderer and API aspects).

cc @glennw @JerryShih

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/548)
<!-- Reviewable:end -->
