### PR TITLE
Flatten the display list in the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,8 @@ dependencies = [
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.8.1",
- "webrender_traits 0.8.1",
+ "webrender 0.9.0",
+ "webrender_traits 0.9.0",
 ]
 
 [[package]]
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,12 +810,12 @@ dependencies = [
  "offscreen_gl_context 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.8.1",
+ "webrender_traits 0.9.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,8 +850,8 @@ dependencies = [
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.8.1",
- "webrender_traits 0.8.1",
+ "webrender 0.9.0",
+ "webrender_traits 0.9.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -12,13 +12,13 @@ use internal_types::{LowLevelFilterOp};
 use internal_types::{RendererFrame};
 use layer::{Layer, ScrollingState};
 use resource_cache::{DummyResources, ResourceCache};
-use scene::{SceneStackingContext, ScenePipeline, Scene, SceneItem, SpecificSceneItem};
+use scene::Scene;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, FrameBuilder, FrameBuilderConfig, PrimitiveFlags};
 use util::MatrixHelpers;
 use webrender_traits::{AuxiliaryLists, PipelineId, Epoch, ScrollPolicy, ScrollLayerId};
-use webrender_traits::{ClipRegion, ColorF, StackingContext, FilterOp, MixBlendMode};
+use webrender_traits::{ClipRegion, ColorF, DisplayItem, StackingContext, FilterOp, MixBlendMode};
 use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, SpecificDisplayItem, ScrollLayerState};
 
 #[cfg(target_os = "macos")]
@@ -33,21 +33,9 @@ pub struct FrameId(pub u32);
 static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF { r: 0.3, g: 0.3, b: 0.3, a: 0.6 };
 
 struct FlattenContext<'a> {
-    resource_cache: &'a mut ResourceCache,
     scene: &'a Scene,
     pipeline_sizes: &'a mut HashMap<PipelineId, Size2D<f32>>,
     builder: &'a mut FrameBuilder,
-}
-
-#[derive(Debug)]
-struct FlattenInfo {
-    // Pipeline this part of the tree belongs to.
-    pipeline_id: PipelineId,
-
-    current_scroll_layer_id: ScrollLayerId,
-    current_fixed_layer_id: ScrollLayerId,
-
-    layer_relative_transform: Matrix4D<f32>,
 }
 
 pub type LayerMap = HashMap<ScrollLayerId, Layer, BuildHasherDefault<FnvHasher>>;
@@ -66,45 +54,16 @@ pub struct Frame {
     frame_builder: Option<FrameBuilder>,
 }
 
-enum SceneItemKind<'a> {
-    StackingContext(&'a SceneStackingContext, PipelineId),
-    Pipeline(&'a ScenePipeline)
+trait DisplayListHelpers {
+    fn starting_stacking_context<'a>(&'a self) -> Option<&'a StackingContext>;
 }
 
-#[derive(Clone)]
-struct SceneItemWithZOrder {
-    item: SceneItem,
-    z_index: i32,
-}
-
-impl<'a> SceneItemKind<'a> {
-    fn collect_scene_items(&self, scene: &Scene) -> Vec<SceneItem> {
-        let mut result = Vec::new();
-        let stacking_context = match *self {
-            SceneItemKind::StackingContext(stacking_context, _) => {
-                &stacking_context.stacking_context
-            }
-            SceneItemKind::Pipeline(pipeline) => {
-                if let Some(background_draw_list) = pipeline.background_draw_list {
-                    result.push(SceneItem {
-                        specific: SpecificSceneItem::DrawList(background_draw_list),
-                    });
-                }
-
-                &scene.stacking_context_map
-                      .get(&pipeline.root_stacking_context_id)
-                      .unwrap()
-                      .stacking_context
-            }
-        };
-
-        for display_list_id in &stacking_context.display_lists {
-            let display_list = &scene.display_list_map[display_list_id];
-            for item in &display_list.items {
-                result.push(item.clone());
-            }
-        }
-        result
+impl DisplayListHelpers for Vec<DisplayItem> {
+    fn starting_stacking_context<'a>(&'a self) -> Option<&'a StackingContext> {
+        self.first().and_then(|item| match item.item {
+            SpecificDisplayItem::PushStackingContext(ref item) => Some(&item.stacking_context),
+            _ => None,
+        })
     }
 }
 
@@ -187,6 +146,56 @@ impl StackingContextHelpers for StackingContext {
         }
 
         composition_operations
+    }
+}
+
+struct DisplayListTraversal<'a> {
+    pub display_list: &'a [DisplayItem],
+    pub next_item_index: usize,
+}
+
+impl<'a> DisplayListTraversal<'a> {
+    pub fn new_skipping_first(display_list: &'a Vec<DisplayItem>) -> DisplayListTraversal {
+        DisplayListTraversal {
+            display_list: display_list,
+            next_item_index: 1,
+        }
+    }
+
+    pub fn skip_current_stacking_context(&mut self) {
+        for item in self {
+            if item.item == SpecificDisplayItem::PopStackingContext {
+                return;
+            }
+        }
+    }
+
+    pub fn current_stacking_context_empty(&self) -> bool {
+        match self.peek() {
+            Some(item) => item.item == SpecificDisplayItem::PopStackingContext,
+            None => true,
+        }
+    }
+
+    fn peek(&self) -> Option<&'a DisplayItem> {
+        if self.next_item_index >= self.display_list.len() {
+            return None
+        }
+        Some(&self.display_list[self.next_item_index])
+    }
+}
+
+impl<'a> Iterator for DisplayListTraversal<'a> {
+    type Item = &'a DisplayItem;
+
+    fn next(&mut self) -> Option<&'a DisplayItem> {
+        if self.next_item_index >= self.display_list.len() {
+            return None
+        }
+
+        let item = &self.display_list[self.next_item_index];
+        self.next_item_index += 1;
+        Some(item)
     }
 }
 
@@ -388,115 +397,127 @@ impl Frame {
 
     pub fn create(&mut self,
                   scene: &Scene,
-                  resource_cache: &mut ResourceCache,
                   dummy_resources: &DummyResources,
                   pipeline_sizes: &mut HashMap<PipelineId, Size2D<f32>>,
                   device_pixel_ratio: f32) {
-        if let Some(root_pipeline_id) = scene.root_pipeline_id {
-            if let Some(root_pipeline) = scene.pipeline_map.get(&root_pipeline_id) {
-                let old_layer_scrolling_states = self.reset();
+        let root_pipeline_id = match scene.root_pipeline_id {
+            Some(root_pipeline_id) => root_pipeline_id,
+            None => return,
+        };
 
-                self.pipeline_auxiliary_lists = scene.pipeline_auxiliary_lists.clone();
+        let root_pipeline = match scene.pipeline_map.get(&root_pipeline_id) {
+            Some(root_pipeline) => root_pipeline,
+            None => return,
+        };
 
-                let root_stacking_context = scene.stacking_context_map
-                                                 .get(&root_pipeline.root_stacking_context_id)
-                                                 .unwrap();
+        let display_list = scene.display_lists.get(&root_pipeline_id);
+        let display_list = match display_list {
+            Some(display_list) => display_list,
+            None => return,
+        };
 
-                let root_scroll_layer_id = root_stacking_context.stacking_context
-                                                                .scroll_layer_id
-                                                                .expect("root layer must be a scroll layer!");
-                self.root_scroll_layer_id = Some(root_scroll_layer_id);
+        let old_layer_scrolling_states = self.reset();
+        self.pipeline_auxiliary_lists = scene.pipeline_auxiliary_lists.clone();
 
-                // Insert global position: fixed elements layer
-                debug_assert!(self.layers.is_empty());
-                let root_fixed_layer_id = ScrollLayerId::create_fixed(root_pipeline_id);
-                let root_viewport = Rect::new(Point2D::zero(), root_pipeline.viewport_size);
-                self.layers.insert(
-                    root_fixed_layer_id,
-                    Layer::new(&root_viewport,
-                               root_stacking_context.stacking_context.overflow.size,
-                               &Matrix4D::identity(),
-                               root_pipeline_id));
+        self.pipeline_epoch_map.insert(root_pipeline_id, root_pipeline.epoch);
 
-                self.layers.insert(
-                    root_scroll_layer_id,
-                    Layer::new(&root_viewport,
-                               root_stacking_context.stacking_context.overflow.size,
-                               &Matrix4D::identity(),
-                               root_pipeline_id));
-
-                // Work around borrow check on resource cache
-                {
-                    let mut frame_builder = FrameBuilder::new(root_pipeline.viewport_size,
-                                                              device_pixel_ratio,
-                                                              dummy_resources.clone(),
-                                                              self.debug,
-                                                              self.frame_builder_config);
-
-                    {
-                        let mut context = FlattenContext {
-                            resource_cache: resource_cache,
-                            scene: scene,
-                            pipeline_sizes: pipeline_sizes,
-                            builder: &mut frame_builder,
-                        };
-
-                        let parent_info = FlattenInfo {
-                            pipeline_id: root_pipeline_id,
-                            current_fixed_layer_id: root_fixed_layer_id,
-                            current_scroll_layer_id: root_scroll_layer_id,
-                            layer_relative_transform: Matrix4D::identity(),
-                        };
-
-                        let root_pipeline = SceneItemKind::Pipeline(root_pipeline);
-                        self.flatten(root_pipeline,
-                                     &parent_info,
-                                     &mut context,
-                                     0);
-                    }
-
-                    self.frame_builder = Some(frame_builder);
-                }
-
-                // TODO(gw): These are all independent - can be run through thread pool if it shows up in the profile!
-                for (scroll_layer_id, layer) in &mut self.layers {
-                    let scrolling_state = match old_layer_scrolling_states.get(&scroll_layer_id) {
-                        Some(old_scrolling_state) => *old_scrolling_state,
-                        None => ScrollingState::new(),
-                    };
-
-                    layer.finalize(&scrolling_state);
-                }
-            }
-        }
-    }
-
-    fn flatten(&mut self,
-               scene_item: SceneItemKind,
-               parent_info: &FlattenInfo,
-               context: &mut FlattenContext,
-               level: i32) {
-        //let _pf = util::ProfileScope::new("  flatten");
-
-        let (stacking_context, pipeline_id) = match scene_item {
-            SceneItemKind::StackingContext(stacking_context, pipeline_id) => {
-                (&stacking_context.stacking_context, pipeline_id)
-            }
-            SceneItemKind::Pipeline(pipeline) => {
-                self.pipeline_epoch_map.insert(pipeline.pipeline_id, pipeline.epoch);
-
-                let stacking_context = &context.scene.stacking_context_map
-                                               .get(&pipeline.root_stacking_context_id)
-                                               .unwrap()
-                                               .stacking_context;
-
-                (stacking_context, pipeline.pipeline_id)
+        let root_stacking_context = match display_list.starting_stacking_context() {
+            Some(stacking_context) => stacking_context,
+            None => {
+                warn!("Pipeline display list does not start with a stacking context.");
+                return;
             }
         };
 
-        let scene_items = scene_item.collect_scene_items(&context.scene);
-        if scene_items.is_empty() {
+        let root_scroll_layer_id =
+            root_stacking_context.scroll_layer_id
+                                 .expect("root layer must be a scroll layer!");
+        self.root_scroll_layer_id = Some(root_scroll_layer_id);
+
+        // Insert global position: fixed elements layer
+        debug_assert!(self.layers.is_empty());
+        let root_fixed_layer_id = ScrollLayerId::create_fixed(root_pipeline_id);
+        let root_viewport = Rect::new(Point2D::zero(), root_pipeline.viewport_size);
+        let layer = Layer::new(&root_viewport,
+                               root_stacking_context.overflow.size,
+                               &Matrix4D::identity(),
+                               root_pipeline_id);
+        self.layers.insert(root_fixed_layer_id, layer.clone());
+        self.layers.insert(root_scroll_layer_id, layer);
+
+        let mut frame_builder = FrameBuilder::new(root_pipeline.viewport_size,
+                                                  device_pixel_ratio,
+                                                  dummy_resources.clone(),
+                                                  self.debug,
+                                                  self.frame_builder_config);
+
+        {
+            let mut context = FlattenContext {
+                scene: scene,
+                pipeline_sizes: pipeline_sizes,
+                builder: &mut frame_builder,
+            };
+
+            let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
+            self.flatten_stacking_context(&mut traversal,
+                                          root_pipeline_id,
+                                          &mut context,
+                                          root_fixed_layer_id,
+                                          root_scroll_layer_id,
+                                          Matrix4D::identity(),
+                                          0,
+                                          &root_stacking_context);
+        }
+
+        self.frame_builder = Some(frame_builder);
+
+        // TODO(gw): These are all independent - can be run through thread pool if it shows up
+        // in the profile!
+        for (scroll_layer_id, layer) in &mut self.layers {
+            let scrolling_state = match old_layer_scrolling_states.get(&scroll_layer_id) {
+                Some(old_scrolling_state) => *old_scrolling_state,
+                None => ScrollingState::new(),
+            };
+
+            layer.finalize(&scrolling_state);
+        }
+    }
+
+    fn flatten_stacking_context<'a>(&mut self,
+                                    traversal: &mut DisplayListTraversal<'a>,
+                                    pipeline_id: PipelineId,
+                                    context: &mut FlattenContext,
+                                    current_fixed_layer_id: ScrollLayerId,
+                                    mut current_scroll_layer_id: ScrollLayerId,
+                                    mut layer_relative_transform: Matrix4D<f32>,
+                                    level: i32,
+                                    stacking_context: &StackingContext) {
+        // Avoid doing unnecessary work for empty stacking contexts.
+        if traversal.current_stacking_context_empty() {
+            traversal.skip_current_stacking_context();
             return;
+        }
+
+        match (stacking_context.scroll_policy, stacking_context.scroll_layer_id) {
+            (ScrollPolicy::Scrollable, Some(inner_scroll_layer_id)) if level != 0 => {
+                debug_assert!(!self.layers.contains_key(&inner_scroll_layer_id));
+
+                let layer = Layer::new(&stacking_context.bounds,
+                                       stacking_context.overflow.size,
+                                       &layer_relative_transform,
+                                       pipeline_id);
+
+                debug_assert!(current_scroll_layer_id != inner_scroll_layer_id);
+                self.layers
+                    .get_mut(&current_scroll_layer_id)
+                    .unwrap()
+                    .add_child(inner_scroll_layer_id);
+
+                self.layers.insert(inner_scroll_layer_id, layer);
+                current_scroll_layer_id = inner_scroll_layer_id;
+                layer_relative_transform = Matrix4D::identity();
+            }
+            _ => {}
         }
 
         let composition_operations = {
@@ -509,7 +530,10 @@ impl Frame {
         // Detect composition operations that will make us invisible.
         for composition_operation in &composition_operations {
             match *composition_operation {
-                CompositionOp::Filter(LowLevelFilterOp::Opacity(Au(0))) => return,
+                CompositionOp::Filter(LowLevelFilterOp::Opacity(Au(0))) => {
+                    traversal.skip_current_stacking_context();
+                    return;
+                }
                 _ => {}
             }
         }
@@ -520,32 +544,27 @@ impl Frame {
         // to account for them and we expand the overflow region to include the area above
         // their origin in the parent context.
         let (transform, overflow) = if stacking_context.scroll_layer_id.is_none() {
-            (parent_info.layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
-                                                                stacking_context.bounds.origin.y,
-                                                                0.0)
-                                                 .pre_mul(&stacking_context.transform)
-                                                 .pre_mul(&stacking_context.perspective),
+            (layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
+                                                     stacking_context.bounds.origin.y,
+                                                     0.0)
+                                     .pre_mul(&stacking_context.transform)
+                                     .pre_mul(&stacking_context.perspective),
              stacking_context.overflow)
         } else {
             let mut overflow = stacking_context.overflow;
             overflow.size.width += stacking_context.bounds.origin.x;
             overflow.size.height += stacking_context.bounds.origin.y;
-            (parent_info.layer_relative_transform, overflow)
+            (layer_relative_transform, overflow)
         };
 
         // Build world space transform
-        let scroll_layer_id =  match (stacking_context.scroll_policy, stacking_context.scroll_layer_id) {
+        let scroll_layer_id = match (stacking_context.scroll_policy,
+                                     stacking_context.scroll_layer_id) {
             (ScrollPolicy::Fixed, _scroll_layer_id) => {
                 debug_assert!(_scroll_layer_id.is_none());
-                parent_info.current_fixed_layer_id
+                current_fixed_layer_id
             }
-            (ScrollPolicy::Scrollable, Some(scroll_layer_id)) => {
-                debug_assert!(self.layers.contains_key(&scroll_layer_id));
-                scroll_layer_id
-            }
-            (ScrollPolicy::Scrollable, None) => {
-                parent_info.current_scroll_layer_id
-            }
+            (ScrollPolicy::Scrollable, _) => current_scroll_layer_id
         };
 
         // TODO(gw): Int with overflow etc
@@ -557,196 +576,40 @@ impl Frame {
                                    &composition_operations);
 
         if level == 0 {
-            // Add a large white rectangle as the root display item. This is removed
-            // by the occlusion culling for most tiles, and means that it's no longer
-            // necessary to clear the framebuffer.
+            // Add a large white rectangle as the root display item if there is no root stacking
+            // context background color. This is removed by the occlusion culling for most tiles,
+            // and means that it's no longer necessary to clear the framebuffer.
             //
-            // TODO(nical) Should this be optional?
-            // on deferred GPUs we probably still want to clear the framebuffer and
-            // Gecko currently supports semit-transparent windows.
-            // Also, this is not needed if the root stacking context has an opaque
-            // background (specified in set_root_stacking_context).
+            // TODO(nical) Should painting a white background be optional if there is no stacking
+            // context background color? On deferred GPUs we probably still want to clear the
+            // framebuffer and Gecko currently supports semi-transparent windows.
             //
             // If we do need this, does it make sense to keep Frame::clear_tiles?
+            let mut root_background_color = match context.scene.pipeline_map.get(&pipeline_id) {
+                Some(pipeline) => pipeline.background_color,
+                None => ColorF::new(1.0, 1.0, 1.0, 1.0),
+            };
+
+            if root_background_color.a == 0.0 {
+                root_background_color = ColorF::new(1.0, 1.0, 1.0, 1.0);
+            }
+
             context.builder.add_solid_rectangle(&stacking_context.bounds,
                                                 &ClipRegion::simple(&stacking_context.bounds),
-                                                &ColorF::new(1.0, 1.0, 1.0, 1.0),
+                                                &root_background_color,
                                                 PrimitiveFlags::None);
         }
 
-        for item in scene_items {
-            match item.specific {
-                SpecificSceneItem::DrawList(draw_list_id) => {
-                    let draw_list = context.resource_cache.get_draw_list(draw_list_id);
-                    let builder = &mut context.builder;
-
-                    for item in &draw_list.items {
-                        match item.item {
-                            SpecificDisplayItem::WebGL(ref info) => {
-                                builder.add_webgl_rectangle(item.rect,
-                                                            &item.clip,
-                                                            info.context_id);
-                            }
-                            SpecificDisplayItem::Image(ref info) => {
-                                builder.add_image(item.rect,
-                                                  &item.clip,
-                                                  &info.stretch_size,
-                                                  &info.tile_spacing,
-                                                  info.image_key,
-                                                  info.image_rendering);
-                            }
-                            SpecificDisplayItem::Text(ref text_info) => {
-                                builder.add_text(item.rect,
-                                                 &item.clip,
-                                                 text_info.font_key,
-                                                 text_info.size,
-                                                 text_info.blur_radius,
-                                                 &text_info.color,
-                                                 text_info.glyphs);
-                            }
-                            SpecificDisplayItem::Rectangle(ref info) => {
-                                builder.add_solid_rectangle(&item.rect,
-                                                            &item.clip,
-                                                            &info.color,
-                                                            PrimitiveFlags::None);
-                            }
-                            SpecificDisplayItem::Gradient(ref info) => {
-                                builder.add_gradient(item.rect,
-                                                     &item.clip,
-                                                     info.start_point,
-                                                     info.end_point,
-                                                     info.stops);
-                            }
-                            SpecificDisplayItem::BoxShadow(ref box_shadow_info) => {
-                                builder.add_box_shadow(&box_shadow_info.box_bounds,
-                                                       &item.clip,
-                                                       &box_shadow_info.offset,
-                                                       &box_shadow_info.color,
-                                                       box_shadow_info.blur_radius,
-                                                       box_shadow_info.spread_radius,
-                                                       box_shadow_info.border_radius,
-                                                       box_shadow_info.clip_mode);
-                            }
-                            SpecificDisplayItem::Border(ref info) => {
-                                builder.add_border(item.rect,
-                                                   &item.clip,
-                                                   info);
-                            }
-                        }
-                    }
-                }
-                SpecificSceneItem::StackingContext(id, pipeline_id) => {
-                    let child_stacking_context = context.scene
-                                                        .stacking_context_map
-                                                        .get(&id)
-                                                        .unwrap();
-
-                    let inner_stacking_context = &child_stacking_context.stacking_context;
-
-                    let mut next_scroll_layer_id = parent_info.current_scroll_layer_id;
-                    let mut layer_relative_transform = transform;
-
-                    match (inner_stacking_context.scroll_policy, inner_stacking_context.scroll_layer_id) {
-                        (ScrollPolicy::Scrollable, Some(inner_scroll_layer_id)) => {
-                            debug_assert!(!self.layers.contains_key(&inner_scroll_layer_id));
-
-                            let layer = Layer::new(&inner_stacking_context.bounds,
-                                                   inner_stacking_context.overflow.size,
-                                                   &transform,
-                                                   parent_info.pipeline_id);
-
-                            debug_assert!(parent_info.current_scroll_layer_id != inner_scroll_layer_id);
-                            self.layers
-                                .get_mut(&scroll_layer_id)
-                                .unwrap()
-                                .add_child(inner_scroll_layer_id);
-
-                            self.layers.insert(inner_scroll_layer_id, layer);
-                            next_scroll_layer_id = inner_scroll_layer_id;
-                            layer_relative_transform = Matrix4D::identity();
-                        }
-                        (ScrollPolicy::Fixed, _) |
-                        (ScrollPolicy::Scrollable, None) => {}
-                    }
-
-                    let child_info = FlattenInfo {
-                        pipeline_id: parent_info.pipeline_id,
-                        current_scroll_layer_id: next_scroll_layer_id,
-                        current_fixed_layer_id: parent_info.current_fixed_layer_id,
-                        layer_relative_transform: layer_relative_transform,
-                    };
-
-                    let child = SceneItemKind::StackingContext(child_stacking_context,
-                                                               pipeline_id);
-
-                    self.flatten(child,
-                                 &child_info,
-                                 context,
-                                 level+1);
-                }
-                SpecificSceneItem::Iframe(ref iframe_info) => {
-                    let pipeline = context.scene
-                                          .pipeline_map
-                                          .get(&iframe_info.id);
-
-                    context.pipeline_sizes.insert(iframe_info.id,
-                                                  iframe_info.bounds.size);
-
-                    if let Some(pipeline) = pipeline {
-                        let iframe = SceneItemKind::Pipeline(pipeline);
-
-                        let transform = transform.pre_translated(iframe_info.bounds.origin.x,
-                                                                 iframe_info.bounds.origin.y,
-                                                                 0.0);
-
-                        let iframe_stacking_context = context.scene
-                                                             .stacking_context_map
-                                                             .get(&pipeline.root_stacking_context_id)
-                                                             .unwrap();
-                        let iframe_stacking_context = &iframe_stacking_context.stacking_context;
-                        let iframe_fixed_layer_id = ScrollLayerId::create_fixed(pipeline.pipeline_id);
-                        let iframe_rect = &Rect::new(Point2D::zero(), iframe_info.bounds.size);
-
-                        self.layers
-                            .insert(iframe_fixed_layer_id,
-                                    Layer::new(&iframe_rect,
-                                               iframe_stacking_context.overflow.size,
-                                               &transform,
-                                               pipeline.pipeline_id));
-
-                        let iframe_scroll_layer_id = iframe_stacking_context.scroll_layer_id.unwrap();
-
-                        self.layers
-                            .insert(iframe_scroll_layer_id,
-                                    Layer::new(&iframe_rect,
-                                               iframe_stacking_context.overflow.size,
-                                               &transform,
-                                               pipeline.pipeline_id));
-
-                        self.layers
-                            .get_mut(&scroll_layer_id)
-                            .unwrap()
-                            .add_child(iframe_scroll_layer_id);
-
-                        let child_info = FlattenInfo {
-                            pipeline_id: pipeline.pipeline_id,
-                            current_scroll_layer_id: iframe_scroll_layer_id,
-                            current_fixed_layer_id: iframe_fixed_layer_id,
-                            layer_relative_transform: Matrix4D::identity(),
-                        };
-
-                        self.flatten(iframe,
-                                     &child_info,
-                                     context,
-                                     level+1);
-                    }
-                }
-            }
-        }
+        self.flatten_items(traversal,
+                           pipeline_id,
+                           context,
+                           current_fixed_layer_id,
+                           current_scroll_layer_id,
+                           transform,
+                           level);
 
         if level == 0 && self.frame_builder_config.enable_scrollbars {
-            let scrollbar_rect = Rect::new(Point2D::zero(),
-                                           Size2D::new(10.0, 70.0));
+            let scrollbar_rect = Rect::new(Point2D::zero(), Size2D::new(10.0, 70.0));
             context.builder.add_solid_rectangle(&scrollbar_rect,
                                                 &ClipRegion::simple(&scrollbar_rect),
                                                 &DEFAULT_SCROLLBAR_COLOR,
@@ -755,6 +618,141 @@ impl Frame {
         }
 
         context.builder.pop_layer();
+    }
+
+    fn flatten_iframe<'a>(&mut self,
+                          pipeline_id: PipelineId,
+                          bounds: &Rect<f32>,
+                          context: &mut FlattenContext,
+                          current_scroll_layer_id: ScrollLayerId,
+                          layer_relative_transform: Matrix4D<f32>) {
+        context.pipeline_sizes.insert(pipeline_id, bounds.size);
+
+        let pipeline = match context.scene.pipeline_map.get(&pipeline_id) {
+            Some(pipeline) => pipeline,
+            None => return,
+        };
+
+        let display_list = context.scene.display_lists.get(&pipeline_id);
+        let display_list = match display_list {
+            Some(display_list) => display_list,
+            None => return,
+        };
+
+        let iframe_stacking_context = match display_list.starting_stacking_context() {
+            Some(stacking_context) => stacking_context,
+            None => {
+                warn!("Pipeline display list does not start with a stacking context.");
+                return;
+            }
+        };
+
+        self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
+
+        let iframe_rect = &Rect::new(Point2D::zero(), bounds.size);
+        let transform = layer_relative_transform.pre_translated(bounds.origin.x,
+                                                                bounds.origin.y,
+                                                                0.0);
+
+        let iframe_fixed_layer_id = ScrollLayerId::create_fixed(pipeline_id);
+        let iframe_scroll_layer_id = iframe_stacking_context.scroll_layer_id.unwrap();
+
+        let layer = Layer::new(&iframe_rect,
+                               iframe_stacking_context.overflow.size,
+                               &transform,
+                               pipeline_id);
+        self.layers.insert(iframe_fixed_layer_id, layer.clone());
+        self.layers.insert(iframe_scroll_layer_id, layer);
+        self.layers.get_mut(&current_scroll_layer_id).unwrap().add_child(iframe_scroll_layer_id);
+
+        let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
+
+        self.flatten_stacking_context(&mut traversal,
+                                      pipeline_id,
+                                      context,
+                                      iframe_fixed_layer_id,
+                                      iframe_scroll_layer_id,
+                                      Matrix4D::identity(),
+                                      0,
+                                      &iframe_stacking_context);
+    }
+
+    fn flatten_items<'a>(&mut self,
+                         traversal: &mut DisplayListTraversal<'a>,
+                         pipeline_id: PipelineId,
+                         context: &mut FlattenContext,
+                         current_fixed_layer_id: ScrollLayerId,
+                         current_scroll_layer_id: ScrollLayerId,
+                         layer_relative_transform: Matrix4D<f32>,
+                         level: i32) {
+        while let Some(item) = traversal.next() {
+            match item.item {
+                SpecificDisplayItem::WebGL(ref info) => {
+                    context.builder.add_webgl_rectangle(item.rect, &item.clip, info.context_id);
+                }
+                SpecificDisplayItem::Image(ref info) => {
+                    context.builder.add_image(item.rect,
+                                              &item.clip,
+                                              &info.stretch_size,
+                                              &info.tile_spacing,
+                                              info.image_key,
+                                              info.image_rendering);
+                }
+                SpecificDisplayItem::Text(ref text_info) => {
+                    context.builder.add_text(item.rect,
+                                             &item.clip,
+                                             text_info.font_key,
+                                             text_info.size,
+                                             text_info.blur_radius,
+                                             &text_info.color,
+                                             text_info.glyphs);
+                }
+                SpecificDisplayItem::Rectangle(ref info) => {
+                    context.builder.add_solid_rectangle(&item.rect,
+                                                        &item.clip,
+                                                        &info.color,
+                                                        PrimitiveFlags::None);
+                }
+                SpecificDisplayItem::Gradient(ref info) => {
+                    context.builder.add_gradient(item.rect,
+                                                 &item.clip,
+                                                 info.start_point,
+                                                 info.end_point,
+                                                 info.stops);
+                }
+                SpecificDisplayItem::BoxShadow(ref box_shadow_info) => {
+                    context.builder.add_box_shadow(&box_shadow_info.box_bounds,
+                                                   &item.clip,
+                                                   &box_shadow_info.offset,
+                                                   &box_shadow_info.color,
+                                                   box_shadow_info.blur_radius,
+                                                   box_shadow_info.spread_radius,
+                                                   box_shadow_info.border_radius,
+                                                   box_shadow_info.clip_mode);
+                }
+                SpecificDisplayItem::Border(ref info) => {
+                    context.builder.add_border(item.rect, &item.clip, info);
+                }
+                SpecificDisplayItem::PushStackingContext(ref info) => {
+                    self.flatten_stacking_context(traversal,
+                                                  pipeline_id,
+                                                  context,
+                                                  current_fixed_layer_id,
+                                                  current_scroll_layer_id,
+                                                  layer_relative_transform,
+                                                  level + 1,
+                                                  &info.stacking_context);
+                }
+                SpecificDisplayItem::Iframe(ref info) => {
+                    self.flatten_iframe(info.pipeline_id,
+                                        &item.rect,
+                                        context,
+                                        current_scroll_layer_id,
+                                        layer_relative_transform);
+                }
+                SpecificDisplayItem::PopStackingContext => return,
+            }
+        }
     }
 
     pub fn build(&mut self,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -6,7 +6,6 @@ use app_units::Au;
 use device::{TextureId, TextureFilter};
 use euclid::{Point2D, Rect, Size2D, TypedRect, TypedPoint2D, TypedSize2D, Length, UnknownUnit};
 use fnv::FnvHasher;
-use freelist::{FreeListItem, FreeListItemId};
 use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle};
 use offscreen_gl_context::{GLContext, NativeGLContextMethods, GLContextDispatcher};
 use offscreen_gl_context::{OSMesaContext, OSMesaContextHandle};
@@ -20,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tiling;
 use webrender_traits::{Epoch, ColorF, PipelineId};
-use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle, DisplayItem};
+use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle};
 use webrender_traits::{ScrollLayerId, WebGLCommand};
 
 pub enum GLContextHandleWrapper {
@@ -161,8 +160,6 @@ pub enum FontTemplate {
     Raw(Arc<Vec<u8>>),
     Native(NativeFontHandle),
 }
-
-pub type DrawListId = FreeListItemId;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum TextureSampler {
@@ -417,36 +414,6 @@ pub enum AxisDirection {
 
 #[derive(Debug, Clone, Copy)]
 pub struct StackingContextIndex(pub usize);
-
-#[derive(Debug)]
-pub struct DrawList {
-    pub items: Vec<DisplayItem>,
-    pub stacking_context_index: Option<StackingContextIndex>,
-    pub pipeline_id: PipelineId,
-    // TODO(gw): Structure squat to remove this field.
-    next_free_id: Option<FreeListItemId>,
-}
-
-impl DrawList {
-    pub fn new(items: Vec<DisplayItem>, pipeline_id: PipelineId) -> DrawList {
-        DrawList {
-            items: items,
-            stacking_context_index: None,
-            pipeline_id: pipeline_id,
-            next_free_id: None,
-        }
-    }
-}
-
-impl FreeListItem for DrawList {
-    fn next_free_id(&self) -> Option<FreeListItemId> {
-        self.next_free_id
-    }
-
-    fn set_next_free_id(&mut self, id: Option<FreeListItemId>) {
-        self.next_free_id = id;
-    }
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct RectUv<T, U = UnknownUnit> {

--- a/webrender/src/layer.rs
+++ b/webrender/src/layer.rs
@@ -7,6 +7,7 @@ use spring::{DAMPING, STIFFNESS, Spring};
 use webrender_traits::{PipelineId, ScrollLayerId};
 
 /// Contains scroll and transform information for scrollable and root stacking contexts.
+#[derive(Clone)]
 pub struct Layer {
     /// Manages scrolling offset, overscroll state etc.
     pub scrolling: ScrollingState,

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -19,9 +19,9 @@ pub fn write_msg(frame: u32, msg: &ApiMsg) {
         &ApiMsg::AddImage(..) |
         &ApiMsg::UpdateImage(..) |
         &ApiMsg::DeleteImage(..)|
-        &ApiMsg::SetRootStackingContext(..) |
+        &ApiMsg::SetRootDisplayList(..) |
         &ApiMsg::SetRootPipeline(..) |
-        &ApiMsg::Scroll(..)|
+        &ApiMsg::Scroll(..) |
         &ApiMsg::TickScrollingBounce |
         &ApiMsg::WebGLCommand(..) => {
             let buff = serialize(msg, bincode::SizeLimit::Infinite).unwrap();

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -150,33 +150,21 @@ impl RenderBackend {
 
                             sender.send(result).unwrap();
                         }
-                        ApiMsg::SetRootStackingContext(stacking_context_id,
-                                                       background_color,
-                                                       epoch,
-                                                       pipeline_id,
-                                                       viewport_size,
-                                                       stacking_contexts,
-                                                       display_lists,
-                                                       auxiliary_lists_descriptor) => {
-                            for (id, stacking_context) in stacking_contexts.into_iter() {
-                                self.scene.add_stacking_context(id,
-                                                                pipeline_id,
-                                                                epoch,
-                                                                stacking_context);
-                            }
-
+                        ApiMsg::SetRootDisplayList(background_color,
+                                                   epoch,
+                                                   pipeline_id,
+                                                   viewport_size,
+                                                   display_list_descriptor,
+                                                   auxiliary_lists_descriptor) => {
                             let mut leftover_auxiliary_data = vec![];
                             let mut auxiliary_data;
                             loop {
                                 auxiliary_data = self.payload_rx.recv().unwrap();
                                 {
                                     let mut payload_reader = Cursor::new(&auxiliary_data[..]);
-                                    let payload_stacking_context_id =
-                                        payload_reader.read_u32::<LittleEndian>().unwrap();
                                     let payload_epoch =
                                         payload_reader.read_u32::<LittleEndian>().unwrap();
-                                    if payload_epoch == epoch.0 &&
-                                            payload_stacking_context_id == stacking_context_id.0 {
+                                    if payload_epoch == epoch.0 {
                                         break
                                     }
                                 }
@@ -188,22 +176,14 @@ impl RenderBackend {
                             if self.enable_recording {
                                 record::write_payload(frame_counter, &auxiliary_data);
                             }
-                            let mut auxiliary_data = Cursor::new(&mut auxiliary_data[8..]);
-                            for (display_list_id,
-                                 display_list_descriptor) in display_lists.into_iter() {
-                                let mut built_display_list_data =
-                                    vec![0; display_list_descriptor.size()];
-                                auxiliary_data.read_exact(&mut built_display_list_data[..])
-                                              .unwrap();
-                                let built_display_list =
-                                    BuiltDisplayList::from_data(built_display_list_data,
-                                                                display_list_descriptor);
-                                self.scene.add_display_list(display_list_id,
-                                                            pipeline_id,
-                                                            epoch,
-                                                            built_display_list,
-                                                            &mut self.resource_cache);
-                            }
+
+                            let mut auxiliary_data = Cursor::new(&mut auxiliary_data[4..]);
+                            let mut built_display_list_data =
+                                vec![0; display_list_descriptor.size()];
+                            auxiliary_data.read_exact(&mut built_display_list_data[..]).unwrap();
+                            let built_display_list =
+                                BuiltDisplayList::from_data(built_display_list_data,
+                                                            display_list_descriptor);
 
                             let mut auxiliary_lists_data =
                                 vec![0; auxiliary_lists_descriptor.size()];
@@ -211,14 +191,14 @@ impl RenderBackend {
                             let auxiliary_lists =
                                 AuxiliaryLists::from_data(auxiliary_lists_data,
                                                           auxiliary_lists_descriptor);
+
                             let frame = profile_counters.total_time.profile(|| {
-                                self.scene.set_root_stacking_context(pipeline_id,
-                                                                     epoch,
-                                                                     stacking_context_id,
-                                                                     background_color,
-                                                                     viewport_size,
-                                                                     &mut self.resource_cache,
-                                                                     auxiliary_lists);
+                                self.scene.set_root_display_list(pipeline_id,
+                                                                 epoch,
+                                                                 built_display_list,
+                                                                 background_color,
+                                                                 viewport_size,
+                                                                 auxiliary_lists);
 
                                 self.build_scene();
                                 self.render()
@@ -362,7 +342,6 @@ impl RenderBackend {
         }
 
         self.frame.create(&self.scene,
-                          &mut self.resource_cache,
                           &self.dummy_resources,
                           &mut new_pipeline_sizes,
                           self.device_pixel_ratio);

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -4,25 +4,32 @@
 
 use euclid::Size2D;
 use fnv::FnvHasher;
-use internal_types::DrawListId;
-use resource_cache::ResourceCache;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::AuxiliaryListsMap;
-use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch};
-use webrender_traits::{ColorF, DisplayListId, StackingContext, StackingContextId};
-use webrender_traits::{SpecificDisplayListItem};
-use webrender_traits::{IframeInfo};
-use webrender_traits::{RectangleDisplayItem, ClipRegion, DisplayItem, SpecificDisplayItem};
+use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch, ColorF};
+use webrender_traits::{DisplayItem, SpecificDisplayItem, StackingContext};
+
+trait DisplayListHelpers {
+    fn starting_stacking_context<'a>(&'a self) -> Option<&'a StackingContext>;
+}
+
+impl DisplayListHelpers for Vec<DisplayItem> {
+    fn starting_stacking_context<'a>(&'a self) -> Option<&'a StackingContext> {
+        self.first().and_then(|item| match item.item {
+            SpecificDisplayItem::PushStackingContext(ref item) => Some(&item.stacking_context),
+            _ => None,
+        })
+    }
+}
 
 /// A representation of the layout within the display port for a given document or iframe.
 #[derive(Debug)]
 pub struct ScenePipeline {
     pub pipeline_id: PipelineId,
     pub epoch: Epoch,
-    pub background_draw_list: Option<DrawListId>,
-    pub root_stacking_context_id: StackingContextId,
     pub viewport_size: Size2D<f32>,
+    pub background_color: ColorF,
 }
 
 /// A complete representation of the layout bundling visible pipelines together.
@@ -31,34 +38,7 @@ pub struct Scene {
     pub pipeline_map: HashMap<PipelineId, ScenePipeline, BuildHasherDefault<FnvHasher>>,
     pub pipeline_sizes: HashMap<PipelineId, Size2D<f32>>,
     pub pipeline_auxiliary_lists: AuxiliaryListsMap,
-    pub display_list_map: HashMap<DisplayListId, SceneDisplayList, BuildHasherDefault<FnvHasher>>,
-    pub stacking_context_map: HashMap<StackingContextId, SceneStackingContext, BuildHasherDefault<FnvHasher>>,
-}
-
-#[derive(Clone, Debug)]
-pub enum SpecificSceneItem {
-    DrawList(DrawListId),
-    StackingContext(StackingContextId, PipelineId),
-    Iframe(IframeInfo),
-}
-
-#[derive(Clone, Debug)]
-pub struct SceneItem {
-    pub specific: SpecificSceneItem,
-}
-
-/// Similar to webrender_traits::DisplayList internal to WebRender.
-pub struct SceneDisplayList {
-    pub pipeline_id: PipelineId,
-    pub epoch: Epoch,
-    pub items: Vec<SceneItem>,
-}
-
-pub struct SceneStackingContext {
-    pub pipeline_id: PipelineId,
-    pub epoch: Epoch,
-    pub stacking_context: StackingContext,
-    pub stacking_context_id: StackingContextId,
+    pub display_lists: HashMap<PipelineId, Vec<DisplayItem>, BuildHasherDefault<FnvHasher>>,
 }
 
 impl Scene {
@@ -68,146 +48,31 @@ impl Scene {
             pipeline_sizes: HashMap::new(),
             pipeline_map: HashMap::with_hasher(Default::default()),
             pipeline_auxiliary_lists: HashMap::with_hasher(Default::default()),
-            display_list_map: HashMap::with_hasher(Default::default()),
-            stacking_context_map: HashMap::with_hasher(Default::default()),
+            display_lists: HashMap::with_hasher(Default::default()),
         }
-    }
-
-    pub fn add_display_list(&mut self,
-                            id: DisplayListId,
-                            pipeline_id: PipelineId,
-                            epoch: Epoch,
-                            built_display_list: BuiltDisplayList,
-                            resource_cache: &mut ResourceCache) {
-        let items = built_display_list.display_list_items().iter().map(|item| {
-            match item.specific {
-                SpecificDisplayListItem::DrawList(ref info) => {
-                    let draw_list_id = resource_cache.add_draw_list(
-                        built_display_list.display_items(&info.items).to_vec(),
-                        pipeline_id);
-                    SceneItem {
-                        specific: SpecificSceneItem::DrawList(draw_list_id)
-                    }
-                }
-                SpecificDisplayListItem::StackingContext(ref info) => {
-                    SceneItem {
-                        specific: SpecificSceneItem::StackingContext(info.id, pipeline_id)
-                    }
-                }
-                SpecificDisplayListItem::Iframe(ref info) => {
-                    SceneItem {
-                        specific: SpecificSceneItem::Iframe(*info)
-                    }
-                }
-            }
-        }).collect();
-
-        let display_list = SceneDisplayList {
-            pipeline_id: pipeline_id,
-            epoch: epoch,
-            items: items,
-        };
-
-        self.display_list_map.insert(id, display_list);
-    }
-
-    pub fn add_stacking_context(&mut self,
-                                id: StackingContextId,
-                                pipeline_id: PipelineId,
-                                epoch: Epoch,
-                                stacking_context: StackingContext) {
-        let stacking_context = SceneStackingContext {
-            pipeline_id: pipeline_id,
-            epoch: epoch,
-            stacking_context: stacking_context,
-            stacking_context_id: id,
-        };
-
-        self.stacking_context_map.insert(id, stacking_context);
     }
 
     pub fn set_root_pipeline_id(&mut self, pipeline_id: PipelineId) {
         self.root_pipeline_id = Some(pipeline_id);
     }
 
-    pub fn set_root_stacking_context(&mut self,
-                                     pipeline_id: PipelineId,
-                                     epoch: Epoch,
-                                     stacking_context_id: StackingContextId,
-                                     background_color: ColorF,
-                                     viewport_size: Size2D<f32>,
-                                     resource_cache: &mut ResourceCache,
-                                     auxiliary_lists: AuxiliaryLists) {
+    pub fn set_root_display_list(&mut self,
+                                 pipeline_id: PipelineId,
+                                 epoch: Epoch,
+                                 built_display_list: BuiltDisplayList,
+                                 background_color: ColorF,
+                                 viewport_size: Size2D<f32>,
+                                 auxiliary_lists: AuxiliaryLists) {
         self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
-
-        let old_display_list_keys: Vec<_> = self.display_list_map.iter()
-                                                .filter(|&(_, ref v)| {
-                                                    v.pipeline_id == pipeline_id &&
-                                                    v.epoch < epoch
-                                                })
-                                                .map(|(k, _)| k.clone())
-                                                .collect();
-
-        // Remove any old draw lists and display lists for this pipeline
-        for key in old_display_list_keys {
-            let display_list = self.display_list_map.remove(&key).unwrap();
-            for item in display_list.items {
-                match item.specific {
-                    SpecificSceneItem::DrawList(draw_list_id) => {
-                        resource_cache.remove_draw_list(draw_list_id);
-                    }
-                    SpecificSceneItem::StackingContext(..) |
-                    SpecificSceneItem::Iframe(..) => {}
-                }
-            }
-        }
-
-        let old_stacking_context_keys: Vec<_> = self.stacking_context_map.iter()
-                                                                         .filter(|&(_, ref v)| {
-                                                                             v.pipeline_id == pipeline_id &&
-                                                                             v.epoch < epoch
-                                                                         })
-                                                                         .map(|(k, _)| k.clone())
-                                                                         .collect();
-
-        // Remove any old draw lists and display lists for this pipeline
-        for key in old_stacking_context_keys {
-            self.stacking_context_map.remove(&key).unwrap();
-
-            // TODO: Could remove all associated DLs here,
-            //       and then the above code could just be a debug assert check...
-        }
-
-        let background_draw_list = if background_color.a > 0.0 {
-            let overflow = self.stacking_context_map[&stacking_context_id].stacking_context.overflow;
-
-            let rectangle_item = RectangleDisplayItem {
-                color: background_color,
-            };
-            let root_bg_color_item = DisplayItem {
-                item: SpecificDisplayItem::Rectangle(rectangle_item),
-                rect: overflow,
-                clip: ClipRegion::simple(&overflow),
-            };
-
-            let draw_list_id = resource_cache.add_draw_list(vec![root_bg_color_item], pipeline_id);
-            Some(draw_list_id)
-        } else {
-            None
-        };
+        self.display_lists.insert(pipeline_id, built_display_list.all_display_items().to_vec());
 
         let new_pipeline = ScenePipeline {
             pipeline_id: pipeline_id,
             epoch: epoch,
-            background_draw_list: background_draw_list,
-            root_stacking_context_id: stacking_context_id,
             viewport_size: viewport_size,
+            background_color: background_color,
         };
 
-        if let Some(old_pipeline) = self.pipeline_map.insert(pipeline_id, new_pipeline) {
-            if let Some(background_draw_list) = old_pipeline.background_draw_list {
-                resource_cache.remove_draw_list(background_draw_list);
-            }
-        }
+        self.pipeline_map.insert(pipeline_id, new_pipeline);
     }
 }

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -7,10 +7,9 @@ use euclid::{Point2D, Size2D};
 use ipc_channel::ipc::{self, IpcBytesSender, IpcSender};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::cell::Cell;
-use {ApiMsg, AuxiliaryLists, BuiltDisplayList, ColorF, DisplayListId, Epoch};
+use {ApiMsg, AuxiliaryLists, BuiltDisplayList, ColorF, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
-use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState};
-use {StackingContext, StackingContextId, WebGLContextId, WebGLCommand};
+use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, WebGLContextId, WebGLCommand};
 use {GlyphKey, GlyphDimensions};
 
 impl RenderApiSender {
@@ -157,38 +156,25 @@ impl RenderApi {
     /// * `auxiliary_lists`: Various items that the display lists and stacking contexts reference.
     ///
     /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
-    pub fn set_root_stacking_context(&self,
-                                     stacking_context_id: StackingContextId,
-                                     background_color: ColorF,
-                                     epoch: Epoch,
-                                     pipeline_id: PipelineId,
-                                     viewport_size: Size2D<f32>,
-                                     stacking_contexts: Vec<(StackingContextId, StackingContext)>,
-                                     display_lists: Vec<(DisplayListId, BuiltDisplayList)>,
-                                     auxiliary_lists: AuxiliaryLists) {
-        let display_list_descriptors = display_lists.iter().map(|&(display_list_id,
-                                                                   ref built_display_list)| {
-            (display_list_id, (*built_display_list.descriptor()).clone())
-        }).collect();
-        let msg = ApiMsg::SetRootStackingContext(stacking_context_id,
-                                                 background_color,
-                                                 epoch,
-                                                 pipeline_id,
-                                                 viewport_size,
-                                                 stacking_contexts,
-                                                 display_list_descriptors,
-                                                 *auxiliary_lists.descriptor());
+    pub fn set_root_display_list(&self,
+                                 background_color: ColorF,
+                                 epoch: Epoch,
+                                 pipeline_id: PipelineId,
+                                 viewport_size: Size2D<f32>,
+                                 display_list: BuiltDisplayList,
+                                 auxiliary_lists: AuxiliaryLists) {
+        let msg = ApiMsg::SetRootDisplayList(background_color,
+                                             epoch,
+                                             pipeline_id,
+                                             viewport_size,
+                                             display_list.descriptor().clone(),
+                                             *auxiliary_lists.descriptor());
         self.api_sender.send(msg).unwrap();
 
         let mut payload = vec![];
-        payload.write_u32::<LittleEndian>(stacking_context_id.0).unwrap();
         payload.write_u32::<LittleEndian>(epoch.0).unwrap();
-
-        for &(_, ref built_display_list) in &display_lists {
-            payload.extend_from_slice(built_display_list.data());
-        }
+        payload.extend_from_slice(display_list.data());
         payload.extend_from_slice(auxiliary_lists.data());
-
         self.payload_sender.send(&payload[..]).unwrap();
     }
 
@@ -238,18 +224,6 @@ impl RenderApi {
     pub fn send_webgl_command(&self, context_id: WebGLContextId, command: WebGLCommand) {
         let msg = ApiMsg::WebGLCommand(context_id, command);
         self.api_sender.send(msg).unwrap();
-    }
-
-    #[inline]
-    pub fn next_stacking_context_id(&self) -> StackingContextId {
-        let new_id = self.next_unique_id();
-        StackingContextId(new_id.0, new_id.1)
-    }
-
-    #[inline]
-    pub fn next_display_list_id(&self) -> DisplayListId {
-        let new_id = self.next_unique_id();
-        DisplayListId(new_id.0, new_id.1)
     }
 
     #[inline]

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -25,7 +25,6 @@ impl StackingContext {
             bounds: bounds,
             overflow: overflow,
             z_index: z_index,
-            display_lists: Vec::new(),
             transform: transform.clone(),
             perspective: perspective.clone(),
             establishes_3d_context: establishes_3d_context,


### PR DESCRIPTION
This changes brings the WebRender API more into line with the Servo
display list and also the frames generated inside WebRender itself.
Most intermediate display list representations are removed as well as
their place on the resource cache. Perhaps most notably, stacking
contexts are started via a PushStackingContext display item and ended
via a PopStackingContext item. Additionally, the flatten pass has been
significantly simplified to account for these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/552)
<!-- Reviewable:end -->
