### PR TITLE
Add an API for providing external images.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -9,7 +9,7 @@ use gleam::gl;
 use std::path::PathBuf;
 use std::ffi::CStr;
 use webrender_traits::{AuxiliaryListsBuilder, ColorF, Epoch, GlyphInstance};
-use webrender_traits::{ImageFormat, PipelineId, RendererKind};
+use webrender_traits::{ImageData, ImageFormat, PipelineId, RendererKind};
 use std::fs::File;
 use std::io::Read;
 use std::env;
@@ -135,7 +135,7 @@ fn main() {
 
     let clip_region = {
         let mask = webrender_traits::ImageMask {
-            image: api.add_image(2, 2, None, ImageFormat::A8, vec![0,80, 180, 255]),
+            image: api.add_image(2, 2, None, ImageFormat::A8, ImageData::Raw(vec![0,80, 180, 255])),
             rect: Rect::new(Point2D::new(75.0, 75.0), Size2D::new(100.0, 100.0)),
             repeat: false,
         };

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -13,17 +13,18 @@ void main(void) {
     TextRun text = fetch_text_run(cpi.specific_prim_index);
     Glyph glyph = fetch_glyph(cpi.sub_index);
     PrimitiveGeometry pg = fetch_prim_geometry(cpi.global_prim_index);
+    ResourceRect res = fetch_resource_rect(cpi.user_data.x);
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by
     // the glyph offset, relative to its primitive bounding rect.
-    vec2 size = glyph.uv_rect.zw - glyph.uv_rect.xy;
+    vec2 size = res.uv_rect.zw - res.uv_rect.xy;
     vec2 origin = task.data0.xy + uDevicePixelRatio * (glyph.offset.xy - pg.local_rect.xy);
     vec4 local_rect = vec4(origin, size);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));
-    vec2 st0 = glyph.uv_rect.xy / texture_size;
-    vec2 st1 = glyph.uv_rect.zw / texture_size;
+    vec2 st0 = res.uv_rect.xy / texture_size;
+    vec2 st1 = res.uv_rect.zw / texture_size;
 
     vec2 pos = mix(local_rect.xy,
                    local_rect.xy + local_rect.zw,

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -6,6 +6,7 @@
 void main(void) {
     Primitive prim = load_primitive(gl_InstanceID);
     Image image = fetch_image(prim.prim_index);
+    ResourceRect res = fetch_resource_rect(prim.user_data.x);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(prim.local_rect,
@@ -26,8 +27,8 @@ void main(void) {
 
     // vUv will contain how many times this image has wrapped around the image size.
     vec2 texture_size = vec2(textureSize(sColor0, 0));
-    vec2 st0 = image.st_rect.xy / texture_size;
-    vec2 st1 = image.st_rect.zw / texture_size;
+    vec2 st0 = res.uv_rect.xy / texture_size;
+    vec2 st1 = res.uv_rect.zw / texture_size;
 
     vTextureSize = st1 - st0;
     vTextureOffset = st0;

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -7,7 +7,9 @@ void main(void) {
     Primitive prim = load_primitive(gl_InstanceID);
     TextRun text = fetch_text_run(prim.prim_index);
     Glyph glyph = fetch_glyph(prim.sub_index);
-    vec4 local_rect = vec4(glyph.offset.xy, (glyph.uv_rect.zw - glyph.uv_rect.xy) / uDevicePixelRatio);
+    ResourceRect res = fetch_resource_rect(prim.user_data.x);
+
+    vec4 local_rect = vec4(glyph.offset.xy, (res.uv_rect.zw - res.uv_rect.xy) / uDevicePixelRatio);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(local_rect,
@@ -28,8 +30,8 @@ void main(void) {
     write_clip(vi.global_clamped_pos, prim.clip_area);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));
-    vec2 st0 = glyph.uv_rect.xy / texture_size;
-    vec2 st1 = glyph.uv_rect.zw / texture_size;
+    vec2 st0 = res.uv_rect.xy / texture_size;
+    vec2 st1 = res.uv_rect.zw / texture_size;
 
     vColor = text.color;
     vUv = mix(st0, st1, f);

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1366,6 +1366,11 @@ impl Device {
                 if u_data128 != -1 {
                     gl::uniform_1i(u_data128, TextureSampler::Data128    as i32);
                 }
+
+                let u_resource_rects = gl::get_uniform_location(program.id, "sResourceRects");
+                if u_resource_rects != -1 {
+                    gl::uniform_1i(u_resource_rects, TextureSampler::ResourceRects as i32);
+                }
             }
         }
     }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tiling;
 use webrender_traits::{Epoch, ColorF, PipelineId};
 use webrender_traits::{ImageFormat, MixBlendMode, NativeFontHandle};
-use webrender_traits::{ScrollLayerId, WebGLCommand};
+use webrender_traits::{ExternalImageId, ScrollLayerId, WebGLCommand};
 
 // An ID for a texture that is owned by the
 // texture cache module. This can include atlases
@@ -45,9 +45,7 @@ pub enum SourceTexture {
     Invalid,
     TextureCache(CacheTextureId),
     WebGL(u32),                         // Is actually a gl::GLuint
-
-    // TODO(gw): Implement external image support via callback
-    //External(i32),
+    External(ExternalImageId),
 }
 
 pub enum GLContextHandleWrapper {
@@ -203,6 +201,7 @@ pub enum TextureSampler {
     Layers,
     RenderTasks,
     Geometry,
+    ResourceRects,
 }
 
 impl TextureSampler {

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -121,4 +121,5 @@ extern crate offscreen_gl_context;
 extern crate byteorder;
 extern crate rayon;
 
+pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{Renderer, RendererOptions};

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -7,7 +7,7 @@ use euclid::{Point2D, Matrix4D, Rect, Size2D};
 use gpu_store::{GpuStore, GpuStoreAddress};
 use internal_types::{device_pixel, DeviceRect, DeviceSize, SourceTexture};
 use mask_cache::{MaskCacheInfo, MaskCacheKey};
-use resource_cache::ResourceCache;
+use resource_cache::{ImageProperties, ResourceCache};
 use std::mem;
 use std::usize;
 use tiling::RenderTask;
@@ -18,6 +18,39 @@ use webrender_traits::{FontKey, FontRenderMode, WebGLContextId};
 
 pub const CLIP_DATA_GPU_SIZE: usize = 5;
 pub const MASK_DATA_GPU_SIZE: usize = 1;
+
+/// Stores two coordinates in texel space. The coordinates
+/// are stored in texel coordinates because the texture atlas
+/// may grow. Storing them as texel coords and normalizing
+/// the UVs in the vertex shader means nothing needs to be
+/// updated on the CPU when the texture size changes.
+#[derive(Clone)]
+pub struct TexelRect {
+    pub uv0: Point2D<f32>,
+    pub uv1: Point2D<f32>,
+}
+
+impl Default for TexelRect {
+    fn default() -> TexelRect {
+        TexelRect {
+            uv0: Point2D::zero(),
+            uv1: Point2D::zero(),
+        }
+    }
+}
+
+/// For external images, it's not possible to know the
+/// UV coords of the image (or the image data itself)
+/// until the render thread receives the frame and issues
+/// callbacks to the client application. For external
+/// images that are visible, a DeferredResolve is created
+/// that is stored in the frame. This allows the render
+/// thread to iterate this list and update any changed
+/// texture data and update the UV rect.
+pub struct DeferredResolve {
+    pub resource_address: GpuStoreAddress,
+    pub image_properties: ImageProperties,
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SpecificPrimitiveIndex(pub usize);
@@ -98,12 +131,11 @@ pub enum ImagePrimitiveKind {
 pub struct ImagePrimitiveCpu {
     pub kind: ImagePrimitiveKind,
     pub color_texture_id: SourceTexture,
+    pub resource_address: GpuStoreAddress,
 }
 
 #[derive(Debug, Clone)]
 pub struct ImagePrimitiveGpu {
-    pub uv0: Point2D<f32>,
-    pub uv1: Point2D<f32>,
     pub stretch_size: Size2D<f32>,
     pub tile_spacing: Size2D<f32>,
 }
@@ -193,14 +225,13 @@ pub struct TextRunPrimitiveCpu {
     pub color_texture_id: SourceTexture,
     pub color: ColorF,
     pub render_mode: FontRenderMode,
+    pub resource_address: GpuStoreAddress,
 }
 
 #[derive(Debug, Clone)]
 struct GlyphPrimitive {
     offset: Point2D<f32>,
     padding: Point2D<f32>,
-    uv0: Point2D<f32>,
-    uv1: Point2D<f32>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,6 +377,9 @@ pub struct PrimitiveStore {
     pub gpu_data64: GpuStore<GpuBlock64>,
     pub gpu_data128: GpuStore<GpuBlock128>,
 
+    // Resolved resource rects.
+    pub gpu_resource_rects: GpuStore<TexelRect>,
+
     // General
     device_pixel_ratio: f32,
     prims_to_resolve: Vec<PrimitiveIndex>,
@@ -365,6 +399,7 @@ impl PrimitiveStore {
             gpu_data32: GpuStore::new(),
             gpu_data64: GpuStore::new(),
             gpu_data128: GpuStore::new(),
+            gpu_resource_rects: GpuStore::new(),
             device_pixel_ratio: device_pixel_ratio,
             prims_to_resolve: Vec::new(),
         }
@@ -406,9 +441,10 @@ impl PrimitiveStore {
 
                 metadata
             }
-            PrimitiveContainer::TextRun(text_cpu, text_gpu) => {
+            PrimitiveContainer::TextRun(mut text_cpu, text_gpu) => {
                 let gpu_address = self.gpu_data16.push(text_gpu);
-                let gpu_glyphs_address = self.gpu_data32.alloc(text_cpu.glyph_range.length);
+                let gpu_glyphs_address = self.gpu_data16.alloc(text_cpu.glyph_range.length);
+                text_cpu.resource_address = self.gpu_resource_rects.alloc(text_cpu.glyph_range.length);
 
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
@@ -425,8 +461,10 @@ impl PrimitiveStore {
                 self.cpu_text_runs.push(text_cpu);
                 metadata
             }
-            PrimitiveContainer::Image(image_cpu, image_gpu) => {
-                let gpu_address = self.gpu_data32.push(image_gpu);
+            PrimitiveContainer::Image(mut image_cpu, image_gpu) => {
+                image_cpu.resource_address = self.gpu_resource_rects.alloc(1);
+
+                let gpu_address = self.gpu_data16.push(image_gpu);
 
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
@@ -540,12 +578,14 @@ impl PrimitiveStore {
         PrimitiveIndex(prim_index)
     }
 
-    pub fn resolve_primitives(&mut self, resource_cache: &ResourceCache) {
+    pub fn resolve_primitives(&mut self, resource_cache: &ResourceCache) -> Vec<DeferredResolve> {
+        let mut deferred_resolves = Vec::new();
+
         for prim_index in self.prims_to_resolve.drain(..) {
             let metadata = &mut self.cpu_metadata[prim_index.0];
 
             if let Some(MaskCacheInfo{ key: MaskCacheKey { image: Some(gpu_address), .. }, image: Some(ref mask), .. }) = metadata.clip_cache_info {
-                let cache_item = resource_cache.get_image(mask.image, ImageRendering::Auto);
+                let cache_item = resource_cache.get_cached_image(mask.image, ImageRendering::Auto);
                 let mask_data = self.gpu_data32.get_slice_mut(gpu_address, MASK_DATA_GPU_SIZE);
                 mask_data[0] = GpuBlock32::from(ImageMaskData {
                     uv_rect: Rect::new(cache_item.uv0,
@@ -563,44 +603,64 @@ impl PrimitiveStore {
                 PrimitiveKind::TextRun => {
                     let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
 
-                    let dest_glyphs = self.gpu_data32.get_slice_mut(metadata.gpu_data_address,
-                                                                    text.glyph_range.length);
+                    let dest_rects = self.gpu_resource_rects.get_slice_mut(text.resource_address,
+                                                                           text.glyph_range.length);
 
                     let texture_id = resource_cache.get_glyphs(text.font_key,
                                                                text.font_size,
                                                                &text.glyph_indices,
                                                                text.render_mode, |index, uv0, uv1| {
-                        let dest_glyph = &mut dest_glyphs[index];
-                        let dest: &mut GlyphPrimitive = unsafe {
-                            mem::transmute(dest_glyph)
-                        };
-                        dest.uv0 = uv0;
-                        dest.uv1 = uv1;
+                        let dest_rect = &mut dest_rects[index];
+                        dest_rect.uv0 = uv0;
+                        dest_rect.uv1 = uv1;
                     });
 
                     text.color_texture_id = texture_id;
                 }
                 PrimitiveKind::Image => {
                     let image_cpu = &mut self.cpu_images[metadata.cpu_prim_index.0];
-                    let image_gpu: &mut ImagePrimitiveGpu = unsafe {
-                        mem::transmute(self.gpu_data32.get_mut(metadata.gpu_prim_index))
-                    };
 
-                    let cache_item = match image_cpu.kind {
+                    let (texture_id, cache_item) = match image_cpu.kind {
                         ImagePrimitiveKind::Image(image_key, image_rendering, _) => {
-                            resource_cache.get_image(image_key, image_rendering)
+                            // Check if an external image that needs to be resolved
+                            // by the render thread.
+                            let image_properties = resource_cache.get_image_properties(image_key);
+
+                            match image_properties.external_id {
+                                Some(external_id) => {
+                                    // This is an external texture - we will add it to
+                                    // the deferred resolves list to be patched by
+                                    // the render thread...
+                                    deferred_resolves.push(DeferredResolve {
+                                        resource_address: image_cpu.resource_address,
+                                        image_properties: image_properties,
+                                    });
+
+                                    (SourceTexture::External(external_id), None)
+                                }
+                                None => {
+                                    let cache_item = resource_cache.get_cached_image(image_key, image_rendering);
+                                    (cache_item.texture_id, Some(cache_item))
+                                }
+                            }
                         }
                         ImagePrimitiveKind::WebGL(context_id) => {
-                            resource_cache.get_webgl_texture(&context_id)
+                            let cache_item = resource_cache.get_webgl_texture(&context_id);
+                            (cache_item.texture_id, Some(cache_item))
                         }
                     };
 
-                    image_cpu.color_texture_id = cache_item.texture_id;
-                    image_gpu.uv0 = cache_item.uv0;
-                    image_gpu.uv1 = cache_item.uv1;
+                    if let Some(cache_item) = cache_item {
+                        let resource_rect = self.gpu_resource_rects.get_mut(image_cpu.resource_address);
+                        resource_rect.uv0 = cache_item.uv0;
+                        resource_rect.uv1 = cache_item.uv1;
+                    }
+                    image_cpu.color_texture_id = texture_id;
                 }
             }
         }
+
+        deferred_resolves
     }
 
     pub fn get_bounding_rect(&self, index: PrimitiveIndex) -> &Option<DeviceRect> {
@@ -695,7 +755,7 @@ impl PrimitiveStore {
                     debug_assert!(metadata.gpu_data_count == text.glyph_range.length as i32);
                     debug_assert!(text.glyph_indices.is_empty());
                     let src_glyphs = auxiliary_lists.glyph_instances(&text.glyph_range);
-                    let dest_glyphs = self.gpu_data32.get_slice_mut(metadata.gpu_data_address,
+                    let dest_glyphs = self.gpu_data16.get_slice_mut(metadata.gpu_data_address,
                                                                     text.glyph_range.length);
                     let mut glyph_key = GlyphKey::new(text.font_key,
                                                       text.font_size,
@@ -724,9 +784,7 @@ impl PrimitiveStore {
                                                          Size2D::new(width, height));
                         local_rect = local_rect.union(&local_glyph_rect);
 
-                        dest_glyphs[actual_glyph_count] = GpuBlock32::from(GlyphPrimitive {
-                            uv0: Point2D::zero(),
-                            uv1: Point2D::zero(),
+                        dest_glyphs[actual_glyph_count] = GpuBlock16::from(GlyphPrimitive {
                             padding: Point2D::zero(),
                             offset: local_glyph_rect.origin,
                         });
@@ -866,6 +924,22 @@ impl From<InstanceRect> for GpuBlock16 {
     }
 }
 
+impl From<ImagePrimitiveGpu> for GpuBlock16 {
+    fn from(data: ImagePrimitiveGpu) -> GpuBlock16 {
+        unsafe {
+            mem::transmute::<ImagePrimitiveGpu, GpuBlock16>(data)
+        }
+    }
+}
+
+impl From<GlyphPrimitive> for GpuBlock16 {
+    fn from(data: GlyphPrimitive) -> GpuBlock16 {
+        unsafe {
+            mem::transmute::<GlyphPrimitive, GpuBlock16>(data)
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct GpuBlock32 {
     data: [f32; 8],
@@ -891,22 +965,6 @@ impl From<GradientStop> for GpuBlock32 {
     fn from(data: GradientStop) -> GpuBlock32 {
         unsafe {
             mem::transmute::<GradientStop, GpuBlock32>(data)
-        }
-    }
-}
-
-impl From<GlyphPrimitive> for GpuBlock32 {
-    fn from(data: GlyphPrimitive) -> GpuBlock32 {
-        unsafe {
-            mem::transmute::<GlyphPrimitive, GpuBlock32>(data)
-        }
-    }
-}
-
-impl From<ImagePrimitiveGpu> for GpuBlock32 {
-    fn from(data: ImagePrimitiveGpu) -> GpuBlock32 {
-        unsafe {
-            mem::transmute::<ImagePrimitiveGpu, GpuBlock32>(data)
         }
     }
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -16,7 +16,7 @@ use std::io::{Cursor, Read};
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 use texture_cache::TextureCache;
-use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace};
+use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace, ImageData};
 use webrender_traits::{FlushNotifier, RenderNotifier, RenderDispatcher, WebGLCommand, WebGLContextId};
 use record;
 use tiling::FrameBuilderConfig;
@@ -124,14 +124,16 @@ impl RenderBackend {
                             };
                             tx.send(glyph_dimensions).unwrap();
                         }
-                        ApiMsg::AddImage(id, width, height, stride, format, bytes) => {
-                            profile_counters.image_templates.inc(bytes.len());
+                        ApiMsg::AddImage(id, width, height, stride, format, data) => {
+                            if let ImageData::Raw(ref bytes) = data {
+                                profile_counters.image_templates.inc(bytes.len());
+                            }
                             self.resource_cache.add_image_template(id,
                                                                    width,
                                                                    height,
                                                                    stride,
                                                                    format,
-                                                                   bytes);
+                                                                   data);
                         }
                         ApiMsg::Flush => {
                             let mut flush_notifier = self.flush_notifier.lock();

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -18,7 +18,8 @@ use std::hash::BuildHasherDefault;
 use std::hash::Hash;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
-use webrender_traits::{FontRenderMode, GlyphDimensions, WebGLContextId};
+use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
+use webrender_traits::ExternalImageId;
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
 
@@ -58,6 +59,10 @@ impl RenderedGlyphKey {
 pub struct ImageProperties {
     pub format: ImageFormat,
     pub is_opaque: bool,
+    pub external_id: Option<ExternalImageId>,
+    pub width: u32,
+    pub height: u32,
+    pub stride: Option<u32>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -68,7 +73,7 @@ enum State {
 }
 
 struct ImageResource {
-    bytes: Vec<u8>,
+    data: ImageData,
     width: u32,
     height: u32,
     stride: Option<u32>,
@@ -218,14 +223,18 @@ impl ResourceCache {
                               height: u32,
                               stride: Option<u32>,
                               format: ImageFormat,
-                              bytes: Vec<u8>) {
+                              data: ImageData) {
+        let is_opaque = match data {
+            ImageData::Raw(ref bytes) => is_image_opaque(format, bytes),
+            ImageData::External(..) => false,           // TODO: Allow providing this through API.
+        };
         let resource = ImageResource {
-            is_opaque: is_image_opaque(format, &bytes),
+            is_opaque: is_opaque,
             width: width,
             height: height,
             stride: stride,
             format: format,
-            bytes: bytes,
+            data: data,
             epoch: Epoch(0),
         };
 
@@ -254,7 +263,7 @@ impl ResourceCache {
             height: height,
             stride: None,
             format: format,
-            bytes: bytes,
+            data: ImageData::Raw(bytes),
             epoch: next_epoch,
         };
 
@@ -397,10 +406,11 @@ impl ResourceCache {
     }
 
     #[inline]
-    pub fn get_image(&self,
-                     image_key: ImageKey,
-                     image_rendering: ImageRendering) -> CacheItem {
+    pub fn get_cached_image(&self,
+                            image_key: ImageKey,
+                            image_rendering: ImageRendering) -> CacheItem {
         debug_assert!(self.state == State::QueryResources);
+
         let image_info = &self.cached_images.get(&(image_key, image_rendering),
                                                  self.current_frame_id);
         let item = self.texture_cache.get(image_info.texture_cache_id);
@@ -416,9 +426,18 @@ impl ResourceCache {
     pub fn get_image_properties(&self, image_key: ImageKey) -> ImageProperties {
         let image_template = &self.image_templates[&image_key];
 
+        let external_id = match image_template.data {
+            ImageData::External(id) => Some(id),
+            ImageData::Raw(..) => None,
+        };
+
         ImageProperties {
             format: image_template.format,
             is_opaque: image_template.is_opaque,
+            external_id: external_id,
+            width: image_template.width,
+            height: image_template.height,
+            stride: image_template.stride,
         }
     }
 
@@ -453,47 +472,54 @@ impl ResourceCache {
                     let cached_images = &mut self.cached_images;
                     let image_template = &self.image_templates[&key];
 
-                    match cached_images.entry((key, rendering), self.current_frame_id) {
-                        Occupied(entry) => {
-                            let image_id = entry.get().texture_cache_id;
+                    match image_template.data {
+                        ImageData::Raw(ref bytes) => {
+                            match cached_images.entry((key, rendering), self.current_frame_id) {
+                                Occupied(entry) => {
+                                    let image_id = entry.get().texture_cache_id;
 
-                            if entry.get().epoch != image_template.epoch {
-                                // TODO: Can we avoid the clone of the bytes here?
-                                self.texture_cache.update(image_id,
-                                                          image_template.width,
-                                                          image_template.height,
-                                                          image_template.stride,
-                                                          image_template.format,
-                                                          image_template.bytes.clone());
+                                    if entry.get().epoch != image_template.epoch {
+                                        // TODO: Can we avoid the clone of the bytes here?
+                                        self.texture_cache.update(image_id,
+                                                                  image_template.width,
+                                                                  image_template.height,
+                                                                  image_template.stride,
+                                                                  image_template.format,
+                                                                  bytes.clone());
 
-                                // Update the cached epoch
-                                *entry.into_mut() = CachedImageInfo {
-                                    texture_cache_id: image_id,
-                                    epoch: image_template.epoch,
-                                };
+                                        // Update the cached epoch
+                                        *entry.into_mut() = CachedImageInfo {
+                                            texture_cache_id: image_id,
+                                            epoch: image_template.epoch,
+                                        };
+                                    }
+                                }
+                                Vacant(entry) => {
+                                    let image_id = self.texture_cache.new_item_id();
+
+                                    let filter = match rendering {
+                                        ImageRendering::Pixelated => TextureFilter::Nearest,
+                                        ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
+                                    };
+
+                                    // TODO: Can we avoid the clone of the bytes here?
+                                    self.texture_cache.insert(image_id,
+                                                              image_template.width,
+                                                              image_template.height,
+                                                              image_template.stride,
+                                                              image_template.format,
+                                                              filter,
+                                                              bytes.clone());
+
+                                    entry.insert(CachedImageInfo {
+                                        texture_cache_id: image_id,
+                                        epoch: image_template.epoch,
+                                    });
+                                }
                             }
                         }
-                        Vacant(entry) => {
-                            let image_id = self.texture_cache.new_item_id();
-
-                            let filter = match rendering {
-                                ImageRendering::Pixelated => TextureFilter::Nearest,
-                                ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
-                            };
-
-                            // TODO: Can we avoid the clone of the bytes here?
-                            self.texture_cache.insert(image_id,
-                                                      image_template.width,
-                                                      image_template.height,
-                                                      image_template.stride,
-                                                      image_template.format,
-                                                      filter,
-                                                      image_template.bytes.clone());
-
-                            entry.insert(CachedImageInfo {
-                                texture_cache_id: image_id,
-                                epoch: image_template.epoch,
-                            });
+                        ImageData::External(..) => {
+                            // External images don't get added to the texture cache!
                         }
                     }
                 }

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -9,8 +9,8 @@ use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::cell::Cell;
 use {ApiMsg, AuxiliaryLists, BuiltDisplayList, ColorF, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
-use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, WebGLContextId, WebGLCommand};
-use {GlyphKey, GlyphDimensions};
+use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState};
+use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
 
 impl RenderApiSender {
     pub fn new(api_sender: IpcSender<ApiMsg>,
@@ -92,10 +92,10 @@ impl RenderApi {
                      height: u32,
                      stride: Option<u32>,
                      format: ImageFormat,
-                     bytes: Vec<u8>) -> ImageKey {
+                     data: ImageData) -> ImageKey {
         let new_id = self.next_unique_id();
         let key = ImageKey::new(new_id.0, new_id.1);
-        let msg = ApiMsg::AddImage(key, width, height, stride, format, bytes);
+        let msg = ApiMsg::AddImage(key, width, height, stride, format, data);
         self.api_sender.send(msg).unwrap();
         key
     }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -28,7 +28,7 @@ pub enum ApiMsg {
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, IpcSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
-    AddImage(ImageKey, u32, u32, Option<u32>, ImageFormat, Vec<u8>),
+    AddImage(ImageKey, u32, u32, Option<u32>, ImageFormat, ImageData),
     /// Updates the the resource cache with the new image data.
     UpdateImage(ImageKey, u32, u32, ImageFormat, Vec<u8>),
     /// Drops an image from the resource cache.
@@ -314,6 +314,18 @@ pub enum ImageFormat {
     RGB8,
     RGBA8,
     RGBAF32,
+}
+
+/// An arbitrary identifier for an external image provided by the
+/// application. It must be a unique identifier for each external
+/// image.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ExternalImageId(pub u64);
+
+#[derive(Serialize, Deserialize)]
+pub enum ImageData {
+    Raw(Vec<u8>),
+    External(ExternalImageId),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
This allows applications to provide images without supplying
the image bytes up front. This can be useful if the application
doesn't have the bytes available immediately (e.g. video decoding)
or wants to manage the buffer allocation and reduce memory
copies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/561)
<!-- Reviewable:end -->
