### PR TITLE
Remove establishes_3d_context field from StackingContext

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -128,7 +128,6 @@ fn main() {
                                                0,
                                                &Matrix4D::identity(),
                                                &Matrix4D::identity(),
-                                               true,
                                                webrender_traits::MixBlendMode::Normal,
                                                Vec::new(),
                                                &mut auxiliary_lists_builder));

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -14,7 +14,6 @@ impl StackingContext {
                z_index: i32,
                transform: &Matrix4D<f32>,
                perspective: &Matrix4D<f32>,
-               establishes_3d_context: bool,
                mix_blend_mode: MixBlendMode,
                filters: Vec<FilterOp>,
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
@@ -27,7 +26,6 @@ impl StackingContext {
             z_index: z_index,
             transform: transform.clone(),
             perspective: perspective.clone(),
-            establishes_3d_context: establishes_3d_context,
             mix_blend_mode: mix_blend_mode,
             filters: auxiliary_lists_builder.add_filters(&filters),
         }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -457,7 +457,6 @@ pub struct StackingContext {
     pub z_index: i32,
     pub transform: Matrix4D<f32>,
     pub perspective: Matrix4D<f32>,
-    pub establishes_3d_context: bool,
     pub mix_blend_mode: MixBlendMode,
     pub filters: ItemRange,
 }


### PR DESCRIPTION
This field is currently unused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/562)
<!-- Reviewable:end -->
