### PR TITLE
Fix a bug with clipping when scrolling after a layout.

### DIFF
--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -8,8 +8,10 @@ use internal_types::DeviceRect;
 use prim_store::{ClipData, GpuBlock32, PrimitiveClipSource, PrimitiveStore};
 use prim_store::{CLIP_DATA_GPU_SIZE, MASK_DATA_GPU_SIZE};
 use tiling::StackingContextIndex;
-use util::TransformedRect;
+use util::{rect_from_points_f, TransformedRect};
 use webrender_traits::{AuxiliaryLists, ImageMask};
+
+const MAX_COORD: f32 = 1.0e+16;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct ClipAddressRange {
@@ -95,15 +97,14 @@ impl MaskCacheInfo {
     pub fn update(&mut self,
                   source: &PrimitiveClipSource,
                   transform: &Matrix4D<f32>,
-                  clip_rect: &Rect<f32>,
                   clip_store: &mut GpuStore<GpuBlock32>,
                   device_pixel_ratio: f32,
                   aux_lists: &AuxiliaryLists) {
 
         if self.local_rect.is_none() {
-            let mut local_rect = Some(clip_rect.clone());
+            let mut local_rect = Some(rect_from_points_f(-MAX_COORD, -MAX_COORD, MAX_COORD, MAX_COORD));
             match source {
-                &PrimitiveClipSource::NoClip => (),
+                &PrimitiveClipSource::NoClip => unreachable!(),
                 &PrimitiveClipSource::Complex(rect, radius) => {
                     let slice = clip_store.get_slice_mut(self.key.clip_range.start, CLIP_DATA_GPU_SIZE);
                     let data = ClipData::uniform(rect, radius);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -719,7 +719,6 @@ impl PrimitiveStore {
                                    prim_index: PrimitiveIndex,
                                    resource_cache: &mut ResourceCache,
                                    layer_transform: &Matrix4D<f32>,
-                                   layer_combined_local_clip_rect: &Rect<f32>,
                                    device_pixel_ratio: f32,
                                    auxiliary_lists: &AuxiliaryLists) -> bool {
 
@@ -730,7 +729,6 @@ impl PrimitiveStore {
         if let Some(ref mut clip_info) = metadata.clip_cache_info {
             clip_info.update(&metadata.clip_source,
                              layer_transform,
-                             layer_combined_local_clip_rect,
                              &mut self.gpu_data32,
                              device_pixel_ratio,
                              auxiliary_lists);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2303,7 +2303,6 @@ impl FrameBuilder {
                             if self.prim_store.prepare_prim_for_render(prim_index,
                                                                        resource_cache,
                                                                        &packed_layer.transform,
-                                                                       &packed_layer.local_clip_rect,
                                                                        self.device_pixel_ratio,
                                                                        auxiliary_lists) {
                                 self.prim_store.build_bounding_rect(prim_index,


### PR DESCRIPTION
The layer local rect is clipped against the root viewport
in local space, so it can't be used in a way that it was.

We don't actually need this here anyway. The local clip rect
of the layer is currently handled by write_vertex, and in the
future will be handled when stacking contexts write their
own clip mask.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/564)
<!-- Reviewable:end -->
