### PR TITLE
Introduce a glyph cache thread.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,14 +146,6 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "deque"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "dlib"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,14 +382,6 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "num_cpus"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "objc"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,17 +465,6 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -674,6 +647,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "time"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +764,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.11.0",
 ]
@@ -877,7 +855,6 @@ dependencies = [
 "checksum core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "66e998abb8823fecd2a8a7205429b17a340d447d8c69b3bce86846dcdea3e33b"
 "checksum core-text 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2debbf22a8358e5e270e958b6d65694667be7a2ef9c3a2bf05a0872a3124dc98"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
 "checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c4c7cc7b396419bc0a4d90371d0cee16cb5053b53647d287c0b728000c41fe"
@@ -905,7 +882,6 @@ dependencies = [
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum memmap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f20f72ed93291a72e22e8b16bb18762183bb4943f0f483da5b8be1a9e8192752"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
-"checksum num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8890e6084723d57d0df8d2720b0d60c6ee67d6c93e7169630e4371e88765dcad"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum offscreen_gl_context 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9da33a538d9c8fc81102e5d5c1ed844568b400d86c22413550a9b8474be62ba3"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
@@ -916,7 +892,6 @@ dependencies = [
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum quote 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1e0c9bc6bfb0a60d539aab6e338207c1a5456e62f5bd5375132cee119aa4b3"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
-"checksum rayon 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b6a6e05e0e6b703e9f2ad266eb63f3712e693a17a2702b95a23de14ce8defa9"
 "checksum rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "bff9fc1c79f2dec76b253273d07682e94a978bd8f132ded071188122b2af9818"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
@@ -937,6 +912,7 @@ dependencies = [
 "checksum target_build_utils 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54c550e226618cd35334b75e92bfa5437c61474bdb75c38bf330ab5a8037b77c"
 "checksum tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9270837a93bad1b1dac18fe67e786b3c960513af86231f6f4f57fddd594ff0c8"
 "checksum term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3deff8a2b3b6607d6d7cc32ac25c0b33709453ca9cceac006caac51e963cf94a"
+"checksum threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59f6d3eff89920113dac9db44dde461d71d01e88a5b57b258a0466c32b5d7fe1"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -25,8 +25,8 @@ lazy_static = "0.2"
 log = "0.3"
 num-traits = "0.1.32"
 offscreen_gl_context = {version = "0.5", features = ["serde_serialization", "osmesa"]}
-rayon = "0.5"
 time = "0.1"
+threadpool = "1.3.2"
 webrender_traits = {path = "../webrender_traits", default-features = false}
 bitflags = "0.7"
 

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -169,7 +169,7 @@ pub const ANGLE_FLOAT_TO_FIXED: f32 = 65535.0;
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;
 pub const ORTHO_FAR_PLANE: f32 = 1000000.0;
 
-
+#[derive(Clone)]
 pub enum FontTemplate {
     Raw(Arc<Vec<u8>>),
     Native(NativeFontHandle),

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -122,7 +122,7 @@ extern crate time;
 extern crate webrender_traits;
 extern crate offscreen_gl_context;
 extern crate byteorder;
-extern crate rayon;
+extern crate threadpool;
 
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{Renderer, RendererOptions};

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -8,21 +8,43 @@ use fnv::FnvHasher;
 use frame::FrameId;
 use internal_types::{FontTemplate, SourceTexture, TextureUpdateList};
 use platform::font::{FontContext, RasterizedGlyph};
-use rayon::prelude::*;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::fmt::Debug;
 use std::hash::BuildHasherDefault;
 use std::hash::Hash;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize};
 use webrender_traits::ExternalImageId;
+use threadpool::ThreadPool;
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
+
+type GlyphCache = ResourceClassCache<RenderedGlyphKey, Option<TextureCacheItemId>>;
+
+/// Message sent from the resource cache to the glyph cache thread.
+enum GlyphCacheMsg {
+    /// Begin the frame - pass ownership of the glyph cache to the thread.
+    BeginFrame(FrameId, GlyphCache),
+    /// Add a new font.
+    AddFont(FontKey, FontTemplate),
+    /// Request glyphs for a text run.
+    RequestGlyphs(FontKey, Au, Vec<u32>, FontRenderMode),
+    /// Finished requesting glyphs. Reply with new glyphs.
+    EndFrame,
+}
+
+/// Results send from glyph cache thread back to main resource cache.
+enum GlyphCacheResultMsg {
+    /// Return the glyph cache, and a list of newly rasterized glyphs.
+    EndFrame(GlyphCache, Vec<GlyphRasterJob>),
+}
 
 // These coordinates are always in texels.
 // They are converted to normalized ST
@@ -81,11 +103,6 @@ struct ImageResource {
     format: ImageFormat,
     epoch: Epoch,
     is_opaque: bool,
-}
-
-struct GlyphRasterJob {
-    glyph_key: RenderedGlyphKey,
-    result: Option<RasterizedGlyph>,
 }
 
 struct CachedImageInfo {
@@ -154,16 +171,15 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
     }
 }
 
-struct TextRunResourceRequest {
-    key: FontKey,
-    size: Au,
-    glyph_indices: Vec<u32>,
-    render_mode: FontRenderMode,
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct ImageRequest {
+    key: ImageKey,
+    rendering: ImageRendering,
 }
 
-enum ResourceRequest {
-    Image(ImageKey, ImageRendering),
-    TextRun(TextRunResourceRequest),
+struct GlyphRasterJob {
+    key: RenderedGlyphKey,
+    result: Option<RasterizedGlyph>,
 }
 
 struct WebGLTexture {
@@ -172,8 +188,8 @@ struct WebGLTexture {
 }
 
 pub struct ResourceCache {
-    cached_glyphs: ResourceClassCache<RenderedGlyphKey, Option<TextureCacheItemId>>,
-    cached_images: ResourceClassCache<(ImageKey, ImageRendering), CachedImageInfo>,
+    cached_glyphs: Option<GlyphCache>,
+    cached_images: ResourceClassCache<ImageRequest, CachedImageInfo>,
 
     // TODO(pcwalton): Figure out the lifecycle of these.
     webgl_textures: HashMap<WebGLContextId, WebGLTexture, BuildHasherDefault<FnvHasher>>,
@@ -188,15 +204,18 @@ pub struct ResourceCache {
 
     // TODO(gw): We should expire (parts of) this cache semi-regularly!
     cached_glyph_dimensions: HashMap<GlyphKey, Option<GlyphDimensions>, BuildHasherDefault<FnvHasher>>,
-    pending_requests: Vec<ResourceRequest>,
-    pending_raster_jobs: Vec<GlyphRasterJob>,
+    pending_image_requests: Vec<ImageRequest>,
+    glyph_cache_tx: Sender<GlyphCacheMsg>,
+    glyph_cache_result_queue: Receiver<GlyphCacheResultMsg>,
 }
 
 impl ResourceCache {
     pub fn new(texture_cache: TextureCache,
                enable_aa: bool) -> ResourceCache {
+        let (glyph_cache_tx, glyph_cache_result_queue) = spawn_glyph_cache_thread();
+
         ResourceCache {
-            cached_glyphs: ResourceClassCache::new(),
+            cached_glyphs: Some(ResourceClassCache::new()),
             cached_images: ResourceClassCache::new(),
             webgl_textures: HashMap::with_hasher(Default::default()),
             font_templates: HashMap::with_hasher(Default::default()),
@@ -206,12 +225,18 @@ impl ResourceCache {
             state: State::Idle,
             enable_aa: enable_aa,
             current_frame_id: FrameId(0),
-            pending_raster_jobs: Vec::new(),
-            pending_requests: Vec::new(),
+            pending_image_requests: Vec::new(),
+            glyph_cache_tx: glyph_cache_tx,
+            glyph_cache_result_queue: glyph_cache_result_queue,
         }
     }
 
     pub fn add_font_template(&mut self, font_key: FontKey, template: FontTemplate) {
+        // Push the new font to the glyph cache thread, and also store
+        // it locally for glyph metric requests.
+        self.glyph_cache_tx
+            .send(GlyphCacheMsg::AddFont(font_key, template.clone()))
+            .unwrap();
         self.font_templates.insert(font_key, template);
     }
 
@@ -291,7 +316,10 @@ impl ResourceCache {
                          key: ImageKey,
                          rendering: ImageRendering) {
         debug_assert!(self.state == State::AddResources);
-        self.pending_requests.push(ResourceRequest::Image(key, rendering));
+        self.pending_image_requests.push(ImageRequest {
+            key: key,
+            rendering: rendering,
+        });
     }
 
     pub fn request_glyphs(&mut self,
@@ -300,40 +328,15 @@ impl ResourceCache {
                           glyph_indices: &[u32],
                           render_mode: FontRenderMode) {
         debug_assert!(self.state == State::AddResources);
-        self.pending_requests.push(ResourceRequest::TextRun(TextRunResourceRequest {
-            key: key,
-            size: size,
-            glyph_indices: glyph_indices.to_vec(),
-            render_mode: render_mode,
-        }));
-    }
-
-    pub fn raster_pending_glyphs(&mut self) {
-        // Run raster jobs in parallel
-        run_raster_jobs(&mut self.pending_raster_jobs,
-                        &self.font_templates,
-                        self.enable_aa);
-
-        // Add completed raster jobs to the texture cache
-        for job in self.pending_raster_jobs.drain(..) {
-            let result = job.result.expect("Failed to rasterize the glyph?");
-            let image_id = if result.width > 0 && result.height > 0 {
-                let image_id = self.texture_cache.new_item_id();
-                let texture_width = result.width;
-                let texture_height = result.height;
-                self.texture_cache.insert(image_id,
-                                          texture_width,
-                                          texture_height,
-                                          None,
-                                          ImageFormat::RGBA8,
-                                          TextureFilter::Linear,
-                                          Arc::new(result.bytes));
-                Some(image_id)
-            } else {
-                None
-            };
-            self.cached_glyphs.insert(job.glyph_key, image_id, self.current_frame_id);
-        }
+        let render_mode = self.get_glyph_render_mode(render_mode);
+        // Immediately request that the glyph cache thread start
+        // rasterizing glyphs from this request if they aren't
+        // already cached.
+        let msg = GlyphCacheMsg::RequestGlyphs(key,
+                                               size,
+                                               glyph_indices.to_vec(),
+                                               render_mode);
+        self.glyph_cache_tx.send(msg).unwrap();
     }
 
     pub fn pending_updates(&mut self) -> TextureUpdateList {
@@ -347,6 +350,8 @@ impl ResourceCache {
                          render_mode: FontRenderMode,
                          mut f: F) -> SourceTexture where F: FnMut(usize, DevicePoint, DevicePoint) {
         debug_assert!(self.state == State::QueryResources);
+        let cache = self.cached_glyphs.as_ref().unwrap();
+        let render_mode = self.get_glyph_render_mode(render_mode);
         let mut glyph_key = RenderedGlyphKey::new(font_key,
                                                   size,
                                                   0,
@@ -354,7 +359,7 @@ impl ResourceCache {
         let mut texture_id = None;
         for (loop_index, glyph_index) in glyph_indices.iter().enumerate() {
             glyph_key.key.index = *glyph_index;
-            let image_id = self.cached_glyphs.get(&glyph_key, self.current_frame_id);
+            let image_id = cache.get(&glyph_key, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
                 let uv0 = DevicePoint::new(cache_item.pixel_rect.top_left.x as f32,
@@ -405,9 +410,11 @@ impl ResourceCache {
                             image_key: ImageKey,
                             image_rendering: ImageRendering) -> CacheItem {
         debug_assert!(self.state == State::QueryResources);
-
-        let image_info = &self.cached_images.get(&(image_key, image_rendering),
-                                                 self.current_frame_id);
+        let key = ImageRequest {
+            key: image_key,
+            rendering: image_rendering,
+        };
+        let image_info = &self.cached_images.get(&key, self.current_frame_id);
         let item = self.texture_cache.get(image_info.texture_cache_id);
         CacheItem {
             texture_id: SourceTexture::TextureCache(item.texture_id),
@@ -447,134 +454,134 @@ impl ResourceCache {
     }
 
     pub fn expire_old_resources(&mut self, frame_id: FrameId) {
-        self.cached_glyphs.expire_old_resources(&mut self.texture_cache, frame_id);
         self.cached_images.expire_old_resources(&mut self.texture_cache, frame_id);
+
+        let cached_glyphs = self.cached_glyphs.as_mut().unwrap();
+        cached_glyphs.expire_old_resources(&mut self.texture_cache, frame_id);
     }
 
     pub fn begin_frame(&mut self, frame_id: FrameId) {
         debug_assert!(self.state == State::Idle);
         self.state = State::AddResources;
         self.current_frame_id = frame_id;
+        let glyph_cache = self.cached_glyphs.take().unwrap();
+        self.glyph_cache_tx.send(GlyphCacheMsg::BeginFrame(frame_id, glyph_cache)).ok();
     }
 
     pub fn block_until_all_resources_added(&mut self) {
         debug_assert!(self.state == State::AddResources);
         self.state = State::QueryResources;
 
-        for request in self.pending_requests.drain(..) {
-            match request {
-                ResourceRequest::Image(key, rendering) => {
-                    let cached_images = &mut self.cached_images;
-                    let image_template = &self.image_templates[&key];
+        // Tell the glyph cache thread that all glyphs have been requested
+        // and block, waiting for any pending glyphs to be rasterized. In the
+        // future, we will expand this to have a timeout. If the glyph rasterizing
+        // takes longer than the timeout, then we will select the best glyphs
+        // available in the cache, render with those, and then re-render at
+        // a later point when the correct resolution glyphs finally become
+        // available.
+        self.glyph_cache_tx.send(GlyphCacheMsg::EndFrame).unwrap();
 
-                    match image_template.data {
-                        ImageData::Raw(ref bytes) => {
-                            match cached_images.entry((key, rendering), self.current_frame_id) {
-                                Occupied(entry) => {
-                                    let image_id = entry.get().texture_cache_id;
+        // Loop until the end frame message is retrieved here. This loop
+        // doesn't serve any real purpose right now, but in the future
+        // it will be receiving small amounts of glyphs at a time, up until
+        // it decides that it should just render the frame.
+        while let Ok(result) = self.glyph_cache_result_queue.recv() {
+            match result {
+                GlyphCacheResultMsg::EndFrame(mut cache, glyph_jobs) => {
+                    // Add any newly rasterized glyphs to the texture cache.
+                    for job in glyph_jobs {
+                        let image_id = job.result.and_then(|glyph| {
+                            if glyph.width > 0 && glyph.height > 0 {
+                                let image_id = self.texture_cache.new_item_id();
+                                self.texture_cache.insert(image_id,
+                                                          glyph.width,
+                                                          glyph.height,
+                                                          None,
+                                                          ImageFormat::RGBA8,
+                                                          TextureFilter::Linear,
+                                                          Arc::new(glyph.bytes));
+                                Some(image_id)
+                            } else {
+                                None
+                            }
+                        });
 
-                                    if entry.get().epoch != image_template.epoch {
-                                        self.texture_cache.update(image_id,
-                                                                  image_template.width,
-                                                                  image_template.height,
-                                                                  image_template.stride,
-                                                                  image_template.format,
-                                                                  bytes.clone());
+                        cache.insert(job.key, image_id, self.current_frame_id);
+                    }
 
-                                        // Update the cached epoch
-                                        *entry.into_mut() = CachedImageInfo {
-                                            texture_cache_id: image_id,
-                                            epoch: image_template.epoch,
-                                        };
-                                    }
-                                }
-                                Vacant(entry) => {
-                                    let image_id = self.texture_cache.new_item_id();
+                    self.cached_glyphs = Some(cache);
+                    break;
+                }
+            }
+        }
 
-                                    let filter = match rendering {
-                                        ImageRendering::Pixelated => TextureFilter::Nearest,
-                                        ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
-                                    };
+        for request in self.pending_image_requests.drain(..) {
+            let cached_images = &mut self.cached_images;
+            let image_template = &self.image_templates[&request.key];
 
-                                    self.texture_cache.insert(image_id,
-                                                              image_template.width,
-                                                              image_template.height,
-                                                              image_template.stride,
-                                                              image_template.format,
-                                                              filter,
-                                                              bytes.clone());
+            match image_template.data {
+                ImageData::External(..) => {}
+                ImageData::Raw(ref bytes) => {
+                    match cached_images.entry(request.clone(), self.current_frame_id) {
+                        Occupied(entry) => {
+                            let image_id = entry.get().texture_cache_id;
 
-                                    entry.insert(CachedImageInfo {
-                                        texture_cache_id: image_id,
-                                        epoch: image_template.epoch,
-                                    });
-                                }
+                            if entry.get().epoch != image_template.epoch {
+                                // TODO: Can we avoid the clone of the bytes here?
+                                self.texture_cache.update(image_id,
+                                                          image_template.width,
+                                                          image_template.height,
+                                                          image_template.stride,
+                                                          image_template.format,
+                                                          bytes.clone());
+
+                                // Update the cached epoch
+                                *entry.into_mut() = CachedImageInfo {
+                                    texture_cache_id: image_id,
+                                    epoch: image_template.epoch,
+                                };
                             }
                         }
-                        ImageData::External(..) => {
-                            // External images don't get added to the texture cache!
-                        }
-                    }
-                }
-                ResourceRequest::TextRun(ref text_run) => {
-                    for glyph_index in &text_run.glyph_indices {
-                        let glyph_key = RenderedGlyphKey::new(text_run.key,
-                                                              text_run.size,
-                                                              *glyph_index,
-                                                              text_run.render_mode);
+                        Vacant(entry) => {
+                            let image_id = self.texture_cache.new_item_id();
 
-                        self.cached_glyphs.mark_as_needed(&glyph_key, self.current_frame_id);
-                        if !self.cached_glyphs.contains_key(&glyph_key) {
-                            self.pending_raster_jobs.push(GlyphRasterJob {
-                                glyph_key: glyph_key,
-                                result: None,
+                            let filter = match request.rendering {
+                                ImageRendering::Pixelated => TextureFilter::Nearest,
+                                ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
+                            };
+
+                            // TODO: Can we avoid the clone of the bytes here?
+                            self.texture_cache.insert(image_id,
+                                                      image_template.width,
+                                                      image_template.height,
+                                                      image_template.stride,
+                                                      image_template.format,
+                                                      filter,
+                                                      bytes.clone());
+
+                            entry.insert(CachedImageInfo {
+                                texture_cache_id: image_id,
+                                epoch: image_template.epoch,
                             });
                         }
                     }
                 }
             }
         }
-
-        self.raster_pending_glyphs();
     }
 
     pub fn end_frame(&mut self) {
         debug_assert!(self.state == State::QueryResources);
         self.state = State::Idle;
     }
-}
 
-fn run_raster_jobs(pending_raster_jobs: &mut Vec<GlyphRasterJob>,
-                   font_templates: &HashMap<FontKey, FontTemplate, BuildHasherDefault<FnvHasher>>,
-                   enable_aa: bool) {
-    if pending_raster_jobs.is_empty() {
-        return
+    fn get_glyph_render_mode(&self, requested_mode: FontRenderMode) -> FontRenderMode {
+        if self.enable_aa {
+            requested_mode
+        } else {
+            FontRenderMode::Mono
+        }
     }
-
-    pending_raster_jobs.par_iter_mut().weight_max().for_each(|job| {
-        let font_template = &font_templates[&job.glyph_key.key.font_key];
-        FONT_CONTEXT.with(move |font_context| {
-            let mut font_context = font_context.borrow_mut();
-            match *font_template {
-                FontTemplate::Raw(ref bytes) => {
-                    font_context.add_raw_font(&job.glyph_key.key.font_key, &**bytes);
-                }
-                FontTemplate::Native(ref native_font_handle) => {
-                    font_context.add_native_font(&job.glyph_key.key.font_key,
-                                                 (*native_font_handle).clone());
-                }
-            }
-            let render_mode = if enable_aa {
-                job.glyph_key.render_mode
-            } else {
-                FontRenderMode::Mono
-            };
-            job.result = font_context.rasterize_glyph(job.glyph_key.key.font_key,
-                                                      job.glyph_key.key.size,
-                                                      job.glyph_key.key.index,
-                                                      render_mode);
-        });
-    });
 }
 
 pub trait Resource {
@@ -621,4 +628,120 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
         ImageFormat::A8 => false,
         ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
     }
+}
+
+fn spawn_glyph_cache_thread() -> (Sender<GlyphCacheMsg>, Receiver<GlyphCacheResultMsg>) {
+    // Used for messages from resource cache -> glyph cache thread.
+    let (msg_tx, msg_rx) = channel();
+    // Used for returning results from glyph cache thread -> resource cache.
+    let (result_tx, result_rx) = channel();
+    // Used for rasterizer worker threads to send glyphs -> glyph cache thread.
+    let (glyph_tx, glyph_rx) = channel();
+
+    thread::spawn(move|| {
+        // TODO(gw): Use a heuristic to select best # of worker threads.
+        let worker_count = 4;
+        let thread_pool = ThreadPool::new(worker_count);
+
+        let mut glyph_cache = None;
+        let mut current_frame_id = FrameId(0);
+
+        // Maintain a set of glyphs that have been requested this
+        // frame. This ensures the glyph thread won't rasterize
+        // the same glyph more than once in a frame. This is required
+        // because the glyph cache hash table is not updated
+        // until the glyph cache is passed back to the resource
+        // cache which is able to add the items to the texture cache.
+        let mut pending_glyphs = HashSet::new();
+
+        while let Ok(msg) = msg_rx.recv() {
+            match msg {
+                GlyphCacheMsg::BeginFrame(frame_id, cache) => {
+                    // We are beginning a new frame. Take ownership of the glyph
+                    // cache hash map, so we can easily see which glyph requests
+                    // actually need to be rasterized.
+                    current_frame_id = frame_id;
+                    glyph_cache = Some(cache);
+                }
+                GlyphCacheMsg::AddFont(font_key, font_template) => {
+                    // Add a new font to the font context in each worker thread.
+                    // Use a barrier to ensure that each worker in the pool handles
+                    // one of these messages, to ensure that the new font gets
+                    // added to each worker thread.
+                    let barrier = Arc::new(Barrier::new(worker_count));
+                    for _ in 0..worker_count {
+                        let barrier = barrier.clone();
+                        let font_template = font_template.clone();
+                        thread_pool.execute(move || {
+                            FONT_CONTEXT.with(|font_context| {
+                                let mut font_context = font_context.borrow_mut();
+                                match font_template {
+                                    FontTemplate::Raw(ref bytes) => {
+                                        font_context.add_raw_font(&font_key, &**bytes);
+                                    }
+                                    FontTemplate::Native(ref native_font_handle) => {
+                                        font_context.add_native_font(&font_key,
+                                                                     (*native_font_handle).clone());
+                                    }
+                                }
+                            });
+
+                            barrier.wait();
+                        });
+                    }
+                }
+                GlyphCacheMsg::RequestGlyphs(key, size, indices, render_mode) => {
+                    // Request some glyphs for a text run.
+                    // For any glyph that isn't currently in the cache,
+                    // immeediately push a job to the worker thread pool
+                    // to start rasterizing this glyph now!
+                    let glyph_cache = glyph_cache.as_mut().unwrap();
+
+                    for glyph_index in indices {
+                        let glyph_key = RenderedGlyphKey::new(key,
+                                                              size,
+                                                              glyph_index,
+                                                              render_mode);
+
+                        glyph_cache.mark_as_needed(&glyph_key, current_frame_id);
+                        if !glyph_cache.contains_key(&glyph_key) &&
+                           !pending_glyphs.contains(&glyph_key) {
+                            let glyph_tx = glyph_tx.clone();
+                            pending_glyphs.insert(glyph_key.clone());
+                            thread_pool.execute(move || {
+                                FONT_CONTEXT.with(move |font_context| {
+                                    let mut font_context = font_context.borrow_mut();
+                                    let result = font_context.rasterize_glyph(glyph_key.key.font_key,
+                                                                              glyph_key.key.size,
+                                                                              glyph_key.key.index,
+                                                                              render_mode);
+                                    glyph_tx.send((glyph_key, result)).unwrap();
+                                });
+                            });
+                        }
+                    }
+                }
+                GlyphCacheMsg::EndFrame => {
+                    // The resource cache has finished requesting glyphs. Block
+                    // on completion of any pending glyph rasterizing jobs, and then
+                    // return the list of new glyphs to the resource cache.
+                    let cache = glyph_cache.take().unwrap();
+                    let mut rasterized_glyphs = Vec::new();
+                    while !pending_glyphs.is_empty() {
+                        let (key, glyph) = glyph_rx.recv()
+                                                   .expect("BUG: Should be glyphs pending!");
+                        debug_assert!(pending_glyphs.contains(&key));
+                        pending_glyphs.remove(&key);
+                        rasterized_glyphs.push(GlyphRasterJob {
+                            key: key,
+                            result: glyph,
+                        });
+                    }
+                    result_tx.send(GlyphCacheResultMsg::EndFrame(cache, rasterized_glyphs)).unwrap();
+                }
+            }
+        }
+    });
+
+    (msg_tx, result_rx)
 }


### PR DESCRIPTION
This is the first step towards making the glyph cache more efficient
and also run asynchronously to allow rendering to continue if the
glyph rasterizing becomes a bottleneck (e.g. during animated zooms).

Previously, we collected the list of glyphs that were required for
a frame, and ran a rayon loop to rasterize any that weren't in the
glyph cache. However, this meant that the glyph rasterizion could
not start until we knew the list of all required glyphs.

Now, all requests for text run glyphs are sent immediately to the
glyph cache thread. The glyph cache thread uses a worker thread
pool to immediately begin rasterizing any uncached glyphs as soon
as they are requested.

In the future, the idea is that instead of waiting at the block()
method for all pending glyphs to be rasterized, the backend thread
will instead receive small numbers of glyphs as they are rasterized.
This will allow the backend thread to make a decision that glyph
rasterizing is taking too long for this frame, and that we should
just draw a frame with the currently cached glyph sizes available.
When this occurs, the glyph cache thread will signal that a new frame
should be rendered when it completes rasterizing any pending glyphs.
This will allow us to keep rendering at 60fps during zoom, even
if the glyph rasterizing threads can't keep up (at a quality
tradeoff of using lower resolution glyphs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/565)
<!-- Reviewable:end -->
