### PR TITLE
Use atomic reference counting to store images and avoid copying them.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
 
     let clip_region = {
         let mask = webrender_traits::ImageMask {
-            image: api.add_image(2, 2, None, ImageFormat::A8, ImageData::Raw(vec![0,80, 180, 255])),
+            image: api.add_image(2, 2, None, ImageFormat::A8, ImageData::new(vec![0,80, 180, 255])),
             rect: Rect::new(Point2D::new(75.0, 75.0), Size2D::new(100.0, 100.0)),
             repeat: false,
         };

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -358,8 +358,8 @@ pub enum RenderTargetMode {
 }
 
 pub enum TextureUpdateOp {
-    Create(u32, u32, ImageFormat, TextureFilter, RenderTargetMode, Option<Vec<u8>>),
-    Update(u32, u32, u32, u32, Vec<u8>, Option<u32>),
+    Create(u32, u32, ImageFormat, TextureFilter, RenderTargetMode, Option<Arc<Vec<u8>>>),
+    Update(u32, u32, u32, u32, Arc<Vec<u8>>, Option<u32>),
     Grow(u32, u32, ImageFormat, TextureFilter, RenderTargetMode),
 }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -594,7 +594,7 @@ impl Renderer {
                              None,
                              ImageFormat::RGBA8,
                              TextureFilter::Linear,
-                             white_pixels);
+                             Arc::new(white_pixels));
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
@@ -603,7 +603,7 @@ impl Renderer {
                              None,
                              ImageFormat::A8,
                              TextureFilter::Linear,
-                             mask_pixels);
+                             Arc::new(mask_pixels));
 
         let debug_renderer = DebugRenderer::new(&mut device);
 
@@ -932,27 +932,14 @@ impl Renderer {
                             self.cache_texture_id_map[cache_texture_index] = Some(texture_id);
                         }
 
-                        // TODO: clean up match
-                        match maybe_bytes {
-                            Some(bytes) => {
-                                self.device.init_texture(texture_id,
-                                                         width,
-                                                         height,
-                                                         format,
-                                                         filter,
-                                                         mode,
-                                                         Some(bytes.as_slice()));
-                            }
-                            None => {
-                                self.device.init_texture(texture_id,
-                                                         width,
-                                                         height,
-                                                         format,
-                                                         filter,
-                                                         mode,
-                                                         None);
-                            }
-                        }
+                        let maybe_slice = maybe_bytes.as_ref().map(|bytes|{ bytes.as_slice() });
+                        self.device.init_texture(texture_id,
+                                                 width,
+                                                 height,
+                                                 format,
+                                                 filter,
+                                                 mode,
+                                                 maybe_slice);
                     }
                     TextureUpdateOp::Grow(new_width,
                                           new_height,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -16,6 +16,7 @@ use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::fmt::Debug;
 use std::hash::BuildHasherDefault;
 use std::hash::Hash;
+use std::sync::Arc;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
@@ -263,7 +264,7 @@ impl ResourceCache {
             height: height,
             stride: None,
             format: format,
-            data: ImageData::Raw(bytes),
+            data: ImageData::new(bytes),
             epoch: next_epoch,
         };
 
@@ -330,7 +331,7 @@ impl ResourceCache {
                                           None,
                                           ImageFormat::RGBA8,
                                           TextureFilter::Linear,
-                                          result.bytes);
+                                          Arc::new(result.bytes));
                 Some(image_id)
             } else {
                 None
@@ -479,7 +480,6 @@ impl ResourceCache {
                                     let image_id = entry.get().texture_cache_id;
 
                                     if entry.get().epoch != image_template.epoch {
-                                        // TODO: Can we avoid the clone of the bytes here?
                                         self.texture_cache.update(image_id,
                                                                   image_template.width,
                                                                   image_template.height,
@@ -502,7 +502,6 @@ impl ResourceCache {
                                         ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
                                     };
 
-                                    // TODO: Can we avoid the clone of the bytes here?
                                     self.texture_cache.insert(image_id,
                                                               image_template.width,
                                                               image_template.height,

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -15,6 +15,7 @@ use std::collections::hash_map::Entry;
 use std::hash::BuildHasherDefault;
 use std::mem;
 use std::slice::Iter;
+use std::sync::Arc;
 use time;
 use util;
 use webrender_traits::ImageFormat;
@@ -729,7 +730,7 @@ impl TextureCache {
                   height: u32,
                   stride: Option<u32>,
                   _format: ImageFormat,
-                  bytes: Vec<u8>) {
+                  bytes: Arc<Vec<u8>>) {
         let existing_item = self.items.get(image_id);
 
         // TODO(gw): Handle updates to size/format!
@@ -758,7 +759,7 @@ impl TextureCache {
                   stride: Option<u32>,
                   format: ImageFormat,
                   filter: TextureFilter,
-                  bytes: Vec<u8>) {
+                  bytes: Arc<Vec<u8>>) {
         let result = self.allocate(image_id,
                                    width,
                                    height,
@@ -798,7 +799,7 @@ impl TextureCache {
                                                 result.item.allocated_rect.origin.y,
                                                 result.item.allocated_rect.size.width,
                                                 1,
-                                                top_row_bytes,
+                                                Arc::new(top_row_bytes),
                                                 None)
                 };
 
@@ -810,7 +811,7 @@ impl TextureCache {
                             result.item.requested_rect.size.height + 1,
                         result.item.allocated_rect.size.width,
                         1,
-                        bottom_row_bytes,
+                        Arc::new(bottom_row_bytes),
                         None)
                 };
 
@@ -821,7 +822,7 @@ impl TextureCache {
                         result.item.requested_rect.origin.y,
                         1,
                         result.item.requested_rect.size.height,
-                        left_column_bytes,
+                        Arc::new(left_column_bytes),
                         None)
                 };
 
@@ -831,7 +832,7 @@ impl TextureCache {
                                                 result.item.requested_rect.origin.y,
                                                 1,
                                                 result.item.requested_rect.size.height,
-                                                right_column_bytes,
+                                                Arc::new(right_column_bytes),
                                                 None)
                 };
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -11,6 +11,7 @@ use core::nonzero::NonZero;
 use euclid::{Matrix4D, Point2D, Rect, Size2D};
 use ipc_channel::ipc::{IpcBytesSender, IpcSender};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
+use std::sync::Arc;
 
 #[cfg(target_os = "macos")] use core_graphics::font::CGFont;
 #[cfg(target_os = "windows")] use dwrote::FontDescriptor;
@@ -324,8 +325,18 @@ pub struct ExternalImageId(pub u64);
 
 #[derive(Serialize, Deserialize)]
 pub enum ImageData {
-    Raw(Vec<u8>),
+    Raw(Arc<Vec<u8>>),
     External(ExternalImageId),
+}
+
+impl ImageData {
+    pub fn new(bytes: Vec<u8>) -> ImageData {
+        ImageData::Raw(Arc::new(bytes))
+    }
+
+    pub fn new_shared(bytes: Arc<Vec<u8>>) -> ImageData {
+        ImageData::Raw(bytes)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
We currently clone the bytes of images and glyphs before inserting them in the texture cache, because we need to keep a copy around in case the device is reset or the image is evicted from the cache. We want the images and glyphs to be managed on the backend thread while the buffers need to be read on the renderer thread when they get uploaded.
This PR removes the clone of the bytes by sharing the buffers using atomic reference counting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/566)
<!-- Reviewable:end -->
