### PR TITLE
Add PushScrollLayer and PopScrollLayer display list items

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -114,14 +114,9 @@ fn main() {
     let mut auxiliary_lists_builder = AuxiliaryListsBuilder::new();
     let mut builder = webrender_traits::DisplayListBuilder::new();
 
-    let root_scroll_layer_id =
-        webrender_traits::ScrollLayerId::new(pipeline_id, 0,
-                                             webrender_traits::ServoScrollRootId(0));
-
     let bounds = Rect::new(Point2D::new(0.0, 0.0), Size2D::new(width as f32, height as f32));
     builder.push_stacking_context(
-        webrender_traits::StackingContext::new(Some(root_scroll_layer_id),
-                                               webrender_traits::ScrollPolicy::Scrollable,
+        webrender_traits::StackingContext::new(webrender_traits::ScrollPolicy::Scrollable,
                                                bounds,
                                                bounds,
                                                0,

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -12,8 +12,8 @@ use {BuiltDisplayListDescriptor, ClipRegion, ComplexClipRegion, ColorF};
 use {DisplayItem, DisplayListMode, FilterOp};
 use {FontKey, GlyphInstance, GradientDisplayItem, GradientStop, IframeDisplayItem};
 use {ImageDisplayItem, ImageKey, ImageRendering, ItemRange, PipelineId,};
-use {PushStackingContextDisplayItem, RectangleDisplayItem, SpecificDisplayItem};
-use {StackingContext, TextDisplayItem, WebGLContextId, WebGLDisplayItem};
+use {PushScrollLayerItem, PushStackingContextDisplayItem, RectangleDisplayItem, ScrollLayerId};
+use {SpecificDisplayItem, StackingContext, TextDisplayItem, WebGLContextId, WebGLDisplayItem};
 
 impl BuiltDisplayListDescriptor {
     pub fn size(&self) -> usize {
@@ -238,6 +238,32 @@ impl DisplayListBuilder {
     pub fn pop_stacking_context(&mut self) {
         let item = DisplayItem {
             item: SpecificDisplayItem::PopStackingContext,
+            rect: Rect::zero(),
+            clip: ClipRegion::simple(&Rect::zero()),
+        };
+        self.list.push(item);
+    }
+
+    pub fn push_scroll_layer(&mut self,
+                             clip: Rect<f32>,
+                             content_size: Size2D<f32>,
+                             id: ScrollLayerId) {
+        let item = PushScrollLayerItem {
+            content_size: content_size,
+            id: id,
+        };
+
+        let item = DisplayItem {
+            item: SpecificDisplayItem::PushScrollLayer(item),
+            rect: clip,
+            clip: ClipRegion::simple(&Rect::zero()),
+        };
+        self.list.push(item);
+    }
+
+    pub fn pop_scroll_layer(&mut self) {
+        let item = DisplayItem {
+            item: SpecificDisplayItem::PopScrollLayer,
             rect: Rect::zero(),
             clip: ClipRegion::simple(&Rect::zero()),
         };

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -4,11 +4,10 @@
 
 use display_list::AuxiliaryListsBuilder;
 use euclid::{Matrix4D, Rect};
-use {FilterOp, MixBlendMode, ScrollLayerId, ScrollPolicy, StackingContext};
+use {FilterOp, MixBlendMode, ScrollPolicy, StackingContext};
 
 impl StackingContext {
-    pub fn new(scroll_layer_id: Option<ScrollLayerId>,
-               scroll_policy: ScrollPolicy,
+    pub fn new(scroll_policy: ScrollPolicy,
                bounds: Rect<f32>,
                overflow: Rect<f32>,
                z_index: i32,
@@ -19,7 +18,6 @@ impl StackingContext {
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
                -> StackingContext {
         StackingContext {
-            scroll_layer_id: scroll_layer_id,
             scroll_policy: scroll_policy,
             bounds: bounds,
             overflow: overflow,

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -292,6 +292,12 @@ pub struct PushStackingContextDisplayItem {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct PushScrollLayerItem {
+    pub content_size: Size2D<f32>,
+    pub id: ScrollLayerId,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct IframeDisplayItem {
     pub pipeline_id: PipelineId,
 }
@@ -424,6 +430,15 @@ pub struct ScrollLayerId {
     pub info: ScrollLayerInfo,
 }
 
+impl ScrollLayerId {
+    pub fn root(pipeline_id: PipelineId) -> ScrollLayerId {
+        ScrollLayerId {
+            pipeline_id: pipeline_id,
+            info: ScrollLayerInfo::Scrollable(0, ServoScrollRootId(0)),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ScrollLayerInfo {
     Fixed,
@@ -458,11 +473,12 @@ pub enum SpecificDisplayItem {
     Iframe(IframeDisplayItem),
     PushStackingContext(PushStackingContextDisplayItem),
     PopStackingContext,
+    PushScrollLayer(PushScrollLayerItem),
+    PopScrollLayer,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StackingContext {
-    pub scroll_layer_id: Option<ScrollLayerId>,
     pub scroll_policy: ScrollPolicy,
     pub bounds: Rect<f32>,
     pub overflow: Rect<f32>,


### PR DESCRIPTION
This removes the scroll layer stacking context hack that was always
meant to be temporary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/567)
<!-- Reviewable:end -->
