### PR TITLE
Use strongly typed geometry - Part 1

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -9,7 +9,7 @@ use euclid::{Matrix4D, Point2D, Size2D, Rect};
 use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, TextureSampler};
 use internal_types::{DebugFontVertex, DebugColorVertex, RenderTargetMode, PackedColor};
 use std::f32;
-use webrender_traits::{ColorF, ImageFormat};
+use webrender_traits::{ColorF, ImageFormat, DeviceUintSize};
 
 pub struct DebugRenderer {
     font_vertices: Vec<DebugFontVertex>,
@@ -160,7 +160,7 @@ impl DebugRenderer {
 
     pub fn render(&mut self,
                   device: &mut Device,
-                  viewport_size: &Size2D<u32>) {
+                  viewport_size: &DeviceUintSize) {
         device.disable_depth();
         device.set_blend(true);
         device.set_blend_mode_alpha();

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use device::TextureFilter;
-use euclid::{Size2D, TypedRect, TypedPoint2D, TypedSize2D, Length, UnknownUnit};
+use euclid::{Size2D, TypedPoint2D, UnknownUnit};
 use fnv::FnvHasher;
 use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle};
 use offscreen_gl_context::{GLContext, NativeGLContextMethods, GLContextDispatcher};
@@ -161,18 +161,6 @@ impl GLContextWrapper {
             }
         }
     }
-}
-
-pub type DeviceRect = TypedRect<i32, DevicePixel>;
-pub type DevicePoint = TypedPoint2D<i32, DevicePixel>;
-pub type DeviceSize = TypedSize2D<i32, DevicePixel>;
-pub type DeviceLength = Length<i32, DevicePixel>;
-
-#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct DevicePixel;
-
-pub fn device_pixel(value: f32, device_pixel_ratio: f32) -> DeviceLength {
-    DeviceLength::new((value * device_pixel_ratio).round() as i32)
 }
 
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;

--- a/webrender/src/layer.rs
+++ b/webrender/src/layer.rs
@@ -2,33 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::{Matrix4D, Point2D, Rect, Size2D};
 use spring::{DAMPING, STIFFNESS, Spring};
 use webrender_traits::{PipelineId, ScrollLayerId};
+use webrender_traits::{LayerRect, LayerPoint, LayerSize};
+use webrender_traits::{LayerToScrollTransform, LayerToWorldTransform};
 
-/// Contains scroll and transform information for scrollable and root stacking contexts.
+/// Contains scrolling and transform information stacking contexts.
 #[derive(Clone)]
 pub struct Layer {
     /// Manages scrolling offset, overscroll state etc.
     pub scrolling: ScrollingState,
 
     /// Size of the content inside the scroll region (in logical pixels)
-    pub content_size: Size2D<f32>,
+    pub content_size: LayerSize,
 
     /// Viewing rectangle
-    pub local_viewport_rect: Rect<f32>,
+    pub local_viewport_rect: LayerRect,
 
     /// Viewing rectangle clipped against parent layer(s)
-    pub combined_local_viewport_rect: Rect<f32>,
+    pub combined_local_viewport_rect: LayerRect,
 
     /// World transform for the viewport rect itself.
-    pub world_viewport_transform: Matrix4D<f32>,
+    pub world_viewport_transform: LayerToWorldTransform,
 
     /// World transform for content within this layer
-    pub world_content_transform: Matrix4D<f32>,
+    pub world_content_transform: LayerToWorldTransform,
 
-    /// Transform for this layer, relative to parent layer.
-    pub local_transform: Matrix4D<f32>,
+    /// Transform for this layer, relative to parent scrollable layer.
+    pub local_transform: LayerToScrollTransform,
 
     /// Pipeline that this layer belongs to
     pub pipeline_id: PipelineId,
@@ -38,9 +39,9 @@ pub struct Layer {
 }
 
 impl Layer {
-    pub fn new(local_viewport_rect: &Rect<f32>,
-               content_size: Size2D<f32>,
-               local_transform: &Matrix4D<f32>,
+    pub fn new(local_viewport_rect: &LayerRect,
+               content_size: LayerSize,
+               local_transform: &LayerToScrollTransform,
                pipeline_id: PipelineId)
                -> Layer {
         Layer {
@@ -48,8 +49,8 @@ impl Layer {
             content_size: content_size,
             local_viewport_rect: *local_viewport_rect,
             combined_local_viewport_rect: *local_viewport_rect,
-            world_viewport_transform: Matrix4D::identity(),
-            world_content_transform: Matrix4D::identity(),
+            world_viewport_transform: LayerToWorldTransform::identity(),
+            world_content_transform: LayerToWorldTransform::identity(),
             local_transform: *local_transform,
             children: Vec::new(),
             pipeline_id: pipeline_id,
@@ -64,7 +65,7 @@ impl Layer {
         self.scrolling = *scrolling;
     }
 
-    pub fn overscroll_amount(&self) -> Size2D<f32> {
+    pub fn overscroll_amount(&self) -> LayerSize {
         let overscroll_x = if self.scrolling.offset.x > 0.0 {
             -self.scrolling.offset.x
         } else if self.scrolling.offset.x < self.local_viewport_rect.size.width - self.content_size.width {
@@ -82,7 +83,7 @@ impl Layer {
             0.0
         };
 
-        Size2D::new(overscroll_x, overscroll_y)
+        LayerSize::new(overscroll_x, overscroll_y)
     }
 
     pub fn stretch_overscroll_spring(&mut self) {
@@ -103,7 +104,7 @@ impl Layer {
 
 #[derive(Copy, Clone)]
 pub struct ScrollingState {
-    pub offset: Point2D<f32>,
+    pub offset: LayerPoint,
     pub spring: Spring,
     pub started_bouncing_back: bool,
     pub bouncing_back: bool,
@@ -112,8 +113,8 @@ pub struct ScrollingState {
 impl ScrollingState {
     pub fn new() -> ScrollingState {
         ScrollingState {
-            offset: Point2D::new(0.0, 0.0),
-            spring: Spring::at(Point2D::new(0.0, 0.0), STIFFNESS, DAMPING),
+            offset: LayerPoint::zero(),
+            spring: Spring::at(LayerPoint::zero(), STIFFNESS, DAMPING),
             started_bouncing_back: false,
             bouncing_back: false,
         }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc::Sender;
 use texture_cache::TextureCache;
 use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace, ImageData};
 use webrender_traits::{FlushNotifier, RenderNotifier, RenderDispatcher, WebGLCommand, WebGLContextId};
+use webrender_traits::{DeviceIntSize};
 use webrender_traits::channel::{PayloadHelperMethods, PayloadReceiver, PayloadSender, MsgReceiver};
 use record;
 use tiling::FrameBuilderConfig;
@@ -282,7 +283,8 @@ impl RenderBackend {
                                         self.webgl_contexts.insert(id, ctx);
 
                                         self.resource_cache
-                                            .add_webgl_texture(id, SourceTexture::WebGL(texture_id), real_size);
+                                            .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
+                                                               DeviceIntSize::from_untyped(&real_size));
 
                                         tx.send(Ok((id, limits))).unwrap();
                                     },
@@ -302,7 +304,8 @@ impl RenderBackend {
                                     // Update webgl texture size. Texture id may change too.
                                     let (real_size, texture_id, _) = ctx.get_info();
                                     self.resource_cache
-                                        .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id), real_size);
+                                        .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
+                                                              DeviceIntSize::from_untyped(&real_size));
                                 },
                                 Err(msg) => {
                                     error!("Error resizing WebGLContext: {}", msg);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -4,7 +4,6 @@
 
 use app_units::Au;
 use device::TextureFilter;
-use euclid::{Point2D, Size2D};
 use fnv::FnvHasher;
 use frame::FrameId;
 use internal_types::{FontTemplate, SourceTexture, TextureUpdateList};
@@ -20,6 +19,7 @@ use std::sync::Arc;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
+use webrender_traits::{DevicePoint, DeviceIntSize};
 use webrender_traits::ExternalImageId;
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
@@ -35,8 +35,8 @@ thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontC
 // various CPU-side structures.
 pub struct CacheItem {
     pub texture_id: SourceTexture,
-    pub uv0: Point2D<f32>,
-    pub uv1: Point2D<f32>,
+    pub uv0: DevicePoint,
+    pub uv1: DevicePoint,
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
@@ -168,7 +168,7 @@ enum ResourceRequest {
 
 struct WebGLTexture {
     id: SourceTexture,
-    size: Size2D<i32>,
+    size: DeviceIntSize,
 }
 
 pub struct ResourceCache {
@@ -275,14 +275,14 @@ impl ResourceCache {
         self.image_templates.remove(&image_key);
     }
 
-    pub fn add_webgl_texture(&mut self, id: WebGLContextId, texture_id: SourceTexture, size: Size2D<i32>) {
+    pub fn add_webgl_texture(&mut self, id: WebGLContextId, texture_id: SourceTexture, size: DeviceIntSize) {
         self.webgl_textures.insert(id, WebGLTexture {
             id: texture_id,
             size: size,
         });
     }
 
-    pub fn update_webgl_texture(&mut self, id: WebGLContextId, texture_id: SourceTexture, size: Size2D<i32>) {
+    pub fn update_webgl_texture(&mut self, id: WebGLContextId, texture_id: SourceTexture, size: DeviceIntSize) {
         let webgl_texture = self.webgl_textures.get_mut(&id).unwrap();
 
         // Update new texture id and size
@@ -349,7 +349,7 @@ impl ResourceCache {
                          size: Au,
                          glyph_indices: &[u32],
                          render_mode: FontRenderMode,
-                         mut f: F) -> SourceTexture where F: FnMut(usize, Point2D<f32>, Point2D<f32>) {
+                         mut f: F) -> SourceTexture where F: FnMut(usize, DevicePoint, DevicePoint) {
         debug_assert!(self.state == State::QueryResources);
         let mut glyph_key = RenderedGlyphKey::new(font_key,
                                                   size,
@@ -361,10 +361,10 @@ impl ResourceCache {
             let image_id = self.cached_glyphs.get(&glyph_key, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
-                let uv0 = Point2D::new(cache_item.pixel_rect.top_left.x as f32,
-                                       cache_item.pixel_rect.top_left.y as f32);
-                let uv1 = Point2D::new(cache_item.pixel_rect.bottom_right.x as f32,
-                                       cache_item.pixel_rect.bottom_right.y as f32);
+                let uv0 = DevicePoint::new(cache_item.pixel_rect.top_left.x as f32,
+                                           cache_item.pixel_rect.top_left.y as f32);
+                let uv1 = DevicePoint::new(cache_item.pixel_rect.bottom_right.x as f32,
+                                           cache_item.pixel_rect.bottom_right.y as f32);
                 f(loop_index, uv0, uv1);
                 debug_assert!(texture_id == None ||
                               texture_id == Some(cache_item.texture_id));
@@ -417,10 +417,10 @@ impl ResourceCache {
         let item = self.texture_cache.get(image_info.texture_cache_id);
         CacheItem {
             texture_id: SourceTexture::TextureCache(item.texture_id),
-            uv0: Point2D::new(item.pixel_rect.top_left.x as f32,
-                              item.pixel_rect.top_left.y as f32),
-            uv1: Point2D::new(item.pixel_rect.bottom_right.x as f32,
-                              item.pixel_rect.bottom_right.y as f32),
+            uv0: DevicePoint::new(item.pixel_rect.top_left.x as f32,
+                                  item.pixel_rect.top_left.y as f32),
+            uv1: DevicePoint::new(item.pixel_rect.bottom_right.x as f32,
+                                  item.pixel_rect.bottom_right.y as f32),
         }
     }
 
@@ -447,8 +447,8 @@ impl ResourceCache {
         let webgl_texture = &self.webgl_textures[context_id];
         CacheItem {
             texture_id: webgl_texture.id,
-            uv0: Point2D::new(0.0, webgl_texture.size.height as f32),
-            uv1: Point2D::new(webgl_texture.size.width as f32, 0.0),
+            uv0: DevicePoint::new(0.0, webgl_texture.size.height as f32),
+            uv1: DevicePoint::new(webgl_texture.size.width as f32, 0.0),
         }
     }
 

--- a/webrender/src/spring.rs
+++ b/webrender/src/spring.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::Point2D;
+use webrender_traits::LayerPoint;
 
 /// Some arbitrarily small positive number used as threshold value.
 pub const EPSILON: f32 = 0.1;
@@ -16,11 +16,11 @@ pub const DAMPING: f32 = 1.0;
 #[derive(Copy, Clone, Debug)]
 pub struct Spring {
     /// The current position of spring.
-    cur: Point2D<f32>,
+    cur: LayerPoint,
     /// The position of spring at previous tick.
-    prev: Point2D<f32>,
+    prev: LayerPoint,
     /// The destination of spring.
-    dest: Point2D<f32>,
+    dest: LayerPoint,
     /// How hard it springs back.
     stiffness: f32,
     /// Friction. 1.0 means no bounce.
@@ -29,7 +29,7 @@ pub struct Spring {
 
 impl Spring {
     /// Create a new spring at location.
-    pub fn at(pos: Point2D<f32>, stiffness: f32, damping: f32) -> Spring {
+    pub fn at(pos: LayerPoint, stiffness: f32, damping: f32) -> Spring {
         Spring {
             cur: pos,
             prev: pos,
@@ -40,13 +40,13 @@ impl Spring {
     }
 
     /// Set coords on a spring, mutating spring
-    pub fn coords(&mut self, cur: Point2D<f32>, prev: Point2D<f32>, dest: Point2D<f32>) {
+    pub fn coords(&mut self, cur: LayerPoint, prev: LayerPoint, dest: LayerPoint) {
         self.cur = cur;
         self.prev = prev;
         self.dest = dest
     }
 
-    pub fn current(&self) -> Point2D<f32> {
+    pub fn current(&self) -> LayerPoint {
         self.cur
     }
 
@@ -54,16 +54,16 @@ impl Spring {
     pub fn animate(&mut self) -> bool {
         if !is_resting(self.cur.x, self.prev.x, self.dest.x) ||
                 !is_resting(self.cur.y, self.prev.y, self.dest.y) {
-            let next = Point2D::new(next(self.cur.x,
-                                         self.prev.x,
-                                         self.dest.x,
-                                         self.stiffness,
-                                         self.damping),
-                                    next(self.cur.y,
-                                         self.prev.y,
-                                         self.dest.y,
-                                         self.stiffness,
-                                         self.damping));
+            let next = LayerPoint::new(next(self.cur.x,
+                                            self.prev.x,
+                                            self.dest.x,
+                                            self.stiffness,
+                                            self.damping),
+                                       next(self.cur.y,
+                                            self.prev.y,
+                                            self.dest.y,
+                                            self.stiffness,
+                                            self.damping));
             let (cur, dest) = (self.cur, self.dest);
             self.coords(next, cur, dest);
             false

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::{Matrix4D, Point2D, Point4D, Rect, Size2D};
-use internal_types::{DeviceRect, DevicePoint, DeviceSize, DeviceLength};
+use euclid::{Point2D, Rect, Size2D};
+use euclid::{TypedRect, TypedPoint2D, TypedSize2D, TypedPoint4D, TypedMatrix4D};
+use webrender_traits::{DeviceIntRect, DeviceIntPoint, DeviceIntSize, DeviceIntLength};
+use webrender_traits::{LayerRect, WorldPoint4D, LayerPoint4D, LayerToWorldTransform};
 use num_traits::Zero;
 use time::precise_time_ns;
 
@@ -32,9 +34,9 @@ impl Drop for ProfileScope {
 }
 
 // TODO: Implement these in euclid!
-pub trait MatrixHelpers {
-    fn transform_point_and_perspective_project(&self, point: &Point4D<f32>) -> Point2D<f32>;
-    fn transform_rect(&self, rect: &Rect<f32>) -> Rect<f32>;
+pub trait MatrixHelpers<Src, Dst> {
+    fn transform_point_and_perspective_project(&self, point: &TypedPoint4D<f32, Src>) -> TypedPoint2D<f32, Dst>;
+    fn transform_rect(&self, rect: &TypedRect<f32, Src>) -> TypedRect<f32, Dst>;
 
     /// Returns true if this matrix transforms an axis-aligned 2D rectangle to another axis-aligned
     /// 2D rectangle.
@@ -46,23 +48,23 @@ pub trait MatrixHelpers {
 
     /// Clears out the portions of the matrix that `transform_rect()` uses. This allows the use of
     /// `transform_rect()` while keeping the Z/W transform portions of the matrix intact.
-    fn reset_after_transforming_rect(&self) -> Matrix4D<f32>;
+    fn reset_after_transforming_rect(&self) -> TypedMatrix4D<f32, Src, Dst>;
 
     fn is_identity(&self) -> bool;
 }
 
-impl MatrixHelpers for Matrix4D<f32> {
-    fn transform_point_and_perspective_project(&self, point: &Point4D<f32>) -> Point2D<f32> {
+impl<Src, Dst> MatrixHelpers<Src, Dst> for TypedMatrix4D<f32, Src, Dst> {
+    fn transform_point_and_perspective_project(&self, point: &TypedPoint4D<f32, Src>) -> TypedPoint2D<f32, Dst> {
         let point = self.transform_point4d(point);
-        Point2D::new(point.x / point.w, point.y / point.w)
+        TypedPoint2D::new(point.x / point.w, point.y / point.w)
     }
 
-    fn transform_rect(&self, rect: &Rect<f32>) -> Rect<f32> {
+    fn transform_rect(&self, rect: &TypedRect<f32, Src>) -> TypedRect<f32, Dst> {
         let top_left = self.transform_point(&rect.origin);
         let top_right = self.transform_point(&rect.top_right());
         let bottom_left = self.transform_point(&rect.bottom_left());
         let bottom_right = self.transform_point(&rect.bottom_right());
-        Rect::from_points(&top_left, &top_right, &bottom_right, &bottom_left)
+        TypedRect::from_points(&top_left, &top_right, &bottom_right, &bottom_left)
     }
 
     fn can_losslessly_transform_a_2d_rect(&self) -> bool {
@@ -73,8 +75,8 @@ impl MatrixHelpers for Matrix4D<f32> {
         self.m12 == 0.0 && self.m21 == 0.0
     }
 
-    fn reset_after_transforming_rect(&self) -> Matrix4D<f32> {
-        Matrix4D::row_major(
+    fn reset_after_transforming_rect(&self) -> TypedMatrix4D<f32, Src, Dst> {
+        TypedMatrix4D::row_major(
             1.0,      0.0,      self.m13, 0.0,
             0.0,      1.0,      self.m23, 0.0,
             self.m31, self.m32, self.m33, self.m34,
@@ -83,25 +85,28 @@ impl MatrixHelpers for Matrix4D<f32> {
     }
 
     fn is_identity(&self) -> bool {
-        *self == Matrix4D::identity()
+        *self == TypedMatrix4D::identity()
     }
 }
 
-pub trait RectHelpers where Self: Sized {
+pub trait RectHelpers<U> where Self: Sized {
 
-    fn from_points(a: &Point2D<f32>,
-                   b: &Point2D<f32>,
-                   c: &Point2D<f32>,
-                   d: &Point2D<f32>)
+    fn from_points(a: &TypedPoint2D<f32, U>,
+                   b: &TypedPoint2D<f32, U>,
+                   c: &TypedPoint2D<f32, U>,
+                   d: &TypedPoint2D<f32, U>)
                    -> Self;
     fn contains_rect(&self, other: &Self) -> bool;
     fn from_floats(x0: f32, y0: f32, x1: f32, y1: f32) -> Self;
     fn is_well_formed_and_nonempty(&self) -> bool;
 }
 
-impl RectHelpers for Rect<f32> {
+impl<U> RectHelpers<U> for TypedRect<f32, U> {
 
-    fn from_points(a: &Point2D<f32>, b: &Point2D<f32>, c: &Point2D<f32>, d: &Point2D<f32>) -> Rect<f32> {
+    fn from_points(a: &TypedPoint2D<f32, U>,
+                   b: &TypedPoint2D<f32, U>,
+                   c: &TypedPoint2D<f32, U>,
+                   d: &TypedPoint2D<f32, U>) -> Self {
         let (mut min_x, mut min_y) = (a.x, a.y);
         let (mut max_x, mut max_y) = (min_x, min_y);
         for point in &[b, c, d] {
@@ -118,8 +123,8 @@ impl RectHelpers for Rect<f32> {
                 max_y = point.y
             }
         }
-        Rect::new(Point2D::new(min_x, min_y),
-                  Size2D::new(max_x - min_x, max_y - min_y))
+        TypedRect::new(TypedPoint2D::new(min_x, min_y),
+                       TypedSize2D::new(max_x - min_x, max_y - min_y))
     }
 
     fn contains_rect(&self, other: &Self) -> bool {
@@ -129,9 +134,9 @@ impl RectHelpers for Rect<f32> {
         self.max_y() >= other.max_y()
     }
 
-    fn from_floats(x0: f32, y0: f32, x1: f32, y1: f32) -> Rect<f32> {
-        Rect::new(Point2D::new(x0, y0),
-                  Size2D::new(x1 - x0, y1 - y0))
+    fn from_floats(x0: f32, y0: f32, x1: f32, y1: f32) -> Self {
+        TypedRect::new(TypedPoint2D::new(x0, y0),
+                       TypedSize2D::new(x1 - x0, y1 - y0))
     }
 
     fn is_well_formed_and_nonempty(&self) -> bool {
@@ -141,17 +146,17 @@ impl RectHelpers for Rect<f32> {
 
 // Don't use `euclid`'s `is_empty` because that has effectively has an "and" in the conditional
 // below instead of an "or".
-pub fn rect_is_empty<N:PartialEq + Zero>(rect: &Rect<N>) -> bool {
+pub fn rect_is_empty<N:PartialEq + Zero, U>(rect: &TypedRect<N, U>) -> bool {
     rect.size.width == Zero::zero() || rect.size.height == Zero::zero()
 }
 
 #[inline]
-pub fn rect_from_points(x0: DeviceLength,
-                        y0: DeviceLength,
-                        x1: DeviceLength,
-                        y1: DeviceLength) -> DeviceRect {
-    DeviceRect::new(DevicePoint::from_lengths(x0, y0),
-                    DeviceSize::from_lengths(x1 - x0, y1 - y0))
+pub fn rect_from_points(x0: DeviceIntLength,
+                        y0: DeviceIntLength,
+                        x1: DeviceIntLength,
+                        y1: DeviceIntLength) -> DeviceIntRect {
+    DeviceIntRect::new(DeviceIntPoint::from_lengths(x0, y0),
+                       DeviceIntSize::from_lengths(x1 - x0, y1 - y0))
 }
 
 #[inline]
@@ -167,9 +172,9 @@ pub fn lerp(a: f32, b: f32, t: f32) -> f32 {
     (b - a) * t + a
 }
 
-pub fn subtract_rect(rect: &Rect<f32>,
-                     other: &Rect<f32>,
-                     results: &mut Vec<Rect<f32>>) {
+pub fn subtract_rect<U>(rect: &TypedRect<f32, U>,
+                        other: &TypedRect<f32, U>,
+                        results: &mut Vec<TypedRect<f32, U>>) {
     results.clear();
 
     let int = rect.intersection(other);
@@ -185,19 +190,19 @@ pub fn subtract_rect(rect: &Rect<f32>,
             let ox1 = ox0 + int.size.width;
             let oy1 = oy0 + int.size.height;
 
-            let r = rect_from_points_f(rx0, ry0, ox0, ry1);
+            let r = TypedRect::from_untyped(&rect_from_points_f(rx0, ry0, ox0, ry1));
             if r.size.width > 0.0 && r.size.height > 0.0 {
                 results.push(r);
             }
-            let r = rect_from_points_f(ox0, ry0, ox1, oy0);
+            let r = TypedRect::from_untyped(&rect_from_points_f(ox0, ry0, ox1, oy0));
             if r.size.width > 0.0 && r.size.height > 0.0 {
                 results.push(r);
             }
-            let r = rect_from_points_f(ox0, oy1, ox1, ry1);
+            let r = TypedRect::from_untyped(&rect_from_points_f(ox0, oy1, ox1, ry1));
             if r.size.width > 0.0 && r.size.height > 0.0 {
                 results.push(r);
             }
-            let r = rect_from_points_f(ox1, ry0, rx1, ry1);
+            let r = TypedRect::from_untyped(&rect_from_points_f(ox1, ry0, rx1, ry1));
             if r.size.width > 0.0 && r.size.height > 0.0 {
                 results.push(r);
             }
@@ -216,16 +221,16 @@ pub enum TransformedRectKind {
 
 #[derive(Debug, Clone)]
 pub struct TransformedRect {
-    pub local_rect: Rect<f32>,
-    pub bounding_rect: DeviceRect,
-    pub inner_rect: DeviceRect,
-    pub vertices: [Point4D<f32>; 4],
+    pub local_rect: LayerRect,
+    pub bounding_rect: DeviceIntRect,
+    pub inner_rect: DeviceIntRect,
+    pub vertices: [WorldPoint4D; 4],
     pub kind: TransformedRectKind,
 }
 
 impl TransformedRect {
-    pub fn new(rect: &Rect<f32>,
-           transform: &Matrix4D<f32>,
+    pub fn new(rect: &LayerRect,
+           transform: &LayerToWorldTransform,
            device_pixel_ratio: f32) -> TransformedRect {
 
         let kind = if transform.can_losslessly_transform_and_perspective_project_a_2d_rect() {
@@ -269,22 +274,22 @@ impl TransformedRect {
             TransformedRectKind::Complex => {
                 */
                 let vertices = [
-                    transform.transform_point4d(&Point4D::new(rect.origin.x,
-                                                              rect.origin.y,
-                                                              0.0,
-                                                              1.0)),
-                    transform.transform_point4d(&Point4D::new(rect.bottom_left().x,
-                                                              rect.bottom_left().y,
-                                                              0.0,
-                                                              1.0)),
-                    transform.transform_point4d(&Point4D::new(rect.bottom_right().x,
-                                                              rect.bottom_right().y,
-                                                              0.0,
-                                                              1.0)),
-                    transform.transform_point4d(&Point4D::new(rect.top_right().x,
-                                                              rect.top_right().y,
-                                                              0.0,
-                                                              1.0)),
+                    transform.transform_point4d(&LayerPoint4D::new(rect.origin.x,
+                                                                   rect.origin.y,
+                                                                   0.0,
+                                                                   1.0)),
+                    transform.transform_point4d(&LayerPoint4D::new(rect.bottom_left().x,
+                                                                   rect.bottom_left().y,
+                                                                   0.0,
+                                                                   1.0)),
+                    transform.transform_point4d(&LayerPoint4D::new(rect.bottom_right().x,
+                                                                   rect.bottom_right().y,
+                                                                   0.0,
+                                                                   1.0)),
+                    transform.transform_point4d(&LayerPoint4D::new(rect.top_right().x,
+                                                                   rect.top_right().y,
+                                                                   0.0,
+                                                                   1.0)),
                 ];
 
                 let (mut xs, mut ys) = ([0.0; 4], [0.0; 4]);
@@ -298,24 +303,24 @@ impl TransformedRect {
                 xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
                 ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-                let outer_min_dp = DevicePoint::new((xs[0] * device_pixel_ratio).floor() as i32,
-                                                    (ys[0] * device_pixel_ratio).floor() as i32);
-                let outer_max_dp = DevicePoint::new((xs[3] * device_pixel_ratio).ceil() as i32,
-                                                    (ys[3] * device_pixel_ratio).ceil() as i32);
-                let inner_min_dp = DevicePoint::new((xs[1] * device_pixel_ratio).ceil() as i32,
-                                                    (ys[1] * device_pixel_ratio).ceil() as i32);
-                let inner_max_dp = DevicePoint::new((xs[2] * device_pixel_ratio).floor() as i32,
-                                                    (ys[2] * device_pixel_ratio).floor() as i32);
+                let outer_min_dp = DeviceIntPoint::new((xs[0] * device_pixel_ratio).floor() as i32,
+                                                       (ys[0] * device_pixel_ratio).floor() as i32);
+                let outer_max_dp = DeviceIntPoint::new((xs[3] * device_pixel_ratio).ceil() as i32,
+                                                       (ys[3] * device_pixel_ratio).ceil() as i32);
+                let inner_min_dp = DeviceIntPoint::new((xs[1] * device_pixel_ratio).ceil() as i32,
+                                                       (ys[1] * device_pixel_ratio).ceil() as i32);
+                let inner_max_dp = DeviceIntPoint::new((xs[2] * device_pixel_ratio).floor() as i32,
+                                                       (ys[2] * device_pixel_ratio).floor() as i32);
 
                 TransformedRect {
                     local_rect: *rect,
                     vertices: vertices,
-                    bounding_rect: DeviceRect::new(outer_min_dp,
-                                                   DeviceSize::new(outer_max_dp.x - outer_min_dp.x,
-                                                                   outer_max_dp.y - outer_min_dp.y)),
-                    inner_rect: DeviceRect::new(inner_min_dp,
-                                                DeviceSize::new(inner_max_dp.x - inner_min_dp.x,
-                                                                inner_max_dp.y - inner_min_dp.y)),
+                    bounding_rect: DeviceIntRect::new(outer_min_dp,
+                                                      DeviceIntSize::new(outer_max_dp.x - outer_min_dp.x,
+                                                                         outer_max_dp.y - outer_min_dp.y)),
+                    inner_rect: DeviceIntRect::new(inner_min_dp,
+                                                   DeviceIntSize::new(inner_max_dp.x - inner_min_dp.x,
+                                                                      inner_max_dp.y - inner_min_dp.y)),
                     kind: kind,
                 }
                 /*

--- a/webrender_traits/src/lib.rs
+++ b/webrender_traits/src/lib.rs
@@ -33,6 +33,7 @@ include!(concat!(env!("OUT_DIR"), "/types.rs"));
 #[cfg(feature = "serde_derive")]
 include!("types.rs");
 
+mod units;
 mod api;
 pub mod channel;
 mod display_item;
@@ -42,3 +43,4 @@ mod webgl;
 
 pub use api::RenderApi;
 pub use display_list::{AuxiliaryListsBuilder, DisplayListBuilder};
+pub use units::*;

--- a/webrender_traits/src/units.rs
+++ b/webrender_traits/src/units.rs
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A collection of coordinate spaces and their corresponding Point, Size and Rect types.
+//!
+//! Physical pixels take into account the device pixel ratio and their dimensions tend
+//! to correspond to the allocated size of resources in memory, while logical pixels
+//! don't have the device pixel ratio applied which means they are agnostic to the usage
+//! of hidpi screens and the like.
+//!
+//! The terms "layer" and "stacking context" can be used interchangeably
+//! in the context of coordinate systems.
+
+use euclid::{TypedMatrix4D, TypedRect, TypedPoint2D, TypedSize2D, TypedPoint4D, Length};
+
+/// Geometry in the coordinate system of the render target (screen or intermediate
+/// surface) in physical pixels.
+#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct DevicePixel;
+
+pub type DeviceIntRect = TypedRect<i32, DevicePixel>;
+pub type DeviceIntPoint = TypedPoint2D<i32, DevicePixel>;
+pub type DeviceIntSize = TypedSize2D<i32, DevicePixel>;
+pub type DeviceIntLength = Length<i32, DevicePixel>;
+
+pub type DeviceUintRect = TypedRect<u32, DevicePixel>;
+pub type DeviceUintPoint = TypedPoint2D<u32, DevicePixel>;
+pub type DeviceUintSize = TypedSize2D<u32, DevicePixel>;
+
+pub type DeviceRect = TypedRect<f32, DevicePixel>;
+pub type DevicePoint = TypedPoint2D<f32, DevicePixel>;
+pub type DeviceSize = TypedSize2D<f32, DevicePixel>;
+
+/// Geometry in a layer's local coordinate space (logical pixels).
+#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct LayerPixel;
+
+pub type LayerRect = TypedRect<f32, LayerPixel>;
+pub type LayerPoint = TypedPoint2D<f32, LayerPixel>;
+pub type LayerSize = TypedSize2D<f32, LayerPixel>;
+pub type LayerPoint4D = TypedPoint4D<f32, LayerPixel>;
+
+/// Geometry in a layer's scrollable parent coordinate space (logical pixels).
+///
+/// Some layers are scrollable while some are not. There is a distinction between
+/// a layer's parent layer and a layer's scrollable parent layer (its closest parent
+/// that is scrollable, but not necessarily its immediate parent). Most of the internal
+/// transforms are expressed in terms of the scrollable parent and not the immediate
+/// parent.
+#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ScrollLayerPixel;
+
+pub type ScrollLayerRect = TypedRect<f32, ScrollLayerPixel>;
+pub type ScrollLayerPoint = TypedPoint2D<f32, ScrollLayerPixel>;
+pub type ScrollLayerSize = TypedSize2D<f32, ScrollLayerPixel>;
+
+/// Geometry in the document's coordinate space (logical pixels).
+#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct WorldPixel;
+
+pub type WorldRect = TypedRect<f32, WorldPixel>;
+pub type WorldPoint = TypedPoint2D<f32, WorldPixel>;
+pub type WorldSize = TypedSize2D<f32, WorldPixel>;
+pub type WorldPoint4D = TypedPoint4D<f32, WorldPixel>;
+
+
+pub type LayerTransform = TypedMatrix4D<f32, LayerPixel, LayerPixel>;
+pub type LayerToScrollTransform = TypedMatrix4D<f32, LayerPixel, ScrollLayerPixel>;
+pub type ScrollToLayerTransform = TypedMatrix4D<f32, ScrollLayerPixel, LayerPixel>;
+pub type LayerToWorldTransform = TypedMatrix4D<f32, LayerPixel, WorldPixel>;
+pub type WorldToLayerTransform = TypedMatrix4D<f32, WorldPixel, LayerPixel>;
+pub type ScrollToWorldTransform = TypedMatrix4D<f32, ScrollLayerPixel, WorldPixel>;
+
+
+pub fn device_length(value: f32, device_pixel_ratio: f32) -> DeviceIntLength {
+    DeviceIntLength::new((value * device_pixel_ratio).round() as i32)
+}
+
+pub fn as_scroll_parent_rect(rect: &LayerRect) -> ScrollLayerRect {
+    ScrollLayerRect::from_untyped(&rect.to_untyped())
+}


### PR DESCRIPTION
Part one of a series of pull requests to convert untyped geometry into strongly typed geometry.
This PR adds LayerPixel, ParentLayerPixel and WorldPixel, as well as the corresponging Rect, Point and Size structures, and converts good chunk of the Rect<f32> that I could identify as LayerRect.

In order to avoid churn in the public API, I postponed converting most of the webrender_trait types, but this will be done as soon as the webrender internals are properly typed. As a result of the step-by-step approach, this PR adds some unpleasant ```LayerFoo::from_untyped``` and ```foo.to_untyped``` at places, but the end goal is to have almost none of them in the end. I hope to land things progressively, though, because this type of changeset is time-consuming to rebase.

The added units are inspired from gecko's units (Layer/ParentLayer) and some of the webrneder terminology (World). Don't hesitate to propose other names.

This needs a careful review, in particular for LayerPixel vs ParentLayerPixel.

r? @glennw @kvark @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/568)
<!-- Reviewable:end -->
