### PR TITLE
Switched the mask generator to work on tiles

### DIFF
--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -7,11 +7,13 @@ use gpu_store::{GpuStore, GpuStoreAddress};
 use internal_types::DeviceRect;
 use prim_store::{ClipData, GpuBlock32, PrimitiveClipSource, PrimitiveStore};
 use prim_store::{CLIP_DATA_GPU_SIZE, MASK_DATA_GPU_SIZE};
+use std::i32;
 use tiling::StackingContextIndex;
 use util::{rect_from_points_f, TransformedRect};
 use webrender_traits::{AuxiliaryLists, ImageMask};
 
 const MAX_COORD: f32 = 1.0e+16;
+pub const OPAQUE_TASK_INDEX: i32 = i32::MAX;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct ClipAddressRange {

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -4,13 +4,13 @@
 
 use euclid::{Rect, Matrix4D};
 use gpu_store::{GpuStore, GpuStoreAddress};
-use internal_types::DeviceRect;
+use internal_types::{DeviceRect, DeviceSize};
 use prim_store::{ClipData, GpuBlock32, PrimitiveClipSource, PrimitiveStore};
 use prim_store::{CLIP_DATA_GPU_SIZE, MASK_DATA_GPU_SIZE};
 use std::i32;
 use tiling::StackingContextIndex;
 use util::{rect_from_points_f, TransformedRect};
-use webrender_traits::{AuxiliaryLists, ImageMask};
+use webrender_traits::{AuxiliaryLists, BorderRadius, ComplexClipRegion, ImageMask};
 
 const MAX_COORD: f32 = 1.0e+16;
 pub const OPAQUE_TASK_INDEX: i32 = i32::MAX;
@@ -50,8 +50,10 @@ pub struct MaskCacheInfo {
     // ResourceCache allocates/load the actual data
     // will be simplified after the TextureCache upgrade
     pub image: Option<ImageMask>,
-    pub device_rect: DeviceRect,
     pub local_rect: Option<Rect<f32>>,
+    pub local_inner: Option<Rect<f32>>,
+    pub inner_rect: DeviceRect,
+    pub outer_rect: DeviceRect,
 }
 
 impl MaskCacheInfo {
@@ -89,7 +91,9 @@ impl MaskCacheInfo {
                 key: clip_key,
                 image: image,
                 local_rect: None,
-                device_rect: DeviceRect::zero(),
+                local_inner: None,
+                inner_rect: DeviceRect::zero(),
+                outer_rect: DeviceRect::zero(),
             })
         } else {
             None
@@ -104,7 +108,7 @@ impl MaskCacheInfo {
                   aux_lists: &AuxiliaryLists) {
 
         if self.local_rect.is_none() {
-            let mut local_rect = Some(rect_from_points_f(-MAX_COORD, -MAX_COORD, MAX_COORD, MAX_COORD));
+            let (mut local_rect, mut local_inner);
             match source {
                 &PrimitiveClipSource::NoClip => unreachable!(),
                 &PrimitiveClipSource::Complex(rect, radius) => {
@@ -112,33 +116,49 @@ impl MaskCacheInfo {
                     let data = ClipData::uniform(rect, radius);
                     PrimitiveStore::populate_clip_data(slice, data);
                     debug_assert_eq!(self.key.clip_range.item_count, 1);
-                    local_rect = local_rect.and_then(|r| r.intersection(&rect));
+                    local_rect = Some(rect);
+                    local_inner = ComplexClipRegion::new(rect,
+                                                         BorderRadius::uniform(radius))
+                                                    .get_inner_rect();
                 }
                 &PrimitiveClipSource::Region(ref region) => {
-                    let clips = aux_lists.complex_clip_regions(&region.complex);
-                    assert_eq!(self.key.clip_range.item_count, clips.len() as u32);
-                    if !clips.is_empty() {
-                        let slice = clip_store.get_slice_mut(self.key.clip_range.start, CLIP_DATA_GPU_SIZE * clips.len());
-                        for (clip, chunk) in clips.iter().zip(slice.chunks_mut(CLIP_DATA_GPU_SIZE)) {
-                            let data = ClipData::from_clip_region(clip);
-                            PrimitiveStore::populate_clip_data(chunk, data);
-                            local_rect = local_rect.and_then(|r| r.intersection(&clip.rect));
-                        }
-                    }
-                    match region.image_mask {
+                    local_rect = Some(rect_from_points_f(-MAX_COORD, -MAX_COORD, MAX_COORD, MAX_COORD));
+                    local_inner = match region.image_mask {
                         Some(ref mask) if !mask.repeat => {
                             local_rect = local_rect.and_then(|r| r.intersection(&mask.rect));
+                            None
                         },
-                        _ => ()
+                        Some(_) => None,
+                        None => local_rect,
+                    };
+                    let clips = aux_lists.complex_clip_regions(&region.complex);
+                    assert_eq!(self.key.clip_range.item_count, clips.len() as u32);
+                    let slice = clip_store.get_slice_mut(self.key.clip_range.start, CLIP_DATA_GPU_SIZE * clips.len());
+                    for (clip, chunk) in clips.iter().zip(slice.chunks_mut(CLIP_DATA_GPU_SIZE)) {
+                        let data = ClipData::from_clip_region(clip);
+                        PrimitiveStore::populate_clip_data(chunk, data);
+                        local_rect = local_rect.and_then(|r| r.intersection(&clip.rect));
+                        local_inner = local_inner.and_then(|r| clip.get_inner_rect()
+                                                                   .and_then(|ref inner| r.intersection(inner)));
                     }
                 }
             };
             self.local_rect = Some(local_rect.unwrap_or(Rect::zero()));
+            self.local_inner = local_inner;
         }
 
         let transformed = TransformedRect::new(self.local_rect.as_ref().unwrap(),
                                                &transform,
                                                device_pixel_ratio);
-        self.device_rect = transformed.bounding_rect;
+        self.outer_rect = transformed.bounding_rect;
+
+        self.inner_rect = if let Some(ref inner_rect) = self.local_inner {
+            let transformed = TransformedRect::new(inner_rect,
+                                                   &transform,
+                                                   device_pixel_ratio);
+            transformed.inner_rect
+        } else {
+            DeviceRect::new(self.outer_rect.origin, DeviceSize::zero())
+        }
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -12,7 +12,7 @@ use internal_types::{DeviceRect, DevicePoint, DeviceSize, DeviceLength, device_p
 use internal_types::{ANGLE_FLOAT_TO_FIXED, LowLevelFilterOp};
 use internal_types::{BatchTextures, CacheTextureId, SourceTexture};
 use layer::Layer;
-use mask_cache::{MaskCacheKey, MaskCacheInfo};
+use mask_cache::{OPAQUE_TASK_INDEX, MaskCacheKey, MaskCacheInfo};
 use prim_store::{PrimitiveGeometry, RectanglePrimitive, PrimitiveContainer};
 use prim_store::{BorderPrimitiveCpu, BorderPrimitiveGpu, BoxShadowPrimitiveGpu};
 use prim_store::{ImagePrimitiveCpu, ImagePrimitiveGpu, ImagePrimitiveKind};
@@ -62,6 +62,7 @@ trait AlphaBatchHelpers {
                          batch: &mut PrimitiveBatch,
                          layer_index: StackingContextIndex,
                          task_index: i32,
+                         tile_id: TileUniqueId,
                          render_tasks: &RenderTaskCollection,
                          pass_index: RenderPassIndex);
 }
@@ -180,6 +181,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
                          batch: &mut PrimitiveBatch,
                          layer_index: StackingContextIndex,
                          task_index: i32,
+                         tile_id: TileUniqueId,
                          render_tasks: &RenderTaskCollection,
                          child_pass_index: RenderPassIndex) {
         let metadata = self.get_metadata(prim_index);
@@ -188,11 +190,16 @@ impl AlphaBatchHelpers for PrimitiveStore {
         let prim_address = metadata.gpu_prim_index;
         let clip_task_index = match metadata.clip_cache_info {
             Some(ref clip_info) => {
-                let cache_task_id = RenderTaskId::Dynamic(RenderTaskKey::CacheMask(clip_info.key));
-                let cache_task_index = render_tasks.get_task_index(&cache_task_id, child_pass_index);
-                cache_task_index.0 as i32
+                let cache_task_key = RenderTaskKey::CacheMask(clip_info.key, tile_id);
+                if render_tasks.has_dynamic_task(&cache_task_key, child_pass_index) {
+                    let cache_task_id = RenderTaskId::Dynamic(cache_task_key);
+                    let cache_task_index = render_tasks.get_task_index(&cache_task_id, child_pass_index);
+                    cache_task_index.0 as i32
+                } else {
+                    OPAQUE_TASK_INDEX
+                }
             },
-            None => i32::MAX, //sentinel value for the dummy mask
+            None => OPAQUE_TASK_INDEX
         };
 
         match &mut batch.data {
@@ -350,12 +357,14 @@ struct RenderPassIndex(isize);
 #[derive(Debug, Copy, Clone)]
 pub struct RenderTaskIndex(usize);
 
+type TileUniqueId = usize;
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum RenderTaskKey {
     /// Draw this primitive to a cache target.
     CachePrimitive(PrimitiveCacheKey),
     /// Draw the tile alpha mask for a primitive.
-    CacheMask(MaskCacheKey),
+    CacheMask(MaskCacheKey, TileUniqueId),
     /// Apply a vertical blur pass of given radius for this primitive.
     VerticalBlur(i32, PrimitiveIndex),
     /// Apply a horizontal blur pass of given radius for this primitive.
@@ -431,6 +440,11 @@ impl RenderTaskCollection {
             }
         }
     }
+
+    fn has_dynamic_task(&self, key: &RenderTaskKey, pass_index: RenderPassIndex) -> bool {
+        //TODO: remove clone
+        self.dynamic_tasks.contains_key(&(key.clone(), pass_index))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -466,6 +480,7 @@ impl Default for PrimitiveGeometry {
 struct AlphaBatchTask {
     task_id: RenderTaskId,
     items: Vec<AlphaRenderItem>,
+    tile_id: TileUniqueId,
 }
 
 /// Encapsulates the logic of building batches for items that are blended.
@@ -578,6 +593,7 @@ impl AlphaBatcher {
                                                          batch,
                                                          sc_index,
                                                          task_index,
+                                                         task.tile_id,
                                                          render_tasks,
                                                          child_pass_index);
                     }
@@ -644,6 +660,7 @@ impl ClipBatcher {
 struct CompileTileContext<'a> {
     layer_store: &'a [StackingContext],
     prim_store: &'a PrimitiveStore,
+    tile_id: TileUniqueId,
     render_task_id_counter: AtomicUsize,
 }
 
@@ -708,6 +725,7 @@ impl RenderTarget {
                 self.alpha_batcher.add_task(AlphaBatchTask {
                     task_id: task.id,
                     items: info.items,
+                    tile_id: info.tile_id,
                 });
             }
             RenderTaskKind::VerticalBlur(_, prim_index) => {
@@ -786,7 +804,7 @@ impl RenderTarget {
             }
             RenderTaskKind::CacheMask(ref task_info) => {
                 let key = match task.id {
-                    RenderTaskId::Dynamic(RenderTaskKey::CacheMask(ref key)) => key,
+                    RenderTaskId::Dynamic(RenderTaskKey::CacheMask(ref key, _)) => key,
                     _ => unreachable!()
                 };
                 let task_index = render_tasks.get_task_index(&task.id, pass_index).0 as i32;
@@ -907,12 +925,22 @@ enum AlphaRenderItem {
 pub struct AlphaRenderTask {
     actual_rect: DeviceRect,
     items: Vec<AlphaRenderItem>,
+    tile_id: TileUniqueId,
 }
 
 #[derive(Debug, Clone)]
 pub struct CacheMaskTask {
     actual_rect: DeviceRect,
     image: Option<ImageKey>,
+}
+
+enum MaskResult {
+    /// The mask is completely outside the region
+    Outside,
+    /// The mask completely covers the region
+    Covering,
+    /// The mask is inside and needs to be processed
+    Inside(RenderTask),
 }
 
 #[derive(Debug, Clone)]
@@ -946,6 +974,7 @@ impl RenderTask {
             kind: RenderTaskKind::Alpha(AlphaRenderTask {
                 actual_rect: actual_rect,
                 items: Vec::new(),
+                tile_id: ctx.tile_id,
             }),
         }
     }
@@ -961,14 +990,17 @@ impl RenderTask {
         }
     }
 
-    fn new_mask(actual_rect: DeviceRect, cache_info: &MaskCacheInfo) -> Option<RenderTask> {
-        //CLIP TODO: handle a case where the tile is completely inside the intersection
-        if !actual_rect.intersects(&cache_info.device_rect) {
-            return None
+    fn new_mask(actual_rect: DeviceRect,
+                cache_info: &MaskCacheInfo,
+                tile_id: TileUniqueId)
+                -> MaskResult {
+        let task_rect = match actual_rect.intersection(&cache_info.device_rect) {
+            None => return MaskResult::Outside,
+            Some(rect) if rect == actual_rect => return MaskResult::Covering,
+            Some(rect) => rect,
         };
-        let task_rect = cache_info.device_rect;
-        Some(RenderTask {
-            id: RenderTaskId::Dynamic(RenderTaskKey::CacheMask(cache_info.key)),
+        MaskResult::Inside(RenderTask {
+            id: RenderTaskId::Dynamic(RenderTaskKey::CacheMask(cache_info.key, tile_id)),
             children: Vec::new(),
             location: RenderTaskLocation::Dynamic(None, task_rect.size),
             kind: RenderTaskKind::CacheMask(CacheMaskTask {
@@ -1686,7 +1718,8 @@ impl ScreenTile {
                             let layer_rect = layer.xf_rect.as_ref().unwrap().bounding_rect;
                             let needed_rect = layer_rect.intersection(&self.rect)
                                                         .expect("bug if these don't overlap");
-                            let prev_task = mem::replace(&mut current_task, RenderTask::new_alpha_batch(needed_rect, ctx));
+                            let prev_task = mem::replace(&mut current_task,
+                                                         RenderTask::new_alpha_batch(needed_rect, ctx));
                             alpha_task_stack.push(prev_task);
                         }
                     }
@@ -1743,9 +1776,11 @@ impl ScreenTile {
 
                     // Add a task to render the updated image mask
                     if let Some(ref clip_info) = prim_metadata.clip_cache_info {
-                        let mask_task = RenderTask::new_mask(self.rect, clip_info)
-                                                   .expect("Primitive be culled by `prim_affects_tile` already");
-                        current_task.children.push(mask_task);
+                        match RenderTask::new_mask(self.rect, clip_info, ctx.tile_id) {
+                            MaskResult::Outside => panic!("Primitive be culled by `prim_affects_tile` already"),
+                            MaskResult::Covering => (), //do nothing
+                            MaskResult::Inside(task) => current_task.children.push(task),
+                        }
                     }
 
                     // Add any dynamic render tasks needed to render this primitive
@@ -2521,9 +2556,10 @@ impl FrameBuilder {
         let mut max_passes_needed = 0;
 
         let mut render_tasks = {
-            let ctx = CompileTileContext {
+            let mut ctx = CompileTileContext {
                 layer_store: &self.layer_store,
                 prim_store: &self.prim_store,
+                tile_id: 0,
 
                 // This doesn't need to be atomic right now (all the screen tiles are
                 // compiled on a single thread). However, in the future each of the
@@ -2537,7 +2573,8 @@ impl FrameBuilder {
             }
 
             // Build list of passes, target allocs that each tile needs.
-            for screen_tile in screen_tiles {
+            for (tile_id, screen_tile) in screen_tiles.into_iter().enumerate() {
+                ctx.tile_id = tile_id;
                 let rect = screen_tile.rect;
                 match screen_tile.compile(&ctx) {
                     Some(compiled_screen_tile) => {

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use display_list::AuxiliaryListsBuilder;
-use euclid::{Rect, Size2D};
+use euclid::{Point2D, Rect, Size2D};
 use {BorderRadius, BorderDisplayItem, ClipRegion, ColorF, ComplexClipRegion};
 use {FontKey, ImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
 use {ImageMask, ItemRange};
@@ -93,10 +93,30 @@ impl ColorF {
 }
 
 impl ComplexClipRegion {
+    /// Create a new complex clip region.
     pub fn new(rect: Rect<f32>, radii: BorderRadius) -> ComplexClipRegion {
         ComplexClipRegion {
             rect: rect,
             radii: radii,
+        }
+    }
+
+    //TODO: move to `util` module?
+    /// Return a maximum aligned rectangle that is fully inside the clip region.
+    pub fn get_inner_rect(&self) -> Option<Rect<f32>> {
+        let k = 0.5; //rough, could be better
+        let xl = self.rect.origin.x +
+            k * self.radii.top_left.width.max(self.radii.bottom_left.width);
+        let xr = self.rect.origin.x + self.rect.size.width -
+            k * self.radii.top_right.width.max(self.radii.bottom_right.width);
+        let yt = self.rect.origin.y +
+            k * self.radii.top_left.height.max(self.radii.top_right.height);
+        let yb = self.rect.origin.y + self.rect.size.height -
+            k * self.radii.bottom_left.height.max(self.radii.bottom_right.height);
+        if xl <= xr && yt <= yb {
+            Some(Rect::new(Point2D::new(xl, yt), Size2D::new(xr-xl, yb-yt)))
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Adds a unique tile ID to the compile context, alpha batch tasks, only to end up in the mask task key.
Computes an estimated inner rectangle of the mask intersection, avoids any work for tiles completely inside it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/569)
<!-- Reviewable:end -->
