### PR TITLE
Add a generate_frame API function to recomposite the last content

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -317,6 +317,15 @@ impl RenderBackend {
                             ctx.apply_command(command);
                             self.current_bound_webgl_context_id = Some(context_id);
                         }
+                        ApiMsg::GenerateFrame => {
+                            let frame = profile_counters.total_time.profile(|| {
+                                self.render()
+                            });
+                            if self.scene.root_pipeline_id.is_some() {
+                                self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
+                                frame_counter += 1;
+                            }
+                        }
                     }
                 }
                 Err(..) => {

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -235,6 +235,11 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
+    pub fn generate_frame(&self) {
+        let msg = ApiMsg::GenerateFrame;
+        self.api_sender.send(msg).unwrap();
+    }
+
     #[inline]
     fn next_unique_id(&self) -> (u32, u32) {
         let IdNamespace(namespace) = self.id_namespace;

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -54,6 +54,7 @@ pub enum ApiMsg {
     RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),
     ResizeWebGLContext(WebGLContextId, Size2D<i32>),
     WebGLCommand(WebGLContextId, WebGLCommand),
+    GenerateFrame,
 }
 
 #[derive(Copy, Clone, Deserialize, Serialize, Debug)]


### PR DESCRIPTION
For Firefox we need to do this sometimes, for a variety of reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/571)
<!-- Reviewable:end -->
