### PR TITLE
reuse alloc_image() to get the image_key in RenderApi::add_image()

### DIFF
--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -93,8 +93,7 @@ impl RenderApi {
                      stride: Option<u32>,
                      format: ImageFormat,
                      data: ImageData) -> ImageKey {
-        let new_id = self.next_unique_id();
-        let key = ImageKey::new(new_id.0, new_id.1);
+        let key = self.alloc_image();
         let msg = ApiMsg::AddImage(key, width, height, stride, format, data);
         self.api_sender.send(msg).unwrap();
         key


### PR DESCRIPTION
This is a trivial update.
WR already has a function to create a image_key obj[1]. RenderApi::add_image() should use that.

[1]
https://github.com/JerryShih/webrender/blob/c3d675d5307c2d34d00cfae67c24228f894678d9/webrender_traits/src/api.rs#L84

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/580)
<!-- Reviewable:end -->
