### PR TITLE
Export the servo-freetype-sys feature from webrender

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -8,7 +8,9 @@ build = "build.rs"
 workspace = ".."
 
 [features]
-default = ["webrender_traits/codegen"]
+default = ["codegen", "freetype-lib"]
+codegen = ["webrender_traits/codegen"]
+freetype-lib = ["freetype/servo-freetype-sys"]
 serde_derive = ["webrender_traits/serde_derive"]
 
 [dependencies]
@@ -29,7 +31,7 @@ webrender_traits = {path = "../webrender_traits", default-features = false}
 bitflags = "0.7"
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
-freetype = "0.1.2"
+freetype = {version = "0.1.2", default-features = false}
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.1.1"


### PR DESCRIPTION
See commit message for why this is needed.

I tested this to ensure that in the Firefox build we can opt-in to the codegen feature but NOT freetype-lib. The servo build seems to also be ok with this change (I cherry-picked this patch to the version of webrender that servo is currently using, and used [replace] to make servo use the modified version with this patch). The sample library in webrender also builds fine with this change, since servo-freetype-sys is enabled in the default configuration. If there's more testing needed please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/582)
<!-- Reviewable:end -->
