### PR TITLE
Change font platforms to work with device pixels directly.

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -121,8 +121,7 @@ impl FontContext {
 
     fn get_ct_font(&mut self,
                    font_key: FontKey,
-                   size: Au,
-                   device_pixel_ratio: f32) -> Option<CTFont> {
+                   size: Au) -> Option<CTFont> {
         match self.ct_fonts.entry(((font_key).clone(), size)) {
             Entry::Occupied(entry) => Some((*entry.get()).clone()),
             Entry::Vacant(entry) => {
@@ -132,7 +131,7 @@ impl FontContext {
                 };
                 let ct_font = core_text::font::new_from_CGFont(
                         cg_font,
-                        size.to_f64_px() * (device_pixel_ratio as f64));
+                        size.to_f64_px());
                 entry.insert(ct_font.clone());
                 Some(ct_font)
             }
@@ -142,9 +141,8 @@ impl FontContext {
     pub fn get_glyph_dimensions(&mut self,
                                 font_key: FontKey,
                                 size: Au,
-                                character: u32,
-                                device_pixel_ratio: f32) -> Option<GlyphDimensions> {
-        self.get_ct_font(font_key, size, device_pixel_ratio).and_then(|ref ct_font| {
+                                character: u32) -> Option<GlyphDimensions> {
+        self.get_ct_font(font_key, size).and_then(|ref ct_font| {
             let glyph = character as CGGlyph;
             let metrics = get_glyph_metrics(ct_font, glyph);
             if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
@@ -164,9 +162,8 @@ impl FontContext {
                            font_key: FontKey,
                            size: Au,
                            character: u32,
-                           device_pixel_ratio: f32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
-        match self.get_ct_font(font_key, size, device_pixel_ratio) {
+        match self.get_ct_font(font_key, size) {
             Some(ref ct_font) => {
                 let glyph = character as CGGlyph;
                 let metrics = get_glyph_metrics(ct_font, glyph);

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -89,14 +89,12 @@ impl FontContext {
     fn load_glyph(&self,
                   font_key: FontKey,
                   size: Au,
-                  character: u32,
-                  device_pixel_ratio: f32) -> Option<FT_GlyphSlot> {
+                  character: u32) -> Option<FT_GlyphSlot> {
         debug_assert!(self.faces.contains_key(&font_key));
         let face = self.faces.get(&font_key).unwrap();
 
         unsafe {
-            let char_size = float_to_fixed_ft(((0.5f64 + size.to_f64_px()) *
-                                               device_pixel_ratio as f64).floor());
+            let char_size = float_to_fixed_ft(size.to_f64_px());
             let result = FT_Set_Char_Size(face.face, char_size as FT_F26Dot6, 0, 0, 0);
             assert!(result.succeeded());
 
@@ -115,9 +113,8 @@ impl FontContext {
     pub fn get_glyph_dimensions(&self,
                                 font_key: FontKey,
                                 size: Au,
-                                character: u32,
-                                device_pixel_ratio: f32) -> Option<GlyphDimensions> {
-        self.load_glyph(font_key, size, character, device_pixel_ratio).and_then(|slot| {
+                                character: u32) -> Option<GlyphDimensions> {
+        self.load_glyph(font_key, size, character).and_then(|slot| {
             let metrics = unsafe { &(*slot).metrics };
             if metrics.width == 0 || metrics.height == 0 {
                 None
@@ -136,14 +133,12 @@ impl FontContext {
                            font_key: FontKey,
                            size: Au,
                            character: u32,
-                           device_pixel_ratio: f32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
         let mut glyph = None;
 
         if let Some(slot) = self.load_glyph(font_key,
                                             size,
-                                            character,
-                                            device_pixel_ratio) {
+                                            character) {
             let render_mode = match render_mode {
                 FontRenderMode::Mono => FT_RENDER_MODE_MONO,
                 FontRenderMode::Alpha => FT_RENDER_MODE_NORMAL,

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -62,7 +62,6 @@ impl FontContext {
                                                 font_key: FontKey,
                                                 size: Au,
                                                 glyph: u32,
-                                                device_pixel_ratio: f32,
                                                 render_mode: Option<FontRenderMode>)
                                                 -> (Option<GlyphDimensions>, Option<RasterizedGlyph>)
     {
@@ -74,7 +73,7 @@ impl FontContext {
 
         let em_size = size.to_f32_px() / 16.; // (16px per em)
         let du_per_pixel = face.metrics().designUnitsPerEm as f32 / 16.; // (once again, 16px per em)
-        let scaled_du_to_pixels = (em_size * device_pixel_ratio) / du_per_pixel;
+        let scaled_du_to_pixels = em_size / du_per_pixel;
 
         let width = (gm.advanceWidth as i32 - (gm.leftSideBearing + gm.rightSideBearing)) as f32
             * scaled_du_to_pixels;
@@ -112,7 +111,7 @@ impl FontContext {
 
         // size is in app units, which we convert to CSS pixels (1/96"), which
         // is the same as DIPs.
-        let size_dip = size.to_f32_px() * device_pixel_ratio;
+        let size_dip = size.to_f32_px();
 
         let rt = self.gdi_interop.create_bitmap_render_target(width_u, height_u);
         rt.set_pixels_per_dip(1.);
@@ -135,10 +134,9 @@ impl FontContext {
     pub fn get_glyph_dimensions(&self,
                                 font_key: FontKey,
                                 size: Au,
-                                glyph: u32,
-                                device_pixel_ratio: f32) -> Option<GlyphDimensions> {
+                                glyph: u32) -> Option<GlyphDimensions> {
         let (maybe_dims, _) =
-            self.get_glyph_dimensions_and_maybe_rasterize(font_key, size, glyph, device_pixel_ratio, None);
+            self.get_glyph_dimensions_and_maybe_rasterize(font_key, size, glyph, None);
         maybe_dims
     }
 
@@ -146,10 +144,9 @@ impl FontContext {
                            font_key: FontKey,
                            size: Au,
                            glyph: u32,
-                           device_pixel_ratio: f32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
         let (_, maybe_glyph) =
-            self.get_glyph_dimensions_and_maybe_rasterize(font_key, size, glyph, device_pixel_ratio, Some(render_mode));
+            self.get_glyph_dimensions_and_maybe_rasterize(font_key, size, glyph, Some(render_mode));
         maybe_glyph
     }
 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -216,7 +216,7 @@ pub struct TextRunPrimitiveGpu {
 #[derive(Debug, Clone)]
 pub struct TextRunPrimitiveCpu {
     pub font_key: FontKey,
-    pub font_size: Au,
+    pub logical_font_size: Au,
     pub blur_radius: Au,
     pub glyph_range: ItemRange,
     pub cache_dirty: bool,
@@ -602,12 +602,13 @@ impl PrimitiveStore {
                 PrimitiveKind::Gradient => {}
                 PrimitiveKind::TextRun => {
                     let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
+                    let font_size_dp = text.logical_font_size.scale_by(self.device_pixel_ratio);
 
                     let dest_rects = self.gpu_resource_rects.get_slice_mut(text.resource_address,
                                                                            text.glyph_range.length);
 
                     let texture_id = resource_cache.get_glyphs(text.font_key,
-                                                               text.font_size,
+                                                               font_size_dp,
                                                                &text.glyph_indices,
                                                                text.render_mode, |index, uv0, uv1| {
                         let dest_rect = &mut dest_rects[index];
@@ -744,6 +745,7 @@ impl PrimitiveStore {
             PrimitiveKind::BoxShadow => {}
             PrimitiveKind::TextRun => {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
+                let font_size_dp = text.logical_font_size.scale_by(self.device_pixel_ratio);
                 prim_needs_resolve = true;
 
                 if text.cache_dirty {
@@ -756,7 +758,7 @@ impl PrimitiveStore {
                     let dest_glyphs = self.gpu_data16.get_slice_mut(metadata.gpu_data_address,
                                                                     text.glyph_range.length);
                     let mut glyph_key = GlyphKey::new(text.font_key,
-                                                      text.font_size,
+                                                      font_size_dp,
                                                       src_glyphs[0].index);
                     let mut local_rect = Rect::zero();
                     let mut actual_glyph_count = 0;
@@ -821,7 +823,7 @@ impl PrimitiveStore {
                 }
 
                 resource_cache.request_glyphs(text.font_key,
-                                              text.font_size,
+                                              font_size_dp,
                                               &text.glyph_indices,
                                               text.render_mode);
             }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -68,7 +68,6 @@ impl RenderBackend {
                main_thread_dispatcher:  Arc<Mutex<Option<Box<RenderDispatcher>>>>) -> RenderBackend {
 
         let resource_cache = ResourceCache::new(texture_cache,
-                                                device_pixel_ratio,
                                                 enable_aa);
 
         RenderBackend {

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2108,7 +2108,7 @@ impl FrameBuilder {
 
             let prim_cpu = TextRunPrimitiveCpu {
                 font_key: font_key,
-                font_size: size,
+                logical_font_size: size,
                 blur_radius: blur_radius,
                 glyph_range: sub_range,
                 cache_dirty: true,

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -243,6 +243,11 @@ pub enum FontRenderMode {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GlyphKey {
     pub font_key: FontKey,
+    // The font size is in *device* pixels, not logical pixels.
+    // It is stored as an Au since we need sub-pixel sizes, but
+    // can't store as a f32 due to use of this type as a hash key.
+    // TODO(gw): Perhaps consider having LogicalAu and DeviceAu
+    //           or something similar to that.
     pub size: Au,
     pub index: u32,
 }


### PR DESCRIPTION
This means that glyph keys are correctly hashed and
cached when the device pixel ratio is changed dynamically.

This is a step towards support zoom functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/583)
<!-- Reviewable:end -->
