### PR TITLE
Add specific shaders for rectangles with CLIP feature.

### DIFF
--- a/webrender/res/ps_rectangle.fs.glsl
+++ b/webrender/res/ps_rectangle.fs.glsl
@@ -9,6 +9,8 @@ void main(void) {
     init_transform_fs(vLocalPos, vLocalRect, alpha);
 #endif
 
+#ifdef WR_FEATURE_CLIP
     alpha = min(alpha, do_clip());
+#endif
     oFragColor = vColor * vec4(1.0, 1.0, 1.0, alpha);
 }

--- a/webrender/res/ps_rectangle.vs.glsl
+++ b/webrender/res/ps_rectangle.vs.glsl
@@ -21,5 +21,7 @@ void main(void) {
                                  prim.tile);
 #endif
 
+#ifdef WR_FEATURE_CLIP
     write_clip(vi.global_clamped_pos, prim.clip_area);
+#endif
 }


### PR DESCRIPTION
Having the base rectangle shader include clip makes the software
mesa implementation (somewhat) slower for reftests. This is enough
of a timing difference that it triggers a lot of intermittent
test failures in Servo.

Instead, include a simple rectangle shader for workloads that
don't have a clip mask.

The other shaders are typically more expensive and not used as
frequently by the reftests, so hopefully this change is enough
to work around the Servo intermittent bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/591)
<!-- Reviewable:end -->
