### PR TITLE
Make sure to call write_clip from vertex shader (ps_yuv_image.vs.glsl)

### DIFF
--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -69,4 +69,7 @@ void main(void) {
             1.16438,  2.11240,  0.0
         );
     }
+
+    write_clip(vi.global_clamped_pos, prim.clip_area);
+
 }


### PR DESCRIPTION
Fix to [Issue #594](https://github.com/servo/webrender/issues/594) where
write_clip was not being called for a future call to do_clip, causing an
error with certain clipping attributes not having been written for the
fragment shader to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/598)
<!-- Reviewable:end -->
