### PR TITLE
Keeping the currently scrolling layer, unless new gesture starts

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -53,6 +53,7 @@ pub struct Frame {
                                           BuildHasherDefault<FnvHasher>>,
     pub root_scroll_layer_id: Option<ScrollLayerId>,
     pending_scroll_offsets: HashMap<(PipelineId, ServoScrollRootId), LayerPoint>,
+    current_scroll_layer_id: Option<ScrollLayerId>,
     id: FrameId,
     debug: bool,
     frame_builder_config: FrameBuilderConfig,
@@ -212,6 +213,7 @@ impl Frame {
             layers: HashMap::with_hasher(Default::default()),
             root_scroll_layer_id: None,
             pending_scroll_offsets: HashMap::new(),
+            current_scroll_layer_id: None,
             id: FrameId(0),
             debug: debug,
             frame_builder: None,
@@ -340,9 +342,17 @@ impl Frame {
             None => return false,
         };
 
-        let scroll_layer_id = match self.get_scroll_layer(&cursor, root_scroll_layer_id) {
-            Some(scroll_layer_id) => scroll_layer_id,
-            None => return false,
+        let scroll_layer_id = match (
+            phase,
+            self.get_scroll_layer(&cursor, root_scroll_layer_id),
+            self.current_scroll_layer_id) {
+            (ScrollEventPhase::Start, Some(scroll_layer_id), _) => {
+                self.current_scroll_layer_id = Some(scroll_layer_id);
+                scroll_layer_id
+            },
+            (ScrollEventPhase::Start, None, _) => return false,
+            (_, _, Some(scroll_layer_id)) => scroll_layer_id,
+            (_, _, None) => return false,
         };
 
         let scroll_root_id = match scroll_layer_id.info {


### PR DESCRIPTION
"If you scroll a long page, and somewhere on that page is a smaller scrollable element, you don't want that element to swallow the rest of your scroll gesture if it suddenly happens to move under your mouse. You want the current scroll gesture to keep scrolling the outer page." servo/servo#13249 (comment)

Page used for testing can be found online [here](https://samuknet.github.io/test_cases/nestedScroll/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/600)
<!-- Reviewable:end -->
