### PR TITLE
Use strongly typed geometry - Part 2

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -8,7 +8,6 @@ extern crate webrender_traits;
 
 use bincode::serde::deserialize;
 use byteorder::{LittleEndian, ReadBytesExt};
-use euclid::Size2D;
 use gleam::gl;
 use std::any::TypeId;
 use std::mem;
@@ -16,7 +15,7 @@ use std::io::Read;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::env;
-use webrender_traits::{ApiMsg, RenderApi, PipelineId};
+use webrender_traits::{ApiMsg, RenderApi, PipelineId, LayerSize, DeviceUintSize};
 use webrender_traits::channel::PayloadHelperMethods;
 use glutin::{Event, ElementState, VirtualKeyCode as Key};
 
@@ -40,7 +39,7 @@ impl webrender_traits::RenderNotifier for Notifier {
 
     fn pipeline_size_changed(&mut self,
                              _pid: PipelineId,
-                             _size: Option<Size2D<f32>>) {
+                             _size: Option<LayerSize>) {
     }
 
     fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {
@@ -145,7 +144,7 @@ fn main() {
                 println!("Rendering frame {}.", frame_num);
                 gl::clear(gl::COLOR_BUFFER_BIT);
                 renderer.update();
-                renderer.render(Size2D::new(width, height));
+                renderer.render(DeviceUintSize::new(width, height));
                 window.swap_buffers().unwrap();
             }
             Event::KeyboardInput(ElementState::Pressed, _, Some(Key::Right)) =>{

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -6,11 +6,11 @@ extern crate webrender_traits;
 extern crate euclid;
 
 use app_units::Au;
-use euclid::{Size2D, Point2D, Rect, Matrix4D};
 use gleam::gl;
 use std::path::PathBuf;
 use webrender_traits::{ColorF, Epoch, GlyphInstance};
 use webrender_traits::{ImageData, ImageFormat, PipelineId, RendererKind};
+use webrender_traits::{LayoutSize, LayoutPoint, LayoutRect, LayoutTransform, DeviceUintSize};
 use std::fs::File;
 use std::io::Read;
 use std::env;
@@ -45,7 +45,7 @@ impl webrender_traits::RenderNotifier for Notifier {
 
     fn pipeline_size_changed(&mut self,
                              _: PipelineId,
-                             _: Option<Size2D<f32>>) {
+                             _: Option<LayoutSize>) {
     }
 }
 
@@ -100,10 +100,10 @@ fn main() {
     let pipeline_id = PipelineId(0, 0);
     let mut builder = webrender_traits::DisplayListBuilder::new(pipeline_id);
 
-    let bounds = Rect::new(Point2D::new(0.0, 0.0), Size2D::new(width as f32, height as f32));
+    let bounds = LayoutRect::new(LayoutPoint::new(0.0, 0.0), LayoutSize::new(width as f32, height as f32));
     let clip_region = {
         let complex = webrender_traits::ComplexClipRegion::new(
-            Rect::new(Point2D::new(50.0, 50.0), Size2D::new(100.0, 100.0)),
+            LayoutRect::new(LayoutPoint::new(50.0, 50.0), LayoutSize::new(100.0, 100.0)),
             webrender_traits::BorderRadius::uniform(20.0));
 
         builder.new_clip_region(&bounds, vec![complex], None)
@@ -113,28 +113,28 @@ fn main() {
                                   bounds,
                                   clip_region,
                                   0,
-                                  &Matrix4D::identity(),
-                                  &Matrix4D::identity(),
+                                  &LayoutTransform::identity(),
+                                  &LayoutTransform::identity(),
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
 
     let sub_clip = {
         let mask = webrender_traits::ImageMask {
             image: api.add_image(2, 2, None, ImageFormat::A8, ImageData::new(vec![0,80, 180, 255])),
-            rect: Rect::new(Point2D::new(75.0, 75.0), Size2D::new(100.0, 100.0)),
+            rect: LayoutRect::new(LayoutPoint::new(75.0, 75.0), LayoutSize::new(100.0, 100.0)),
             repeat: false,
         };
         let complex = webrender_traits::ComplexClipRegion::new(
-            Rect::new(Point2D::new(50.0, 50.0), Size2D::new(100.0, 100.0)),
+            LayoutRect::new(LayoutPoint::new(50.0, 50.0), LayoutSize::new(100.0, 100.0)),
             webrender_traits::BorderRadius::uniform(20.0));
 
         builder.new_clip_region(&bounds, vec![complex], Some(mask))
     };
 
-    builder.push_rect(Rect::new(Point2D::new(100.0, 100.0), Size2D::new(100.0, 100.0)),
+    builder.push_rect(LayoutRect::new(LayoutPoint::new(100.0, 100.0), LayoutSize::new(100.0, 100.0)),
                       sub_clip,
                       ColorF::new(0.0, 1.0, 0.0, 1.0));
-    builder.push_rect(Rect::new(Point2D::new(250.0, 100.0), Size2D::new(100.0, 100.0)),
+    builder.push_rect(LayoutRect::new(LayoutPoint::new(250.0, 100.0), LayoutSize::new(100.0, 100.0)),
                       sub_clip,
                       ColorF::new(0.0, 1.0, 0.0, 1.0));
 
@@ -142,7 +142,7 @@ fn main() {
         let font_bytes = load_file("res/FreeSans.ttf");
         let font_key = api.add_raw_font(font_bytes);
 
-        let text_bounds = Rect::new(Point2D::new(100.0, 200.0), Size2D::new(700.0, 300.0));
+        let text_bounds = LayoutRect::new(LayoutPoint::new(100.0, 200.0), LayoutSize::new(700.0, 300.0));
 
         let glyphs = vec![
             GlyphInstance {
@@ -221,7 +221,7 @@ fn main() {
     api.set_root_display_list(
         root_background_color,
         epoch,
-        Size2D::new(width as f32, height as f32),
+        LayoutSize::new(width as f32, height as f32),
         builder);
     api.set_root_pipeline(pipeline_id);
 
@@ -229,7 +229,7 @@ fn main() {
         gl::clear(gl::COLOR_BUFFER_BIT);
         renderer.update();
 
-        renderer.render(Size2D::new(width, height));
+        renderer.render(DeviceUintSize::new(width, height));
 
         window.swap_buffers().ok();
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use euclid::{Point2D, Point3D, Rect, Size2D};
+use euclid::Point3D;
 use fnv::FnvHasher;
 use geometry::ray_intersects_rect;
 use internal_types::{ANGLE_FLOAT_TO_FIXED, AxisDirection};
@@ -22,8 +22,8 @@ use webrender_traits::{ClipRegion, ColorF, DisplayItem, StackingContext, FilterO
 use webrender_traits::{ScrollEventPhase, ScrollLayerInfo, ScrollLocation, SpecificDisplayItem, ScrollLayerState};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
 use webrender_traits::{ServoScrollRootId, ScrollLayerRect, as_scroll_parent_rect, ScrollLayerPixel};
-use webrender_traits::WorldPoint4D;
-use webrender_traits::{LayerTransform, LayerToScrollTransform, ScrollToWorldTransform};
+use webrender_traits::{WorldPoint, WorldPoint4D};
+use webrender_traits::{LayerToScrollTransform, ScrollToWorldTransform};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -38,7 +38,7 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF { r: 0.3, g: 0.3, b: 0.3, a: 0.6
 
 struct FlattenContext<'a> {
     scene: &'a Scene,
-    pipeline_sizes: &'a mut HashMap<PipelineId, Size2D<f32>>,
+    pipeline_sizes: &'a mut HashMap<PipelineId, LayerSize>,
     builder: &'a mut FrameBuilder,
 }
 
@@ -234,7 +234,7 @@ impl Frame {
         old_layer_scrolling_states
     }
 
-    pub fn get_scroll_layer(&self, cursor: &Point2D<f32>, scroll_layer_id: ScrollLayerId)
+    pub fn get_scroll_layer(&self, cursor: &WorldPoint, scroll_layer_id: ScrollLayerId)
                             -> Option<ScrollLayerId> {
         self.layers.get(&scroll_layer_id).and_then(|layer| {
             for child_layer_id in layer.children.iter().rev() {
@@ -286,7 +286,7 @@ impl Frame {
                     result.push(ScrollLayerState {
                         pipeline_id: scroll_layer.pipeline_id,
                         scroll_root_id: servo_scroll_root_id,
-                        scroll_offset: scroll_layer.scrolling.offset.to_untyped(),
+                        scroll_offset: scroll_layer.scrolling.offset,
                     })
                 }
                 ScrollLayerInfo::Fixed => {}
@@ -297,7 +297,7 @@ impl Frame {
 
     /// Returns true if any layers actually changed position or false otherwise.
     pub fn scroll_layers(&mut self,
-                         origin: Point2D<f32>,
+                         origin: LayerPoint,
                          pipeline_id: PipelineId,
                          scroll_root_id: ServoScrollRootId)
                           -> bool {
@@ -330,7 +330,7 @@ impl Frame {
     /// Returns true if any layers actually changed position or false otherwise.
     pub fn scroll(&mut self,
                   scroll_location: ScrollLocation,
-                  cursor: Point2D<f32>,
+                  cursor: WorldPoint,
                   phase: ScrollEventPhase)
                   -> bool {
         let root_scroll_layer_id = match self.root_scroll_layer_id {
@@ -384,7 +384,7 @@ impl Frame {
                         // Nothing to do on this layer.
                         continue;
                     }
-                
+
                     layer.scrolling.offset.y = end_pos;
                     scrolled_a_layer = true;
                     continue;
@@ -460,7 +460,7 @@ impl Frame {
 
     pub fn create(&mut self,
                   scene: &Scene,
-                  pipeline_sizes: &mut HashMap<PipelineId, Size2D<f32>>) {
+                  pipeline_sizes: &mut HashMap<PipelineId, LayerSize>) {
         let root_pipeline_id = match scene.root_pipeline_id {
             Some(root_pipeline_id) => root_pipeline_id,
             None => return,
@@ -496,9 +496,9 @@ impl Frame {
         // Insert global position: fixed elements layer
         debug_assert!(self.layers.is_empty());
         let root_fixed_layer_id = ScrollLayerId::create_fixed(root_pipeline_id);
-        let root_viewport = LayerRect::new(LayerPoint::zero(), LayerSize::from_untyped(&root_pipeline.viewport_size));
+        let root_viewport = LayerRect::new(LayerPoint::zero(), root_pipeline.viewport_size);
         let layer = Layer::new(&root_viewport,
-                               LayerSize::from_untyped(&root_clip.main.size),
+                               root_clip.main.size,
                                &LayerToScrollTransform::identity(),
                                root_pipeline_id);
         self.layers.insert(root_fixed_layer_id, layer.clone());
@@ -587,7 +587,7 @@ impl Frame {
                                         LayerSize::new(content_size.width + clip.origin.x,
                                                        content_size.height + clip.origin.y));
         context.builder.push_layer(layer_rect,
-                                   &ClipRegion::simple(&layer_rect.to_untyped()),
+                                   &ClipRegion::simple(&layer_rect),
                                    LayerToScrollTransform::identity(),
                                    pipeline_id,
                                    current_scroll_layer_id,
@@ -638,14 +638,11 @@ impl Frame {
             }
         }
 
-        // TODO(nical): make them LayerTransforms in the public API.
-        let sc_transform: LayerTransform = unsafe { ::std::mem::transmute(stacking_context.transform) };
-        let sc_perspective: LayerTransform = unsafe { ::std::mem::transmute(stacking_context.perspective) };
         let transform = layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
                                                                 stacking_context.bounds.origin.y,
                                                                 0.0)
-                                                .pre_mul(&sc_transform)
-                                                .pre_mul(&sc_perspective);
+                                                .pre_mul(&stacking_context.transform)
+                                                .pre_mul(&stacking_context.perspective);
 
         // Build world space transform
         let scroll_layer_id = match stacking_context.scroll_policy {
@@ -674,7 +671,7 @@ impl Frame {
 
             // Adding a dummy layer for this rectangle in order to disable clipping.
             let no_clip = ClipRegion::simple(&clip_region.main);
-            context.builder.push_layer(LayerRect::from_untyped(&clip_region.main),
+            context.builder.push_layer(clip_region.main,
                                        &no_clip,
                                        transform,
                                        pipeline_id,
@@ -683,7 +680,7 @@ impl Frame {
 
             //Note: we don't use the original clip region here,
             // it's already processed by the layer we just pushed.
-            context.builder.add_solid_rectangle(&LayerRect::from_untyped(&clip_region.main),
+            context.builder.add_solid_rectangle(&clip_region.main,
                                                 &no_clip,
                                                 &root_background_color,
                                                 PrimitiveFlags::None);
@@ -692,7 +689,7 @@ impl Frame {
         }
 
          // TODO(gw): Int with overflow etc
-        context.builder.push_layer(LayerRect::from_untyped(&clip_region.main),
+        context.builder.push_layer(clip_region.main,
                                    &clip_region,
                                    transform,
                                    pipeline_id,
@@ -710,7 +707,7 @@ impl Frame {
         if level == 0 && self.frame_builder_config.enable_scrollbars {
             let scrollbar_rect = LayerRect::new(LayerPoint::zero(), LayerSize::new(10.0, 70.0));
             context.builder.add_solid_rectangle(&scrollbar_rect,
-                                                &ClipRegion::simple(&scrollbar_rect.to_untyped()),
+                                                &ClipRegion::simple(&scrollbar_rect),
                                                 &DEFAULT_SCROLLBAR_COLOR,
                                                 PrimitiveFlags::Scrollbar(self.root_scroll_layer_id.unwrap(),
                                                                           4.0));
@@ -721,7 +718,7 @@ impl Frame {
 
     fn flatten_iframe<'a>(&mut self,
                           pipeline_id: PipelineId,
-                          bounds: &Rect<f32>,
+                          bounds: &LayerRect,
                           context: &mut FlattenContext,
                           current_scroll_layer_id: ScrollLayerId,
                           layer_relative_transform: LayerToScrollTransform) {
@@ -748,7 +745,7 @@ impl Frame {
 
         self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
 
-        let iframe_rect = &LayerRect::new(LayerPoint::zero(), LayerSize::from_untyped(&bounds.size));
+        let iframe_rect = &LayerRect::new(LayerPoint::zero(), bounds.size);
         let transform = layer_relative_transform.pre_translated(bounds.origin.x,
                                                                 bounds.origin.y,
                                                                 0.0);
@@ -757,7 +754,7 @@ impl Frame {
         let iframe_scroll_layer_id = ScrollLayerId::root(pipeline_id);
 
         let layer = Layer::new(iframe_rect,
-                               LayerSize::from_untyped(&iframe_clip.main.size),
+                               iframe_clip.main.size,
                                &transform,
                                pipeline_id);
         self.layers.insert(iframe_fixed_layer_id, layer.clone());
@@ -788,19 +785,19 @@ impl Frame {
         while let Some(item) = traversal.next() {
             match item.item {
                 SpecificDisplayItem::WebGL(ref info) => {
-                    context.builder.add_webgl_rectangle(LayerRect::from_untyped(&item.rect),
+                    context.builder.add_webgl_rectangle(item.rect,
                                                         &item.clip, info.context_id);
                 }
                 SpecificDisplayItem::Image(ref info) => {
-                    context.builder.add_image(LayerRect::from_untyped(&item.rect),
+                    context.builder.add_image(item.rect,
                                               &item.clip,
-                                              &LayerSize::from_untyped(&info.stretch_size),
-                                              &LayerSize::from_untyped(&info.tile_spacing),
+                                              &info.stretch_size,
+                                              &info.tile_spacing,
                                               info.image_key,
                                               info.image_rendering);
                 }
                 SpecificDisplayItem::YuvImage(ref info) => {
-                    context.builder.add_yuv_image(LayerRect::from_untyped(&item.rect),
+                    context.builder.add_yuv_image(item.rect,
                                                   &item.clip,
                                                   info.y_image_key,
                                                   info.u_image_key,
@@ -808,7 +805,7 @@ impl Frame {
                                                   info.color_space);
                 }
                 SpecificDisplayItem::Text(ref text_info) => {
-                    context.builder.add_text(LayerRect::from_untyped(&item.rect),
+                    context.builder.add_text(item.rect,
                                              &item.clip,
                                              text_info.font_key,
                                              text_info.size,
@@ -817,22 +814,22 @@ impl Frame {
                                              text_info.glyphs);
                 }
                 SpecificDisplayItem::Rectangle(ref info) => {
-                    context.builder.add_solid_rectangle(&LayerRect::from_untyped(&item.rect),
+                    context.builder.add_solid_rectangle(&item.rect,
                                                         &item.clip,
                                                         &info.color,
                                                         PrimitiveFlags::None);
                 }
                 SpecificDisplayItem::Gradient(ref info) => {
-                    context.builder.add_gradient(LayerRect::from_untyped(&item.rect),
+                    context.builder.add_gradient(item.rect,
                                                  &item.clip,
-                                                 LayerPoint::from_untyped(&info.start_point),
-                                                 LayerPoint::from_untyped(&info.end_point),
+                                                 info.start_point,
+                                                 info.end_point,
                                                  info.stops);
                 }
                 SpecificDisplayItem::BoxShadow(ref box_shadow_info) => {
-                    context.builder.add_box_shadow(&LayerRect::from_untyped(&box_shadow_info.box_bounds),
+                    context.builder.add_box_shadow(&box_shadow_info.box_bounds,
                                                    &item.clip,
-                                                   &LayerPoint::from_untyped(&box_shadow_info.offset),
+                                                   &box_shadow_info.offset,
                                                    &box_shadow_info.color,
                                                    box_shadow_info.blur_radius,
                                                    box_shadow_info.spread_radius,
@@ -840,7 +837,7 @@ impl Frame {
                                                    box_shadow_info.clip_mode);
                 }
                 SpecificDisplayItem::Border(ref info) => {
-                    context.builder.add_border(LayerRect::from_untyped(&item.rect), &item.clip, info);
+                    context.builder.add_border(item.rect, &item.clip, info);
                 }
                 SpecificDisplayItem::PushStackingContext(ref info) => {
                     self.flatten_stacking_context(traversal,
@@ -861,8 +858,8 @@ impl Frame {
                                               current_scroll_layer_id,
                                               layer_relative_transform,
                                               level,
-                                              &LayerRect::from_untyped(&item.rect),
-                                              &LayerSize::from_untyped(&info.content_size),
+                                              &item.rect,
+                                              &info.content_size,
                                               info.id);
                 }
                 SpecificDisplayItem::Iframe(ref info) => {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -317,7 +317,7 @@ impl ClipData {
     pub fn from_clip_region(clip: &ComplexClipRegion) -> ClipData {
         ClipData {
             rect: ClipRect {
-                rect: LayerRect::from_untyped(&clip.rect),
+                rect: clip.rect,
                 padding: [0.0, 0.0, 0.0, 0.0],
             },
             top_left: ClipCorner {
@@ -642,7 +642,7 @@ impl PrimitiveStore {
                 uv_rect: DeviceRect::new(cache_item.uv0,
                                          DeviceSize::new(cache_item.uv1.x - cache_item.uv0.x,
                                                          cache_item.uv1.y - cache_item.uv0.y)),
-                local_rect: LayerRect::from_untyped(&mask.rect),
+                local_rect: mask.rect,
             });
         }
     }
@@ -769,7 +769,7 @@ impl PrimitiveStore {
         let (rect, is_complex) = match source {
             ClipSource::NoClip => (None, false),
             ClipSource::Complex(rect, radius) => (Some(rect), radius > 0.0),
-            ClipSource::Region(ref region) => (Some(LayerRect::from_untyped(&region.main)), region.is_complex()),
+            ClipSource::Region(ref region) => (Some(region.main), region.is_complex()),
         };
         if let Some(rect) = rect {
             self.gpu_geometry.get_mut(GpuStoreAddress(index.0 as i32))

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -18,7 +18,6 @@ use std::sync::mpsc::Sender;
 use texture_cache::TextureCache;
 use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace, ImageData};
 use webrender_traits::{RenderNotifier, RenderDispatcher, WebGLCommand, WebGLContextId};
-use webrender_traits::{DeviceIntSize};
 use webrender_traits::channel::{PayloadHelperMethods, PayloadReceiver, PayloadSender, MsgReceiver};
 use webrender_traits::{VRCompositorCommand, VRCompositorHandler};
 use tiling::FrameBuilderConfig;
@@ -299,7 +298,7 @@ impl RenderBackend {
 
                                         self.resource_cache
                                             .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
-                                                               DeviceIntSize::from_untyped(&real_size));
+                                                               real_size);
 
                                         tx.send(Ok((id, limits))).unwrap();
                                     },
@@ -320,7 +319,7 @@ impl RenderBackend {
                                     let (real_size, texture_id, _) = ctx.get_info();
                                     self.resource_cache
                                         .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
-                                                              DeviceIntSize::from_untyped(&real_size));
+                                                              real_size);
                                 },
                                 Err(msg) => {
                                     error!("Error resizing WebGLContext: {}", msg);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -13,7 +13,7 @@ use debug_colors;
 use debug_render::DebugRenderer;
 use device::{Device, ProgramId, TextureId, VertexFormat, GpuMarker, GpuProfiler};
 use device::{TextureFilter, VAOId, VertexUsageHint, FileWatcherHandler, TextureTarget};
-use euclid::{Size2D, Matrix4D};
+use euclid::Matrix4D;
 use fnv::FnvHasher;
 use internal_types::{CacheTextureId, RendererFrame, ResultMsg, TextureUpdateOp};
 use internal_types::{TextureUpdateList, PackedVertex, RenderTargetMode};
@@ -864,8 +864,7 @@ impl Renderer {
     ///
     /// A Frame is supplied by calling [set_root_stacking_context()][newframe].
     /// [newframe]: ../../webrender_traits/struct.RenderApi.html#method.set_root_stacking_context
-    pub fn render(&mut self, framebuffer_size: Size2D<u32>) {
-        let framebuffer_size = DeviceUintSize::from_untyped(&framebuffer_size);
+    pub fn render(&mut self, framebuffer_size: DeviceUintSize) {
         if let Some(mut frame) = self.current_frame.take() {
             if let Some(ref mut frame) = frame.frame {
                 let mut profile_timers = RendererProfileTimers::new();
@@ -1456,8 +1455,8 @@ impl Renderer {
         // Some tests use a restricted viewport smaller than the main screen size.
         // Ensure we clear the framebuffer in these tests.
         // TODO(gw): Find a better solution for this?
-        let viewport_size = DeviceIntSize::new(frame.viewport_size.width * frame.device_pixel_ratio as i32,
-                                               frame.viewport_size.height * frame.device_pixel_ratio as i32);
+        let viewport_size = DeviceIntSize::new((frame.viewport_size.width * frame.device_pixel_ratio) as i32,
+                                               (frame.viewport_size.height * frame.device_pixel_ratio) as i32);
         let needs_clear = viewport_size.width < framebuffer_size.width as i32 ||
                           viewport_size.height < framebuffer_size.height as i32;
 

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::Size2D;
 use fnv::FnvHasher;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::AuxiliaryListsMap;
 use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch, ColorF};
 use webrender_traits::{DisplayItem, SpecificDisplayItem, StackingContext};
+use webrender_traits::LayerSize;
 
 trait DisplayListHelpers {
     fn starting_stacking_context<'a>(&'a self) -> Option<&'a StackingContext>;
@@ -28,7 +28,7 @@ impl DisplayListHelpers for Vec<DisplayItem> {
 pub struct ScenePipeline {
     pub pipeline_id: PipelineId,
     pub epoch: Epoch,
-    pub viewport_size: Size2D<f32>,
+    pub viewport_size: LayerSize,
     pub background_color: ColorF,
 }
 
@@ -36,7 +36,7 @@ pub struct ScenePipeline {
 pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipeline_map: HashMap<PipelineId, ScenePipeline, BuildHasherDefault<FnvHasher>>,
-    pub pipeline_sizes: HashMap<PipelineId, Size2D<f32>>,
+    pub pipeline_sizes: HashMap<PipelineId, LayerSize>,
     pub pipeline_auxiliary_lists: AuxiliaryListsMap,
     pub display_lists: HashMap<PipelineId, Vec<DisplayItem>, BuildHasherDefault<FnvHasher>>,
 }
@@ -61,7 +61,7 @@ impl Scene {
                                  epoch: Epoch,
                                  built_display_list: BuiltDisplayList,
                                  background_color: ColorF,
-                                 viewport_size: Size2D<f32>,
+                                 viewport_size: LayerSize,
                                  auxiliary_lists: AuxiliaryLists) {
         self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
         self.display_lists.insert(pipeline_id, built_display_list.all_display_items().to_vec());

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -4,7 +4,6 @@
 
 use app_units::Au;
 use batch_builder::BorderSideHelpers;
-use euclid::{Point2D, Rect, Size2D};
 use fnv::FnvHasher;
 use frame::FrameId;
 use gpu_store::GpuStoreAddress;
@@ -1661,7 +1660,7 @@ impl FrameBuilderConfig {
 }
 
 pub struct FrameBuilder {
-    screen_rect: Rect<i32>,
+    screen_rect: LayerRect,
     prim_store: PrimitiveStore,
     cmds: Vec<PrimitiveRunCmd>,
     debug: bool,
@@ -1676,7 +1675,7 @@ pub struct FrameBuilder {
 /// A rendering-oriented representation of frame::Frame built by the render backend
 /// and presented to the renderer.
 pub struct Frame {
-    pub viewport_size: Size2D<i32>,
+    pub viewport_size: LayerSize,
     pub device_pixel_ratio: f32,
     pub debug_rects: Vec<DebugRect>,
     pub cache_size: DeviceSize,
@@ -1983,12 +1982,11 @@ impl ScreenTile {
 }
 
 impl FrameBuilder {
-    pub fn new(viewport_size: Size2D<f32>,
+    pub fn new(viewport_size: LayerSize,
                debug: bool,
                config: FrameBuilderConfig) -> FrameBuilder {
-        let viewport_size = Size2D::new(viewport_size.width as i32, viewport_size.height as i32);
         FrameBuilder {
-            screen_rect: Rect::new(Point2D::zero(), viewport_size),
+            screen_rect: LayerRect::new(LayerPoint::zero(), viewport_size),
             layer_store: Vec::new(),
             prim_store: PrimitiveStore::new(),
             cmds: Vec::new(),
@@ -2006,7 +2004,7 @@ impl FrameBuilder {
 
         let geometry = PrimitiveGeometry {
             local_rect: *rect,
-            local_clip_rect: LayerRect::from_untyped(&clip_region.main),
+            local_clip_rect: clip_region.main,
         };
         let clip_source = if clip_region.is_complex() {
             ClipSource::Region(clip_region.clone())
@@ -2183,10 +2181,10 @@ impl FrameBuilder {
                 pack_as_float(bottom.style as u32),
             ],
             radii: [
-                LayerSize::from_untyped(&radius.top_left),
-                LayerSize::from_untyped(&radius.top_right),
-                LayerSize::from_untyped(&radius.bottom_right),
-                LayerSize::from_untyped(&radius.bottom_left),
+                radius.top_left,
+                radius.top_right,
+                radius.bottom_right,
+                radius.bottom_left,
             ],
         };
 

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -4,13 +4,13 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use channel::{self, MsgSender, PayloadHelperMethods, PayloadSender};
-use euclid::{Point2D, Size2D};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::cell::Cell;
 use {ApiMsg, ColorF, DisplayListBuilder, Epoch};
 use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLocation, ServoScrollRootId};
 use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
+use {DeviceIntSize, LayoutPoint, LayoutSize, WorldPoint};
 use VRCompositorCommand;
 
 impl RenderApiSender {
@@ -157,7 +157,7 @@ impl RenderApi {
     pub fn set_root_display_list(&self,
                                  background_color: ColorF,
                                  epoch: Epoch,
-                                 viewport_size: Size2D<f32>,
+                                 viewport_size: LayoutSize,
                                  builder: DisplayListBuilder) {
         let pipeline_id = builder.pipeline_id;
         let (display_list, auxiliary_lists) = builder.finalize();
@@ -180,13 +180,13 @@ impl RenderApi {
     ///
     /// Webrender looks for the layer closest to the user
     /// which has `ScrollPolicy::Scrollable` set.
-    pub fn scroll(&self, scroll_location: ScrollLocation, cursor: Point2D<f32>, phase: ScrollEventPhase) {
+    pub fn scroll(&self, scroll_location: ScrollLocation, cursor: WorldPoint, phase: ScrollEventPhase) {
         let msg = ApiMsg::Scroll(scroll_location, cursor, phase);
         self.api_sender.send(msg).unwrap();
     }
 
     pub fn scroll_layers_with_scroll_root_id(&self,
-                                             new_scroll_origin: Point2D<f32>,
+                                             new_scroll_origin: LayoutPoint,
                                              pipeline_id: PipelineId,
                                              scroll_root_id: ServoScrollRootId) {
         let msg = ApiMsg::ScrollLayersWithScrollId(new_scroll_origin, pipeline_id, scroll_root_id);
@@ -199,8 +199,8 @@ impl RenderApi {
     }
 
     /// Translates a point from viewport coordinates to layer space
-    pub fn translate_point_to_layer_space(&self, point: &Point2D<f32>)
-                                          -> (Point2D<f32>, PipelineId) {
+    pub fn translate_point_to_layer_space(&self, point: &WorldPoint)
+                                          -> (LayoutPoint, PipelineId) {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::TranslatePointToLayerSpace(*point, tx);
         self.api_sender.send(msg).unwrap();
@@ -214,7 +214,7 @@ impl RenderApi {
         rx.recv().unwrap()
     }
 
-    pub fn request_webgl_context(&self, size: &Size2D<i32>, attributes: GLContextAttributes)
+    pub fn request_webgl_context(&self, size: &DeviceIntSize, attributes: GLContextAttributes)
                                  -> Result<(WebGLContextId, GLLimits), String> {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
@@ -222,7 +222,7 @@ impl RenderApi {
         rx.recv().unwrap()
     }
 
-    pub fn resize_webgl_context(&self, context_id: WebGLContextId, size: &Size2D<i32>) {
+    pub fn resize_webgl_context(&self, context_id: WebGLContextId, size: &DeviceIntSize) {
         let msg = ApiMsg::ResizeWebGLContext(context_id, *size);
         self.api_sender.send(msg).unwrap();
     }

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -3,55 +3,55 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use display_list::AuxiliaryListsBuilder;
-use euclid::{Point2D, Rect, Size2D};
 use {BorderRadius, BorderDisplayItem, ClipRegion, ColorF, ComplexClipRegion};
 use {FontKey, ImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
 use {ImageMask, ItemRange};
+use {LayoutSize, LayoutPoint, LayoutRect};
 
 impl BorderDisplayItem {
-    pub fn top_left_inner_radius(&self) -> Size2D<f32> {
-        Size2D::new((self.radius.top_left.width - self.left.width).max(0.0),
-                    (self.radius.top_left.height - self.top.width).max(0.0))
+    pub fn top_left_inner_radius(&self) -> LayoutSize {
+        LayoutSize::new((self.radius.top_left.width - self.left.width).max(0.0),
+                     (self.radius.top_left.height - self.top.width).max(0.0))
     }
 
-    pub fn top_right_inner_radius(&self) -> Size2D<f32> {
-        Size2D::new((self.radius.top_right.width - self.right.width).max(0.0),
-                    (self.radius.top_right.height - self.top.width).max(0.0))
+    pub fn top_right_inner_radius(&self) -> LayoutSize {
+        LayoutSize::new((self.radius.top_right.width - self.right.width).max(0.0),
+                     (self.radius.top_right.height - self.top.width).max(0.0))
     }
 
-    pub fn bottom_left_inner_radius(&self) -> Size2D<f32> {
-        Size2D::new((self.radius.bottom_left.width - self.left.width).max(0.0),
-                    (self.radius.bottom_left.height - self.bottom.width).max(0.0))
+    pub fn bottom_left_inner_radius(&self) -> LayoutSize {
+        LayoutSize::new((self.radius.bottom_left.width - self.left.width).max(0.0),
+                     (self.radius.bottom_left.height - self.bottom.width).max(0.0))
     }
 
-    pub fn bottom_right_inner_radius(&self) -> Size2D<f32> {
-        Size2D::new((self.radius.bottom_right.width - self.right.width).max(0.0),
-                    (self.radius.bottom_right.height - self.bottom.width).max(0.0))
+    pub fn bottom_right_inner_radius(&self) -> LayoutSize {
+        LayoutSize::new((self.radius.bottom_right.width - self.right.width).max(0.0),
+                     (self.radius.bottom_right.height - self.bottom.width).max(0.0))
     }
 }
 
 impl BorderRadius {
     pub fn zero() -> BorderRadius {
         BorderRadius {
-            top_left: Size2D::new(0.0, 0.0),
-            top_right: Size2D::new(0.0, 0.0),
-            bottom_left: Size2D::new(0.0, 0.0),
-            bottom_right: Size2D::new(0.0, 0.0),
+            top_left: LayoutSize::new(0.0, 0.0),
+            top_right: LayoutSize::new(0.0, 0.0),
+            bottom_left: LayoutSize::new(0.0, 0.0),
+            bottom_right: LayoutSize::new(0.0, 0.0),
         }
     }
 
     pub fn uniform(radius: f32) -> BorderRadius {
         BorderRadius {
-            top_left: Size2D::new(radius, radius),
-            top_right: Size2D::new(radius, radius),
-            bottom_left: Size2D::new(radius, radius),
-            bottom_right: Size2D::new(radius, radius),
+            top_left: LayoutSize::new(radius, radius),
+            top_right: LayoutSize::new(radius, radius),
+            bottom_left: LayoutSize::new(radius, radius),
+            bottom_right: LayoutSize::new(radius, radius),
         }
     }
 }
 
 impl ClipRegion {
-    pub fn new(rect: &Rect<f32>,
+    pub fn new(rect: &LayoutRect,
                complex: Vec<ComplexClipRegion>,
                image_mask: Option<ImageMask>,
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
@@ -63,7 +63,7 @@ impl ClipRegion {
         }
     }
 
-    pub fn simple(rect: &Rect<f32>) -> ClipRegion {
+    pub fn simple(rect: &LayoutRect) -> ClipRegion {
         ClipRegion {
             main: *rect,
             complex: ItemRange::empty(),
@@ -98,7 +98,7 @@ impl ColorF {
 
 impl ComplexClipRegion {
     /// Create a new complex clip region.
-    pub fn new(rect: Rect<f32>, radii: BorderRadius) -> ComplexClipRegion {
+    pub fn new(rect: LayoutRect, radii: BorderRadius) -> ComplexClipRegion {
         ComplexClipRegion {
             rect: rect,
             radii: radii,
@@ -107,7 +107,7 @@ impl ComplexClipRegion {
 
     //TODO: move to `util` module?
     /// Return a maximum aligned rectangle that is fully inside the clip region.
-    pub fn get_inner_rect(&self) -> Option<Rect<f32>> {
+    pub fn get_inner_rect(&self) -> Option<LayoutRect> {
         let k = 0.3; //roughly higher than `1.0 - sqrt(0.5)`
         let xl = self.rect.origin.x +
             k * self.radii.top_left.width.max(self.radii.bottom_left.width);
@@ -118,7 +118,7 @@ impl ComplexClipRegion {
         let yb = self.rect.origin.y + self.rect.size.height -
             k * self.radii.bottom_left.height.max(self.radii.bottom_right.height);
         if xl <= xr && yt <= yb {
-            Some(Rect::new(Point2D::new(xl, yt), Size2D::new(xr-xl, yb-yt)))
+            Some(LayoutRect::new(LayoutPoint::new(xl, yt), LayoutSize::new(xr-xl, yb-yt)))
         } else {
             None
         }

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use display_list::AuxiliaryListsBuilder;
-use euclid::{Matrix4D, Rect};
 use {FilterOp, MixBlendMode, ScrollPolicy, StackingContext};
+use {LayoutTransform, LayoutRect};
 
 impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
-               bounds: Rect<f32>,
+               bounds: LayoutRect,
                z_index: i32,
-               transform: &Matrix4D<f32>,
-               perspective: &Matrix4D<f32>,
+               transform: &LayoutTransform,
+               perspective: &LayoutTransform,
                mix_blend_mode: MixBlendMode,
                filters: Vec<FilterOp>,
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -9,7 +9,6 @@ use app_units::Au;
 use channel::{PayloadSender, MsgSender};
 #[cfg(feature = "nightly")]
 use core::nonzero::NonZero;
-use euclid::{Matrix4D, Point2D, Rect, Size2D};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::sync::Arc;
 
@@ -42,17 +41,17 @@ pub enum ApiMsg {
     SetRootDisplayList(ColorF,
                        Epoch,
                        PipelineId,
-                       Size2D<f32>,
+                       LayoutSize,
                        BuiltDisplayListDescriptor,
                        AuxiliaryListsDescriptor),
     SetRootPipeline(PipelineId),
-    Scroll(ScrollLocation, Point2D<f32>, ScrollEventPhase),
-    ScrollLayersWithScrollId(Point2D<f32>, PipelineId, ServoScrollRootId),
+    Scroll(ScrollLocation, WorldPoint, ScrollEventPhase),
+    ScrollLayersWithScrollId(LayoutPoint, PipelineId, ServoScrollRootId),
     TickScrollingBounce,
-    TranslatePointToLayerSpace(Point2D<f32>, MsgSender<(Point2D<f32>, PipelineId)>),
+    TranslatePointToLayerSpace(WorldPoint, MsgSender<(LayoutPoint, PipelineId)>),
     GetScrollLayerState(MsgSender<Vec<ScrollLayerState>>),
-    RequestWebGLContext(Size2D<i32>, GLContextAttributes, MsgSender<Result<(WebGLContextId, GLLimits), String>>),
-    ResizeWebGLContext(WebGLContextId, Size2D<i32>),
+    RequestWebGLContext(DeviceIntSize, GLContextAttributes, MsgSender<Result<(WebGLContextId, GLLimits), String>>),
+    ResizeWebGLContext(WebGLContextId, DeviceIntSize),
     WebGLCommand(WebGLContextId, WebGLCommand),
     GenerateFrame,
     // WebVR commands that must be called in the WebGL render thread.
@@ -98,10 +97,10 @@ pub struct BorderDisplayItem {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BorderRadius {
-    pub top_left: Size2D<f32>,
-    pub top_right: Size2D<f32>,
-    pub bottom_left: Size2D<f32>,
-    pub bottom_right: Size2D<f32>,
+    pub top_left: LayoutSize,
+    pub top_right: LayoutSize,
+    pub bottom_left: LayoutSize,
+    pub bottom_right: LayoutSize,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -134,8 +133,8 @@ pub enum BoxShadowClipMode {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BoxShadowDisplayItem {
-    pub box_bounds: Rect<f32>,
-    pub offset: Point2D<f32>,
+    pub box_bounds: LayoutRect,
+    pub offset: LayoutPoint,
     pub color: ColorF,
     pub blur_radius: f32,
     pub spread_radius: f32,
@@ -176,13 +175,13 @@ known_heap_size!(0, ColorF);
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageMask {
     pub image: ImageKey,
-    pub rect: Rect<f32>,
+    pub rect: LayoutRect,
     pub repeat: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ClipRegion {
-    pub main: Rect<f32>,
+    pub main: LayoutRect,
     pub complex: ItemRange,
     pub image_mask: Option<ImageMask>,
 }
@@ -190,7 +189,7 @@ pub struct ClipRegion {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.
-    pub rect: Rect<f32>,
+    pub rect: LayoutRect,
     /// Border radii of this rectangle.
     pub radii: BorderRadius,
 }
@@ -198,7 +197,7 @@ pub struct ComplexClipRegion {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
-    pub rect: Rect<f32>,
+    pub rect: LayoutRect,
     pub clip: ClipRegion,
 }
 
@@ -275,8 +274,8 @@ pub struct GlyphInstance {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GradientDisplayItem {
-    pub start_point: Point2D<f32>,
-    pub end_point: Point2D<f32>,
+    pub start_point: LayoutPoint,
+    pub end_point: LayoutPoint,
     pub stops: ItemRange,
 }
 
@@ -295,7 +294,7 @@ pub struct PushStackingContextDisplayItem {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PushScrollLayerItem {
-    pub content_size: Size2D<f32>,
+    pub content_size: LayoutSize,
     pub id: ScrollLayerId,
 }
 
@@ -310,8 +309,8 @@ pub struct IdNamespace(pub u32);
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageDisplayItem {
     pub image_key: ImageKey,
-    pub stretch_size: Size2D<f32>,
-    pub tile_spacing: Size2D<f32>,
+    pub stretch_size: LayoutSize,
+    pub tile_spacing: LayoutSize,
     pub image_rendering: ImageRendering,
 }
 
@@ -424,7 +423,7 @@ pub struct RenderApiSender {
 pub trait RenderNotifier: Send {
     fn new_frame_ready(&mut self);
     fn new_scroll_frame_ready(&mut self, composite_needed: bool);
-    fn pipeline_size_changed(&mut self, pipeline_id: PipelineId, size: Option<Size2D<f32>>);
+    fn pipeline_size_changed(&mut self, pipeline_id: PipelineId, size: Option<LayoutSize>);
 }
 
 // Trait to allow dispatching functions to a specific thread or event loop.
@@ -478,7 +477,7 @@ pub enum ScrollLayerInfo {
 pub struct ScrollLayerState {
     pub pipeline_id: PipelineId,
     pub scroll_root_id: ServoScrollRootId,
-    pub scroll_offset: Point2D<f32>,
+    pub scroll_offset: LayoutPoint,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -490,7 +489,7 @@ pub enum ScrollPolicy {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum ScrollLocation {
     /// Scroll by a certain amount.
-    Delta(Point2D<f32>), 
+    Delta(LayoutPoint), 
     /// Scroll to very top of element.
     Start,
     /// Scroll to very bottom of element. 
@@ -520,10 +519,10 @@ pub enum SpecificDisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StackingContext {
     pub scroll_policy: ScrollPolicy,
-    pub bounds: Rect<f32>,
+    pub bounds: LayoutRect,
     pub z_index: i32,
-    pub transform: Matrix4D<f32>,
-    pub perspective: Matrix4D<f32>,
+    pub transform: LayoutTransform,
+    pub perspective: LayoutTransform,
     pub mix_blend_mode: MixBlendMode,
     pub filters: ItemRange,
 }

--- a/webrender_traits/src/units.rs
+++ b/webrender_traits/src/units.rs
@@ -32,6 +32,15 @@ pub type DeviceRect = TypedRect<f32, DevicePixel>;
 pub type DevicePoint = TypedPoint2D<f32, DevicePixel>;
 pub type DeviceSize = TypedSize2D<f32, DevicePixel>;
 
+/// Geometry in a stacking context's local coordinate space (logical pixels).
+///
+/// For now layout pixels are equivalent to layer pixels, but it may change.
+pub type LayoutPixel = LayerPixel;
+
+pub type LayoutRect = LayerRect;
+pub type LayoutPoint = LayerPoint;
+pub type LayoutSize = LayerSize;
+
 /// Geometry in a layer's local coordinate space (logical pixels).
 #[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LayerPixel;
@@ -65,6 +74,7 @@ pub type WorldSize = TypedSize2D<f32, WorldPixel>;
 pub type WorldPoint4D = TypedPoint4D<f32, WorldPixel>;
 
 
+pub type LayoutTransform = TypedMatrix4D<f32, LayoutPixel, LayoutPixel>;
 pub type LayerTransform = TypedMatrix4D<f32, LayerPixel, LayerPixel>;
 pub type LayerToScrollTransform = TypedMatrix4D<f32, LayerPixel, ScrollLayerPixel>;
 pub type ScrollToLayerTransform = TypedMatrix4D<f32, ScrollLayerPixel, LayerPixel>;
@@ -80,3 +90,4 @@ pub fn device_length(value: f32, device_pixel_ratio: f32) -> DeviceIntLength {
 pub fn as_scroll_parent_rect(rect: &LayerRect) -> ScrollLayerRect {
     ScrollLayerRect::from_untyped(&rect.to_untyped())
 }
+

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -1,7 +1,6 @@
 extern crate yaml_rust;
 
 use app_units::Au;
-use euclid::{Point2D, Size2D, Rect, Matrix4D};
 use image::{ColorType, save_buffer};
 use std::borrow::BorrowMut;
 use std::cell::Cell;
@@ -10,7 +9,6 @@ use std::collections::hash_map::Entry;
 use std::fs;
 use std::fs::File;
 use std::io::{Cursor, Read, Write};
-use std::slice;
 use std::path::{Path, PathBuf};
 use webrender;
 use webrender_traits::*;
@@ -69,7 +67,7 @@ impl JsonFrameWriter {
                                          _: &ColorF,
                                          _: &Epoch,
                                          _: &PipelineId,
-                                         _: &Size2D<f32>,
+                                         _: &LayoutSize,
                                          display_list: &BuiltDisplayListDescriptor,
                                          auxiliary_lists: &AuxiliaryListsDescriptor)
     {

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -26,7 +26,6 @@ extern crate dwrote;
 #[cfg(target_os = "linux")]
 extern crate font_loader;
 
-use euclid::Size2D;
 use gleam::gl;
 use glutin::{ElementState, VirtualKeyCode};
 use std::path::PathBuf;
@@ -76,7 +75,7 @@ impl ThingKind {
     }
 }
 
-fn make_window(size: Size2D<u32>,
+fn make_window(size: DeviceUintSize,
                dp_ratio: Option<f32>,
                vsync: bool)
                -> glutin::Window
@@ -122,8 +121,8 @@ fn main() {
         let x = s.find('x').expect("Size must be specified exactly as widthxheight");
         let w = s[0..x].parse::<u32>().expect("Invalid size width");
         let h = s[x+1..].parse::<u32>().expect("Invalid size height");
-        Size2D::new(w, h)
-    }).unwrap_or(Size2D::<u32>::new(1920, 1080));
+        DeviceUintSize::new(w, h)
+    }).unwrap_or(DeviceUintSize::new(1920, 1080));
 
     let mut window = make_window(size, dp_ratio, args.is_present("vsync"));
     let dp_ratio = dp_ratio.unwrap_or(window.hidpi_factor());
@@ -153,7 +152,7 @@ fn main() {
     for _ in 0..queue_frames {
         let thing = thing.thing();
         let (width, height) = window.get_inner_size().unwrap();
-        let dim = Size2D::new(width, height);
+        let dim = DeviceUintSize::new(width, height);
         wrench.update(dim);
 
         let frame_num = thing.do_frame(&mut wrench);
@@ -187,7 +186,7 @@ fn main() {
         match event {
             glutin::Event::Awakened => {
                 let (width, height) = window.get_inner_size().unwrap();
-                let dim = Size2D::new(width, height);
+                let dim = DeviceUintSize::new(width, height);
                 wrench.update(dim);
 
                 let frame_num = thing.do_frame(&mut wrench);

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -4,7 +4,6 @@
 
 use app_units::Au;
 use clap;
-use euclid::{Size2D, Point2D, Rect, Matrix4D};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -87,11 +86,11 @@ impl YamlFrameReader {
 
         let bounds_raws = item["bounds"].as_vec_f32().unwrap();
         let bounds = if bounds_raws.len() == 2 {
-            Rect::new(Point2D::new(bounds_raws[0], bounds_raws[1]),
-                      image_dims)
+            LayoutRect::new(LayoutPoint::new(bounds_raws[0], bounds_raws[1]),
+                            image_dims)
         } else if bounds_raws.len() == 4 {
-            Rect::new(Point2D::new(bounds_raws[0], bounds_raws[1]),
-                      Size2D::new(bounds_raws[2], bounds_raws[3]))
+            LayoutRect::new(LayoutPoint::new(bounds_raws[0], bounds_raws[1]),
+                            LayoutSize::new(bounds_raws[2], bounds_raws[3]))
         } else {
             panic!("image expected 2 or 4 values in bounds, got '{:?}'", item["bounds"]);
         };
@@ -101,7 +100,7 @@ impl YamlFrameReader {
         let stretch_size = item["stretch_size"].as_size()
             .unwrap_or(image_dims);
         let tile_spacing = item["tile_spacing"].as_size()
-            .unwrap_or(Size2D::new(0.0, 0.0));
+            .unwrap_or(LayoutSize::new(0.0, 0.0));
         let rendering = match item["rendering"].as_str() {
             Some("auto") | None => ImageRendering::Auto,
             Some("crisp_edges") => ImageRendering::CrispEdges,
@@ -136,7 +135,7 @@ impl YamlFrameReader {
         let (glyphs, rect) = if item["text"].is_badvalue() {
             // if glyphs are specified, then the glyph positions can have the
             // origin baked in.
-            let origin = item["origin"].as_point().unwrap_or(Point2D::new(0.0, 0.0));
+            let origin = item["origin"].as_point().unwrap_or(LayoutPoint::new(0.0, 0.0));
             let glyph_indices = item["glyphs"].as_vec_u32().unwrap();
             let glyph_offsets = item["offsets"].as_vec_f32().unwrap();
             assert!(glyph_offsets.len() == glyph_indices.len() * 2);
@@ -171,7 +170,7 @@ impl YamlFrameReader {
                 x = x + arg.1;
                 gi
             }).collect();
-            let rect = Rect::new(Point2D::new(0.0, 0.0), wrench.window_size_f32());
+            let rect = LayoutRect::new(LayoutPoint::new(0.0, 0.0), wrench.window_size_f32());
             (glyphs, rect)
         };
 
@@ -184,7 +183,7 @@ impl YamlFrameReader {
     pub fn add_display_list_items_from_yaml(&mut self, wrench: &mut Wrench, yaml: &Yaml) {
         let full_clip_region = {
             let win_size = wrench.window_size_f32();
-            self.builder().new_clip_region(&Rect::new(Point2D::new(0.0, 0.0), win_size),
+            self.builder().new_clip_region(&LayoutRect::new(LayoutPoint::new(0.0, 0.0), win_size),
                                            Vec::new(), None)
         };
 
@@ -224,11 +223,11 @@ impl YamlFrameReader {
     }
 
     pub fn add_stacking_context_from_yaml(&mut self, wrench: &mut Wrench, yaml: &Yaml) {
-        let bounds = yaml["bounds"].as_rect().unwrap_or(Rect::new(Point2D::new(0.0, 0.0), wrench.window_size_f32()));
+        let bounds = yaml["bounds"].as_rect().unwrap_or(LayoutRect::new(LayoutPoint::new(0.0, 0.0), wrench.window_size_f32()));
         let overflow_bounds = yaml["overflow"].as_rect().unwrap_or(bounds);
         let z_index = yaml["z_index"].as_i64().unwrap_or(0);
-        let transform = yaml["transform"].as_matrix4d().unwrap_or(Matrix4D::identity());
-        let perspective = yaml["perspective"].as_matrix4d().unwrap_or(Matrix4D::identity());
+        let transform = yaml["transform"].as_matrix4d().unwrap_or(LayoutTransform::identity());
+        let perspective = yaml["perspective"].as_matrix4d().unwrap_or(LayoutTransform::identity());
 
         // FIXME handle these
         let mix_blend_mode = MixBlendMode::Normal;

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1,7 +1,6 @@
 extern crate yaml_rust;
 
 use app_units::Au;
-use euclid::{Point2D, Size2D, Rect, Matrix4D};
 use image::{ColorType, save_buffer};
 use std::borrow::BorrowMut;
 use std::cell::Cell;
@@ -63,16 +62,16 @@ fn color_node(parent: &mut Table, key: &str, value: ColorF) {
     yaml_node(parent, key, Yaml::String(color_to_string(value)));
 }
 
-fn size_node(parent: &mut Table, key: &str, value: &Size2D<f32>) {
+fn size_node(parent: &mut Table, key: &str, value: &LayoutSize) {
     yaml_node(parent, key, Yaml::String(format!("{} {}", value.width, value.height)));
 }
 
-fn rect_node(parent: &mut Table, key: &str, value: &Rect<f32>) {
+fn rect_node(parent: &mut Table, key: &str, value: &LayoutRect) {
     yaml_node(parent, key, Yaml::String(format!("{} {} {} {}", value.origin.x, value.origin.y,
                                                                value.size.width, value.size.height)));
 }
 
-fn matrix4d_node(parent: &mut Table, key: &str, value: &Matrix4D<f32>) {
+fn matrix4d_node(parent: &mut Table, key: &str, value: &LayoutTransform) {
     yaml_node(parent, key, Yaml::String(format!("{} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}",
                                                 value.m11, value.m12, value.m13, value.m14,
                                                 value.m21, value.m22, value.m23, value.m24,
@@ -145,10 +144,10 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
     // scroll_policy
     rect_node(parent, "bounds", &sc.bounds);
     i32_node(parent, "z_index", sc.z_index);
-    if sc.transform != Matrix4D::<f32>::identity() {
+    if sc.transform != LayoutTransform::identity() {
         matrix4d_node(parent, "transform", &sc.transform);
     }
-    if sc.perspective != Matrix4D::<f32>::identity() {
+    if sc.perspective != LayoutTransform::identity() {
         matrix4d_node(parent, "perspective", &sc.perspective);
     }
     // mix_blend_mode
@@ -219,7 +218,7 @@ impl YamlFrameWriter {
                                          _: &ColorF,
                                          _: &Epoch,
                                          _: &PipelineId,
-                                         _: &Size2D<f32>,
+                                         _: &LayoutSize,
                                          display_list: &BuiltDisplayListDescriptor,
                                          auxiliary_lists: &AuxiliaryListsDescriptor)
     {

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::{Size2D, Point2D, Rect, Matrix4D};
 use std::str::FromStr;
 use app_units::Au;
 
@@ -14,10 +13,10 @@ pub trait YamlHelper {
     fn as_force_f32(&self) -> Option<f32>;
     fn as_vec_f32(&self) -> Option<Vec<f32>>;
     fn as_vec_u32(&self) -> Option<Vec<u32>>;
-    fn as_rect(&self) -> Option<Rect<f32>>;
-    fn as_size(&self) -> Option<Size2D<f32>>;
-    fn as_point(&self) -> Option<Point2D<f32>>;
-    fn as_matrix4d(&self) -> Option<Matrix4D<f32>>;
+    fn as_rect(&self) -> Option<LayoutRect>;
+    fn as_size(&self) -> Option<LayoutSize>;
+    fn as_point(&self) -> Option<LayoutPoint>;
+    fn as_matrix4d(&self) -> Option<LayoutTransform>;
     fn as_colorf(&self) -> Option<ColorF>;
     fn as_complex_clip_rect(&self) -> Option<ComplexClipRegion>;
     fn as_clip_region(&self, &mut DisplayListBuilder) -> Option<ClipRegion>;
@@ -77,7 +76,7 @@ impl YamlHelper for Yaml {
         }
     }
 
-    fn as_rect(&self) -> Option<Rect<f32>> {
+    fn as_rect(&self) -> Option<LayoutRect> {
         if self.is_badvalue() {
             return None;
         }
@@ -86,10 +85,10 @@ impl YamlHelper for Yaml {
         if nums.len() != 4 {
             panic!("rect expected 4 float values, got {} instead ('{:?}')", nums.len(), self);
         }
-        Some(Rect::new(Point2D::new(nums[0], nums[1]), Size2D::new(nums[2], nums[3])))
+        Some(LayoutRect::new(LayoutPoint::new(nums[0], nums[1]), LayoutSize::new(nums[2], nums[3])))
     }
 
-    fn as_size(&self) -> Option<Size2D<f32>> {
+    fn as_size(&self) -> Option<LayoutSize> {
         if self.is_badvalue() {
             return None;
         }
@@ -98,10 +97,10 @@ impl YamlHelper for Yaml {
         if nums.len() != 2 {
             panic!("size expected 2 float values, got {} instead ('{:?}')", nums.len(), self);
         }
-        Some(Size2D::new(nums[0], nums[1]))
+        Some(LayoutSize::new(nums[0], nums[1]))
     }
 
-    fn as_point(&self) -> Option<Point2D<f32>> {
+    fn as_point(&self) -> Option<LayoutPoint> {
         if self.is_badvalue() {
             return None;
         }
@@ -110,10 +109,10 @@ impl YamlHelper for Yaml {
         if nums.len() != 2 {
             panic!("point expected 2 float values, got {} instead ('{:?}')", nums.len(), self);
         }
-        Some(Point2D::new(nums[0], nums[1]))
+        Some(LayoutPoint::new(nums[0], nums[1]))
     }
 
-    fn as_matrix4d(&self) -> Option<Matrix4D<f32>> {
+    fn as_matrix4d(&self) -> Option<LayoutTransform> {
         None
     }
 
@@ -146,23 +145,23 @@ impl YamlHelper for Yaml {
 
         let nums = self.as_vec_f32().unwrap();
         match nums.len() {
-            4 => Some(ComplexClipRegion::new(Rect::new(Point2D::new(nums[0], nums[1]), Size2D::new(nums[2], nums[3])),
+            4 => Some(ComplexClipRegion::new(LayoutRect::new(LayoutPoint::new(nums[0], nums[1]), LayoutSize::new(nums[2], nums[3])),
                                              BorderRadius::zero())),
-            5 => Some(ComplexClipRegion::new(Rect::new(Point2D::new(nums[0], nums[1]), Size2D::new(nums[2], nums[3])),
+            5 => Some(ComplexClipRegion::new(LayoutRect::new(LayoutPoint::new(nums[0], nums[1]), LayoutSize::new(nums[2], nums[3])),
                                              BorderRadius::uniform(nums[4]))),
-            8 => Some(ComplexClipRegion::new(Rect::new(Point2D::new(nums[0], nums[1]), Size2D::new(nums[2], nums[3])),
+            8 => Some(ComplexClipRegion::new(LayoutRect::new(LayoutPoint::new(nums[0], nums[1]), LayoutSize::new(nums[2], nums[3])),
                                              BorderRadius {
-                                                 top_left: Size2D::new(nums[4], nums[4]),
-                                                 top_right: Size2D::new(nums[5], nums[5]),
-                                                 bottom_left: Size2D::new(nums[6], nums[6]),
-                                                 bottom_right: Size2D::new(nums[7], nums[7]),
+                                                 top_left: LayoutSize::new(nums[4], nums[4]),
+                                                 top_right: LayoutSize::new(nums[5], nums[5]),
+                                                 bottom_left: LayoutSize::new(nums[6], nums[6]),
+                                                 bottom_right: LayoutSize::new(nums[7], nums[7]),
                                              })),
-            12 => Some(ComplexClipRegion::new(Rect::new(Point2D::new(nums[0], nums[1]), Size2D::new(nums[2], nums[3])),
+            12 => Some(ComplexClipRegion::new(LayoutRect::new(LayoutPoint::new(nums[0], nums[1]), LayoutSize::new(nums[2], nums[3])),
                                               BorderRadius {
-                                                  top_left: Size2D::new(nums[4], nums[5]),
-                                                  top_right: Size2D::new(nums[6], nums[7]),
-                                                  bottom_left: Size2D::new(nums[8], nums[9]),
-                                                  bottom_right: Size2D::new(nums[10], nums[11]),
+                                                  top_left: LayoutSize::new(nums[4], nums[5]),
+                                                  top_right: LayoutSize::new(nums[6], nums[7]),
+                                                  bottom_left: LayoutSize::new(nums[8], nums[9]),
+                                                  bottom_right: LayoutSize::new(nums[10], nums[11]),
                                               })),
             n => panic!("complex clip rect expected 4, 5, 8, or 12 floats; got {} instead at '{:?}'", n, self),
         }
@@ -183,7 +182,7 @@ impl YamlHelper for Yaml {
         }
 
         // otherwise it's an array of complex clip rects
-        let mut bounds = Rect::<f32>::zero();
+        let mut bounds = LayoutRect::zero();
         let mut clips = Vec::<ComplexClipRegion>::new();
 
         for item in self.as_vec().unwrap() {


### PR DESCRIPTION
Use strongly typed geometry in the public API. This changeset adds the LayoutPixel unit which is basically an alias to LayerPixel.
I think that it's best to keep the "Layer" terminology internal to webrender, and since the 1-1 correspondence between the api's layout pixels and internal layer pixels is somewhat coincidental, it will help to have separate names if things like async zoom introduce an actual difference between the two coordinate spaces (as it does in Gecko). Using an alias instead of a separate type comes from a mix of laziness (not having to cast from layout t layer pixels all over frame.rs) and the fact that currently layer and layout pixels are the same thing, but I'll add a separate unit if there is a preference for it.

I did not introduce ParentLayoutPixel. I don't know the API well enough yet to be sure whether some geometry is passed in a stacking context's parent coordinate space, but if so we should consider introducing a special unit for it, if only for the sake of proper documentation.

This PR is a lot easier to rebase than part 1 and is a breaking change to the public API, so it's fine to wait a bit if there are cross-crates changes that we want to coordinate before having to adapt servo to this (although it should be easy to do).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/602)
<!-- Reviewable:end -->
