### PR TITLE
Adding clear_method as a RendererOptions

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -108,6 +108,7 @@ fn main() {
         renderer_kind: webrender_traits::RendererKind::Native,
         debug: false,
         enable_subpixel_aa: false,
+        clear_method: webrender::CLEAR_ALL
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
         precache_shaders: true,
         renderer_kind: RendererKind::Native,
         enable_subpixel_aa: false,
+        clear_method: webrender::CLEAR_ALL
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -126,3 +126,4 @@ extern crate threadpool;
 
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{Renderer, RendererOptions};
+pub use renderer::{CLEAR_NONE, CLEAR_BACKGROUND, CLEAR_TILES, CLEAR_ALL};

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -688,7 +688,8 @@ impl Renderer {
         };
 
         let config = FrameBuilderConfig::new(options.enable_scrollbars,
-                                             options.enable_subpixel_aa);
+                                             options.enable_subpixel_aa,
+                                             options.clear_method);
 
         let debug = options.debug;
         let (device_pixel_ratio, enable_aa) = (options.device_pixel_ratio, options.enable_aa);
@@ -1461,8 +1462,10 @@ impl Renderer {
         // TODO(gw): Find a better solution for this?
         let viewport_size = DeviceIntSize::new(frame.viewport_size.width * self.device_pixel_ratio as i32,
                                                frame.viewport_size.height * self.device_pixel_ratio as i32);
-        let needs_clear = viewport_size.width < framebuffer_size.width as i32 ||
-                          viewport_size.height < framebuffer_size.height as i32;
+
+        let needs_clear = frame.clear_method.contains(CLEAR_TILES) &&
+                          (viewport_size.width < framebuffer_size.width as i32 ||
+                          viewport_size.height < framebuffer_size.height as i32);
 
         {
             let _ = GpuMarker::new("debug rectangles");
@@ -1536,7 +1539,7 @@ impl Renderer {
                      DeviceSize::new(framebuffer_size.width as f32, framebuffer_size.height as f32),
                      None)
                 } else {
-                    (true, frame.cache_size, Some(self.render_targets[pass_index]))
+                    (needs_clear, frame.cache_size, Some(self.render_targets[pass_index]))
                 };
 
                 for (target_index, target) in pass.targets.iter().enumerate() {
@@ -1548,7 +1551,6 @@ impl Renderer {
                                      &size,
                                      src_id,
                                      do_clear);
-
                 }
 
                 src_id = target_id;
@@ -1558,7 +1560,7 @@ impl Renderer {
         let _ = self.gpu_profile.add_marker(GPU_TAG_CLEAR_TILES);
 
         // Clear tiles with no items
-        if !frame.clear_tiles.is_empty() {
+        if !frame.clear_tiles.is_empty() && needs_clear {
             self.device.set_blend(false);
             let shader = self.tile_clear_shader.get(&mut self.device);
             let max_prim_items = self.max_clear_tiles;
@@ -1616,6 +1618,19 @@ pub trait ExternalImageHandler {
     fn release(&mut self, key: ExternalImageId);
 }
 
+/// TODO: A future improvement would be to allow for the ability
+/// to selectively clear the background / tiles as well. Alterations
+/// are necessary for the clear shader for this to occur however
+bitflags! {
+    pub flags ClearMethod: u8 {
+        const CLEAR_NONE  = 0b00000000,
+        const CLEAR_BACKGROUND = 0b00000001,
+        const CLEAR_TILES = 0b00000010,
+        const CLEAR_ALL = CLEAR_BACKGROUND.bits
+                        | CLEAR_TILES.bits,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct RendererOptions {
     pub device_pixel_ratio: f32,
@@ -1629,4 +1644,5 @@ pub struct RendererOptions {
     pub precache_shaders: bool,
     pub renderer_kind: RendererKind,
     pub enable_subpixel_aa: bool,
+    pub clear_method: ClearMethod
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -21,7 +21,7 @@ use prim_store::{GradientPrimitiveCpu, GradientPrimitiveGpu, GradientType};
 use prim_store::{PrimitiveCacheKey, TextRunPrimitiveGpu, TextRunPrimitiveCpu};
 use prim_store::{PrimitiveStore, GpuBlock16, GpuBlock32, GpuBlock64, GpuBlock128};
 use profiler::FrameProfileCounters;
-use renderer::BlendMode;
+use renderer::{BlendMode, ClearMethod};
 use resource_cache::ResourceCache;
 use std::cmp;
 use std::collections::{HashMap};
@@ -1644,14 +1644,17 @@ pub struct ClearTile {
 pub struct FrameBuilderConfig {
     pub enable_scrollbars: bool,
     pub enable_subpixel_aa: bool,
+    pub clear_method: ClearMethod,
 }
 
 impl FrameBuilderConfig {
     pub fn new(enable_scrollbars: bool,
-               enable_subpixel_aa: bool) -> FrameBuilderConfig {
+               enable_subpixel_aa: bool,
+               clear_method: ClearMethod) -> FrameBuilderConfig {
         FrameBuilderConfig {
             enable_scrollbars: enable_scrollbars,
             enable_subpixel_aa: enable_subpixel_aa,
+            clear_method: clear_method,
         }
     }
 }
@@ -1694,6 +1697,7 @@ pub struct Frame {
     // will use a callback to resolve these and
     // patch the data structures.
     pub deferred_resolves: Vec<DeferredResolve>,
+    pub clear_method: ClearMethod,
 }
 
 #[derive(Debug)]
@@ -2923,6 +2927,7 @@ impl FrameBuilder {
             gpu_geometry: self.prim_store.gpu_geometry.build(),
             gpu_resource_rects: self.prim_store.gpu_resource_rects.build(),
             deferred_resolves: deferred_resolves,
+            clear_method: self.config.clear_method
         }
     }
 }


### PR DESCRIPTION
This adds ClearMethod flags which can be used to select what type of method for clearing would like to be used during rendering, and adds an option to RendererOptions.

I went with flags vs just a boolean for clearing (yes / no) as I found there seemed to be different clears going on throughout the rendering (CLEAR_ALL, CLEAR_BACKGROUND, CLEAR_TILES, CLEAR_NONE).  However, I don't currently have a great reason on why you would choose to only clear the background and not do tile clearing. My need was for the CLEAR_NONE option, however I thought this might be more useful than just a boolean. Happy to reconsider this via someone that is more familiar with the current direction of the project.

[Issue Reference](https://github.com/servo/webrender/issues/601)

@nical  @kvark @glennw (tagging those that posted on the issue this far)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/606)
<!-- Reviewable:end -->
