### PR TITLE
delete flush notification api

### DIFF
--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -100,15 +100,6 @@ impl RenderApi {
         key
     }
 
-    /// Flushes all messages and will send a notification when the render
-    /// backend thread has finished processing all previous messages.
-    /// This is a temporary API And users should not expect this to be API
-    /// to exist in the future.
-    pub fn flush(&self) {
-        let msg = ApiMsg::Flush;
-        self.api_sender.send(msg).unwrap();
-    }
-
     /// Updates a specific image.
     ///
     /// Currently doesn't support changing dimensions or format by updating.

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -35,8 +35,6 @@ pub enum ApiMsg {
     /// Drops an image from the resource cache.
     DeleteImage(ImageKey),
     CloneApi(MsgSender<IdNamespace>),
-    // Flushes all messages
-    Flush,
     /// Supplies a new frame to WebRender.
     ///
     /// After receiving this message, WebRender will read the display list, followed by the
@@ -427,10 +425,6 @@ pub trait RenderNotifier: Send {
     fn new_frame_ready(&mut self);
     fn new_scroll_frame_ready(&mut self, composite_needed: bool);
     fn pipeline_size_changed(&mut self, pipeline_id: PipelineId, size: Option<Size2D<f32>>);
-}
-
-pub trait FlushNotifier: Send {
-    fn all_messages_flushed(&mut self);
 }
 
 // Trait to allow dispatching functions to a specific thread or event loop.


### PR DESCRIPTION
Since we use epochs for reftests like servo now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/611)
<!-- Reviewable:end -->
