### PR TITLE
Support dynamic changes to device_pixel_ratio.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -386,9 +386,7 @@ impl RenderBackend {
             webgl_context.unbind();
         }
 
-        self.frame.create(&self.scene,
-                          &mut new_pipeline_sizes,
-                          self.device_pixel_ratio);
+        self.frame.create(&self.scene, &mut new_pipeline_sizes);
 
         let mut updated_pipeline_sizes = HashMap::new();
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -329,7 +329,6 @@ pub struct Renderer {
     pending_texture_updates: Vec<TextureUpdateList>,
     pending_shader_updates: Vec<PathBuf>,
     current_frame: Option<RendererFrame>,
-    device_pixel_ratio: f32,
 
     // These are "cache shaders". These shaders are used to
     // draw intermediate results to cache targets. The results
@@ -459,9 +458,9 @@ impl Renderer {
         };
 
         let mut device = Device::new(options.resource_override_path.clone(),
-                                     options.device_pixel_ratio,
                                      Box::new(file_watch_handler));
-        device.begin_frame();
+        // device-pixel ratio doesn't matter here - we are just creating resources.
+        device.begin_frame(1.0);
 
         let max_ubo_size = device.get_capabilities().max_ubo_size;
         let max_ubo_vectors = max_ubo_size / 16;
@@ -724,7 +723,6 @@ impl Renderer {
             current_frame: None,
             pending_texture_updates: Vec::new(),
             pending_shader_updates: Vec::new(),
-            device_pixel_ratio: options.device_pixel_ratio,
             tile_clear_shader: tile_clear_shader,
             cs_box_shadow: cs_box_shadow,
             cs_text_run: cs_text_run,
@@ -895,7 +893,7 @@ impl Renderer {
                 }
 
                 profile_timers.cpu_time.profile(|| {
-                    self.device.begin_frame();
+                    self.device.begin_frame(frame.device_pixel_ratio);
                     self.gpu_profile.begin_frame();
                     let _ = self.gpu_profile.add_marker(GPU_TAG_INIT);
 
@@ -1474,8 +1472,8 @@ impl Renderer {
         // Some tests use a restricted viewport smaller than the main screen size.
         // Ensure we clear the framebuffer in these tests.
         // TODO(gw): Find a better solution for this?
-        let viewport_size = DeviceIntSize::new(frame.viewport_size.width * self.device_pixel_ratio as i32,
-                                               frame.viewport_size.height * self.device_pixel_ratio as i32);
+        let viewport_size = DeviceIntSize::new(frame.viewport_size.width * frame.device_pixel_ratio as i32,
+                                               frame.viewport_size.height * frame.device_pixel_ratio as i32);
         let needs_clear = viewport_size.width < framebuffer_size.width as i32 ||
                           viewport_size.height < framebuffer_size.height as i32;
 

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -230,8 +230,8 @@ pub struct TransformedRect {
 
 impl TransformedRect {
     pub fn new(rect: &LayerRect,
-           transform: &LayerToWorldTransform,
-           device_pixel_ratio: f32) -> TransformedRect {
+               transform: &LayerToWorldTransform,
+               device_pixel_ratio: f32) -> TransformedRect {
 
         let kind = if transform.can_losslessly_transform_and_perspective_project_a_2d_rect() {
             TransformedRectKind::AxisAligned


### PR DESCRIPTION
Ensures that the device pixel ratio isn't stored in any
structures permanently, and that any code that depends
on the value of the device pixel ratio is moved to sections
that are executed each render.

The idea is that the current device pixel ratio is stored
in the render backend, and this gets passed through the entire
pipeline each frame to the renderer.

In the future there will be an API provided to modify the
device pixel ratio, but for now it is still fixed to a single
value at init time.

This is prep work for supporting functionality such as zoom, and
moving the window between monitors with different device pixel ratios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/612)
<!-- Reviewable:end -->
