### PR TITLE
Fix for some new intermittent ref test failures.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -61,7 +61,7 @@ pub struct CacheItem {
     pub uv1: DevicePoint,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 pub struct RenderedGlyphKey {
     pub key: GlyphKey,
     pub render_mode: FontRenderMode,
@@ -737,6 +737,14 @@ fn spawn_glyph_cache_thread() -> (Sender<GlyphCacheMsg>, Receiver<GlyphCacheResu
                             result: glyph,
                         });
                     }
+                    // Ensure that the glyphs are always processed in the same
+                    // order for a given text run (since iterating a hash set doesn't
+                    // guarantee order). This can show up as very small float inaccuacry
+                    // differences in rasterizers due to the different coordinates
+                    // that text runs get associated with by the texture cache allocator.
+                    rasterized_glyphs.sort_by(|a, b| {
+                        a.key.cmp(&b.key)
+                    });
                     result_tx.send(GlyphCacheResultMsg::EndFrame(cache, rasterized_glyphs)).unwrap();
                 }
             }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -224,17 +224,17 @@ pub enum FilterOp {
     Sepia(f32),
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, Ord, PartialOrd)]
 pub struct FontKey(u32, u32);
 
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum FontRenderMode {
     Mono,
     Alpha,
     Subpixel,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
 pub struct GlyphKey {
     pub font_key: FontKey,
     // The font size is in *device* pixels, not logical pixels.


### PR DESCRIPTION
This ensures that text run glyphs are added to the texture cache
in the same order between runs, to remove a source of floating
point accuracy issues in the rasterizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/625)
<!-- Reviewable:end -->
