### PR TITLE
Fix default precision of `sampler2DArray`

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -3,6 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp sampler2DArray;
+#else
+precision mediump sampler2DArray;
+#endif
+
 #define PST_TOP_LEFT     0
 #define PST_TOP          1
 #define PST_TOP_RIGHT    2


### PR DESCRIPTION
This fixes the `no default precision defined for variable 'sCache'` error produced by Servo on Android.

Related: servo/servo#13154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/627)
<!-- Reviewable:end -->
