### PR TITLE
Fix a type mismatch in `cs_blur.vs.glsl`

### DIFF
--- a/webrender/res/cs_blur.vs.glsl
+++ b/webrender/res/cs_blur.vs.glsl
@@ -40,7 +40,7 @@ void main(void) {
                    local_rect.xy + local_rect.zw,
                    aPosition.xy);
 
-    vec2 texture_size = textureSize(sCache, 0).xy;
+    vec2 texture_size = vec2(textureSize(sCache, 0).xy);
     vUv.z = src_task.data1.x;
     vBlurRadius = int(task.data1.y);
     vSigma = task.data1.y * 0.5;


### PR DESCRIPTION
Similarly to #626.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/633)
<!-- Reviewable:end -->
