### PR TITLE
add ability to set weather the background should be cleared on RendererOptions

### DIFF
--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -119,6 +119,7 @@ fn main() {
         renderer_kind: webrender_traits::RendererKind::Native,
         debug: false,
         enable_subpixel_aa: false,
+        clear_background: true,
         clear_framebuffer: true,
         clear_empty_tiles: false,
         clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -85,6 +85,7 @@ fn main() {
         precache_shaders: true,
         renderer_kind: RendererKind::Native,
         enable_subpixel_aa: false,
+        clear_background: true,
         clear_framebuffer: true,
         clear_empty_tiles: false,
         clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -335,6 +335,7 @@ pub struct Renderer {
     notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
 
     enable_profiler: bool,
+    clear_background: bool,
     clear_framebuffer: bool,
     clear_empty_tiles: bool,
     clear_color: ColorF,
@@ -672,6 +673,7 @@ impl Renderer {
             profile_counters: RendererProfileCounters::new(),
             profiler: Profiler::new(),
             enable_profiler: options.enable_profiler,
+            clear_background: options.clear_background,
             clear_framebuffer: options.clear_framebuffer,
             clear_empty_tiles: options.clear_empty_tiles,
             clear_color: options.clear_color,
@@ -1376,7 +1378,7 @@ impl Renderer {
                      DeviceSize::new(framebuffer_size.width as f32, framebuffer_size.height as f32),
                      None)
                 } else {
-                    (true, frame.cache_size, Some(self.render_targets[pass_index]))
+                    (self.clear_background, frame.cache_size, Some(self.render_targets[pass_index]))
                 };
 
                 for (target_index, target) in pass.targets.iter().enumerate() {
@@ -1471,5 +1473,6 @@ pub struct RendererOptions {
     // TODO: this option ignores the clear color (always opaque white).
     pub clear_empty_tiles: bool,
     pub clear_framebuffer: bool,
+    pub clear_background: bool,
     pub clear_color: ColorF,
 }


### PR DESCRIPTION
Addition to https://github.com/servo/webrender/pull/605 to have the ability to selectively clear the background.

The above pr almost did everything for my use case with not wanting the main background to be cleared. Even though you can currently set the clear color as transparent, this is obviously not good enough. I need the ability to draw over a pre-existing context entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/655)
<!-- Reviewable:end -->
