### PR TITLE
Fix broken debug text in the profiler.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -295,6 +295,7 @@ pub struct PackedVertex {
 }
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct DebugFontVertex {
     pub x: f32,
     pub y: f32,
@@ -315,6 +316,7 @@ impl DebugFontVertex {
     }
 }
 
+#[repr(C)]
 pub struct DebugColorVertex {
     pub x: f32,
     pub y: f32,


### PR DESCRIPTION
The recent rustc update is more likely to re-order structures. This
change ensures that the vertex structures are marked as repr(C) so
that the fields are not re-ordered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/664)
<!-- Reviewable:end -->
