### PR TITLE
Don't overallocate data buffer size for windows fonts.

### DIFF
--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -123,18 +123,19 @@ impl FontContext {
         }
 
         let pixels = analysis.create_alpha_texture(tex_type, bounds);
-        let mut rgba_pixels = vec![0; pixels.len() * 4];
-
-        match render_mode.unwrap() {
+        let rgba_pixels = match render_mode.unwrap() {
             FontRenderMode::Mono => {
+                let mut rgba_pixels = vec![0; pixels.len() * 4];
                 for i in 0..pixels.len() {
                     rgba_pixels[i*4+0] = 0xff;
                     rgba_pixels[i*4+1] = 0xff;
                     rgba_pixels[i*4+2] = 0xff;
                     rgba_pixels[i*4+3] = pixels[i];
                 }
+                rgba_pixels
             }
             FontRenderMode::Alpha => {
+                let mut rgba_pixels = vec![0; pixels.len()/3 * 4];
                 for i in 0..pixels.len()/3 {
                     // TODO(vlad): we likely need to do something smarter
                     let alpha = (pixels[i*3+0] as u32 + pixels[i*3+0] as u32 + pixels[i*3+0] as u32) / 3;
@@ -143,16 +144,19 @@ impl FontContext {
                     rgba_pixels[i*4+2] = 0xff;
                     rgba_pixels[i*4+3] = alpha as u8;
                 }
+                rgba_pixels
             }
             FontRenderMode::Subpixel => {
+                let mut rgba_pixels = vec![0; pixels.len()/3 * 4];
                 for i in 0..pixels.len()/3 {
                     rgba_pixels[i*4+0] = pixels[i*3+0];
                     rgba_pixels[i*4+1] = pixels[i*3+1];
                     rgba_pixels[i*4+2] = pixels[i*3+2];
                     rgba_pixels[i*4+3] = 0xff;
                 }
+                rgba_pixels
             }
-        }
+        };
 
         (Some(dims), Some(RasterizedGlyph {
             width: dims.width,


### PR DESCRIPTION
Fixes #663. Buffer was overallocated in the grayscale AA case.  Not sure how I didn't catch this in testing, since I tested both grayscale AA and cleartype AA...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/667)
<!-- Reviewable:end -->
