### PR TITLE
Fix invalid precision qualifiers on Desktop OpenGL

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -3,10 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#if defined(GL_ES) && GL_ES == 1
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp sampler2DArray;
 #else
 precision mediump sampler2DArray;
+#endif
 #endif
 
 #define PST_TOP_LEFT     0


### PR DESCRIPTION
This patch fixes shader compile errors on AMD drivers; See [Servo issue #14621.](https://github.com/servo/servo/issues/14621)

The statement
`precision highp sampler2DArray;`
is invalid in GLSL versions prior to 4.40. Many OpenGL implementations let it pass, but it fails validation on AMD drivers. Shader compiler errors occur on both Linux and Windows.

Desktop OpenGL ignores `precision` statements like the one above. The GLSL specification mentions them to say they are ignored, and only exist for compatibility with OpenGL ES.