### PR TITLE
Add debug mode to visualize intermediate render targets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "dwrote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-loader 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -94,7 +94,7 @@ name = "cgl"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "gleam"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -647,7 +647,7 @@ dependencies = [
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1128,7 +1128,7 @@ dependencies = [
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1147,7 +1147,7 @@ dependencies = [
  "core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1199,7 +1199,7 @@ dependencies = [
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.11.0",
  "webrender_traits 0.11.0",
@@ -1211,7 +1211,7 @@ version = "0.1.0"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.11.0",
  "webrender_traits 0.11.0",
@@ -1294,7 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum gif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01c7c19a035de94bd7afbaa62c241aadfbdf1a70f560b348d2312eafa566ca16"
 "checksum gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d8edc81c5ae84605a62f5dac661a2313003b26d59839f81d47d46cf0f16a55"
-"checksum gleam 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b83402229bde9d923f0b92811be017f9df5946ee86f8647367b1e02bcf5c293"
+"checksum gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "6af023107aa969ccf8868a0304fead4b2f813c19aa9a6a243fddc041f3e51da5"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "06786fae66e7aa8464b3d8d3fb7a7c470f89d62ae511f9613ea7fbbeef61d680"
 "checksum glutin 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9ccb9cbbf1bc2599688293030c51a51aa9c860c37989179c3ed1f9fc51a11c"

--- a/replay/src/main.rs
+++ b/replay/src/main.rs
@@ -120,6 +120,7 @@ fn main() {
         enable_subpixel_aa: false,
         clear_framebuffer: true,
         clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
+        render_target_debug: false,
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
         enable_subpixel_aa: false,
         clear_framebuffer: true,
         clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
+        render_target_debug: false,
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/webrender/res/cs_clip_copy.fs.glsl
+++ b/webrender/res/cs_clip_copy.fs.glsl
@@ -4,5 +4,5 @@
 
 void main(void) {
     float alpha = texelFetch(sCache, ivec3(vClipMaskUv), 0).a;
-    oFragColor = vec4(1.0, 1.0, 1.0, alpha);
+    oFragColor = vec4(alpha, 0.0, 0.0, 1.0);
 }

--- a/webrender/res/cs_clip_image.fs.glsl
+++ b/webrender/res/cs_clip_image.fs.glsl
@@ -12,5 +12,5 @@ void main(void) {
     vec2 source_uv = clamped_mask_uv * vClipMaskUvRect.zw + vClipMaskUvRect.xy;
     float clip_alpha = texture(sMask, source_uv).r; //careful: texture has type A8
 
-    oFragColor = vec4(1.0, 1.0, 1.0, min(alpha, clip_alpha));
+    oFragColor = vec4(min(alpha, clip_alpha), 1.0, 1.0, 1.0);
 }

--- a/webrender/res/cs_clip_rectangle.fs.glsl
+++ b/webrender/res/cs_clip_rectangle.fs.glsl
@@ -40,5 +40,5 @@ void main(void) {
 
     float clip_alpha = rounded_rect(local_pos);
 
-    oFragColor = vec4(1.0, 1.0, 1.0, min(alpha, clip_alpha));
+    oFragColor = vec4(min(alpha, clip_alpha), 0.0, 0.0, 1.0);
 }

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -636,6 +636,6 @@ float do_clip() {
         vec4(vClipMaskUv.xy, vClipMaskUvBounds.zw));
     // check for the dummy bounds, which are given to the opaque objects
     return vClipMaskUvBounds.xy == vClipMaskUvBounds.zw ? 1.0:
-        all(inside) ? textureLod(sCache, vClipMaskUv, 0.0).a : 0.0;
+        all(inside) ? textureLod(sCache, vClipMaskUv, 0.0).r : 0.0;
 }
 #endif //WR_FRAGMENT_SHADER

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -43,8 +43,6 @@ pub struct ClipAddressRange {
     pub item_count: u32,
 }
 
-type ImageMaskIndex = u16;
-
 #[derive(Clone, Debug)]
 pub struct MaskCacheInfo {
     pub clip_range: ClipAddressRange,

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -172,6 +172,7 @@ impl Wrench {
             renderer_kind: RendererKind::Native,
             clear_framebuffer: true,
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
+            render_target_debug: false,
         };
 
         let (renderer, sender) = webrender::renderer::Renderer::new(opts);


### PR DESCRIPTION
Optionally blit the contents of any intermediate render targets to the bottom of the frame buffer, to allow visual debugging and inspection of render target contents and usage.

![rt-debug](https://cloud.githubusercontent.com/assets/2350882/21597018/45dd62ae-d18f-11e6-8137-eba4408dccd9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/672)
<!-- Reviewable:end -->
