### PR TITLE
Add RendererOptionsBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.11.0",
+ "webrender 0.11.1",
  "webrender_traits 0.11.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1201,7 +1201,7 @@ dependencies = [
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.11.0",
+ "webrender 0.11.1",
  "webrender_traits 0.11.0",
 ]
 
@@ -1213,7 +1213,7 @@ dependencies = [
  "euclid 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.11.0",
+ "webrender 0.11.1",
  "webrender_traits 0.11.0",
 ]
 

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -9,7 +9,7 @@ use app_units::Au;
 use gleam::gl;
 use std::path::PathBuf;
 use webrender_traits::{ColorF, Epoch, GlyphInstance};
-use webrender_traits::{ImageData, ImageFormat, PipelineId, RendererKind};
+use webrender_traits::{ImageData, ImageFormat, PipelineId};
 use webrender_traits::{LayoutSize, LayoutPoint, LayoutRect, LayoutTransform, DeviceUintSize};
 use std::fs::File;
 use std::io::Read;
@@ -74,19 +74,10 @@ fn main() {
     let (width, height) = window.get_inner_size().unwrap();
 
     let opts = webrender::RendererOptions {
-        device_pixel_ratio: 1.0,
         resource_override_path: res_path,
-        enable_aa: false,
-        enable_profiler: false,
-        enable_recording: false,
-        enable_scrollbars: false,
         debug: true,
         precache_shaders: true,
-        renderer_kind: RendererKind::Native,
-        enable_subpixel_aa: false,
-        clear_framebuffer: true,
-        clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
-        render_target_debug: false,
+        .. Default::default()
     };
 
     let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1495,3 +1495,23 @@ pub struct RendererOptions {
     pub clear_color: ColorF,
     pub render_target_debug: bool,
 }
+
+impl Default for RendererOptions {
+    fn default() -> RendererOptions {
+        RendererOptions {
+            device_pixel_ratio: 1.0,
+            resource_override_path: None,
+            enable_aa: false,
+            enable_profiler: false,
+            debug: false,
+            enable_recording: false,
+            enable_scrollbars: false,
+            precache_shaders: false,
+            renderer_kind: RendererKind::Native,
+            enable_subpixel_aa: false,
+            clear_framebuffer: true,
+            clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
+            render_target_debug: false,
+        }
+    }
+}

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -167,17 +167,10 @@ impl Wrench {
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dp_ratio,
             resource_override_path: shader_override_path,
-            enable_aa: false,
-            enable_profiler: false,
             enable_recording: save_type.is_some(),
-            enable_scrollbars: false,
             enable_subpixel_aa: subpixel_aa,
             debug: debug,
-            precache_shaders: false,
-            renderer_kind: RendererKind::Native,
-            clear_framebuffer: true,
-            clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
-            render_target_debug: false,
+            .. Default::default()
         };
 
         let (renderer, sender) = webrender::renderer::Renderer::new(opts);


### PR DESCRIPTION
Having to fix up dependent code whenever unrelated options are added/removed is annoying; so I made a builder.  Not required to use it so as to not break existing code (and I only updated the sample), but we can consider doing so in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/678)
<!-- Reviewable:end -->
