### PR TITLE
Free CacheTextureId's in Renderer but persist their TextureId.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -345,6 +345,7 @@ pub enum TextureUpdateOp {
     Create(u32, u32, ImageFormat, TextureFilter, RenderTargetMode, Option<Arc<Vec<u8>>>),
     Update(u32, u32, u32, u32, Arc<Vec<u8>>, Option<u32>),
     Grow(u32, u32, ImageFormat, TextureFilter, RenderTargetMode),
+    Free
 }
 
 pub type ExternalImageUpdateList = Vec<ExternalImageId>;

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -877,6 +877,10 @@ impl TextureCache {
                 None => {
                     // This is a standalone texture allocation. Just push it back onto the free
                     // list.
+                    self.pending_updates.push(TextureUpdate {
+                        id: item.texture_id,
+                        op: TextureUpdateOp::Free,
+                    });
                     self.cache_id_list.free(item.texture_id);
                 }
             }


### PR DESCRIPTION
Currently the TextureCache will free CacheTextureId's for standalone texture allocations. This isn't synced to Renderer::cache_texture_id_map, which will then hit an assert when the CacheTextureId is reused. (#676)

When we get a TextureUpdateOp::Create and detect that they're reusing a CacheTextureId, we should just reuse the existing TextureId. The cache_texture_id_map can then drop Option and be Vec<TextureId>.

For the TextureId's that haven't been reused yet, we should send a TextureUpdateOp::Free that notifies Renderer to free the texture memory of the TextureId. This wouldn't gl::delete_textures the TextureId, but just deinit the TextureId until it is reused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/682)
<!-- Reviewable:end -->
