### PR TITLE
Only rerun build.rs on changes to the res directory

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -38,6 +38,7 @@ fn main() {
     let shaders_file = Path::new(&out_dir).join("shaders.rs");
     let mut glsl_files = vec![];
 
+    println!("cargo:rerun-if-changed=res");
     let res_dir = Path::new("res");
     for entry in read_dir(res_dir).unwrap() {
         let entry = entry.unwrap();


### PR DESCRIPTION
Without this change, cargo will rebuild webrender anytime there are any changes in the directory structure. I noticed this because webrender was being rebuilt after opening files vim was creating .swp files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/683)
<!-- Reviewable:end -->
