### PR TITLE
Support non-square texture page sizes.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -848,7 +848,8 @@ impl RenderTarget {
             vertical_blurs: Vec::new(),
             horizontal_blurs: Vec::new(),
             page_allocator: TexturePage::new(CacheTextureId(0),
-                                             RENDERABLE_CACHE_SIZE as u32),
+                                             DeviceUintSize::new(RENDERABLE_CACHE_SIZE as u32,
+                                                                 RENDERABLE_CACHE_SIZE as u32)),
         }
     }
 


### PR DESCRIPTION
This will be taken advantage of in a follow up PR
that adjusts the intermediate render targets (which
use the texture page allocator) to be the same size
as the framebuffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/687)
<!-- Reviewable:end -->
