### PR TITLE
Add an opaque external event message (for use in Gecko).

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -349,8 +349,7 @@ impl RenderBackend {
                         }
                         ApiMsg::ExternalEvent(evt) => {
                             let mut notifier = self.notifier.lock();
-                            notifier.as_mut()
-                                    .unwrap()
+                            notifier.unwrap()
                                     .as_mut()
                                     .unwrap()
                                     .external_event(evt);

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -347,6 +347,14 @@ impl RenderBackend {
                                 frame_counter += 1;
                             }
                         }
+                        ApiMsg::ExternalEvent(evt) => {
+                            let mut notifier = self.notifier.lock();
+                            notifier.as_mut()
+                                    .unwrap()
+                                    .as_mut()
+                                    .unwrap()
+                                    .external_event(evt);
+                        }
                     }
                 }
                 Err(..) => {

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -12,6 +12,7 @@ use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLoca
 use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
 use {DeviceIntSize, LayoutPoint, LayoutSize, WorldPoint};
 use VRCompositorCommand;
+use ExternalEvent;
 
 impl RenderApiSender {
     pub fn new(api_sender: MsgSender<ApiMsg>,
@@ -239,6 +240,11 @@ impl RenderApi {
 
     pub fn send_vr_compositor_command(&self, context_id: WebGLContextId, command: VRCompositorCommand) {
         let msg = ApiMsg::VRCompositorCommand(context_id, command);
+        self.api_sender.send(msg).unwrap();
+    }
+
+    pub fn send_external_event(&self, evt: ExternalEvent) {
+        let msg = ApiMsg::ExternalEvent(evt);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -56,23 +56,23 @@ pub enum ApiMsg {
     GenerateFrame,
     // WebVR commands that must be called in the WebGL render thread.
     VRCompositorCommand(WebGLContextId, VRCompositorCommand),
-    // An opaque handle that must be passed to the render notifier. It is used by Gecko
-    // to forward gecko-specific messages to the render thread preserving the ordering
-    // within the other messages.
+    /// An opaque handle that must be passed to the render notifier. It is used by Gecko
+    /// to forward gecko-specific messages to the render thread preserving the ordering
+    /// within the other messages.
     ExternalEvent(ExternalEvent),
 }
 
+/// An opaque pointer-sized value.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ExternalEvent {
-    // An opaque pointer-sized value.
     raw: usize,
 }
 
 unsafe impl Send for ExternalEvent {}
 
 impl ExternalEvent {
-    pub fn new(raw: usize) -> Self { ExternalEvent { raw: raw } }
-    // Consume self to make it obvious that the callback should be forwarded only once.
+    pub fn from_raw(raw: usize) -> Self { ExternalEvent { raw: raw } }
+    /// Consumes self to make it obvious that the event should be forwarded only once.
     pub fn unwrap(self) -> usize { self.raw }
 }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -55,7 +55,25 @@ pub enum ApiMsg {
     WebGLCommand(WebGLContextId, WebGLCommand),
     GenerateFrame,
     // WebVR commands that must be called in the WebGL render thread.
-    VRCompositorCommand(WebGLContextId, VRCompositorCommand)
+    VRCompositorCommand(WebGLContextId, VRCompositorCommand),
+    // An opaque handle that must be passed to the render notifier. It is used by Gecko
+    // to forward gecko-specific messages to the render thread preserving the ordering
+    // within the other messages.
+    ExternalEvent(ExternalEvent),
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct ExternalEvent {
+    // An opaque pointer-sized value.
+    raw: usize,
+}
+
+unsafe impl Send for ExternalEvent {}
+
+impl ExternalEvent {
+    pub fn new(raw: usize) -> Self { ExternalEvent { raw: raw } }
+    // Consume self to make it obvious that the callback should be forwarded only once.
+    pub fn unwrap(self) -> usize { self.raw }
 }
 
 #[derive(Copy, Clone, Deserialize, Serialize, Debug)]
@@ -424,6 +442,7 @@ pub trait RenderNotifier: Send {
     fn new_frame_ready(&mut self);
     fn new_scroll_frame_ready(&mut self, composite_needed: bool);
     fn pipeline_size_changed(&mut self, pipeline_id: PipelineId, size: Option<LayoutSize>);
+    fn external_event(&mut self, _evt: ExternalEvent) { unimplemented!() }
 }
 
 // Trait to allow dispatching functions to a specific thread or event loop.


### PR DESCRIPTION
Gecko's WebRender integration needs to send a few gecko-specific messages to the render thread. These messages have to preserve their ordering with respect to the other WebRender messages such as set_root_display_list, so they have to go through the render backend thread along with the rest.

The simplest way I could find was to add a pointer-sized opaque handle that is to be passed to the RenderNotifier. Since gecko implements its own RenderNotifier we can let the meaning of the opaque handle be completely up to gecko and only have the render backend pass it along in order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/688)
<!-- Reviewable:end -->
