### PR TITLE
Add a ShutDown API message and RenderNotifier callback.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -348,15 +348,28 @@ impl RenderBackend {
                             }
                         }
                         ApiMsg::ExternalEvent(evt) => {
-                            let mut notifier = self.notifier.lock();
+                            let notifier = self.notifier.lock();
                             notifier.unwrap()
                                     .as_mut()
                                     .unwrap()
                                     .external_event(evt);
                         }
+                        ApiMsg::ShutDown => {
+                            let notifier = self.notifier.lock();
+                            notifier.unwrap()
+                                    .as_mut()
+                                    .unwrap()
+                                    .shut_down();
+                            break;
+                        }
                     }
                 }
                 Err(..) => {
+                    let notifier = self.notifier.lock();
+                    notifier.unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .shut_down();
                     break;
                 }
             }

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -248,6 +248,10 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
+    pub fn shut_down(&self) {
+        self.api_sender.send(ApiMsg::ShutDown).unwrap();
+    }
+
     #[inline]
     fn next_unique_id(&self) -> (u32, u32) {
         let IdNamespace(namespace) = self.id_namespace;

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -60,6 +60,7 @@ pub enum ApiMsg {
     /// to forward gecko-specific messages to the render thread preserving the ordering
     /// within the other messages.
     ExternalEvent(ExternalEvent),
+    ShutDown,
 }
 
 /// An opaque pointer-sized value.
@@ -443,6 +444,7 @@ pub trait RenderNotifier: Send {
     fn new_scroll_frame_ready(&mut self, composite_needed: bool);
     fn pipeline_size_changed(&mut self, pipeline_id: PipelineId, size: Option<LayoutSize>);
     fn external_event(&mut self, _evt: ExternalEvent) { unimplemented!() }
+    fn shut_down(&mut self) {}
 }
 
 // Trait to allow dispatching functions to a specific thread or event loop.


### PR DESCRIPTION
The bulk of the shutdown implementation is up to the program embedding WebRender. This new API message makes it possible to stop a render backend explicitly instead of waiting for an error to happen on the receiver.
r? @kvark @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/699)
<!-- Reviewable:end -->
