### PR TITLE
Don't generate a frame when calling set_root_pipeline

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -214,6 +214,10 @@ impl RenderBackend {
                             }
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
+                            if scene.pipeline_map.get(&pipeline_id).is_none() {
+                                return;
+                            }
+
                             let frame = profile_counters.total_time.profile(|| {
                                 self.scene.set_root_pipeline_id(pipeline_id);
 


### PR DESCRIPTION
The current API causes us generate an extra frame when setting
the root pipeline. I can't think of reason why this would be desirable
behaviour. Getting rid of the extra frame also makes things easier
for the reftesting code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/701)
<!-- Reviewable:end -->
