### PR TITLE
Avoid frame notification when root pipeline doesn't exist

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -214,9 +214,13 @@ impl RenderBackend {
                             }
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
-                            let frame = profile_counters.total_time.profile(|| {
-                                self.scene.set_root_pipeline_id(pipeline_id);
+                            self.scene.set_root_pipeline_id(pipeline_id);
 
+                            if self.scene.display_lists.get(&pipeline_id).is_none() {
+                                continue;
+                            }
+
+                            let frame = profile_counters.total_time.profile(|| {
                                 self.build_scene();
                                 self.render()
                             });


### PR DESCRIPTION
If we don't have a pipeline to draw don't try to draw it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/703)
<!-- Reviewable:end -->
