### PR TITLE
Add shader validation via ANGLE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "angle"
+version = "0.1.2"
+source = "git+https://github.com/servo/angle?branch=servo#3dd4940bd79697ebe52c83e164b8ab1c5c577924"
+dependencies = [
+ "cmake 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,7 @@ dependencies = [
 name = "webrender"
 version = "0.11.1"
 dependencies = [
+ "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1266,6 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e2b80445d331077679dfc6f3014f3e9ab7083e588423d35041d3fc017198189"
+"checksum angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "636ee56f12e31dbc11dc0a1ac6004f08b04e6e6595963716fc8130e90d4e04cf"
 "checksum bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fbba641f73d3e74a5431d4a6d9e42a70bcce76d466d796c852ba1db31ba41bc"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -30,6 +30,9 @@ threadpool = "1.3.2"
 webrender_traits = {path = "../webrender_traits", default-features = false}
 bitflags = "0.7"
 
+[dev-dependencies]
+angle = {git = "https://github.com/servo/angle", branch = "servo"}
+
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
 freetype = { version = "0.2", default-features = false }
 

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -1,0 +1,85 @@
+extern crate angle;
+#[macro_use]
+extern crate lazy_static;
+extern crate webrender;
+
+use angle::hl::{BuiltInResources, Output, ShaderSpec, ShaderValidator};
+
+include!(concat!(env!("OUT_DIR"), "/shaders.rs"));
+
+
+// from glslang
+const FRAGMENT_SHADER: u32 = 0x8B30;
+const VERTEX_SHADER: u32 = 0x8B31;
+
+
+#[test]
+fn validate_shaders() {
+    angle::hl::initialize().unwrap();
+
+    let shared_src = SHADERS.get("shared").unwrap();
+    let prim_shared_src = SHADERS.get("prim_shared").unwrap();
+    let clip_shared_src = SHADERS.get("clip_shared").unwrap();
+
+    for (filename, file_source) in SHADERS.iter() {
+        let is_prim = filename.starts_with("ps_");
+        let is_clip = filename.starts_with("cs_");
+        let is_vert = filename.ends_with(".vs");
+        let is_frag = filename.ends_with(".fs");
+        if !(is_prim ^ is_clip) || !(is_vert ^ is_frag) {
+            continue;
+        }
+
+
+        let base_filename = filename.splitn(2, '.').next().unwrap();
+        let mut shader_prefix = format!("#version 300 es\n
+            // Base shader: {}\n
+            #define WR_MAX_VERTEX_TEXTURE_WIDTH {}\n",
+            base_filename, webrender::renderer::MAX_VERTEX_TEXTURE_WIDTH);
+
+        if is_vert {
+            shader_prefix.push_str("#define WR_VERTEX_SHADER\n");
+        } else {
+            shader_prefix.push_str("#define WR_FRAGMENT_SHADER\n");
+        }
+
+        let mut build_configs = vec!["#define WR_FEATURE_TRANSFORM\n"];
+        if is_prim {
+            // the transform feature may be disabled for the prim shaders
+            build_configs.push("// WR_FEATURE_TRANSFORM disabled\n");
+        }
+
+        for config_prefix in build_configs {
+            let mut shader_source = String::new();
+            shader_source.push_str(shader_prefix.as_str());
+            shader_source.push_str(config_prefix);
+            shader_source.push_str(shared_src);
+            shader_source.push_str(prim_shared_src);
+            if is_clip {
+                shader_source.push_str(clip_shared_src);
+            }
+            if let Some(optional_src) = SHADERS.get(base_filename) {
+                shader_source.push_str(optional_src);
+            }
+            shader_source.push_str(file_source);
+
+
+            let gl_type = if is_vert { VERTEX_SHADER } else { FRAGMENT_SHADER };
+            let resources = BuiltInResources::default();
+            let validator = ShaderValidator::new(gl_type,
+                                                 ShaderSpec::Gles3,
+                                                 Output::Essl,
+                                                 &resources).unwrap();
+
+            match validator.compile_and_translate(&[&shader_source]) {
+                Ok(_) => {
+                    println!("Shader translated succesfully: {}", filename);
+                },
+                Err(_) => {
+                    panic!("Shader compilation failed: {}\n{}",
+                        filename, validator.info_log());
+                },
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds shader validation to `cargo test` via ANGLE (use `-- --nocapture` to see the output). Tested on desktop (x86_64, GeForce 210) and Odroid XU3 (armv7, Mali T628), all shaders passed. Please review the shader concatenation if it's correct; there are some base GLSL files (eg. `cs_blur.glsl`), I wonder if they should be included too?

Requires https://github.com/servo/angle/pull/17 to land first.

Fixes https://github.com/servo/webrender/issues/616 and https://github.com/servo/webrender/issues/665 (we could still add `glslang` though).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/713)
<!-- Reviewable:end -->
