### PR TITLE
Require v0.4.2 of core-graphics for use of kCGBitmapByteOrder32Little

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -37,5 +37,5 @@ freetype = {version = "0.1.2", default-features = false}
 dwrote = "0.1.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-graphics = "0.4.1"
+core-graphics = "0.4.2"
 core-text = "2.0"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/714)
<!-- Reviewable:end -->
