### PR TITLE
Publish a frame explicitly with RenderApi::generate_frame()

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -229,6 +229,7 @@ fn main() {
         LayoutSize::new(width as f32, height as f32),
         builder);
     api.set_root_pipeline(pipeline_id);
+    api.generate_frame();
 
     for event in window.wait_events() {
         renderer.update();

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -202,9 +202,16 @@ impl RenderBackend {
                                                              background_color,
                                                              viewport_size,
                                                              auxiliary_lists);
+                            self.build_scene();
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
                             self.scene.set_root_pipeline_id(pipeline_id);
+
+                            if self.scene.display_lists.get(&pipeline_id).is_none() {
+                                continue;
+                            }
+
+                            self.build_scene();
                         }
                         ApiMsg::Scroll(delta, cursor, move_phase) => {
                             let frame = profile_counters.total_time.profile(|| {
@@ -321,7 +328,6 @@ impl RenderBackend {
                         }
                         ApiMsg::GenerateFrame => {
                             let frame = profile_counters.total_time.profile(|| {
-                                self.build_scene();
                                 self.render()
                             });
                             if self.scene.root_pipeline_id.is_some() {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -205,10 +205,6 @@ impl RenderBackend {
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
                             self.scene.set_root_pipeline_id(pipeline_id);
-
-                            if self.scene.display_lists.get(&pipeline_id).is_none() {
-                                continue;
-                            }
                         }
                         ApiMsg::Scroll(delta, cursor, move_phase) => {
                             let frame = profile_counters.total_time.profile(|| {
@@ -497,4 +493,3 @@ impl GLContextDispatcher for WebRenderGLDispatcher {
         dispatcher.as_mut().unwrap().as_mut().unwrap().dispatch(f);
     }
 }
-

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -196,22 +196,12 @@ impl RenderBackend {
                                 AuxiliaryLists::from_data(auxiliary_lists_data,
                                                           auxiliary_lists_descriptor);
 
-                            let frame = profile_counters.total_time.profile(|| {
-                                self.scene.set_root_display_list(pipeline_id,
-                                                                 epoch,
-                                                                 built_display_list,
-                                                                 background_color,
-                                                                 viewport_size,
-                                                                 auxiliary_lists);
-
-                                self.build_scene();
-                                self.render()
-                            });
-
-                            if self.scene.root_pipeline_id.is_some() {
-                                self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
-                                frame_counter += 1;
-                            }
+                            self.scene.set_root_display_list(pipeline_id,
+                                                             epoch,
+                                                             built_display_list,
+                                                             background_color,
+                                                             viewport_size,
+                                                             auxiliary_lists);
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
                             self.scene.set_root_pipeline_id(pipeline_id);
@@ -219,15 +209,6 @@ impl RenderBackend {
                             if self.scene.display_lists.get(&pipeline_id).is_none() {
                                 continue;
                             }
-
-                            let frame = profile_counters.total_time.profile(|| {
-                                self.build_scene();
-                                self.render()
-                            });
-
-                            // the root pipeline is guaranteed to be Some() at this point
-                            self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
-                            frame_counter += 1;
                         }
                         ApiMsg::Scroll(delta, cursor, move_phase) => {
                             let frame = profile_counters.total_time.profile(|| {
@@ -344,6 +325,7 @@ impl RenderBackend {
                         }
                         ApiMsg::GenerateFrame => {
                             let frame = profile_counters.total_time.profile(|| {
+                                self.build_scene();
                                 self.render()
                             });
                             if self.scene.root_pipeline_id.is_some() {

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -135,7 +135,6 @@ impl RenderApi {
     pub fn set_root_pipeline(&self, pipeline_id: PipelineId) {
         let msg = ApiMsg::SetRootPipeline(pipeline_id);
         self.api_sender.send(msg).unwrap();
-        self.generate_frame();
     }
 
     /// Supplies a new frame to WebRender.
@@ -170,7 +169,6 @@ impl RenderApi {
                                              display_list.descriptor().clone(),
                                              *auxiliary_lists.descriptor());
         self.api_sender.send(msg).unwrap();
-        self.generate_frame();
 
         let mut payload = vec![];
         payload.write_u32::<LittleEndian>(epoch.0).unwrap();
@@ -262,4 +260,3 @@ impl RenderApi {
         (namespace, id)
     }
 }
-

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -135,6 +135,7 @@ impl RenderApi {
     pub fn set_root_pipeline(&self, pipeline_id: PipelineId) {
         let msg = ApiMsg::SetRootPipeline(pipeline_id);
         self.api_sender.send(msg).unwrap();
+        self.generate_frame();
     }
 
     /// Supplies a new frame to WebRender.
@@ -169,6 +170,7 @@ impl RenderApi {
                                              display_list.descriptor().clone(),
                                              *auxiliary_lists.descriptor());
         self.api_sender.send(msg).unwrap();
+        self.generate_frame();
 
         let mut payload = vec![];
         payload.write_u32::<LittleEndian>(epoch.0).unwrap();

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -206,9 +206,6 @@ impl Wrench {
         };
 
         wrench.set_title("start");
-        // there's a "frame 0" that webrender itself renders; push this to
-        // not confuse our notifier
-        wrench.frame_start_sender.push(time::SteadyTime::now());
         wrench.api.set_root_pipeline(wrench.root_pipeline_id);
 
         wrench
@@ -343,6 +340,7 @@ impl Wrench {
                                        Epoch(frame_number),
                                        self.window_size_f32(),
                                        display_list);
+        self.api.generate_frame();
     }
 
     pub fn render(&mut self) {


### PR DESCRIPTION
Remove the frame publishing code from the message handling for `ApiMsg::SetRootDisplayList` and `ApiMsg::SetRootPipeline`. Instead, `ApiMsg::GenerateFrame` now builds the scene and `RenderApi::set_root_display_list()` and `set_root_pipeline()` now send a `GenerateFrame` message.

This change seems pretty straightforward, but I have a few things I'm not sure about:

- I moved the call to `build_scene()` from `ApiMsg::SetRootDisplayList` to `ApiMsg::GenerateFrame`, but `ApiMsg::SetRootPipeline` wasn't calling `build_scene()` so I'm not sure that was the right thing to do.
- I added a call to `generate_frame()` to `RenderApi::set_root_display_list()` and `set_root_pipeline()`, keeping the public API the same. I'm not sure if this was the desired change, I would understand if the goal was to have code using WebRender explicitly call `generate_frame()` after calling `set_root_display_list()` and/or `set_root_pipeline()`, but I'll wait for feedback before making that change.

I tested these changes with with the wr-sample project and everything seemed kosher, but let me know if there other regression tests I should run.

As an aside, is there any reading about WebRender's design/architecture that I could look at? I don't fully understand the rational behind this change or the context in which it was requested, but I figure it'd make more sense if I knew more about how WebRender works.

closes #702

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/722)
<!-- Reviewable:end -->
