### PR TITLE
Fix missing Multiply case in ps_composite.fs.glsl

### DIFF
--- a/webrender/res/ps_composite.fs.glsl
+++ b/webrender/res/ps_composite.fs.glsl
@@ -168,6 +168,9 @@ void main(void) {
     vec4 result = vec4(1.0, 1.0, 0.0, 1.0);
 
     switch (vOp) {
+        case 1:
+            result.rgb = Multiply(Cb.rgb, Cs.rgb);
+            break;
         case 2:
             result.rgb = Screen(Cb.rgb, Cs.rgb);
             break;

--- a/wrench/reftests/multiply-ref.yaml
+++ b/wrench/reftests/multiply-ref.yaml
@@ -1,0 +1,7 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: green

--- a/wrench/reftests/multiply.yaml
+++ b/wrench/reftests/multiply.yaml
@@ -1,0 +1,16 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: green
+        -
+          bounds: [25, 25, 50, 50]
+          type: stacking_context
+          mix-blend-mode: multiply
+          items:
+            -
+              bounds: [0, 0, 50, 50]
+              type: rect
+              color: green

--- a/wrench/reftests/reftest.list
+++ b/wrench/reftests/reftest.list
@@ -1,3 +1,5 @@
 == mask.yaml mask-ref.yaml
 == nested-mask.yaml nested-mask-ref.yaml
 != mask.yaml green.yaml
+
+== multiply.yaml multiply-ref.yaml

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -413,11 +413,11 @@ impl YamlFrameReader {
         let z_index = yaml["z_index"].as_i64().unwrap_or(0);
         let transform = yaml["transform"].as_matrix4d().unwrap_or(LayoutTransform::identity());
         let perspective = yaml["perspective"].as_matrix4d().unwrap_or(LayoutTransform::identity());
+        let mix_blend_mode = yaml["mix-blend-mode"].as_mix_blend_mode().unwrap_or(MixBlendMode::Normal);
         let sc_full_rect = LayoutRect::new(LayoutPoint::new(0.0, 0.0), bounds.size);
         let clip = self.to_clip_region(&yaml["clip"], &sc_full_rect, wrench).unwrap_or(ClipRegion::simple(&sc_full_rect));
 
         // FIXME handle these
-        let mix_blend_mode = MixBlendMode::Normal;
         let filters: Vec<FilterOp> = Vec::new();
 
         self.builder().push_stacking_context(ScrollPolicy::Scrollable,

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use webrender;
 use webrender_traits::*;
 use yaml_rust::{Yaml, YamlEmitter};
+use yaml_helper::mix_blend_mode_to_string;
 use scene::Scene;
 use time;
 
@@ -143,6 +144,10 @@ fn vec_node(parent: &mut Table, key: &str, value: Vec<Yaml>) {
     yaml_node(parent, key, Yaml::Array(value));
 }
 
+fn mix_blend_mode_node(parent: &mut Table, key: &str, value: MixBlendMode) {
+    yaml_node(parent, key, Yaml::String(mix_blend_mode_to_string(value).to_owned()));
+}
+
 fn maybe_radius_yaml(radius: &BorderRadius) -> Option<Yaml> {
     if let Some(radius) = radius.is_uniform() {
         if radius == 0.0 {
@@ -172,6 +177,9 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
         matrix4d_node(parent, "perspective", &sc.perspective);
     }
     // mix_blend_mode
+    if sc.mix_blend_mode != MixBlendMode::Normal {
+        mix_blend_mode_node(parent, "mix-blend-mode", sc.mix_blend_mode)
+    }
     // filters
 }
 

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -25,6 +25,7 @@ pub trait YamlHelper {
     fn as_pt_to_au(&self) -> Option<Au>;
     fn as_vec_string(&self) -> Option<Vec<String>>;
     fn as_border_radius(&self) -> Option<BorderRadius>;
+    fn as_mix_blend_mode(&self) -> Option<MixBlendMode>;
 }
 
 fn string_to_color(color: &str) -> Option<ColorF> {
@@ -46,6 +47,41 @@ fn string_to_color(color: &str) -> Option<ColorF> {
         }
     }
 }
+
+macro_rules! define_enum_conversion {
+    ($read_func:ident, $write_func:ident, $T:ty, [ $( ( $x:expr, $y:path ) ),* ]) => {
+        pub fn $read_func(text: &str) -> Option<$T> {
+            match text {
+            $( $x => Some($y), )*
+                _ => None
+            }
+        }
+        pub fn $write_func(val: $T) -> &'static str {
+            match val {
+            $( $y => $x, )*
+            }
+        }
+    }
+}
+
+define_enum_conversion!(string_to_mix_blend_mode, mix_blend_mode_to_string, MixBlendMode, [
+    ("normal", MixBlendMode::Normal),
+    ("multiply", MixBlendMode::Multiply),
+    ("screen", MixBlendMode::Screen),
+    ("overlay", MixBlendMode::Overlay),
+    ("darken", MixBlendMode::Darken),
+    ("lighten", MixBlendMode::Lighten),
+    ("color-dodge", MixBlendMode::ColorDodge),
+    ("color-burn", MixBlendMode::ColorBurn),
+    ("hard-light", MixBlendMode::HardLight),
+    ("soft-light", MixBlendMode::SoftLight),
+    ("difference", MixBlendMode::Difference),
+    ("exclusion", MixBlendMode::Exclusion),
+    ("hue", MixBlendMode::Hue),
+    ("saturation", MixBlendMode::Saturation),
+    ("color", MixBlendMode::Color),
+    ("luminosity", MixBlendMode::Luminosity)
+]);
 
 impl YamlHelper for Yaml {
     fn as_force_f32(&self) -> Option<f32> {
@@ -238,5 +274,9 @@ impl YamlHelper for Yaml {
                 panic!("Invalid border radius specified: {:?}", self);
             }
         }
+    }
+
+    fn as_mix_blend_mode(&self) -> Option<MixBlendMode> {
+        return self.as_str().and_then(|x| string_to_mix_blend_mode(x));
     }
 }


### PR DESCRIPTION
It looks like the Multiply case for a composite operation was missing. This would cause mix-blend-mode: multiply to yield yellow pixels. I've included a reftest for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/736)
<!-- Reviewable:end -->
