### PR TITLE
Pipe text color information to rasterize_glyphs

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -15,7 +15,7 @@ use core_text::font_descriptor::kCTFontDefaultOrientation;
 use core_text;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use webrender_traits::{FontKey, FontRenderMode, GlyphDimensions};
+use webrender_traits::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
 
 pub type NativeFontHandle = CGFont;
 
@@ -178,6 +178,7 @@ impl FontContext {
     pub fn rasterize_glyph(&mut self,
                            font_key: FontKey,
                            size: Au,
+                           color: ColorU,
                            character: u32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
         match self.get_ct_font(font_key, size) {

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use webrender_traits::{FontKey, FontRenderMode, GlyphDimensions, NativeFontHandle};
+use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions, NativeFontHandle};
 
 use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode};
 use freetype::freetype::{FT_Done_FreeType, FT_Library_SetLcdFilter};
@@ -133,6 +133,7 @@ impl FontContext {
     pub fn rasterize_glyph(&mut self,
                            font_key: FontKey,
                            size: Au,
+                           color: ColorU,
                            character: u32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
         let mut glyph = None;

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use std::collections::HashMap;
-use webrender_traits::{FontKey, FontRenderMode, GlyphDimensions};
+use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions};
 
 use dwrote;
 
@@ -182,6 +182,7 @@ impl FontContext {
     pub fn rasterize_glyph(&mut self,
                            font_key: FontKey,
                            size: Au,
+                           color: ColorU,
                            glyph: u32,
                            render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
         let (_, maybe_glyph) =

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -737,9 +737,9 @@ impl PrimitiveStore {
 
                     let dest_rects = self.gpu_resource_rects.get_slice_mut(text.resource_address,
                                                                            text.glyph_range.length);
-
                     let texture_id = resource_cache.get_glyphs(text.font_key,
                                                                font_size_dp,
+                                                               text.color,
                                                                &text.glyph_indices,
                                                                text.render_mode, |index, uv0, uv1| {
                         let dest_rect = &mut dest_rects[index];
@@ -933,6 +933,7 @@ impl PrimitiveStore {
                                                                     text.glyph_range.length);
                     let mut glyph_key = GlyphKey::new(text.font_key,
                                                       font_size_dp,
+                                                      text.color,
                                                       src_glyphs[0].index);
                     let mut local_rect = LayerRect::zero();
                     let mut actual_glyph_count = 0;
@@ -998,6 +999,7 @@ impl PrimitiveStore {
 
                 resource_cache.request_glyphs(text.font_key,
                                               font_size_dp,
+                                              text.color,
                                               &text.glyph_indices,
                                               text.render_mode);
             }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -191,6 +191,55 @@ pub struct ColorF {
 }
 known_heap_size!(0, ColorF);
 
+#[derive(Clone, Copy, Hash, Eq, Debug, Deserialize, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct ColorU {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl From<ColorF> for ColorU {
+    fn from(color: ColorF) -> ColorU {
+        ColorU {
+            r: ColorU::round_to_int(color.r),
+            g: ColorU::round_to_int(color.g),
+            b: ColorU::round_to_int(color.b),
+            a: ColorU::round_to_int(color.a),
+        }
+    }
+}
+
+impl Into<ColorF> for ColorU {
+    fn into(self) -> ColorF {
+        ColorF {
+            r: self.r as f32 / 255.0,
+            g: self.g as f32 / 255.0,
+            b: self.b as f32 / 255.0,
+            a: self.a as f32 / 255.0,
+        }
+    }
+}
+
+impl ColorU {
+    fn round_to_int(x: f32) -> u8 {
+        debug_assert!((0.0 <= x) && (x <= 1.0));
+        let f = (255.0 * x) + 0.5;
+        let val = f.floor();
+        debug_assert!(val <= 255.0);
+        val as u8
+    }
+
+    pub fn new(r: u8, g: u8, b: u8, a: u8) -> ColorU {
+        ColorU {
+            r: r,
+            g: g,
+            b: b,
+            a: a,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageDescriptor {
     pub format: ImageFormat,
@@ -272,15 +321,18 @@ pub struct GlyphKey {
     //           or something similar to that.
     pub size: Au,
     pub index: u32,
+    pub color: ColorU,
 }
 
 impl GlyphKey {
     pub fn new(font_key: FontKey,
                size: Au,
+               color: ColorF,
                index: u32) -> GlyphKey {
         GlyphKey {
             font_key: font_key,
             size: size,
+            color: ColorU::from(color),
             index: index,
         }
     }


### PR DESCRIPTION
@kvark r? Required to do the gamma look up table stuff. The unfortunate side effect of this is that the Glyph keys require ColorU as u8 rgb channels instead of floats since f32 doesn't implement std::eq :/. Also, all the other API calls expects color information as ColorF. Instead of making users of the api give text as ColorU, we just translate it into/out of ColorU when we create the glyph key. I'd be happy if you become picky again and find a better way :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/748)
<!-- Reviewable:end -->
