### PR TITLE
Add ImageDescriptor to describe the layout and format of images in memory.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -9,7 +9,7 @@ use app_units::Au;
 use gleam::gl;
 use std::path::PathBuf;
 use webrender_traits::{ColorF, Epoch, GlyphInstance};
-use webrender_traits::{ImageData, ImageFormat, PipelineId};
+use webrender_traits::{ImageDescriptor, ImageData, ImageFormat, PipelineId};
 use webrender_traits::{LayoutSize, LayoutPoint, LayoutRect, LayoutTransform, DeviceUintSize};
 use std::fs::File;
 use std::io::Read;
@@ -112,7 +112,16 @@ fn main() {
 
     let sub_clip = {
         let mask = webrender_traits::ImageMask {
-            image: api.add_image(2, 2, None, ImageFormat::A8, ImageData::new(vec![0,80, 180, 255])),
+            image: api.add_image(
+                ImageDescriptor {
+                    width: 2,
+                    height: 2,
+                    stride: None,
+                    format: ImageFormat::A8,
+                    is_opaque: true,
+                },
+                ImageData::new(vec![0,80, 180, 255])
+            ),
             rect: LayoutRect::new(LayoutPoint::new(75.0, 75.0), LayoutSize::new(100.0, 100.0)),
             repeat: false,
         };

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1014,7 +1014,7 @@ impl PrimitiveStore {
                         // right now, but if we introduce a cache for images for some other
                         // reason then we might as well cache this with it.
                         let image_properties = resource_cache.get_image_properties(image_key);
-                        metadata.is_opaque = image_properties.is_opaque &&
+                        metadata.is_opaque = image_properties.descriptor.is_opaque &&
                                              tile_spacing.width == 0.0 &&
                                              tile_spacing.height == 0.0;
                     }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -125,23 +125,14 @@ impl RenderBackend {
                             };
                             tx.send(glyph_dimensions).unwrap();
                         }
-                        ApiMsg::AddImage(id, width, height, stride, format, data) => {
+                        ApiMsg::AddImage(id, descriptor, data) => {
                             if let ImageData::Raw(ref bytes) = data {
                                 profile_counters.image_templates.inc(bytes.len());
                             }
-                            self.resource_cache.add_image_template(id,
-                                                                   width,
-                                                                   height,
-                                                                   stride,
-                                                                   format,
-                                                                   data);
+                            self.resource_cache.add_image_template(id, descriptor, data);
                         }
-                        ApiMsg::UpdateImage(id, width, height, format, bytes) => {
-                            self.resource_cache.update_image_template(id,
-                                                                      width,
-                                                                      height,
-                                                                      format,
-                                                                      bytes);
+                        ApiMsg::UpdateImage(id, descriptor, bytes) => {
+                            self.resource_cache.update_image_template(id, descriptor, bytes);
                         }
                         ApiMsg::DeleteImage(id) => {
                             self.resource_cache.delete_image_template(id);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -39,6 +39,7 @@ use util::TransformedRectKind;
 use webrender_traits::{ColorF, Epoch, PipelineId, RenderNotifier, RenderDispatcher};
 use webrender_traits::{ExternalImageId, ImageFormat, RenderApiSender, RendererKind};
 use webrender_traits::{DeviceIntRect, DevicePoint, DeviceIntPoint, DeviceIntSize, DeviceUintSize};
+use webrender_traits::ImageDescriptor;
 use webrender_traits::channel;
 use webrender_traits::VRCompositorHandler;
 
@@ -551,19 +552,25 @@ impl Renderer {
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
         let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
-                             2,
-                             2,
-                             None,
-                             ImageFormat::RGBA8,
+                             ImageDescriptor {
+                                width: 2,
+                                height: 2,
+                                stride: None,
+                                format: ImageFormat::RGBA8,
+                                is_opaque: false,
+                             },
                              TextureFilter::Linear,
                              Arc::new(white_pixels));
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
-                             2,
-                             2,
-                             None,
-                             ImageFormat::A8,
+                             ImageDescriptor {
+                                width: 2,
+                                height: 2,
+                                stride: None,
+                                format: ImageFormat::A8,
+                                is_opaque: true,
+                             },
                              TextureFilter::Linear,
                              Arc::new(mask_pixels));
 

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -18,6 +18,7 @@ use time;
 use util;
 use webrender_traits::{ImageFormat, DevicePixel, DeviceIntPoint};
 use webrender_traits::{DeviceUintRect, DeviceUintSize, DeviceUintPoint};
+use webrender_traits::ImageDescriptor;
 
 /// The number of bytes we're allowed to use for a texture.
 const MAX_BYTES_PER_TEXTURE: u32 = 1024 * 1024 * 256;  // 256MB
@@ -740,23 +741,20 @@ impl TextureCache {
 
     pub fn update(&mut self,
                   image_id: TextureCacheItemId,
-                  width: u32,
-                  height: u32,
-                  stride: Option<u32>,
-                  _format: ImageFormat,
+                  descriptor: ImageDescriptor,
                   bytes: Arc<Vec<u8>>) {
         let existing_item = self.items.get(image_id);
 
         // TODO(gw): Handle updates to size/format!
-        debug_assert!(existing_item.requested_rect.size.width == width);
-        debug_assert!(existing_item.requested_rect.size.height == height);
+        debug_assert!(existing_item.requested_rect.size.width == descriptor.width);
+        debug_assert!(existing_item.requested_rect.size.height == descriptor.height);
 
         let op = TextureUpdateOp::Update(existing_item.requested_rect.origin.x,
                                          existing_item.requested_rect.origin.y,
-                                         width,
-                                         height,
+                                         descriptor.width,
+                                         descriptor.height,
                                          bytes,
-                                         stride);
+                                         descriptor.stride);
 
         let update_op = TextureUpdate {
             id: existing_item.texture_id,
@@ -768,12 +766,14 @@ impl TextureCache {
 
     pub fn insert(&mut self,
                   image_id: TextureCacheItemId,
-                  width: u32,
-                  height: u32,
-                  stride: Option<u32>,
-                  format: ImageFormat,
+                  descriptor: ImageDescriptor,
                   filter: TextureFilter,
                   bytes: Arc<Vec<u8>>) {
+        let width = descriptor.width;
+        let height = descriptor.height;
+        let format = descriptor.format;
+        let stride = descriptor.stride;
+
         let result = self.allocate(image_id,
                                    width,
                                    height,

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -6,8 +6,8 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use channel::{self, MsgSender, PayloadHelperMethods, PayloadSender};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use std::cell::Cell;
-use {ApiMsg, ColorF, DisplayListBuilder, Epoch};
-use {FontKey, IdNamespace, ImageFormat, ImageKey, NativeFontHandle, PipelineId};
+use {ApiMsg, ColorF, DisplayListBuilder, Epoch, ImageDescriptor};
+use {FontKey, IdNamespace, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLocation, ServoScrollRootId};
 use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
 use {DeviceIntSize, LayoutPoint, LayoutSize, WorldPoint};
@@ -90,13 +90,10 @@ impl RenderApi {
 
     /// Adds an image and returns the corresponding `ImageKey`.
     pub fn add_image(&self,
-                     width: u32,
-                     height: u32,
-                     stride: Option<u32>,
-                     format: ImageFormat,
+                     descriptor: ImageDescriptor,
                      data: ImageData) -> ImageKey {
         let key = self.alloc_image();
-        let msg = ApiMsg::AddImage(key, width, height, stride, format, data);
+        let msg = ApiMsg::AddImage(key, descriptor, data);
         self.api_sender.send(msg).unwrap();
         key
     }
@@ -107,11 +104,9 @@ impl RenderApi {
     // TODO: Support changing dimensions (and format) during image update?
     pub fn update_image(&self,
                         key: ImageKey,
-                        width: u32,
-                        height: u32,
-                        format: ImageFormat,
+                        descriptor: ImageDescriptor,
                         bytes: Vec<u8>) {
-        let msg = ApiMsg::UpdateImage(key, width, height, format, bytes);
+        let msg = ApiMsg::UpdateImage(key, descriptor, bytes);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -203,15 +203,14 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 self.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
             }
 
-            &ApiMsg::AddImage(ref key, width, height, stride,
-                              format, ref data) => {
-                let stride = if let Some(stride) = stride {
+            &ApiMsg::AddImage(ref key, ref descriptor, ref data) => {
+                let stride = if let Some(stride) = descriptor.stride {
                     stride
                 } else {
-                    match format {
-                        ImageFormat::A8 => width,
-                        ImageFormat::RGBA8 | ImageFormat::RGB8 => width*4,
-                        ImageFormat::RGBAF32 => width*16,
+                    match descriptor.format {
+                        ImageFormat::A8 => descriptor.width,
+                        ImageFormat::RGBA8 | ImageFormat::RGB8 => descriptor.width*4,
+                        ImageFormat::RGBAF32 => descriptor.width*16,
                         _ => panic!("Invalid image format"),
                     }
                 };
@@ -220,19 +219,20 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                     &ImageData::External(_) => { return; }
                 };
                 self.images.insert(*key, CachedImage {
-                    width: width, height: height, stride: stride,
-                    format: format,
+                    width: descriptor.width,
+                    height: descriptor.height,
+                    stride: stride,
+                    format: descriptor.format,
                     bytes: Some(bytes),
                     path: None,
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, width, height,
-                                 format, ref bytes) => {
+            &ApiMsg::UpdateImage(ref key, descriptor, ref bytes) => {
                 if let Some(ref mut data) = self.images.get_mut(key) {
-                    assert!(data.width == width);
-                    assert!(data.height == height);
-                    assert!(data.format == format);
+                    assert!(data.width == descriptor.width);
+                    assert!(data.height == descriptor.height);
+                    assert!(data.format == descriptor.format);
 
                     *data.path.borrow_mut() = None;
                     *data.bytes.borrow_mut() = Some(bytes.clone());

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -305,15 +305,22 @@ impl Wrench {
 
         let image = image::open(file).unwrap();
         let image_dims = image.dimensions();
-        let image_key = self.api.add_image(image_dims.0, image_dims.1,
-                                           None, // stride
-                                           match image {
-                                               image::ImageLuma8(_) => ImageFormat::A8,
-                                               image::ImageRgb8(_) => ImageFormat::RGB8,
-                                               image::ImageRgba8(_) => ImageFormat::RGBA8,
-                                               _ => panic!("We don't support whatever your crazy image type is, come on"),
-                                           },
-                                           ImageData::Raw(Arc::new(image.raw_pixels())));
+        let format = match image {
+            image::ImageLuma8(_) => ImageFormat::A8,
+            image::ImageRgb8(_) => ImageFormat::RGB8,
+            image::ImageRgba8(_) => ImageFormat::RGBA8,
+            _ => panic!("We don't support whatever your crazy image type is, come on"),
+        };
+        let bytes = image.raw_pixels();
+        let image_key = self.api.add_image(
+            ImageDescriptor {
+                width: image_dims.0,
+                height: image_dims.1,
+                stride: None,
+                format: format,
+                is_opaque: is_image_opaque(format, &bytes[..]),
+            },
+            ImageData::Raw(Arc::new(bytes)));
 
         let val = (image_key, LayoutSize::new(image_dims.0 as f32, image_dims.1 as f32));
         self.image_map.insert(key, val);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -647,15 +647,14 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 self.frame_writer.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
             }
 
-            &ApiMsg::AddImage(ref key, width, height, stride,
-                              format, ref data) => {
-                let stride = if let Some(stride) = stride {
+            &ApiMsg::AddImage(ref key, ref descriptor, ref data) => {
+                let stride = if let Some(stride) = descriptor.stride {
                     stride
                 } else {
-                    match format {
-                        ImageFormat::A8 => width,
-                        ImageFormat::RGBA8 | ImageFormat::RGB8 => width*4,
-                        ImageFormat::RGBAF32 => width*16,
+                    match descriptor.format {
+                        ImageFormat::A8 => descriptor.width,
+                        ImageFormat::RGBA8 | ImageFormat::RGB8 => descriptor.width*4,
+                        ImageFormat::RGBAF32 => descriptor.width*16,
                         _ => panic!("Invalid image format"),
                     }
                 };
@@ -664,19 +663,20 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                     &ImageData::External(_) => { return; }
                 };
                 self.frame_writer.images.insert(*key, CachedImage {
-                    width: width, height: height, stride: stride,
-                    format: format,
+                    width: descriptor.width,
+                    height: descriptor.height,
+                    stride: stride,
+                    format: descriptor.format,
                     bytes: Some(bytes),
                     path: None,
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, width, height,
-                                 format, ref bytes) => {
+            &ApiMsg::UpdateImage(ref key, ref descriptor, ref bytes) => {
                 if let Some(ref mut data) = self.frame_writer.images.get_mut(key) {
-                    assert!(data.width == width);
-                    assert!(data.height == height);
-                    assert!(data.format == format);
+                    assert!(data.width == descriptor.width);
+                    assert!(data.height == descriptor.height);
+                    assert!(data.format == descriptor.format);
 
                     *data.path.borrow_mut() = None;
                     *data.bytes.borrow_mut() = Some(bytes.clone());


### PR DESCRIPTION
The most notable change is that this moves the responsibility of specifying whether images are opaque to the consumer of the webrender api rather than webrender itself, which should be more efficient, and lets us handle opaque RGBA surfaces efficiently.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/756)
<!-- Reviewable:end -->
