### PR TITLE
Propagate errors when initializing WebRender instead of panicking

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
         .. Default::default()
     };
 
-    let (mut renderer, sender) = webrender::renderer::Renderer::new(opts);
+    let (mut renderer, sender) = webrender::renderer::Renderer::new(opts).unwrap();
     let api = sender.create_api();
 
     let notifier = Box::new(Notifier::new(window.create_window_proxy()));

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -28,8 +28,8 @@ pub struct DebugRenderer {
 
 impl DebugRenderer {
     pub fn new(device: &mut Device) -> DebugRenderer {
-        let font_program_id = device.create_program("debug_font", "shared_other", VertexFormat::DebugFont);
-        let color_program_id = device.create_program("debug_color", "shared_other", VertexFormat::DebugColor);
+        let font_program_id = device.create_program("debug_font", "shared_other", VertexFormat::DebugFont).unwrap();
+        let color_program_id = device.create_program("debug_color", "shared_other", VertexFormat::DebugColor).unwrap();
 
         let font_vao = device.create_vao(VertexFormat::DebugFont, 32);
         let line_vao = device.create_vao(VertexFormat::DebugColor, 32);

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -174,7 +174,7 @@ impl Wrench {
             .. Default::default()
         };
 
-        let (renderer, sender) = webrender::renderer::Renderer::new(opts);
+        let (renderer, sender) = webrender::renderer::Renderer::new(opts).unwrap();
         let api = sender.create_api();
 
         let proxy = window.create_window_proxy();


### PR DESCRIPTION
First step towards proper error handing in WebRender. This patch focuses on making the initialization of the Renderer fallible. This is important in order to let Gecko be able to catch potential errors and fallback to a different rendering backend.

r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/768)
<!-- Reviewable:end -->
