### PR TITLE
Pipe dwrite rendering options to rasterize_glyphs

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -227,7 +227,8 @@ fn main() {
                           font_key,
                           ColorF::new(1.0, 1.0, 0.0, 1.0),
                           Au::from_px(32),
-                          Au::from_px(0));
+                          Au::from_px(0),
+                          None);
     }
 
     builder.pop_stacking_context();

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -554,7 +554,8 @@ impl Frame {
                                              text_info.size,
                                              text_info.blur_radius,
                                              &text_info.color,
-                                             text_info.glyphs);
+                                             text_info.glyphs,
+                                             text_info.glyph_options);
                 }
                 SpecificDisplayItem::Rectangle(ref info) => {
                     context.builder.add_solid_rectangle(&item.rect,

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -15,7 +15,7 @@ use core_text::font_descriptor::kCTFontDefaultOrientation;
 use core_text;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use webrender_traits::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
+use webrender_traits::{ColorU, FontKey, FontRenderMode, GlyphDimensions, GlyphOptions};
 
 pub type NativeFontHandle = CGFont;
 
@@ -180,7 +180,8 @@ impl FontContext {
                            size: Au,
                            color: ColorU,
                            character: u32,
-                           render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
+                           render_mode: FontRenderMode,
+                           glyph_options: Option<GlyphOptions>) -> Option<RasterizedGlyph> {
         match self.get_ct_font(font_key, size) {
             Some(ref ct_font) => {
                 let glyph = character as CGGlyph;

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions, NativeFontHandle};
+use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions, NativeFontHandle, GlyphOptions};
 
 use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode};
 use freetype::freetype::{FT_Done_FreeType, FT_Library_SetLcdFilter};
@@ -135,7 +135,8 @@ impl FontContext {
                            size: Au,
                            color: ColorU,
                            character: u32,
-                           render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
+                           render_mode: FontRenderMode,
+                           glyph_options: Option<GlyphOptions>) -> Option<RasterizedGlyph> {
         let mut glyph = None;
 
         if let Some(slot) = self.load_glyph(font_key,

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use std::collections::HashMap;
-use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions};
+use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions, GlyphOptions};
 
 use dwrote;
 
@@ -184,7 +184,8 @@ impl FontContext {
                            size: Au,
                            color: ColorU,
                            glyph: u32,
-                           render_mode: FontRenderMode) -> Option<RasterizedGlyph> {
+                           render_mode: FontRenderMode,
+                           glyph_options: Option<GlyphOptions>) -> Option<RasterizedGlyph> {
         let (_, maybe_glyph) =
             self.get_glyph_dimensions_and_maybe_rasterize(font_key, size, glyph, Some(render_mode));
         maybe_glyph

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -19,6 +19,7 @@ use webrender_traits::{device_length, DeviceIntRect, DeviceIntSize};
 use webrender_traits::{DeviceRect, DevicePoint, DeviceSize};
 use webrender_traits::{LayerRect, LayerSize, LayerPoint};
 use webrender_traits::LayerToWorldTransform;
+use webrender_traits::{GlyphOptions};
 
 pub const CLIP_DATA_GPU_SIZE: usize = 5;
 pub const MASK_DATA_GPU_SIZE: usize = 1;
@@ -290,6 +291,7 @@ pub struct TextRunPrimitiveCpu {
     pub color: ColorF,
     pub render_mode: FontRenderMode,
     pub resource_address: GpuStoreAddress,
+    pub glyph_options: Option<GlyphOptions>,
 }
 
 #[derive(Debug, Clone)]
@@ -741,7 +743,8 @@ impl PrimitiveStore {
                                                                font_size_dp,
                                                                text.color,
                                                                &text.glyph_indices,
-                                                               text.render_mode, |index, uv0, uv1| {
+                                                               text.render_mode,
+                                                               text.glyph_options, |index, uv0, uv1| {
                         let dest_rect = &mut dest_rects[index];
                         dest_rect.uv0 = uv0;
                         dest_rect.uv1 = uv1;
@@ -1001,7 +1004,8 @@ impl PrimitiveStore {
                                               font_size_dp,
                                               text.color,
                                               &text.glyph_indices,
-                                              text.render_mode);
+                                              text.render_mode,
+                                              text.glyph_options);
             }
             PrimitiveKind::Image => {
                 let image_cpu = &mut self.cpu_images[metadata.cpu_prim_index.0];

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -42,6 +42,7 @@ use webrender_traits::{DeviceUintSize, DeviceUintPoint};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
 use webrender_traits::{LayerToScrollTransform, LayerToWorldTransform, WorldToLayerTransform};
 use webrender_traits::{WorldPoint4D, ScrollLayerPixel, as_scroll_parent_rect};
+use webrender_traits::{GlyphOptions};
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.
@@ -2324,7 +2325,8 @@ impl FrameBuilder {
                     size: Au,
                     blur_radius: Au,
                     color: &ColorF,
-                    glyph_range: ItemRange) {
+                    glyph_range: ItemRange,
+                    glyph_options: Option<GlyphOptions>) {
         if color.a == 0.0 {
             return
         }
@@ -2370,6 +2372,7 @@ impl FrameBuilder {
                 color_texture_id: SourceTexture::Invalid,
                 color: *color,
                 render_mode: render_mode,
+                glyph_options: glyph_options,
                 resource_address: GpuStoreAddress(0),
             };
 

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -15,6 +15,7 @@ use {PushScrollLayerItem, PushStackingContextDisplayItem, RectangleDisplayItem, 
 use {ScrollPolicy, ServoScrollRootId, SpecificDisplayItem, StackingContext, TextDisplayItem};
 use {WebGLContextId, WebGLDisplayItem, YuvImageDisplayItem};
 use {LayoutTransform, LayoutPoint, LayoutRect, LayoutSize};
+use {GlyphOptions};
 
 impl BuiltDisplayListDescriptor {
     pub fn size(&self) -> usize {
@@ -154,7 +155,8 @@ impl DisplayListBuilder {
                      font_key: FontKey,
                      color: ColorF,
                      size: Au,
-                     blur_radius: Au) {
+                     blur_radius: Au,
+                     glyph_options: Option<GlyphOptions>) {
         // Sanity check - anything with glyphs bigger than this
         // is probably going to consume too much memory to render
         // efficiently anyway. This is specifically to work around
@@ -168,6 +170,7 @@ impl DisplayListBuilder {
                 font_key: font_key,
                 size: size,
                 blur_radius: blur_radius,
+                glyph_options: glyph_options,
             };
 
             let display_item = DisplayItem {

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -631,6 +631,13 @@ pub struct StackingContext {
     pub filters: ItemRange,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct GlyphOptions {
+    // These are currently only used on windows for dwrite fonts.
+    use_embedded_bitmap: bool,
+    force_gdi_rendering: bool,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct TextDisplayItem {
     pub glyphs: ItemRange,
@@ -638,6 +645,7 @@ pub struct TextDisplayItem {
     pub size: Au,
     pub color: ColorF,
     pub blur_radius: Au,
+    pub glyph_options: Option<GlyphOptions>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -371,7 +371,7 @@ impl YamlFrameReader {
         };
 
         let clip = self.to_clip_region(&item["clip"], &rect, wrench).unwrap_or(*clip_region);
-        self.builder().push_text(rect, clip, glyphs, font_key, color, size, blur_radius);
+        self.builder().push_text(rect, clip, glyphs, font_key, color, size, blur_radius, None);
     }
 
     fn handle_iframe(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml)


### PR DESCRIPTION
Essentially replicating this from gecko - http://searchfox.org/mozilla-central/source/gfx/2d/DrawTargetSkia.cpp#1390

I contemplated various ways to pass glyph rendering options to rasterize_glyphs either through traits or some struct, but we don't do anything special for linux or mac, so using a option seemed like the best thing, even though it exposes "dwrite" and forces the other platforms to use it. Nor could I find a clean way to pass derived types with data only as traits seemed to only pass down method interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/770)
<!-- Reviewable:end -->
