### PR TITLE
Quantize glyph positions for subpixel text positioning.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -18,8 +18,8 @@ use webrender_traits::{FontKey, FontRenderMode, WebGLContextId};
 use webrender_traits::{device_length, DeviceIntRect, DeviceIntSize};
 use webrender_traits::{DeviceRect, DevicePoint, DeviceSize};
 use webrender_traits::{LayerRect, LayerSize, LayerPoint};
-use webrender_traits::LayerToWorldTransform;
-use webrender_traits::{GlyphOptions};
+use webrender_traits::{LayerToWorldTransform, GlyphOptions};
+use tiling::{AuxiliaryListsMap, StackingContext, StackingContextIndex};
 
 pub const CLIP_DATA_GPU_SIZE: usize = 5;
 pub const MASK_DATA_GPU_SIZE: usize = 1;
@@ -457,7 +457,7 @@ pub struct PrimitiveStore {
     pub gpu_resource_rects: GpuStore<TexelRect>,
 
     // General
-    prims_to_resolve: Vec<PrimitiveIndex>,
+    prims_to_resolve: Vec<(StackingContextIndex, PrimitiveIndex)>,
 }
 
 impl PrimitiveStore {
@@ -718,10 +718,12 @@ impl PrimitiveStore {
 
     pub fn resolve_primitives(&mut self,
                               resource_cache: &ResourceCache,
-                              device_pixel_ratio: f32) -> Vec<DeferredResolve> {
+                              device_pixel_ratio: f32,
+                              layer_store: &Vec<StackingContext>,
+                              auxiliary_lists_map: &AuxiliaryListsMap) -> Vec<DeferredResolve> {
         let mut deferred_resolves = Vec::new();
 
-        for prim_index in self.prims_to_resolve.drain(..) {
+        for (sc_index, prim_index) in self.prims_to_resolve.drain(..) {
             let metadata = &mut self.cpu_metadata[prim_index.0];
             if let Some(ref clip_info) = metadata.clip_cache_info {
                 Self::resolve_clip_cache_internal(&mut self.gpu_data32, clip_info, resource_cache);
@@ -735,14 +737,21 @@ impl PrimitiveStore {
                 PrimitiveKind::RadialGradient=> {}
                 PrimitiveKind::TextRun => {
                     let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
+
                     let font_size_dp = text.logical_font_size.scale_by(device_pixel_ratio);
 
                     let dest_rects = self.gpu_resource_rects.get_slice_mut(text.resource_address,
                                                                            text.glyph_range.length);
+
+                    let layer = &layer_store[sc_index.0];
+                    let auxiliary_lists = auxiliary_lists_map.get(&layer.pipeline_id)
+                                                             .expect("No auxiliary lists?");
+                    let src_glyphs = auxiliary_lists.glyph_instances(&text.glyph_range);
+
                     let texture_id = resource_cache.get_glyphs(text.font_key,
                                                                font_size_dp,
                                                                text.color,
-                                                               &text.glyph_indices,
+                                                               src_glyphs,
                                                                text.render_mode,
                                                                text.glyph_options, |index, uv0, uv1| {
                         let dest_rect = &mut dest_rects[index];
@@ -878,7 +887,8 @@ impl PrimitiveStore {
                                    resource_cache: &mut ResourceCache,
                                    layer_transform: &LayerToWorldTransform,
                                    device_pixel_ratio: f32,
-                                   auxiliary_lists: &AuxiliaryLists) -> bool {
+                                   auxiliary_lists: &AuxiliaryLists,
+                                   stackingcontext_index: StackingContextIndex) -> bool {
 
         let metadata = &mut self.cpu_metadata[prim_index.0];
         let mut prim_needs_resolve = false;
@@ -918,7 +928,9 @@ impl PrimitiveStore {
             }
             PrimitiveKind::TextRun => {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
+
                 let font_size_dp = text.logical_font_size.scale_by(device_pixel_ratio);
+                let src_glyphs = auxiliary_lists.glyph_instances(&text.glyph_range);
                 prim_needs_resolve = true;
 
                 if text.cache_dirty {
@@ -927,18 +939,22 @@ impl PrimitiveStore {
 
                     debug_assert!(metadata.gpu_data_count == text.glyph_range.length as i32);
                     debug_assert!(text.glyph_indices.is_empty());
-                    let src_glyphs = auxiliary_lists.glyph_instances(&text.glyph_range);
+
                     let dest_glyphs = self.gpu_data16.get_slice_mut(metadata.gpu_data_address,
                                                                     text.glyph_range.length);
                     let mut glyph_key = GlyphKey::new(text.font_key,
                                                       font_size_dp,
                                                       text.color,
-                                                      src_glyphs[0].index);
+                                                      src_glyphs[0].index,
+                                                      src_glyphs[0].x,
+                                                      src_glyphs[0].y,
+                                                      text.render_mode);
                     let mut local_rect = LayerRect::zero();
                     let mut actual_glyph_count = 0;
 
                     for src in src_glyphs {
                         glyph_key.index = src.index;
+                        glyph_key.set_subpixel_offset(src.x, src.y, text.render_mode);
 
                         let dimensions = match resource_cache.get_glyph_dimensions(&glyph_key) {
                             None => continue,
@@ -999,7 +1015,7 @@ impl PrimitiveStore {
                 resource_cache.request_glyphs(text.font_key,
                                               font_size_dp,
                                               text.color,
-                                              &text.glyph_indices,
+                                              src_glyphs,
                                               text.render_mode,
                                               text.glyph_options);
             }
@@ -1087,7 +1103,7 @@ impl PrimitiveStore {
         }
 
         if prim_needs_resolve {
-            self.prims_to_resolve.push(prim_index);
+            self.prims_to_resolve.push((stackingcontext_index, prim_index));
         }
 
         rebuild_bounding_rect

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -22,7 +22,7 @@ use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, ImageDescriptor, ColorF};
-use webrender_traits::{ExternalImageId, GlyphOptions};
+use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance};
 use threadpool::ThreadPool;
 
 thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
@@ -36,7 +36,7 @@ enum GlyphCacheMsg {
     /// Add a new font.
     AddFont(FontKey, FontTemplate),
     /// Request glyphs for a text run.
-    RequestGlyphs(FontKey, Au, ColorF, Vec<u32>, FontRenderMode, Option<GlyphOptions>),
+    RequestGlyphs(FontKey, Au, ColorF, Vec<GlyphInstance>, FontRenderMode, Option<GlyphOptions>),
     /// Finished requesting glyphs. Reply with new glyphs.
     EndFrame,
 }
@@ -74,10 +74,12 @@ impl RenderedGlyphKey {
                size: Au,
                color: ColorF,
                index: u32,
+               x: f32,
+               y: f32,
                render_mode: FontRenderMode,
                glyph_options: Option<GlyphOptions>) -> RenderedGlyphKey {
         RenderedGlyphKey {
-            key: GlyphKey::new(font_key, size, color, index),
+            key: GlyphKey::new(font_key, size, color, index, x, y, render_mode),
             render_mode: render_mode,
             glyph_options: glyph_options,
         }
@@ -330,7 +332,7 @@ impl ResourceCache {
                           key: FontKey,
                           size: Au,
                           color: ColorF,
-                          glyph_indices: &[u32],
+                          glyph_instances: &[GlyphInstance],
                           render_mode: FontRenderMode,
                           glyph_options: Option<GlyphOptions>) {
         debug_assert!(self.state == State::AddResources);
@@ -341,7 +343,7 @@ impl ResourceCache {
         let msg = GlyphCacheMsg::RequestGlyphs(key,
                                                size,
                                                color,
-                                               glyph_indices.to_vec(),
+                                               glyph_instances.to_vec(),
                                                render_mode,
                                                glyph_options);
         self.glyph_cache_tx.send(msg).unwrap();
@@ -359,7 +361,7 @@ impl ResourceCache {
                          font_key: FontKey,
                          size: Au,
                          color: ColorF,
-                         glyph_indices: &[u32],
+                         glyph_instances: &[GlyphInstance],
                          render_mode: FontRenderMode,
                          glyph_options: Option<GlyphOptions>,
                          mut f: F) -> SourceTexture where F: FnMut(usize, DevicePoint, DevicePoint) {
@@ -370,11 +372,15 @@ impl ResourceCache {
                                                   size,
                                                   color,
                                                   0,
+                                                  0.0, 0.0,
                                                   render_mode,
                                                   glyph_options);
         let mut texture_id = None;
-        for (loop_index, glyph_index) in glyph_indices.iter().enumerate() {
-            glyph_key.key.index = *glyph_index;
+        for (loop_index, glyph_instance) in glyph_instances.iter().enumerate() {
+            glyph_key.key.index = glyph_instance.index;
+            glyph_key.key.set_subpixel_offset(glyph_instance.x, glyph_instance.y,
+                                              render_mode);
+
             let image_id = cache.get(&glyph_key, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
@@ -675,18 +681,20 @@ fn spawn_glyph_cache_thread() -> (Sender<GlyphCacheMsg>, Receiver<GlyphCacheResu
                         });
                     }
                 }
-                GlyphCacheMsg::RequestGlyphs(key, size, color, indices, render_mode, glyph_options) => {
+                GlyphCacheMsg::RequestGlyphs(key, size, color, glyph_instances, render_mode, glyph_options) => {
                     // Request some glyphs for a text run.
                     // For any glyph that isn't currently in the cache,
                     // immeediately push a job to the worker thread pool
                     // to start rasterizing this glyph now!
                     let glyph_cache = glyph_cache.as_mut().unwrap();
 
-                    for glyph_index in indices {
+                    for glyph_instance in glyph_instances {
                         let glyph_key = RenderedGlyphKey::new(key,
                                                               size,
                                                               color,
-                                                              glyph_index,
+                                                              glyph_instance.index,
+                                                              glyph_instance.x,
+                                                              glyph_instance.y,
                                                               render_mode,
                                                               glyph_options);
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1679,10 +1679,10 @@ impl PrimitiveBatch {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct StackingContextIndex(usize);
+pub struct StackingContextIndex(pub usize);
 
-struct StackingContext {
-    pipeline_id: PipelineId,
+pub struct StackingContext {
+    pub pipeline_id: PipelineId,
     local_transform: LayerToScrollTransform,
     local_rect: LayerRect,
     scroll_layer_id: ScrollLayerId,
@@ -2402,7 +2402,8 @@ impl FrameBuilder {
                                                                        resource_cache,
                                                                        &packed_layer.transform,
                                                                        device_pixel_ratio,
-                                                                       auxiliary_lists) {
+                                                                       auxiliary_lists,
+                                                                       *sc_index) {
                                 self.prim_store.build_bounding_rect(prim_index,
                                                                     screen_rect,
                                                                     &packed_layer.transform,
@@ -2687,7 +2688,10 @@ impl FrameBuilder {
             }
         }
 
-        let deferred_resolves = self.prim_store.resolve_primitives(resource_cache, device_pixel_ratio);
+        let deferred_resolves = self.prim_store.resolve_primitives(resource_cache,
+                                                                   device_pixel_ratio,
+                                                                   &self.layer_store,
+                                                                   auxiliary_lists_map);
 
         let mut passes = Vec::new();
 


### PR DESCRIPTION
Changes the GlyphKey to take into account subpixel text positioning. After this patch, I'll pipe in the subpixel text position into rasterize_glyphs. (I'm trying to make smaller, more easily reviewable patches. Please let me know if you prefer bigger ones that are all "done").

The big issue I had with this patch was that GlyphInstances are attached to auxiliary display lists which are only available with a stacking context. To get around it, I added the stacking context id to TextRunPrimitiveCpu and assign it when we're iterating over the primitive commands in tiling.rs::cull_layers. That's where we were originally getting access to the GlyphInstances. I'm not sure this is the best way to do this, but the logic seems to be cull_layers, rasterize the glyphs, then fetch the glyphs based on the GlyphKeys. However, the GlyphKeys now need the GlyphInstances to calculate the subpixel text position key to fetch later, but we don't get access to those without the auxiliary display lists.

I'd be happy if you have a better idea (or we rewrite how GlyphInstances are handled in general). Was passing around GlyphInstances that expensive vs indices (1 u32 vs 1 u32 + 2 f32)? I can understand the raw font data, but the indices? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/780)
<!-- Reviewable:end -->
