### PR TITLE
Replace fixed position layer with reference frame

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, FrameBuilder, FrameBuilderConfig, PrimitiveFlags};
 use webrender_traits::{AuxiliaryLists, ClipRegion, ColorF, DisplayItem, Epoch, FilterOp};
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
 use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerId, ScrollLayerState};
 use webrender_traits::{ScrollLocation, ScrollPolicy, ServoScrollRootId, SpecificDisplayItem};
 use webrender_traits::{StackingContext, WorldPoint};
@@ -270,18 +270,9 @@ impl Frame {
             }
         };
 
-        // Insert global position: fixed elements layer
-        debug_assert!(self.scroll_tree.layers.is_empty());
-        let root_scroll_layer_id = ScrollLayerId::root(root_pipeline_id);
-        let root_fixed_layer_id = ScrollLayerId::create_fixed(root_pipeline_id);
-        let root_viewport = LayerRect::new(LayerPoint::zero(), root_pipeline.viewport_size);
-        let layer = Layer::new(&root_viewport,
-                               root_clip.main.size,
-                               &LayerToScrollTransform::identity(),
-                               root_pipeline_id);
-        self.scroll_tree.add_layer(layer.clone(), root_fixed_layer_id, None);
-        self.scroll_tree.add_layer(layer, root_scroll_layer_id, None);
-        self.scroll_tree.root_scroll_layer_id = Some(root_scroll_layer_id);
+        self.scroll_tree.establish_root(root_pipeline_id,
+                                        &root_pipeline.viewport_size,
+                                        &root_clip.main.size);
 
         let background_color = root_pipeline.background_color.and_then(|color| {
             if color.a > 0.0 {
@@ -304,11 +295,13 @@ impl Frame {
             };
 
             let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
+            let reference_frame_id = self.scroll_tree.root_reference_frame_id();
+            let topmost_scroll_layer_id = self.scroll_tree.topmost_scroll_layer_id();
             self.flatten_stacking_context(&mut traversal,
                                           root_pipeline_id,
                                           &mut context,
-                                          root_fixed_layer_id,
-                                          root_scroll_layer_id,
+                                          reference_frame_id,
+                                          topmost_scroll_layer_id,
                                           LayerToScrollTransform::identity(),
                                           0,
                                           &root_stacking_context,
@@ -323,7 +316,7 @@ impl Frame {
                                 traversal: &mut DisplayListTraversal<'a>,
                                 pipeline_id: PipelineId,
                                 context: &mut FlattenContext,
-                                current_fixed_layer_id: ScrollLayerId,
+                                current_reference_frame_id: ScrollLayerId,
                                 mut current_scroll_layer_id: ScrollLayerId,
                                 layer_relative_transform: LayerToScrollTransform,
                                 level: i32,
@@ -337,7 +330,7 @@ impl Frame {
         }
 
         let layer = Layer::new(&clip, *content_size, &layer_relative_transform, pipeline_id);
-        self.scroll_tree.add_layer(layer, new_scroll_layer_id, Some(current_scroll_layer_id));
+        self.scroll_tree.add_layer(layer, new_scroll_layer_id, current_scroll_layer_id);
         current_scroll_layer_id = new_scroll_layer_id;
 
         let layer_rect = LayerRect::new(LayerPoint::zero(),
@@ -353,7 +346,7 @@ impl Frame {
         self.flatten_items(traversal,
                            pipeline_id,
                            context,
-                           current_fixed_layer_id,
+                           current_reference_frame_id,
                            current_scroll_layer_id,
                            LayerToScrollTransform::identity(),
                            level);
@@ -365,7 +358,7 @@ impl Frame {
                                     traversal: &mut DisplayListTraversal<'a>,
                                     pipeline_id: PipelineId,
                                     context: &mut FlattenContext,
-                                    current_fixed_layer_id: ScrollLayerId,
+                                    current_reference_frame_id: ScrollLayerId,
                                     current_scroll_layer_id: ScrollLayerId,
                                     layer_relative_transform: LayerToScrollTransform,
                                     level: i32,
@@ -395,17 +388,30 @@ impl Frame {
             }
         }
 
-        let transform = layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
-                                                                stacking_context.bounds.origin.y,
-                                                                0.0)
-                                                .pre_mul(&stacking_context.transform)
-                                                .pre_mul(&stacking_context.perspective);
+        let mut transform =
+            layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
+                                                    stacking_context.bounds.origin.y,
+                                                    0.0)
+                                     .pre_mul(&stacking_context.transform)
+                                     .pre_mul(&stacking_context.perspective);
 
-        // Build world space transform
-        let scroll_layer_id = match stacking_context.scroll_policy {
-            ScrollPolicy::Fixed => current_fixed_layer_id,
+        let mut reference_frame_id = current_reference_frame_id;
+        let mut scroll_layer_id = match stacking_context.scroll_policy {
+            ScrollPolicy::Fixed => current_reference_frame_id,
             ScrollPolicy::Scrollable => current_scroll_layer_id,
         };
+
+        // If we have a transformation, we establish a new reference frame. This means
+        // that fixed position stacking contexts are positioned relative to us.
+        if stacking_context.transform != LayoutTransform::identity() ||
+           stacking_context.perspective != LayoutTransform::identity() {
+            scroll_layer_id = self.scroll_tree.add_reference_frame(clip_region.main,
+                                                                   transform,
+                                                                   pipeline_id,
+                                                                   scroll_layer_id);
+            reference_frame_id = scroll_layer_id;
+            transform = LayerToScrollTransform::identity();
+        }
 
         if level == 0 {
             if let Some(pipeline) = context.scene.pipeline_map.get(&pipeline_id) {
@@ -443,8 +449,8 @@ impl Frame {
         self.flatten_items(traversal,
                            pipeline_id,
                            context,
-                           current_fixed_layer_id,
-                           current_scroll_layer_id,
+                           reference_frame_id,
+                           scroll_layer_id,
                            transform,
                            level);
 
@@ -454,7 +460,7 @@ impl Frame {
                 &scrollbar_rect,
                 &ClipRegion::simple(&scrollbar_rect),
                 &DEFAULT_SCROLLBAR_COLOR,
-                PrimitiveFlags::Scrollbar(self.scroll_tree.root_scroll_layer_id.unwrap(), 4.0));
+                PrimitiveFlags::Scrollbar(self.scroll_tree.topmost_scroll_layer_id, 4.0));
         }
 
         context.builder.pop_layer();
@@ -489,27 +495,30 @@ impl Frame {
 
         self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
 
-        let iframe_rect = &LayerRect::new(LayerPoint::zero(), bounds.size);
+        let iframe_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
         let transform = layer_relative_transform.pre_translated(bounds.origin.x,
                                                                 bounds.origin.y,
                                                                 0.0);
-
-        let iframe_fixed_layer_id = ScrollLayerId::create_fixed(pipeline_id);
-        let iframe_scroll_layer_id = ScrollLayerId::root(pipeline_id);
-
-        let layer = Layer::new(iframe_rect,
+        let iframe_reference_frame_id =
+            self.scroll_tree.add_reference_frame(iframe_rect,
+                                                 transform,
+                                                 pipeline_id,
+                                                 current_scroll_layer_id);
+        let iframe_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
+        let layer = Layer::new(&LayerRect::new(LayerPoint::zero(), iframe_rect.size),
                                iframe_clip.main.size,
-                               &transform,
+                               &LayerToScrollTransform::identity(),
                                pipeline_id);
-        self.scroll_tree.add_layer(layer.clone(), iframe_fixed_layer_id, None);
-        self.scroll_tree.add_layer(layer, iframe_scroll_layer_id, Some(current_scroll_layer_id));
+        self.scroll_tree.add_layer(layer.clone(),
+                                   iframe_scroll_layer_id,
+                                   iframe_reference_frame_id);
 
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
 
         self.flatten_stacking_context(&mut traversal,
                                       pipeline_id,
                                       context,
-                                      iframe_fixed_layer_id,
+                                      iframe_reference_frame_id,
                                       iframe_scroll_layer_id,
                                       LayerToScrollTransform::identity(),
                                       0,
@@ -521,7 +530,7 @@ impl Frame {
                          traversal: &mut DisplayListTraversal<'a>,
                          pipeline_id: PipelineId,
                          context: &mut FlattenContext,
-                         current_fixed_layer_id: ScrollLayerId,
+                         current_reference_frame_id: ScrollLayerId,
                          current_scroll_layer_id: ScrollLayerId,
                          layer_relative_transform: LayerToScrollTransform,
                          level: i32) {
@@ -595,7 +604,7 @@ impl Frame {
                     self.flatten_stacking_context(traversal,
                                                   pipeline_id,
                                                   context,
-                                                  current_fixed_layer_id,
+                                                  current_reference_frame_id,
                                                   current_scroll_layer_id,
                                                   layer_relative_transform,
                                                   level + 1,
@@ -606,7 +615,7 @@ impl Frame {
                     self.flatten_scroll_layer(traversal,
                                               pipeline_id,
                                               context,
-                                              current_fixed_layer_id,
+                                              current_reference_frame_id,
                                               current_scroll_layer_id,
                                               layer_relative_transform,
                                               level,

--- a/webrender/src/scroll_tree.rs
+++ b/webrender/src/scroll_tree.rs
@@ -6,10 +6,10 @@ use fnv::FnvHasher;
 use layer::{Layer, ScrollingState};
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use webrender_traits::{LayerPoint, PipelineId, ScrollEventPhase, ScrollLayerId, ScrollLayerInfo};
-use webrender_traits::{ScrollLayerPixel, ScrollLayerRect, ScrollLayerState, ScrollLocation};
-use webrender_traits::{ScrollToWorldTransform, ServoScrollRootId, WorldPoint};
-use webrender_traits::as_scroll_parent_rect;
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
+use webrender_traits::{ScrollEventPhase, ScrollLayerId, ScrollLayerInfo, ScrollLayerPixel};
+use webrender_traits::{ScrollLayerRect, ScrollLayerState, ScrollLocation, ScrollToWorldTransform};
+use webrender_traits::{ServoScrollRootId, WorldPoint, as_scroll_parent_rect};
 
 pub type ScrollStates = HashMap<ScrollLayerId, ScrollingState, BuildHasherDefault<FnvHasher>>;
 
@@ -17,17 +17,62 @@ pub struct ScrollTree {
     pub layers: HashMap<ScrollLayerId, Layer, BuildHasherDefault<FnvHasher>>,
     pub pending_scroll_offsets: HashMap<(PipelineId, ServoScrollRootId), LayerPoint>,
     pub current_scroll_layer_id: Option<ScrollLayerId>,
-    pub root_scroll_layer_id: Option<ScrollLayerId>,
+    pub current_reference_frame_id: usize,
+
+    /// The root reference frame, which is the true root of the ScrollTree. Initially
+    /// this ID is not valid, which is indicated by ```layers``` being empty.
+    pub root_reference_frame_id: ScrollLayerId,
+
+    /// The root scroll layer, which is the first child of the root reference frame.
+    /// Initially this ID is not valid, which is indicated by ```layers``` being empty.
+    pub topmost_scroll_layer_id: ScrollLayerId,
 }
 
 impl ScrollTree {
     pub fn new() -> ScrollTree {
+        let dummy_pipeline = PipelineId(0, 0);
         ScrollTree {
             layers: HashMap::with_hasher(Default::default()),
             pending_scroll_offsets: HashMap::new(),
             current_scroll_layer_id: None,
-            root_scroll_layer_id: None,
+            root_reference_frame_id: ScrollLayerId::root_reference_frame(dummy_pipeline),
+            topmost_scroll_layer_id: ScrollLayerId::root_scroll_layer(dummy_pipeline),
+            current_reference_frame_id: 1,
         }
+    }
+
+    pub fn root_reference_frame_id(&self) -> ScrollLayerId {
+        // TODO(mrobinson): We should eventually make this impossible to misuse.
+        debug_assert!(!self.layers.is_empty());
+        debug_assert!(self.layers.contains_key(&self.root_reference_frame_id));
+        self.root_reference_frame_id
+    }
+
+    pub fn topmost_scroll_layer_id(&self) -> ScrollLayerId {
+        // TODO(mrobinson): We should eventually make this impossible to misuse.
+        debug_assert!(!self.layers.is_empty());
+        debug_assert!(self.layers.contains_key(&self.topmost_scroll_layer_id));
+        self.topmost_scroll_layer_id
+    }
+
+    pub fn establish_root(&mut self,
+                          pipeline_id: PipelineId,
+                          viewport_size: &LayerSize,
+                          content_size: &LayerSize) {
+        debug_assert!(self.layers.is_empty());
+
+        let identity = LayerToScrollTransform::identity();
+        let viewport = LayerRect::new(LayerPoint::zero(), *viewport_size);
+
+        let root_reference_frame_id = ScrollLayerId::root_reference_frame(pipeline_id);
+        self.root_reference_frame_id = root_reference_frame_id;
+        let reference_frame = Layer::new(&viewport, viewport.size, &identity, pipeline_id);
+        self.layers.insert(self.root_reference_frame_id, reference_frame);
+
+        let scroll_layer = Layer::new(&viewport, *content_size, &identity, pipeline_id);
+        let topmost_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
+        self.topmost_scroll_layer_id = topmost_scroll_layer_id;
+        self.add_layer(scroll_layer, topmost_scroll_layer_id, root_reference_frame_id);
     }
 
     pub fn collect_layers_bouncing_back(&self)
@@ -41,18 +86,19 @@ impl ScrollTree {
         layers_bouncing_back
     }
 
-    pub fn get_scroll_layer(&self,
-                            cursor: &WorldPoint,
-                            scroll_layer_id: ScrollLayerId)
-                            -> Option<ScrollLayerId> {
+    fn find_scrolling_layer_at_point_in_layer(&self,
+                                              cursor: &WorldPoint,
+                                              scroll_layer_id: ScrollLayerId)
+                                              -> Option<ScrollLayerId> {
         self.layers.get(&scroll_layer_id).and_then(|layer| {
             for child_layer_id in layer.children.iter().rev() {
-                if let Some(layer_id) = self.get_scroll_layer(cursor, *child_layer_id) {
+            if let Some(layer_id) =
+                self.find_scrolling_layer_at_point_in_layer(cursor, *child_layer_id) {
                     return Some(layer_id);
                 }
             }
 
-            if scroll_layer_id.info == ScrollLayerInfo::Fixed {
+            if let ScrollLayerInfo::ReferenceFrame(_) = scroll_layer_id.info {
                 return None;
             }
 
@@ -62,6 +108,11 @@ impl ScrollTree {
                 None
             }
         })
+    }
+
+    pub fn find_scrolling_layer_at_point(&self, cursor: &WorldPoint) -> ScrollLayerId {
+        self.find_scrolling_layer_at_point_in_layer(cursor, self.root_reference_frame_id())
+            .unwrap_or(self.topmost_scroll_layer_id())
     }
 
     pub fn get_scroll_layer_state(&self) -> Vec<ScrollLayerState> {
@@ -75,13 +126,15 @@ impl ScrollTree {
                         scroll_offset: scroll_layer.scrolling.offset,
                     })
                 }
-                ScrollLayerInfo::Fixed => {}
+                ScrollLayerInfo::ReferenceFrame(..) => {}
             }
         }
         result
     }
 
     pub fn drain(&mut self) -> ScrollStates {
+        self.current_reference_frame_id = 1;
+
         let mut scroll_states = HashMap::with_hasher(Default::default());
         for (layer_id, old_layer) in &mut self.layers.drain() {
             scroll_states.insert(layer_id, old_layer.scrolling);
@@ -94,6 +147,10 @@ impl ScrollTree {
                          pipeline_id: PipelineId,
                          scroll_root_id: ServoScrollRootId)
                          -> bool {
+        if self.layers.is_empty() {
+            return false;
+        }
+
         let origin = LayerPoint::new(origin.x.max(0.0), origin.y.max(0.0));
 
         let mut scrolled_a_layer = false;
@@ -105,8 +162,8 @@ impl ScrollTree {
 
             match layer_id.info {
                 ScrollLayerInfo::Scrollable(_, id) if id != scroll_root_id => continue,
-                ScrollLayerInfo::Fixed => continue,
-                _ => {}
+                ScrollLayerInfo::ReferenceFrame(..) => continue,
+                ScrollLayerInfo::Scrollable(..) => {}
             }
 
             found_layer = true;
@@ -125,25 +182,24 @@ impl ScrollTree {
                   cursor: WorldPoint,
                   phase: ScrollEventPhase)
                   -> bool {
-        let root_scroll_layer_id = match self.root_scroll_layer_id {
-            Some(root_scroll_layer_id) => root_scroll_layer_id,
-            None => return false,
-        };
+        if self.layers.is_empty() {
+            return false;
+        }
 
         let scroll_layer_id = match (
             phase,
-            self.get_scroll_layer(&cursor, root_scroll_layer_id),
+            self.find_scrolling_layer_at_point(&cursor),
             self.current_scroll_layer_id) {
-            (ScrollEventPhase::Start, Some(scroll_layer_id), _) => {
+            (ScrollEventPhase::Start, scroll_layer_id, _) => {
                 self.current_scroll_layer_id = Some(scroll_layer_id);
                 scroll_layer_id
             },
-            (ScrollEventPhase::Start, None, _) => return false,
             (_, _, Some(scroll_layer_id)) => scroll_layer_id,
             (_, _, None) => return false,
         };
 
-        let non_root_overscroll = if scroll_layer_id != root_scroll_layer_id {
+        let topmost_scroll_layer_id = self.topmost_scroll_layer_id();
+        let non_root_overscroll = if scroll_layer_id != topmost_scroll_layer_id {
             // true if the current layer is overscrolling,
             // and it is not the root scroll layer.
             let child_layer = self.layers.get(&scroll_layer_id).unwrap();
@@ -177,14 +233,14 @@ impl ScrollTree {
         };
 
         let scroll_layer_info = if switch_layer {
-            root_scroll_layer_id.info
+            topmost_scroll_layer_id.info
         } else {
             scroll_layer_id.info
         };
 
         let scroll_root_id = match scroll_layer_info {
              ScrollLayerInfo::Scrollable(_, scroll_root_id) => scroll_root_id,
-             _ => unreachable!("Tried to scroll a non-scrolling layer."),
+             _ => unreachable!("Tried to scroll a reference frame."),
 
         };
 
@@ -196,7 +252,7 @@ impl ScrollTree {
 
             match layer_id.info {
                 ScrollLayerInfo::Scrollable(_, id) if id != scroll_root_id => continue,
-                ScrollLayerInfo::Fixed => continue,
+                ScrollLayerInfo::ReferenceFrame(..) => continue,
                 _ => {}
             }
 
@@ -207,8 +263,15 @@ impl ScrollTree {
     }
 
     pub fn update_all_layer_transforms(&mut self) {
-        let root_scroll_layer_id = self.root_scroll_layer_id;
-        self.update_layer_transforms(root_scroll_layer_id);
+        if self.layers.is_empty() {
+            return;
+        }
+
+        let root_reference_frame_id = self.root_reference_frame_id();
+        let root_viewport = self.layers[&root_reference_frame_id].local_viewport_rect;
+        self.update_layer_transform(root_reference_frame_id,
+                                    &ScrollToWorldTransform::identity(),
+                                    &as_scroll_parent_rect(&root_viewport));
     }
 
     fn update_layer_transform(&mut self,
@@ -234,33 +297,6 @@ impl ScrollTree {
             self.update_layer_transform(child_layer_id,
                                         &layer_transform_for_children,
                                         &viewport_rect);
-        }
-    }
-
-    pub fn update_layer_transforms(&mut self, root_scroll_layer_id: Option<ScrollLayerId>) {
-        if let Some(root_scroll_layer_id) = root_scroll_layer_id {
-            let root_viewport = self.layers[&root_scroll_layer_id].local_viewport_rect;
-
-            self.update_layer_transform(root_scroll_layer_id,
-                                        &ScrollToWorldTransform::identity(),
-                                        &as_scroll_parent_rect(&root_viewport));
-
-            // Update any fixed layers
-            let mut fixed_layers = Vec::new();
-            for (layer_id, _) in &self.layers {
-                match layer_id.info {
-                    ScrollLayerInfo::Scrollable(..) => {}
-                    ScrollLayerInfo::Fixed => {
-                        fixed_layers.push(*layer_id);
-                    }
-                }
-            }
-
-            for layer_id in fixed_layers {
-                self.update_layer_transform(layer_id,
-                                            &ScrollToWorldTransform::identity(),
-                                            &as_scroll_parent_rect(&root_viewport));
-            }
         }
     }
 
@@ -296,14 +332,28 @@ impl ScrollTree {
 
     }
 
-    pub fn add_layer(&mut self, layer: Layer, id: ScrollLayerId, parent_id: Option<ScrollLayerId>) {
+    pub fn add_reference_frame(&mut self,
+                               rect: LayerRect,
+                               transform: LayerToScrollTransform,
+                               pipeline_id: PipelineId,
+                               parent_id: ScrollLayerId) -> ScrollLayerId {
+        let reference_frame_id = ScrollLayerId {
+            pipeline_id: pipeline_id,
+            info: ScrollLayerInfo::ReferenceFrame(self.current_reference_frame_id),
+        };
+        self.current_reference_frame_id += 1;
+
+        let layer = Layer::new(&rect, rect.size, &transform, pipeline_id);
+        self.add_layer(layer, reference_frame_id, parent_id);
+        reference_frame_id
+    }
+
+    pub fn add_layer(&mut self, layer: Layer, id: ScrollLayerId, parent_id: ScrollLayerId) {
         debug_assert!(!self.layers.contains_key(&id));
         self.layers.insert(id, layer);
 
-        if let Some(parent_id) = parent_id {
-            debug_assert!(parent_id != id);
-            self.layers.get_mut(&parent_id).unwrap().add_child(id);
-        }
+        debug_assert!(parent_id != id);
+        self.layers.get_mut(&parent_id).unwrap().add_child(id);
     }
 }
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2556,7 +2556,8 @@ impl FrameBuilder {
                     }
 
                     let inv_layer_transform = layer.local_transform.inverse().unwrap();
-                    let local_viewport_rect = as_scroll_parent_rect(&scroll_layer.combined_local_viewport_rect);
+                    let local_viewport_rect =
+                        as_scroll_parent_rect(&scroll_layer.combined_local_viewport_rect);
                     let viewport_rect = inv_layer_transform.transform_rect(&local_viewport_rect);
                     let local_clip_rect = layer.clip_source.to_rect().unwrap_or(layer.local_rect);
                     let layer_local_rect = layer.local_rect

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -169,11 +169,4 @@ impl ScrollLayerId {
             info: ScrollLayerInfo::Scrollable(index, scroll_root_id),
         }
     }
-
-    pub fn create_fixed(pipeline_id: PipelineId) -> ScrollLayerId {
-        ScrollLayerId {
-            pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Fixed,
-        }
-    }
 }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -554,25 +554,32 @@ pub struct ScrollLayerId {
 }
 
 impl ScrollLayerId {
-    pub fn root(pipeline_id: PipelineId) -> ScrollLayerId {
+    pub fn root_scroll_layer(pipeline_id: PipelineId) -> ScrollLayerId {
         ScrollLayerId {
             pipeline_id: pipeline_id,
             info: ScrollLayerInfo::Scrollable(0, ServoScrollRootId(0)),
         }
     }
 
+    pub fn root_reference_frame(pipeline_id: PipelineId) -> ScrollLayerId {
+        ScrollLayerId {
+            pipeline_id: pipeline_id,
+            info: ScrollLayerInfo::ReferenceFrame(0),
+        }
+    }
+
     pub fn scroll_root_id(&self) -> Option<ServoScrollRootId> {
         match self.info {
             ScrollLayerInfo::Scrollable(_, scroll_root_id) => Some(scroll_root_id),
-            ScrollLayerInfo::Fixed => None,
+            ScrollLayerInfo::ReferenceFrame(..) => None,
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ScrollLayerInfo {
-    Fixed,
-    Scrollable(usize, ServoScrollRootId)
+    Scrollable(usize, ServoScrollRootId),
+    ReferenceFrame(usize),
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Instead of creating fixed position layers which hang onto the outside of the
ScrollTree, create reference frames, which exist within the tree of
scroll layers. Eventually this tree of reference frames and scroll
layers will be combined with stacking context offsets to position and
clip all display items.

This change fixes an issue where fixed position items wouldn't scroll
even when their transformed ancestors which defined their coordinate
system did.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/781)
<!-- Reviewable:end -->
