### PR TITLE
Make ImageKey and FontKey members public.

### DIFF
--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -302,7 +302,7 @@ pub enum FilterOp {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, Ord, PartialOrd)]
-pub struct FontKey(u32, u32);
+pub struct FontKey(pub u32, pub u32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum FontRenderMode {
@@ -460,7 +460,7 @@ impl ImageData {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ImageKey(u32, u32);
+pub struct ImageKey(pub u32, pub u32);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageRendering {


### PR DESCRIPTION
We need some ffi types to represent them and to that end we have to poke at their members. Some other types like `PipelineId` have their members public so I suppose this should not be an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/783)
<!-- Reviewable:end -->
