### PR TITLE
Add an optimization for drawing simple borders.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2000,6 +2000,51 @@ impl FrameBuilder {
         let br_inner = br_outer - LayerPoint::new(radius.bottom_right.width.max(right.width),
                                                   radius.bottom_right.height.max(bottom.width));
 
+        // The border shader is quite expensive. For simple borders, we can just draw
+        // the border with a few rectangles. This generally gives better batching, and
+        // a GPU win in fragment shader time.
+        // More importantly, the software (OSMesa) implementation we run tests on is
+        // particularly slow at running our complex border shader, compared to the
+        // rectangle shader. This has the effect of making some of our tests time
+        // out more often on CI (the actual cause is simply too many Servo processes and
+        // threads being run on CI at once).
+        // TODO(gw): Detect some more simple cases and handle those with simpler shaders too.
+        // TODO(gw): Consider whether it's only worth doing this for large rectangles (since
+        //           it takes a little more CPU time to handle multiple rectangles compared
+        //           to a single border primitive).
+        if left.style == BorderStyle::Solid {
+            let same_color = left_color == top_color &&
+                             left_color == right_color &&
+                             left_color == bottom_color;
+            let same_style = left.style == top.style &&
+                             left.style == right.style &&
+                             left.style == bottom.style;
+
+            if same_color && same_style && radius.is_zero() {
+                let rects = [
+                    LayerRect::new(rect.origin,
+                                   LayerSize::new(rect.size.width, top.width)),
+                    LayerRect::new(LayerPoint::new(tl_outer.x, tl_inner.y),
+                                   LayerSize::new(left.width,
+                                                  rect.size.height - top.width - bottom.width)),
+                    LayerRect::new(tr_inner,
+                                   LayerSize::new(right.width,
+                                                  rect.size.height - top.width - bottom.width)),
+                    LayerRect::new(LayerPoint::new(bl_outer.x, bl_inner.y),
+                                   LayerSize::new(rect.size.width, bottom.width))
+                ];
+
+                for rect in &rects {
+                    self.add_solid_rectangle(rect,
+                                             clip_region,
+                                             &top_color,
+                                             PrimitiveFlags::None);
+                }
+
+                return;
+            }
+        }
+
         //Note: while similar to `ComplexClipRegion::get_inner_rect()` in spirit,
         // this code is a bit more complex and can not there for be merged.
         let inner_rect = rect_from_points_f(tl_inner.x.max(bl_inner.x),


### PR DESCRIPTION
This is primarily to speed up the time it takes to draw
large, simple borders on OSMesa. This makes some tests
run a lot faster when using software rendering, which
reduces the chances of timeouts occurring due to the
large number of tests that the Servo CI machines run
in parallel.

It's also a reasonable optimization for simple borders
when running a hardware renderer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/793)
<!-- Reviewable:end -->
