### PR TITLE
Move subpixel_quantize_offset into render mode

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -719,7 +719,7 @@ impl PrimitiveStore {
     pub fn resolve_primitives(&mut self,
                               resource_cache: &ResourceCache,
                               device_pixel_ratio: f32,
-                              layer_store: &Vec<StackingContext>,
+                              layer_store: &[StackingContext],
                               auxiliary_lists_map: &AuxiliaryListsMap) -> Vec<DeferredResolve> {
         let mut deferred_resolves = Vec::new();
 


### PR DESCRIPTION
@kvark Implementing some of the review feedback from https://github.com/servo/webrender/pull/780#pullrequestreview-18877347

Not sure how you feel about the f32 instead of euclid units for GlyphInstances though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/797)
<!-- Reviewable:end -->
