### PR TITLE
Fix a regression in text rendering where non-renderable glyphs are present.

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -133,10 +133,10 @@ impl FontContext {
     pub fn rasterize_glyph(&mut self,
                            font_key: FontKey,
                            size: Au,
-                           color: ColorU,
+                           _color: ColorU,
                            character: u32,
                            render_mode: FontRenderMode,
-                           glyph_options: Option<GlyphOptions>) -> Option<RasterizedGlyph> {
+                           _glyph_options: Option<GlyphOptions>) -> Option<RasterizedGlyph> {
         let mut glyph = None;
 
         if let Some(slot) = self.load_glyph(font_key,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2199,7 +2199,7 @@ impl FrameBuilder {
                 blur_radius: blur_radius,
                 glyph_range: sub_range,
                 cache_dirty: true,
-                glyph_indices: Vec::new(),
+                glyph_instances: Vec::new(),
                 color_texture_id: SourceTexture::Invalid,
                 color: *color,
                 render_mode: render_mode,
@@ -2448,8 +2448,7 @@ impl FrameBuilder {
                                                                        resource_cache,
                                                                        &packed_layer.transform,
                                                                        device_pixel_ratio,
-                                                                       auxiliary_lists,
-                                                                       *sc_index) {
+                                                                       auxiliary_lists) {
                                 self.prim_store.build_bounding_rect(prim_index,
                                                                     screen_rect,
                                                                     &packed_layer.transform,
@@ -2735,9 +2734,7 @@ impl FrameBuilder {
         }
 
         let deferred_resolves = self.prim_store.resolve_primitives(resource_cache,
-                                                                   device_pixel_ratio,
-                                                                   &self.layer_store,
-                                                                   auxiliary_lists_map);
+                                                                   device_pixel_ratio);
 
         let mut passes = Vec::new();
 


### PR DESCRIPTION
The text run code in prepare_prim_for_render() takes account of
non-renderable glyphs and pushes only the renderable glyphs into
the list of glyphs for the text run.

The recent subpixel positioning changes stopped using this and were
using the source glyph indices. This can result in incorrect indexing
of glyph information in the text run shader.

This patch modifies the text run request and render code to use
the glyph indices array. It extends it to contain the x/y coords
of the glyph, allowing the subpixel positioning to work. It also
tidies up some of the code so that the resolve step no longer
requires access to the stacking context and aux maps.

Fixes several of the WPT ref tests that use whitespace: pre.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/803)
<!-- Reviewable:end -->
