### PR TITLE
Fix is_uniform() method on border radius.

### DIFF
--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -49,12 +49,12 @@ impl BorderRadius {
         }
     }
 
-    pub fn is_uniform(&self) -> Option<f32> {
-        let uniform_radius = LayoutSize::new(self.top_left.width, self.top_left.width);
+    pub fn is_uniform(&self) -> Option<LayoutSize> {
+        let uniform_radius = self.top_left;
         if self.top_right == uniform_radius &&
            self.bottom_left == uniform_radius &&
            self.bottom_right == uniform_radius {
-            Some(uniform_radius.width)
+            Some(uniform_radius)
         } else {
             None
         }
@@ -62,7 +62,7 @@ impl BorderRadius {
 
     pub fn is_zero(&self) -> bool {
         if let Some(radius) = self.is_uniform() {
-            radius == 0.0
+            radius.width == 0.0 && radius.height == 0.0
         } else {
             false
         }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -151,7 +151,7 @@ fn mix_blend_mode_node(parent: &mut Table, key: &str, value: MixBlendMode) {
 
 fn maybe_radius_yaml(radius: &BorderRadius) -> Option<Yaml> {
     if let Some(radius) = radius.is_uniform() {
-        if radius == 0.0 {
+        if radius == LayoutSize::zero() {
             None
         } else {
             Some(Yaml::Real(radius.to_string()))


### PR DESCRIPTION
This was breaking the CSS border tests in one case, as a result
of this method being used by the simple border optimization
that recently landed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/804)
<!-- Reviewable:end -->
