### PR TITLE
Pass GlyphKey to platform font contexts

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -5,6 +5,7 @@
 use app_units::Au;
 use webrender_traits::{FontKey, ColorU, FontRenderMode, GlyphDimensions};
 use webrender_traits::{NativeFontHandle, GlyphOptions,  SubpixelOffset};
+use webrender_traits::{GlyphKey};
 
 use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode};
 use freetype::freetype::{FT_Done_FreeType, FT_Library_SetLcdFilter};
@@ -112,14 +113,9 @@ impl FontContext {
         None
     }
 
-    pub fn get_glyph_dimensions(&self,
-                                font_key: FontKey,
-                                size: Au,
-                                character: u32,
-                                _x_subpixel: SubpixelOffset,
-                                _y_subpixel: SubpixelOffset)
-                                -> Option<GlyphDimensions> {
-        self.load_glyph(font_key, size, character).and_then(|slot| {
+     pub fn get_glyph_dimensions(&mut self,
+                                 key: &GlyphKey) -> Option<GlyphDimensions> {
+        self.load_glyph(key.font_key, key.size, key.index).and_then(|slot| {
             let metrics = unsafe { &(*slot).metrics };
             if metrics.width == 0 || metrics.height == 0 {
                 None
@@ -135,20 +131,15 @@ impl FontContext {
     }
 
     pub fn rasterize_glyph(&mut self,
-                           font_key: FontKey,
-                           size: Au,
-                           _color: ColorU,
-                           character: u32,
+                           key: &GlyphKey,
                            render_mode: FontRenderMode,
-                           _x_suboffset: SubpixelOffset,
-                           _y_suboffset: SubpixelOffset,
                            _glyph_options: Option<GlyphOptions>)
                            -> Option<RasterizedGlyph> {
         let mut glyph = None;
 
-        if let Some(slot) = self.load_glyph(font_key,
-                                            size,
-                                            character) {
+        if let Some(slot) = self.load_glyph(key.font_key,
+                                            key.size,
+                                            key.index) {
             let render_mode = match render_mode {
                 FontRenderMode::Mono => FT_Render_Mode::FT_RENDER_MODE_MONO,
                 FontRenderMode::Alpha => FT_Render_Mode::FT_RENDER_MODE_NORMAL,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -417,11 +417,7 @@ impl ResourceCache {
                         }
                     }
 
-                    dimensions = font_context.get_glyph_dimensions(glyph_key.font_key,
-                                                                   glyph_key.size,
-                                                                   glyph_key.index,
-                                                                   glyph_key.x_suboffset,
-                                                                   glyph_key.y_suboffset);
+                    dimensions = font_context.get_glyph_dimensions(glyph_key);
                 });
 
                 *entry.insert(dimensions)
@@ -708,13 +704,8 @@ fn spawn_glyph_cache_thread() -> (Sender<GlyphCacheMsg>, Receiver<GlyphCacheResu
                             thread_pool.execute(move || {
                                 FONT_CONTEXT.with(move |font_context| {
                                     let mut font_context = font_context.borrow_mut();
-                                    let result = font_context.rasterize_glyph(glyph_key.key.font_key,
-                                                                              glyph_key.key.size,
-                                                                              glyph_key.key.color,
-                                                                              glyph_key.key.index,
+                                    let result = font_context.rasterize_glyph(&glyph_key.key,
                                                                               render_mode,
-                                                                              glyph_key.key.x_suboffset,
-                                                                              glyph_key.key.y_suboffset,
                                                                               glyph_options);
                                     glyph_tx.send((glyph_key, result)).unwrap();
                                 });


### PR DESCRIPTION
This might be too much to review for now. Doh. Maybe easier to just review the single commit? https://github.com/servo/webrender/commit/a311e1dddea17df08b9dda17440a49a4dce19051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/811)
<!-- Reviewable:end -->
