### PR TITLE
Improve wrench reftest harness output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "wrench"
 version = "0.1.0"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -55,6 +56,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +105,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1179,6 +1193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "636ee56f12e31dbc11dc0a1ac6004f08b04e6e6595963716fc8130e90d4e04cf"
+"checksum base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d156a04ec694d726e92ea3c13e4a62949b4f0488a9344f04341d679ec6b127b"
 "checksum bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fbba641f73d3e74a5431d4a6d9e42a70bcce76d466d796c852ba1db31ba41bc"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
@@ -1186,6 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8bdd78cca65a739cb5475dbf6b6bbb49373e327f4a6f2b499c0f98632df38c10"
 "checksum clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef87e92396a3d29bf7e611c8a595be35ae90d9cb844a3571425900eaca4f51c8"
 "checksum cmake 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0e5bcf27e097a184c1df4437654ed98df3d7a516e8508a6ba45d8b092bbdf283"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 workspace = ".."
 
 [dependencies]
+base64 = "0.3"
 bincode = "0.6"
 byteorder = "0.5"
 euclid = "0.10"

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -4,6 +4,7 @@
 
 extern crate app_units;
 extern crate byteorder;
+extern crate base64;
 extern crate bincode;
 extern crate webrender;
 extern crate glutin;

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::io::BufReader;
 use std::io::BufRead;
 use std::fs::File;
@@ -5,6 +6,10 @@ use wrench::{Wrench, WrenchThing};
 use std::path::Path;
 use gleam::gl;
 use std::sync::mpsc::{channel, Sender, Receiver};
+
+use base64;
+use image::ColorType;
+use image::png::PNGEncoder;
 
 use yaml_frame_reader::YamlFrameReader;
 use webrender_traits::*;
@@ -21,6 +26,73 @@ pub struct Reftest<'a> {
     test: &'a Path,
     reference: &'a Path,
 }
+
+struct ReftestImage {
+    data: Vec<u8>,
+    size: DeviceUintSize,
+}
+enum ReftestImageComparison {
+    Equal,
+    NotEqual { max_difference: usize, count_different: usize },
+}
+impl ReftestImage {
+    fn compare(&self, other: &ReftestImage) -> ReftestImageComparison {
+        assert!(self.size == other.size);
+        assert!(self.data.len() == other.data.len());
+        assert!(self.data.len() % 4 == 0);
+
+        let mut count = 0;
+        let mut max = 0;
+
+        for (a, b) in self.data.chunks(4).zip(other.data.chunks(4)) {
+            if a != b {
+                let pixel_max = a.iter()
+                                 .zip(b.iter())
+                                 .map(|(x, y)| (*x as isize - *y as isize).abs() as usize)
+                                 .max().unwrap();
+
+                count += 1;
+                max = cmp::max(max, pixel_max);
+            }
+        }
+
+        if count != 0 {
+            ReftestImageComparison::NotEqual {
+                max_difference: max,
+                count_different: count,
+            }
+        } else {
+            ReftestImageComparison::Equal
+        }
+    }
+
+    fn create_data_uri(mut self) -> String {
+        let width = self.size.width;
+        let height = self.size.height;
+
+        // flip image vertically (texture is upside down)
+        let orig_pixels = self.data.clone();
+        let stride = width as usize * 4;
+        for y in 0..height as usize {
+            let dst_start = y * stride;
+            let src_start = (height as usize - y - 1) * stride;
+            let src_slice = &orig_pixels[src_start .. src_start + stride];
+            (&mut self.data[dst_start .. dst_start + stride]).clone_from_slice(&src_slice[..stride]);
+        }
+
+        let mut png: Vec<u8> = vec![];
+        {
+            let encoder = PNGEncoder::new(&mut png);
+            encoder.encode(&self.data[..],
+                            width,
+                            height,
+                            ColorType::RGBA(8)).expect("Unable to encode PNG!");
+        }
+        let png_base64 = base64::encode(&png);
+        format!("data:image/png;base64,{}", png_base64)
+    }
+}
+
 
 fn parse_reftests<F>(manifest: &Path, runner: &mut F)
     where F: FnMut(Reftest)
@@ -65,12 +137,11 @@ fn parse_reftests<F>(manifest: &Path, runner: &mut F)
 
 }
 
-
 fn render_yaml(wrench: &mut Wrench,
                window: &mut WindowWrapper,
                filename: &Path,
                rx: &Receiver<()>)
-               -> Vec<u8> {
+               -> ReftestImage {
     let mut reader = YamlFrameReader::new(filename);
     reader.do_frame(wrench);
     // wait for the frame
@@ -85,7 +156,11 @@ fn render_yaml(wrench: &mut Wrench,
                                  gl::RGBA,
                                  gl::UNSIGNED_BYTE);
     window.swap_buffers();
-    pixels
+
+    ReftestImage {
+        data: pixels,
+        size: DeviceUintSize::new(size.0, size.1)
+    }
 }
 
 pub fn run_reftests(wrench: &mut Wrench, window: &mut WindowWrapper, filename: &str) {
@@ -103,13 +178,53 @@ pub fn run_reftests(wrench: &mut Wrench, window: &mut WindowWrapper, filename: &
     let (tx, rx) = channel();
     wrench.renderer.set_render_notifier(Box::new(Notifier { tx: tx }));
 
+    let mut total_passing = 0;
+    let mut total_failing = 0;
+
     parse_reftests(Path::new(filename), &mut |t: Reftest| {
-        println!("{} {}", t.test.display(), t.reference.display());
+        let name = match t.op {
+            ReftestOp::Equal => format!("{} == {}", t.test.display(), t.reference.display()),
+            ReftestOp::NotEqual => format!("{} != {}", t.test.display(), t.reference.display()),
+        };
+
+        println!("REFTEST {}", name);
+
         let test = render_yaml(wrench, window, t.test, &rx);
         let reference = render_yaml(wrench, window, t.reference, &rx);
-        match t.op {
-            ReftestOp::Equal => assert!(test == reference),
-            ReftestOp::NotEqual => assert!(test != reference),
+        let comparison = test.compare(&reference);
+
+        let success = match (t.op, comparison) {
+            (ReftestOp::Equal, ReftestImageComparison::Equal) => true,
+            (ReftestOp::Equal, ReftestImageComparison::NotEqual { max_difference, count_different }) => {
+                println!("REFTEST TEST-UNEXPECTED-FAIL | {} | image comparison, max difference: {}, number of differing pixels: {}",
+                         name,
+                         max_difference,
+                         count_different);
+                println!("REFTEST   IMAGE 1 (TEST): {}", test.create_data_uri());
+                println!("REFTEST   IMAGE 2 (REFERENCE): {}", reference.create_data_uri());
+                println!("REFTEST TEST-END | {}", name);
+
+                false
+            },
+            (ReftestOp::NotEqual, ReftestImageComparison::Equal) => {
+                println!("REFTEST TEST-UNEXPECTED-FAIL | {} | image comparison", name);
+                println!("REFTEST TEST-END | {}", name);
+
+                false
+            },
+            (ReftestOp::NotEqual, ReftestImageComparison::NotEqual{..}) => true,
+        };
+
+        if success {
+            total_passing += 1;
+        } else {
+            total_failing += 1;
         }
     });
+
+    println!("REFTEST INFO | {} passing, {} failing", total_passing, total_failing);
+
+    if total_failing > 0 {
+        panic!();
+    }
 }


### PR DESCRIPTION
This PR makes the reftest ouput more verbose and compatible with the [reftest analyzer](https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml) in mozilla-central. (for #810)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/813)
<!-- Reviewable:end -->
