### PR TITLE
Handle empty stacking context masks

### DIFF
--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -162,4 +162,12 @@ impl MaskCacheInfo {
             DeviceIntRect::new(self.outer_rect.origin, DeviceIntSize::zero())
         }
     }
+
+    /// Check if this `MaskCacheInfo` actually carries any masks.
+    /// For stacking contexts, we always create the `MaskCacheInfo` and
+    /// change `effective_clip_count` during the `update` call
+    /// depending on the transformation. So the mask may appear to be empty.
+    pub fn is_masking(&self) -> bool {
+        self.image.is_some() || self.effective_clip_count != 0
+    }
 }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -42,7 +42,7 @@ pub trait MatrixHelpers<Src, Dst> {
     /// 2D rectangle.
     fn can_losslessly_transform_a_2d_rect(&self) -> bool;
 
-    /// Returns true if this matrix will transforms an axis-aligned 2D rectangle to another axis-
+    /// Returns true if this matrix transforms an axis-aligned 2D rectangle to another axis-
     /// aligned 2D rectangle after perspective divide.
     fn can_losslessly_transform_and_perspective_project_a_2d_rect(&self) -> bool;
 


### PR DESCRIPTION
Fixes the performance regression of #763

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/815)
<!-- Reviewable:end -->
