### PR TITLE
Remove image borders

### DIFF
--- a/webrender/res/ps_image.fs.glsl
+++ b/webrender/res/ps_image.fs.glsl
@@ -24,8 +24,13 @@ void main(void) {
     // account the spacing in between tiles. We only paint if our fragment does
     // not fall into that spacing.
     vec2 position_in_tile = mod(relative_pos_in_rect, vStretchSize + vTileSpacing);
-    vec2 st = vTextureOffset + ((position_in_tile / vStretchSize) * vTextureSize);
+    // We clamp the texture coordinates to the half-pixel offset from the borders
+    // in order to avoid sampling outside of the texture area.
+    vec2 st = vTextureOffset + clamp(
+        (position_in_tile / vStretchSize) * vTextureSize,
+        vHalfTexel, vTextureSize - vHalfTexel);
+
     alpha = alpha * float(all(bvec2(step(position_in_tile, vStretchSize))));
 
-    oFragColor = vec4(1.0, 1.0, 1.0, alpha) * texture(sColor0, st);
+    oFragColor = vec4(1.0, 1.0, 1.0, alpha) * textureLod(sColor0, st, 0.0);
 }

--- a/webrender/res/ps_image.glsl
+++ b/webrender/res/ps_image.glsl
@@ -5,6 +5,7 @@
 flat varying vec2 vTextureOffset; // Offset of this image into the texture atlas.
 flat varying vec2 vTextureSize;   // Size of the image in the texture atlas.
 flat varying vec2 vTileSpacing;   // Amount of space between tiled instances of this image.
+flat varying vec2 vHalfTexel;     // Normalized length of the half of a texel.
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -36,4 +36,5 @@ void main(void) {
     vTextureOffset = st0;
     vTileSpacing = image.stretch_size_and_tile_spacing.zw;
     vStretchSize = image.stretch_size_and_tile_spacing.xy;
+    vHalfTexel = vec2(0.5) / texture_size;
 }

--- a/webrender/res/ps_text_run.fs.glsl
+++ b/webrender/res/ps_text_run.fs.glsl
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
+    vec2 tc = clamp(vUv, vUvBorder.xy, vUvBorder.zw);
 #ifdef WR_FEATURE_SUBPIXEL_AA
     //note: the blend mode is not compatible with clipping
-    oFragColor = texture(sColor0, vUv);
+    oFragColor = texture(sColor0, tc);
 #else
-    float alpha = texture(sColor0, vUv).a;
+    float alpha = texture(sColor0, tc).a;
 #ifdef WR_FEATURE_TRANSFORM
     float a = 0.0;
     init_transform_fs(vLocalPos, vLocalRect, a);

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -4,6 +4,7 @@
 
 flat varying vec4 vColor;
 varying vec2 vUv;
+flat varying vec4 vUvBorder;
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -37,4 +37,5 @@ void main(void) {
 
     vColor = text.color;
     vUv = mix(st0, st1, f);
+    vUvBorder = (res.uv_rect + vec4(0.5, 0.5, -0.5, -0.5)) / texture_size.xyxy;
 }

--- a/webrender/res/ps_yuv_image.fs.glsl
+++ b/webrender/res/ps_yuv_image.fs.glsl
@@ -19,13 +19,20 @@ void main(void) {
 
     alpha = min(alpha, do_clip());
 
-    vec2 st_y = vTextureOffsetY + relative_pos_in_rect / vStretchSize * vTextureSizeY;
-    vec2 st_u = vTextureOffsetU + relative_pos_in_rect / vStretchSize * vTextureSizeUv;
-    vec2 st_v = vTextureOffsetV + relative_pos_in_rect / vStretchSize * vTextureSizeUv;
+    // We clamp the texture coordinates to the half-pixel offset from the borders
+    // in order to avoid sampling outside of the texture area.
+    vec2 st_y = vTextureOffsetY + clamp(
+        relative_pos_in_rect / vStretchSize * vTextureSizeY,
+        vHalfTexelY, vTextureSizeY - vHalfTexelY);
+    vec2 uv_offset = clamp(
+        relative_pos_in_rect / vStretchSize * vTextureSizeUv,
+        vHalfTexelUv, vTextureSizeUv - vHalfTexelUv);
+    vec2 st_u = vTextureOffsetU + uv_offset;
+    vec2 st_v = vTextureOffsetV + uv_offset;
 
-    float y = texture(sColor0, st_y).r;
-    float u = texture(sColor1, st_u).r;
-    float v = texture(sColor2, st_v).r;
+    float y = textureLod(sColor0, st_y, 0.0).r;
+    float u = textureLod(sColor1, st_u, 0.0).r;
+    float v = textureLod(sColor2, st_v, 0.0).r;
 
     // See the vertex shader for an explanation of where the constants come from.
     vec3 rgb = vYuvColorMatrix * vec3(y - 0.06275, u - 0.50196, v - 0.50196);

--- a/webrender/res/ps_yuv_image.glsl
+++ b/webrender/res/ps_yuv_image.glsl
@@ -8,6 +8,8 @@ flat varying vec2 vTextureOffsetV; // Offset of the v plane into the texture atl
 flat varying vec2 vTextureSizeY;   // Size of the y plane in the texture atlas.
 flat varying vec2 vTextureSizeUv;  // Size of the u and v planes in the texture atlas.
 flat varying vec2 vStretchSize;
+flat varying vec2 vHalfTexelY;     // Normalized length of the half of a Y texel.
+flat varying vec2 vHalfTexelUv;    // Normalized length of the half of u and v texels.
 
 flat varying mat3 vYuvColorMatrix;
 

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -45,6 +45,9 @@ void main(void) {
 
     vStretchSize = image.size;
 
+    vHalfTexelY = vec2(0.5) / y_texture_size;
+    vHalfTexelUv = vec2(0.5) / uv_texture_size;
+
     // The constants added to the Y, U and V components are applied in the fragment shader.
     if (image.color_space == YUV_REC601) {
         // From Rec601:

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -388,10 +388,8 @@ pub enum TextureUpdateOp {
         stride: Option<u32>,
     },
     UpdateForExternalBuffer {
-        allocated_rect: DeviceUintRect,
-        requested_rect: DeviceUintRect,
+        rect: DeviceUintRect,
         id: ExternalImageId,
-        bpp: u32,
         stride: Option<u32>,
     },
     Grow {

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1080,7 +1080,7 @@ impl Renderer {
                                                    width, height, stride,
                                                    data.as_slice());
                     }
-                    TextureUpdateOp::UpdateForExternalBuffer { allocated_rect, requested_rect, id, bpp, stride } => {
+                    TextureUpdateOp::UpdateForExternalBuffer { rect, id, stride } => {
                         let handler = self.external_image_handler
                                           .as_mut()
                                           .expect("Found external image, but no handler set!");
@@ -1089,23 +1089,12 @@ impl Renderer {
 
                         match handler.lock(id).source {
                             ExternalImageSource::RawData(data) => {
-                                // image itself
                                 device.update_texture(cached_id,
-                                                      requested_rect.origin.x,
-                                                      requested_rect.origin.y,
-                                                      requested_rect.size.width,
-                                                      requested_rect.size.height,
+                                                      rect.origin.x,
+                                                      rect.origin.y,
+                                                      rect.size.width,
+                                                      rect.size.height,
                                                       stride, data);
-                                // image's borders
-                                let op = |x , y , w , h , src: Arc<Vec<u8>> , stride| {
-                                    device.update_texture(cached_id, x, y, w, h, stride, src.as_slice());
-                                };
-                                TextureCache::insert_image_border(data,
-                                                                  allocated_rect,
-                                                                  requested_rect,
-                                                                  stride,
-                                                                  bpp,
-                                                                  op);
                             }
                             _ => panic!("No external buffer found"),
                         };


### PR DESCRIPTION
Fixes #789 

Clamping the texture coordinates in pixel shaders (as well as using textureLod) to ensure sampling within original borders now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/818)
<!-- Reviewable:end -->
