### PR TITLE
Have scroll layers clip instead of stacking contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ dependencies = [
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.14.0",
- "webrender_traits 0.13.0",
+ "webrender 0.15.0",
+ "webrender_traits 0.14.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1105,12 +1105,12 @@ dependencies = [
  "offscreen_gl_context 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.13.0",
+ "webrender_traits 0.14.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1170,8 +1170,8 @@ dependencies = [
  "euclid 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.14.0",
- "webrender_traits 0.13.0",
+ "webrender 0.15.0",
+ "webrender_traits 0.14.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -282,6 +282,19 @@ impl Frame {
             let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
             let reference_frame_id = self.scroll_tree.root_reference_frame_id();
             let topmost_scroll_layer_id = self.scroll_tree.topmost_scroll_layer_id();
+            debug_assert!(reference_frame_id != topmost_scroll_layer_id);
+
+            let viewport_rect = LayerRect::new(LayerPoint::zero(), root_pipeline.viewport_size);
+            let clip = ClipRegion::simple(&viewport_rect);
+            context.builder.push_scroll_layer(reference_frame_id,
+                                              &clip,
+                                              &LayerPoint::zero(),
+                                              &root_pipeline.viewport_size);
+            context.builder.push_scroll_layer(topmost_scroll_layer_id,
+                                              &clip,
+                                              &LayerPoint::zero(),
+                                              &root_clip.main.size);
+
             self.flatten_stacking_context(&mut traversal,
                                           root_pipeline_id,
                                           &mut context,
@@ -291,6 +304,9 @@ impl Frame {
                                           0,
                                           &root_stacking_context,
                                           root_clip);
+
+            context.builder.pop_scroll_layer();
+            context.builder.pop_scroll_layer();
         }
 
         self.frame_builder = Some(frame_builder);
@@ -302,10 +318,10 @@ impl Frame {
                                 pipeline_id: PipelineId,
                                 context: &mut FlattenContext,
                                 current_reference_frame_id: ScrollLayerId,
-                                mut current_scroll_layer_id: ScrollLayerId,
+                                parent_scroll_layer_id: ScrollLayerId,
                                 layer_relative_transform: LayerToScrollTransform,
                                 level: i32,
-                                clip: &LayerRect,
+                                clip: &ClipRegion,
                                 content_size: &LayerSize,
                                 new_scroll_layer_id: ScrollLayerId) {
         // Avoid doing unnecessary work for empty stacking contexts.
@@ -314,29 +330,23 @@ impl Frame {
             return;
         }
 
-        let layer = Layer::new(&clip, *content_size, &layer_relative_transform, pipeline_id);
-        self.scroll_tree.add_layer(layer, new_scroll_layer_id, current_scroll_layer_id);
-        current_scroll_layer_id = new_scroll_layer_id;
-
-        let layer_rect = LayerRect::new(LayerPoint::zero(),
-                                        LayerSize::new(content_size.width + clip.origin.x,
-                                                       content_size.height + clip.origin.y));
-        context.builder.push_stacking_context(layer_rect,
-                                              &ClipRegion::simple(&layer_rect),
-                                              LayerToScrollTransform::identity(),
-                                              pipeline_id,
-                                              current_scroll_layer_id,
-                                              CompositeOps::empty());
+        let clip_rect = clip.main;
+        let layer = Layer::new(&clip_rect, *content_size, &layer_relative_transform, pipeline_id);
+        self.scroll_tree.add_layer(layer, new_scroll_layer_id, parent_scroll_layer_id);
+        context.builder.push_scroll_layer(new_scroll_layer_id,
+                                          clip,
+                                          &clip_rect.origin,
+                                          &content_size);
 
         self.flatten_items(traversal,
                            pipeline_id,
                            context,
                            current_reference_frame_id,
-                           current_scroll_layer_id,
+                           new_scroll_layer_id,
                            LayerToScrollTransform::identity(),
                            level);
 
-        context.builder.pop_stacking_context();
+        context.builder.pop_scroll_layer();
     }
 
     fn flatten_stacking_context<'a>(&mut self,
@@ -401,7 +411,6 @@ impl Frame {
                     // Adding a dummy layer for this rectangle in order to disable clipping.
                     let no_clip = ClipRegion::simple(&clip_region.main);
                     context.builder.push_stacking_context(clip_region.main,
-                                                          &no_clip,
                                                           transform,
                                                           pipeline_id,
                                                           scroll_layer_id,
@@ -421,7 +430,6 @@ impl Frame {
 
          // TODO(gw): Int with overflow etc
         context.builder.push_stacking_context(clip_region.main,
-                                              &clip_region,
                                               transform,
                                               pipeline_id,
                                               scroll_layer_id,
@@ -494,6 +502,15 @@ impl Frame {
                                    iframe_scroll_layer_id,
                                    iframe_reference_frame_id);
 
+        context.builder.push_scroll_layer(iframe_reference_frame_id,
+                                          iframe_clip,
+                                          &LayerPoint::zero(),
+                                          &iframe_rect.size);
+        context.builder.push_scroll_layer(iframe_scroll_layer_id,
+                                          iframe_clip,
+                                          &LayerPoint::zero(),
+                                          &iframe_clip.main.size);
+
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
 
         self.flatten_stacking_context(&mut traversal,
@@ -505,6 +522,9 @@ impl Frame {
                                       0,
                                       &iframe_stacking_context,
                                       iframe_clip);
+
+        context.builder.pop_scroll_layer();
+        context.builder.pop_scroll_layer();
     }
 
     fn flatten_items<'a>(&mut self,
@@ -603,7 +623,7 @@ impl Frame {
                                               current_scroll_layer_id,
                                               layer_relative_transform,
                                               level,
-                                              &item.rect,
+                                              &item.clip,
                                               &info.content_size,
                                               info.id);
                 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -32,8 +32,8 @@ use std::usize;
 use texture_cache::TexturePage;
 use util::{self, pack_as_float, rect_from_points_f, subtract_rect};
 use util::{TransformedRect, TransformedRectKind};
-use webrender_traits::{ColorF, ExtendMode, FontKey, ImageKey, ImageRendering, MixBlendMode};
-use webrender_traits::{BorderDisplayItem, BorderSide, BorderStyle, YuvColorSpace};
+use webrender_traits::{ColorF, ExtendMode, FontKey, ImageKey, ImageRendering};
+use webrender_traits::{BorderDisplayItem, BorderSide, BorderStyle, MixBlendMode, YuvColorSpace};
 use webrender_traits::{AuxiliaryLists, ItemRange, BoxShadowClipMode, ClipRegion};
 use webrender_traits::{PipelineId, ScrollLayerId, WebGLContextId, FontRenderMode};
 use webrender_traits::{DeviceIntRect, DeviceIntPoint, DeviceIntSize, DeviceIntLength, device_length};
@@ -378,8 +378,12 @@ struct ScrollbarPrimitive {
 
 enum PrimitiveRunCmd {
     PushStackingContext(StackingContextIndex),
-    PrimitiveRun(PrimitiveIndex, usize),
     PopStackingContext,
+
+    PushScrollLayer(ScrollLayerIndex),
+    PopScrollLayer,
+
+    PrimitiveRun(PrimitiveIndex, usize),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -407,7 +411,7 @@ pub struct RenderTaskIndex(usize);
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum MaskCacheKey {
     Primitive(PrimitiveIndex),
-    StackingContext(StackingContextIndex),
+    ScrollLayer(ScrollLayerIndex),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -794,16 +798,14 @@ impl ClipBatcher {
 
     fn add<'a>(&mut self,
                task_index: RenderTaskIndex,
-               clips: &[(StackingContextIndex, MaskCacheInfo)],
+               clips: &[(PackedLayerIndex, MaskCacheInfo)],
                resource_cache: &ResourceCache,
-               stacking_context_store: &'a [StackingContext],
                geometry_kind: MaskGeometryKind) {
 
-        for &(stacking_context_index, ref info) in clips.iter() {
-            let stacking_context = &stacking_context_store[stacking_context_index.0];
+        for &(packed_layer_index, ref info) in clips.iter() {
             let instance = CacheClipInstance {
                 task_id: task_index.0 as i32,
-                layer_index: stacking_context.packed_layer_index.0 as i32,
+                layer_index: packed_layer_index.0 as i32,
                 address: GpuStoreAddress(0),
                 segment: 0,
             };
@@ -1008,7 +1010,6 @@ impl RenderTarget {
                 self.clip_batcher.add(task_index,
                                       &task_info.clips,
                                       &ctx.resource_cache,
-                                      &ctx.stacking_context_store,
                                       task_info.geometry_kind);
             }
             RenderTaskKind::Readback(device_rect) => {
@@ -1162,7 +1163,7 @@ enum MaskGeometryKind {
 pub struct CacheMaskTask {
     actual_rect: DeviceIntRect,
     inner_rect: DeviceIntRect,
-    clips: Vec<(StackingContextIndex, MaskCacheInfo)>,
+    clips: Vec<(PackedLayerIndex, MaskCacheInfo)>,
     geometry_kind: MaskGeometryKind,
 }
 
@@ -1234,8 +1235,7 @@ impl RenderTask {
 
     fn new_mask(actual_rect: DeviceIntRect,
                 mask_key: MaskCacheKey,
-                clips: &[(StackingContextIndex, MaskCacheInfo)],
-                stacking_context_store: &[StackingContext])
+                clips: &[(PackedLayerIndex, MaskCacheInfo)])
                 -> MaskResult {
         if clips.is_empty() {
             return MaskResult::Outside;
@@ -1265,13 +1265,11 @@ impl RenderTask {
         //           In the future, we'll expand this to handle the
         //           more complex types of clip mask geometry.
         let mut geometry_kind = MaskGeometryKind::Default;
-
         if inner_rect.is_some() && clips.len() == 1 {
-            let (stacking_context_index, ref clip_info) = clips[0];
-            let stacking_context = &stacking_context_store[stacking_context_index.0];
-
-            if clip_info.image.is_none() && clip_info.effective_clip_count == 1 &&
-               stacking_context.xf_rect.as_ref().unwrap().kind == TransformedRectKind::AxisAligned {
+            let (_, ref clip_info) = clips[0];
+            if clip_info.image.is_none() &&
+               clip_info.effective_clip_count == 1 &&
+               clip_info.is_aligned {
                 geometry_kind = MaskGeometryKind::CornersOnly;
             }
         }
@@ -1700,9 +1698,18 @@ pub struct StackingContext {
     scroll_layer_id: ScrollLayerId,
     xf_rect: Option<TransformedRect>,
     composite_ops: CompositeOps,
+    packed_layer_index: PackedLayerIndex,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ScrollLayerIndex(pub usize);
+
+pub struct ScrollLayer {
+    scroll_layer_id: ScrollLayerId,
     clip_source: ClipSource,
     clip_cache_info: Option<MaskCacheInfo>,
     packed_layer_index: PackedLayerIndex,
+    xf_rect: Option<TransformedRect>,
 }
 
 #[derive(Debug, Clone)]
@@ -1798,6 +1805,7 @@ pub struct FrameBuilder {
     config: FrameBuilderConfig,
 
     stacking_context_store: Vec<StackingContext>,
+    scroll_layer_store: Vec<ScrollLayer>,
     packed_layers: Vec<PackedLayer>,
 
     scrollbar_prims: Vec<ScrollbarPrimitive>,
@@ -1839,6 +1847,7 @@ impl FrameBuilder {
             screen_rect: LayerRect::new(LayerPoint::zero(), viewport_size),
             background_color: background_color,
             stacking_context_store: Vec::new(),
+            scroll_layer_store: Vec::new(),
             prim_store: PrimitiveStore::new(),
             cmds: Vec::new(),
             _debug: debug,
@@ -1878,7 +1887,9 @@ impl FrameBuilder {
                 return prim_index;
             }
             &mut PrimitiveRunCmd::PushStackingContext(..) |
-            &mut PrimitiveRunCmd::PopStackingContext => {}
+            &mut PrimitiveRunCmd::PopStackingContext |
+            &mut PrimitiveRunCmd::PushScrollLayer(..) |
+            &mut PrimitiveRunCmd::PopScrollLayer => {}
         }
 
         self.cmds.push(PrimitiveRunCmd::PrimitiveRun(prim_index, 1));
@@ -1888,18 +1899,12 @@ impl FrameBuilder {
 
     pub fn push_stacking_context(&mut self,
                                  rect: LayerRect,
-                                 clip_region: &ClipRegion,
                                  transform: LayerToScrollTransform,
                                  pipeline_id: PipelineId,
                                  scroll_layer_id: ScrollLayerId,
                                  composite_ops: CompositeOps) {
         let stacking_context_index = StackingContextIndex(self.stacking_context_store.len());
         let packed_layer_index = PackedLayerIndex(self.packed_layers.len());
-
-        let clip_source = ClipSource::Region(clip_region.clone());
-        let clip_info = MaskCacheInfo::new(&clip_source,
-                                           true, // needs an extra clip for the clip rectangle
-                                           &mut self.prim_store.gpu_data32);
 
         self.stacking_context_store.push(StackingContext {
             local_rect: rect,
@@ -1908,8 +1913,6 @@ impl FrameBuilder {
             pipeline_id: pipeline_id,
             xf_rect: None,
             composite_ops: composite_ops,
-            clip_source: clip_source,
-            clip_cache_info: clip_info,
             packed_layer_index: packed_layer_index,
         });
 
@@ -1919,6 +1922,48 @@ impl FrameBuilder {
 
     pub fn pop_stacking_context(&mut self) {
         self.cmds.push(PrimitiveRunCmd::PopStackingContext);
+    }
+
+    pub fn push_scroll_layer(&mut self,
+                             scroll_layer_id: ScrollLayerId,
+                             clip_region: &ClipRegion,
+                             iframe_origin: &LayerPoint,
+                             content_size: &LayerSize) {
+        let scroll_layer_index = ScrollLayerIndex(self.scroll_layer_store.len());
+        let packed_layer_index = PackedLayerIndex(self.packed_layers.len());
+
+        let clip_source = ClipSource::Region(clip_region.clone());
+        let clip_info = MaskCacheInfo::new(&clip_source,
+                                           true, // needs an extra clip for the clip rectangle
+                                           &mut self.prim_store.gpu_data32);
+
+        self.scroll_layer_store.push(ScrollLayer {
+            scroll_layer_id: scroll_layer_id,
+            clip_source: clip_source,
+            clip_cache_info: clip_info,
+            xf_rect: None,
+            packed_layer_index: packed_layer_index,
+        });
+
+        self.packed_layers.push(Default::default());
+        self.cmds.push(PrimitiveRunCmd::PushScrollLayer(scroll_layer_index));
+
+        // We need to push a fake stacking context here, because primitives that are
+        // direct children of this stacking context, need to be adjusted by the scroll
+        // offset of this layer. Eventually we should be able to remove this.
+        let rect = LayerRect::new(LayerPoint::zero(),
+                                  LayerSize::new(content_size.width + iframe_origin.x,
+                                                 content_size.height + iframe_origin.y));
+        self.push_stacking_context(rect,
+                                   LayerToScrollTransform::identity(),
+                                   scroll_layer_id.pipeline_id,
+                                   scroll_layer_id,
+                                   CompositeOps::empty());
+    }
+
+    pub fn pop_scroll_layer(&mut self) {
+        self.pop_stacking_context();
+        self.cmds.push(PrimitiveRunCmd::PopScrollLayer);
     }
 
     pub fn add_solid_rectangle(&mut self,
@@ -2386,6 +2431,7 @@ impl FrameBuilder {
 
         // TODO(gw): Remove this stack once the layers refactor is done!
         let mut stacking_context_stack: Vec<StackingContextIndex> = Vec::new();
+        let mut scroll_layer_stack: Vec<ScrollLayerIndex> = Vec::new();
         let mut clip_info_stack = Vec::new();
 
         for cmd in &self.cmds {
@@ -2410,15 +2456,14 @@ impl FrameBuilder {
                     }
 
                     let inv_layer_transform = stacking_context.local_transform.inverse().unwrap();
+
                     let local_viewport_rect =
                         as_scroll_parent_rect(&scroll_layer.combined_local_viewport_rect);
+
                     let viewport_rect = inv_layer_transform.transform_rect(&local_viewport_rect);
-                    let local_clip_rect =
-                        stacking_context.clip_source.to_rect().unwrap_or(stacking_context.local_rect);
+
                     let layer_local_rect =
-                         stacking_context.local_rect
-                                         .intersection(&viewport_rect)
-                                         .and_then(|rect| rect.intersection(&local_clip_rect));
+                         stacking_context.local_rect.intersection(&viewport_rect);
 
                     if let Some(layer_local_rect) = layer_local_rect {
                         let layer_xf_rect = TransformedRect::new(&layer_local_rect,
@@ -2431,25 +2476,51 @@ impl FrameBuilder {
                             stacking_context.xf_rect = Some(layer_xf_rect);
                         }
                     }
+                }
+                &PrimitiveRunCmd::PushScrollLayer(scroll_layer_index) => {
+                    scroll_layer_stack.push(scroll_layer_index);
+                    let scroll_layer = &mut self.scroll_layer_store[scroll_layer_index.0];
+                    let packed_layer_index = scroll_layer.packed_layer_index;
 
-                    if let Some(ref mut clip_info) = stacking_context.clip_cache_info {
-                        let auxiliary_lists = auxiliary_lists_map.get(&stacking_context.pipeline_id)
+                    let scroll_tree_layer = &scroll_tree.layers[&scroll_layer.scroll_layer_id];
+                    let packed_layer = &mut self.packed_layers[packed_layer_index.0];
+
+                    packed_layer.transform = scroll_tree_layer.world_viewport_transform;
+                    packed_layer.inv_transform = packed_layer.transform.inverse().unwrap();
+
+                    let local_rect = &scroll_tree_layer.combined_local_viewport_rect
+                                                       .translate(&scroll_tree_layer.scrolling.offset);
+                    if !local_rect.is_empty() {
+                        let layer_xf_rect = TransformedRect::new(local_rect,
+                                                                 &packed_layer.transform,
+                                                                 device_pixel_ratio);
+
+                        if layer_xf_rect.bounding_rect.intersects(&screen_rect) {
+                            packed_layer.screen_vertices = layer_xf_rect.vertices.clone();
+                            packed_layer.local_clip_rect = *local_rect;
+                            scroll_layer.xf_rect = Some(layer_xf_rect);
+                        }
+                    }
+
+                    if let Some(ref mut clip_info) = scroll_layer.clip_cache_info {
+                        let pipeline_id = scroll_layer.scroll_layer_id.pipeline_id;
+                        let auxiliary_lists = auxiliary_lists_map.get(&pipeline_id)
                                                                  .expect("No auxiliary lists?");
-                        clip_info.update(&stacking_context.clip_source,
+                        clip_info.update(&scroll_layer.clip_source,
                                          &packed_layer.transform,
                                          &mut self.prim_store.gpu_data32,
                                          device_pixel_ratio,
                                          auxiliary_lists);
-                        if let ClipSource::Region(ClipRegion{ image_mask: Some(ref mask), .. }) = stacking_context.clip_source {
+                        if let Some(mask) = scroll_layer.clip_source.image_mask() {
+                            // Note: no need to add the image mask for resolution, because all
+                            // layer masks get resolved later.
                             resource_cache.request_image(mask.image, ImageRendering::Auto);
-                            //Note: no need to add the stacking context for resolve, all layers get resolved
                         }
 
                         // Create a task for the stacking context mask, if needed, i.e. if there
                         // are rounded corners or image masks for the stacking context.
-                        clip_info_stack.push((stacking_context_index, clip_info.clone()));
+                        clip_info_stack.push((packed_layer_index, clip_info.clone()));
                     }
-
                 }
                 &PrimitiveRunCmd::PrimitiveRun(prim_index, prim_count) => {
                     let stacking_context_index = stacking_context_stack.last().unwrap();
@@ -2458,7 +2529,11 @@ impl FrameBuilder {
                         continue;
                     }
 
-                    let packed_layer = &self.packed_layers[stacking_context.packed_layer_index.0];
+                    let scroll_layer_index = scroll_layer_stack.last().unwrap();
+                    let scroll_layer = &self.scroll_layer_store[scroll_layer_index.0];
+
+                    let packed_layer_index = stacking_context.packed_layer_index;
+                    let packed_layer = &self.packed_layers[packed_layer_index.0];
                     let auxiliary_lists = auxiliary_lists_map.get(&stacking_context.pipeline_id)
                                                              .expect("No auxiliary lists?");
 
@@ -2490,7 +2565,7 @@ impl FrameBuilder {
                                 let mut visible = true;
 
                                 if let Some(info) = prim_clip_info {
-                                    clip_info_stack.push((*stacking_context_index, info.clone()));
+                                    clip_info_stack.push((packed_layer_index, info.clone()));
                                 }
 
                                 // Try to create a mask if we may need to.
@@ -2505,15 +2580,12 @@ impl FrameBuilder {
                                             (MaskCacheKey::Primitive(prim_index), prim_bounding_rect)
                                         }
                                         None => {
-                                            (MaskCacheKey::StackingContext(*stacking_context_index),
-                                             stacking_context.xf_rect.as_ref().unwrap().bounding_rect)
+                                            (MaskCacheKey::ScrollLayer(*scroll_layer_index),
+                                             scroll_layer.xf_rect.as_ref().unwrap().bounding_rect)
                                         }
                                     };
                                     let mask_opt =
-                                        RenderTask::new_mask(mask_rect,
-                                                             mask_key,
-                                                             &clip_info_stack,
-                                                             &self.stacking_context_store);
+                                        RenderTask::new_mask(mask_rect, mask_key, &clip_info_stack);
                                     match mask_opt {
                                         MaskResult::Outside => {
                                             // Primitive is completely clipped out.
@@ -2540,15 +2612,16 @@ impl FrameBuilder {
                     }
                 }
                 &PrimitiveRunCmd::PopStackingContext => {
-                    let stacking_context_index = *stacking_context_stack.last().unwrap();
-                    let stacking_context = &self.stacking_context_store[stacking_context_index.0];
-                    if stacking_context.can_contribute_to_scene() {
-                        if stacking_context.clip_cache_info.is_some() {
-                            clip_info_stack.pop().unwrap();
-                        }
+                    stacking_context_stack.pop();
+                }
+                &PrimitiveRunCmd::PopScrollLayer => {
+                    let scroll_layer_index = *scroll_layer_stack.last().unwrap();
+                    let scroll_layer = &self.scroll_layer_store[scroll_layer_index.0];
+                    if scroll_layer.clip_cache_info.is_some() {
+                        clip_info_stack.pop().unwrap();
                     }
+                    scroll_layer_stack.pop().unwrap();
 
-                    stacking_context_stack.pop().unwrap();
                 }
             }
         }
@@ -2711,6 +2784,7 @@ impl FrameBuilder {
                         }
                     }
                 }
+                PrimitiveRunCmd::PushScrollLayer(_) | PrimitiveRunCmd::PopScrollLayer => { }
             }
         }
 
@@ -2760,8 +2834,8 @@ impl FrameBuilder {
 
         resource_cache.block_until_all_resources_added();
 
-        for stacking_context in self.stacking_context_store.iter() {
-            if let Some(ref clip_info) = stacking_context.clip_cache_info {
+        for scroll_layer in self.scroll_layer_store.iter() {
+            if let Some(ref clip_info) = scroll_layer.clip_cache_info {
                 self.prim_store.resolve_clip_cache(clip_info, resource_cache);
             }
         }

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -326,7 +326,7 @@ impl DisplayListBuilder {
     }
 
     pub fn push_scroll_layer(&mut self,
-                             clip: LayoutRect,
+                             clip: ClipRegion,
                              content_size: LayoutSize,
                              scroll_root_id: ServoScrollRootId) {
         let scroll_layer_id = self.next_scroll_layer_id;
@@ -339,8 +339,8 @@ impl DisplayListBuilder {
 
         let item = DisplayItem {
             item: SpecificDisplayItem::PushScrollLayer(item),
-            rect: clip,
-            clip: ClipRegion::simple(&LayoutRect::zero()),
+            rect: clip.main,
+            clip: clip,
         };
         self.list.push(item);
     }

--- a/wrench/reftests/mask/aligned-layer-rect.yaml
+++ b/wrench/reftests/mask/aligned-layer-rect.yaml
@@ -2,14 +2,16 @@
 root:
   items:
     - 
-      type: stacking_context
+      type: scroll_layer
       bounds: [0, 0, 95, 88]
+      content-size: [95, 88]
       clip:
         rect: [9, 9, 10, 10]
       items:
         - 
-          type: stacking_context
+          type: scroll_layer
           bounds: [0, 0, 95, 88]
+          content-size: [95, 88]
           clip:
               rect: [0, 0, 100, 100]
           items:

--- a/wrench/reftests/mask/mask.yaml
+++ b/wrench/reftests/mask/mask.yaml
@@ -1,17 +1,13 @@
 ---
 root:
   items:
-    - 
+    -
       bounds: [0, 0, 95, 88]
+      type: rect
+      color: blue
       clip:
         image_mask:
           image: "mask.png"
           rect: [0, 0, 35, 35]
           repeat: false
         rect: [0, 0, 95, 88]
-      items:
-        - 
-          bounds: [0, 0, 95, 88]
-          type: rect
-          color: blue
-      type: stacking_context

--- a/wrench/reftests/mask/nested-mask.yaml
+++ b/wrench/reftests/mask/nested-mask.yaml
@@ -2,8 +2,9 @@
 root:
   items:
     - 
-      type: stacking_context
+      type: scroll_layer
       bounds: [0, 0, 95, 88]
+      content-size: [95, 88]
       clip:
         image_mask:
           image: "mask.png"
@@ -12,8 +13,9 @@ root:
         rect: [0, 0, 95, 88]
       items:
         - 
-          type: stacking_context
+          type: scroll_layer
           bounds: [0, 0, 95, 88]
+          content-size: [95, 88]
           clip:
             image_mask:
               image: "mask.png"

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -457,6 +457,8 @@ impl YamlFrameReader {
         let bounds = yaml["bounds"].as_rect().expect("scroll layer must have bounds");
         let content_size = yaml["content-size"].as_size()
                                                .expect("scroll layer must have content size");
+        let clip = self.to_clip_region(&yaml["clip"], &bounds, wrench)
+                       .unwrap_or(ClipRegion::simple(&bounds));
 
         let scroll_root_id = ServoScrollRootId(self.current_scroll_root_id);
         if let Some(size) = yaml["scroll-offset"].as_point() {
@@ -464,7 +466,7 @@ impl YamlFrameReader {
             *entry = LayerPoint::new(size.x, size.y);
         }
 
-        self.builder().push_scroll_layer(bounds, content_size, scroll_root_id);
+        self.builder().push_scroll_layer(clip, content_size, scroll_root_id);
 
         if !yaml["items"].is_badvalue() {
             self.add_display_list_items_from_yaml(wrench, &yaml["items"]);


### PR DESCRIPTION
This is another step on the path to make clipping totally independent
of stacking contexts in order to have contents of the same stacking
contents clipped by different scrolling roots. As part of this change,
scrolling roots are integrated into the frame builder's primitive run
commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/828)
<!-- Reviewable:end -->
