### PR TITLE
Implement an API that allows animating certain properties of an existing display list.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -112,8 +112,8 @@ fn main() {
                                   bounds,
                                   clip_region,
                                   0,
-                                  &LayoutTransform::identity(),
-                                  &LayoutTransform::identity(),
+                                  LayoutTransform::identity().into(),
+                                  LayoutTransform::identity(),
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
 
@@ -235,7 +235,7 @@ fn main() {
         builder,
         true);
     api.set_root_pipeline(pipeline_id);
-    api.generate_frame();
+    api.generate_frame(None);
 
     for event in window.wait_events() {
         renderer.update();

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -68,7 +68,7 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         &ApiMsg::AddRawFont(..) |
         &ApiMsg::AddNativeFont(..) |
         &ApiMsg::AddImage(..) |
-        &ApiMsg::GenerateFrame |
+        &ApiMsg::GenerateFrame(..) |
         &ApiMsg::UpdateImage(..) |
         &ApiMsg::DeleteImage(..) |
         &ApiMsg::SetRootDisplayList(..) |

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -7,7 +7,71 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::AuxiliaryListsMap;
 use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch, ColorF};
-use webrender_traits::{DisplayItem, LayerSize};
+use webrender_traits::{DisplayItem, DynamicProperties, LayerSize, LayoutTransform};
+use webrender_traits::{PropertyBinding, PropertyBindingId};
+
+/// Stores a map of the animated property bindings for the current display list. These
+/// can be used to animate the transform and/or opacity of a display list without
+/// re-submitting the display list itself.
+pub struct SceneProperties {
+    transform_properties: HashMap<PropertyBindingId, LayoutTransform>,
+    float_properties: HashMap<PropertyBindingId, f32>,
+}
+
+impl SceneProperties {
+    pub fn new() -> SceneProperties {
+        SceneProperties {
+            transform_properties: HashMap::with_hasher(Default::default()),
+            float_properties: HashMap::with_hasher(Default::default()),
+        }
+    }
+
+    /// Set the current property list for this display list.
+    pub fn set_properties(&mut self, properties: DynamicProperties) {
+        self.transform_properties.clear();
+        self.float_properties.clear();
+
+        for property in properties.transforms {
+            self.transform_properties.insert(property.key.id, property.value);
+        }
+
+        for property in properties.floats {
+            self.float_properties.insert(property.key.id, property.value);
+        }
+    }
+
+    /// Get the current value for a transform property.
+    pub fn resolve_layout_transform(&self, property: &PropertyBinding<LayoutTransform>) -> LayoutTransform {
+        match *property {
+            PropertyBinding::Value(matrix) => matrix,
+            PropertyBinding::Binding(ref key) => {
+                self.transform_properties
+                    .get(&key.id)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        warn!("Property binding {:?} has an invalid value.", key);
+                        LayoutTransform::identity()
+                    })
+            }
+        }
+    }
+
+    /// Get the current value for a float property.
+    pub fn resolve_float(&self, property: &PropertyBinding<f32>, default_value: f32) -> f32 {
+        match *property {
+            PropertyBinding::Value(value) => value,
+            PropertyBinding::Binding(ref key) => {
+                self.float_properties
+                    .get(&key.id)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        warn!("Property binding {:?} has an invalid value.", key);
+                        default_value
+                    })
+            }
+        }
+    }
+}
 
 /// A representation of the layout within the display port for a given document or iframe.
 #[derive(Debug)]
@@ -24,6 +88,7 @@ pub struct Scene {
     pub pipeline_map: HashMap<PipelineId, ScenePipeline, BuildHasherDefault<FnvHasher>>,
     pub pipeline_auxiliary_lists: AuxiliaryListsMap,
     pub display_lists: HashMap<PipelineId, Vec<DisplayItem>, BuildHasherDefault<FnvHasher>>,
+    pub properties: SceneProperties,
 }
 
 impl Scene {
@@ -33,6 +98,7 @@ impl Scene {
             pipeline_map: HashMap::with_hasher(Default::default()),
             pipeline_auxiliary_lists: HashMap::with_hasher(Default::default()),
             display_lists: HashMap::with_hasher(Default::default()),
+            properties: SceneProperties::new(),
         }
     }
 

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -15,7 +15,7 @@ use {PushScrollLayerItem, PushStackingContextDisplayItem, RectangleDisplayItem, 
 use {ScrollPolicy, ServoScrollRootId, SpecificDisplayItem, StackingContext, TextDisplayItem};
 use {WebGLContextId, WebGLDisplayItem, YuvImageDisplayItem};
 use {LayoutTransform, LayoutPoint, LayoutRect, LayoutSize};
-use {GlyphOptions};
+use {GlyphOptions, PropertyBinding};
 
 impl BuiltDisplayListDescriptor {
     pub fn size(&self) -> usize {
@@ -292,16 +292,16 @@ impl DisplayListBuilder {
                                  bounds: LayoutRect,
                                  clip: ClipRegion,
                                  z_index: i32,
-                                 transform: &LayoutTransform,
-                                 perspective: &LayoutTransform,
+                                 transform: PropertyBinding<LayoutTransform>,
+                                 perspective: LayoutTransform,
                                  mix_blend_mode: MixBlendMode,
                                  filters: Vec<FilterOp>) {
         let stacking_context = StackingContext {
             scroll_policy: scroll_policy,
             bounds: bounds,
             z_index: z_index,
-            transform: transform.clone(),
-            perspective: perspective.clone(),
+            transform: transform,
+            perspective: perspective,
             mix_blend_mode: mix_blend_mode,
             filters: self.auxiliary_lists_builder.add_filters(&filters),
         };

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -4,14 +4,14 @@
 
 use display_list::AuxiliaryListsBuilder;
 use {FilterOp, MixBlendMode, ScrollPolicy, StackingContext};
-use {LayoutTransform, LayoutRect};
+use {LayoutTransform, LayoutRect, PropertyBinding};
 
 impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
                bounds: LayoutRect,
                z_index: i32,
-               transform: &LayoutTransform,
-               perspective: &LayoutTransform,
+               transform: PropertyBinding<LayoutTransform>,
+               perspective: LayoutTransform,
                mix_blend_mode: MixBlendMode,
                filters: Vec<FilterOp>,
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
@@ -20,8 +20,8 @@ impl StackingContext {
             scroll_policy: scroll_policy,
             bounds: bounds,
             z_index: z_index,
-            transform: transform.clone(),
-            perspective: perspective.clone(),
+            transform: transform,
+            perspective: perspective,
             mix_blend_mode: mix_blend_mode,
             filters: auxiliary_lists_builder.add_filters(&filters),
         }

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -132,7 +132,7 @@ impl WrenchThing for BinaryFrameReader {
                     let mut buffer = vec![0; len as usize];
                     self.file.read_exact(&mut buffer).unwrap();
                     let msg = deserialize(&buffer).unwrap();
-                    let found_frame_marker = match &msg { &ApiMsg::GenerateFrame => true, _ => false };
+                    let found_frame_marker = match &msg { &ApiMsg::GenerateFrame(..) => true, _ => false };
                     self.frame_data.push(Item::Message(msg));
                     if found_frame_marker {
                         break;

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -344,7 +344,7 @@ impl Wrench {
                                                        *scroll_root_id);
         }
 
-        self.api.generate_frame();
+        self.api.generate_frame(None);
     }
 
     pub fn render(&mut self) {
@@ -354,7 +354,7 @@ impl Wrench {
 
     pub fn refresh(&mut self) {
         self.begin_frame();
-        self.api.generate_frame();
+        self.api.generate_frame(None);
     }
 
     pub fn show_onscreen_help(&mut self) {

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -511,8 +511,8 @@ impl YamlFrameReader {
                                              bounds,
                                              clip,
                                              z_index as i32,
-                                             &transform,
-                                             &perspective,
+                                             transform.into(),
+                                             perspective,
                                              mix_blend_mode,
                                              filters);
 

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -177,8 +177,12 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
     scroll_policy_node(parent, "scroll-policy", sc.scroll_policy);
     i32_node(parent, "z_index", sc.z_index);
 
-    if sc.transform != LayoutTransform::identity() {
-        matrix4d_node(parent, "transform", &sc.transform);
+    let transform = match sc.transform {
+        PropertyBinding::Value(m) => m,
+        PropertyBinding::Binding(..) => panic!("TODO: Handle property bindings in wrench!"),
+    };
+    if transform != LayoutTransform::identity() {
+        matrix4d_node(parent, "transform", &transform);
     }
     if sc.perspective != LayoutTransform::identity() {
         matrix4d_node(parent, "perspective", &sc.perspective);

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -344,7 +344,8 @@ impl YamlHelper for Yaml {
                     Some(FilterOp::Invert(args[0].parse().unwrap()))
                 }
                 ("opacity", ref args) if args.len() == 1 =>  {
-                    Some(FilterOp::Opacity(args[0].parse().unwrap()))
+                    let amount: f32 = args[0].parse().unwrap();
+                    Some(FilterOp::Opacity(amount.into()))
                 }
                 ("saturate", ref args) if args.len() == 1 =>  {
                     Some(FilterOp::Saturate(args[0].parse().unwrap()))


### PR DESCRIPTION
Currently, this allows animating the transform and opacity of
a stacking context, but it can easily be extended in the future
to handle other property types (e.g. other filters etc).

The current list of property values are passed via the
GenerateFrame message, which ensures that all animated properties
are updated atomically.

The implementation right now is far from optimal. The idea here
is to get the public API correct and implemented, and then we can
focus on optimizing the implementation, once the in-progress work
on scroll layers and reference frames lands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/832)
<!-- Reviewable:end -->
