### PR TITLE
Switch to get_inner_size_pixels()

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -205,9 +205,9 @@ impl WindowWrapper {
         }
     }
 
-    fn get_inner_size(&self) -> (u32, u32) {
+    fn get_inner_size_pixels(&self) -> (u32, u32) {
         match *self {
-            WindowWrapper::Window(ref window) => window.get_inner_size().unwrap(),
+            WindowWrapper::Window(ref window) => window.get_inner_size_pixels().unwrap(),
             WindowWrapper::Headless(ref context) => (context.width, context.height),
         }
     }
@@ -330,7 +330,7 @@ fn main() {
 
     let queue_frames = thing.queue_frames();
     for _ in 0..queue_frames {
-        let (width, height) = window.get_inner_size();
+        let (width, height) = window.get_inner_size_pixels();
         let dim = DeviceUintSize::new(width, height);
         wrench.update(dim);
 
@@ -401,7 +401,7 @@ fn main() {
 
             match event {
                 glutin::Event::Awakened => {
-                    let (width, height) = window.get_inner_size();
+                    let (width, height) = window.get_inner_size_pixels();
                     let dim = DeviceUintSize::new(width, height);
                     wrench.update(dim);
 

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -148,7 +148,7 @@ fn render_yaml(wrench: &mut Wrench,
     rx.recv().unwrap();
     wrench.render();
 
-    let size = window.get_inner_size();
+    let size = window.get_inner_size_pixels();
     let pixels = gl::read_pixels(0,
                                  0,
                                  size.0 as gl::GLsizei,


### PR DESCRIPTION
This fixes rendering on hidpi mac. get_inner_size() is deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/851)
<!-- Reviewable:end -->
