### PR TITLE
Support using the same vector cache thread and thread pool with several render backends

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -9,7 +9,7 @@ use internal_types::{FontTemplate, GLContextHandleWrapper, GLContextWrapper};
 use internal_types::{SourceTexture, ResultMsg, RendererFrame};
 use profiler::BackendProfileCounters;
 use record::ApiRecordingReceiver;
-use resource_cache::ResourceCache;
+use resource_cache::{ResourceCache, VectorCacheMsg};
 use scene::Scene;
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
@@ -57,6 +57,7 @@ impl RenderBackend {
                payload_rx: PayloadReceiver,
                payload_tx: PayloadSender,
                result_tx: Sender<ResultMsg>,
+               vector_cache_tx: Sender<VectorCacheMsg>,
                device_pixel_ratio: f32,
                texture_cache: TextureCache,
                enable_aa: bool,
@@ -68,6 +69,7 @@ impl RenderBackend {
                vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>) -> RenderBackend {
 
         let resource_cache = ResourceCache::new(texture_cache,
+                                                vector_cache_tx,
                                                 enable_aa);
 
         RenderBackend {


### PR DESCRIPTION
This PR renames the glyph cache thread into vector cache thread in preparation for the upcoming vector image renderer work, and makes it possible for several render backends to use the same vector cache thread.
This makes it possible to prevent creating 5 threads for each window (Gecko tends to have a bunch of them since each tooltip and popup is its own window), although by default (as in RendererOption::default()), each Renderer creates its own vector cache thread with 4 worker threads.

The main difference is that the vector cache thread doesn't keep a Sender<VectorCacheResultMsg> anymore, the latter being passed in the EndFrame message every time.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/852)
<!-- Reviewable:end -->
