### PR TITLE
Remove unnecessary workspace pointers.

### DIFF
--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -2,7 +2,6 @@
 name = "wr_sample"
 version = "0.1.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
-workspace = ".."
 license = "MPL-2.0"
 
 [dependencies.webrender]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
 build = "build.rs"
-workspace = ".."
 
 [features]
 default = ["codegen", "freetype-lib"]

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
 build = "build.rs"
-workspace = ".."
 
 [features]
 default = ["codegen"]

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -3,7 +3,6 @@ name = "wrench"
 version = "0.1.1"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 build = "build.rs"
-workspace = ".."
 license = "MPL-2.0"
 
 [dependencies]


### PR DESCRIPTION
Cargo will automatically walk up the file system hierarchy to find a containing
workspace, so the explicitly specifying the workspace path in the workspace
members is not necessary. For standalone webrender it is harmless, but it is
causing a problem when trying to wrap all the rust projects in mozilla-central
in another workspace (see https://bugzilla.mozilla.org/show_bug.cgi?id=1302704#c25).
Removing this should fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/856)
<!-- Reviewable:end -->
