### PR TITLE
Blob image renderer

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -21,7 +21,7 @@ use threadpool::ThreadPool;
 use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace, ImageData};
 use webrender_traits::{PipelineId, RenderNotifier, RenderDispatcher, WebGLCommand, WebGLContextId};
 use webrender_traits::channel::{PayloadHelperMethods, PayloadReceiver, PayloadSender, MsgReceiver};
-use webrender_traits::{VRCompositorCommand, VRCompositorHandler};
+use webrender_traits::{BlobImageRenderer, VRCompositorCommand, VRCompositorHandler};
 use offscreen_gl_context::GLContextDispatcher;
 
 /// The render backend is responsible for transforming high level display lists into
@@ -68,9 +68,10 @@ impl RenderBackend {
                config: FrameBuilderConfig,
                recorder: Option<Box<ApiRecordingReceiver>>,
                main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
+               blob_image_renderer: Option<Box<BlobImageRenderer>>,
                vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>) -> RenderBackend {
 
-        let resource_cache = ResourceCache::new(texture_cache, workers, enable_aa);
+        let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer, enable_aa);
 
         register_thread_with_profiler("Backend".to_string());
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -24,6 +24,7 @@ use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRen
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, ImageDescriptor, ColorF};
 use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance};
+use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError};
 use threadpool::ThreadPool;
 use euclid::Point2D;
 
@@ -209,11 +210,15 @@ pub struct ResourceCache {
     glyph_cache_tx: Sender<GlyphCacheMsg>,
     glyph_cache_result_queue: Receiver<GlyphCacheResultMsg>,
     pending_external_image_update_list: ExternalImageUpdateList,
+
+    blob_image_renderer: Option<Box<BlobImageRenderer>>,
+    blob_image_requests: HashSet<ImageRequest>,
 }
 
 impl ResourceCache {
     pub fn new(texture_cache: TextureCache,
                workers: Arc<Mutex<ThreadPool>>,
+               blob_image_renderer: Option<Box<BlobImageRenderer>>,
                enable_aa: bool) -> ResourceCache {
         let (glyph_cache_tx, glyph_cache_result_queue) = spawn_glyph_cache_thread(workers);
 
@@ -232,6 +237,9 @@ impl ResourceCache {
             glyph_cache_tx: glyph_cache_tx,
             glyph_cache_result_queue: glyph_cache_result_queue,
             pending_external_image_update_list: ExternalImageUpdateList::new(),
+
+            blob_image_renderer: blob_image_renderer,
+            blob_image_requests: HashSet::new(),
         }
     }
 
@@ -321,14 +329,38 @@ impl ResourceCache {
         webgl_texture.size = size;
     }
 
-    pub fn request_image(&mut self,
-                         key: ImageKey,
-                         rendering: ImageRendering) {
+    pub fn request_image(&mut self, key: ImageKey, rendering: ImageRendering) {
         debug_assert!(self.state == State::AddResources);
-        self.pending_image_requests.push(ImageRequest {
+        let request = ImageRequest {
             key: key,
             rendering: rendering,
-        });
+        };
+
+        let template = self.image_templates.get(&key).unwrap();
+        if let ImageData::Vector(ref data) = template.data {
+            if let Some(ref mut renderer) = self.blob_image_renderer {
+                let same_epoch = match self.cached_images.resources.get(&request) {
+                    Some(entry) => entry.epoch == template.epoch,
+                    None => false,
+                };
+
+                if !same_epoch && self.blob_image_requests.insert(request) {
+                    renderer.request_blob_image(
+                        key,
+                        data.clone(),
+                        &BlobImageDescriptor {
+                            width: template.descriptor.width,
+                            height: template.descriptor.height,
+                            format: template.descriptor.format,
+                            // TODO(nical): figure out the scale factor (should change with zoom).
+                            scale_factor: 1.0,
+                        },
+                    );
+                }
+            }
+        } else {
+            self.pending_image_requests.push(request);
+        }
     }
 
     pub fn request_glyphs(&mut self,
@@ -453,7 +485,7 @@ impl ResourceCache {
         let external_id = match image_template.data {
             ImageData::ExternalHandle(id) => Some(id),
             // raw and externalBuffer are all use resource_cache.
-            ImageData::Raw(..) | ImageData::ExternalBuffer(..) => None,
+            ImageData::Raw(..) | ImageData::ExternalBuffer(..) | ImageData::Vector(..) => None,
         };
 
         ImageProperties {
@@ -539,50 +571,84 @@ impl ResourceCache {
             }
         }
 
-        for request in self.pending_image_requests.drain(..) {
-            let cached_images = &mut self.cached_images;
-            let image_template = &self.image_templates[&request.key];
-            let image_data = image_template.data.clone();
+        let mut image_requests = mem::replace(&mut self.pending_image_requests, Vec::new());
+        for request in image_requests.drain(..) {
+            self.finalize_image_request(request, None);
+        }
 
-            match image_template.data {
-                ImageData::ExternalHandle(..) => {
-                    // external handle doesn't need to update the texture_cache.
+        let mut blob_image_requests = mem::replace(&mut self.blob_image_requests, HashSet::new());
+        if self.blob_image_renderer.is_some() {
+            for request in blob_image_requests.drain() {
+                match self.blob_image_renderer.as_mut().unwrap()
+                                                .resolve_blob_image(request.key) {
+                    Ok(image) => {
+                        self.finalize_image_request(request, Some(ImageData::new(image.data)));
+                    }
+                    // TODO(nical): I think that we should handle these somewhat gracefully,
+                    // at least in the out-of-memory scenario.
+                    Err(BlobImageError::Oom) => {
+                        // This one should be recoverable-ish.
+                        panic!("Failed to render a vector image (OOM)");
+                    }
+                    Err(BlobImageError::InvalidKey) => {
+                        panic!("Invalid vector image key");
+                    }
+                    Err(BlobImageError::InvalidData) => {
+                        // TODO(nical): If we run into this we should kill the content process.
+                        panic!("Invalid vector image data");
+                    }
+                    Err(BlobImageError::Other(msg)) => {
+                        panic!("Vector image error {}", msg);
+                    }
                 }
-                ImageData::Raw(..) | ImageData::ExternalBuffer(..) => {
-                    match cached_images.entry(request.clone(), self.current_frame_id) {
-                        Occupied(entry) => {
-                            let image_id = entry.get().texture_cache_id;
+            }
+        }
+    }
 
-                            if entry.get().epoch != image_template.epoch {
-                                self.texture_cache.update(image_id,
-                                                          image_template.descriptor,
-                                                          image_data);
+    fn finalize_image_request(&mut self, request: ImageRequest, image_data: Option<ImageData>) {
+        let image_template = &self.image_templates[&request.key];
+        let image_data = image_data.unwrap_or_else(||{
+            image_template.data.clone()
+        });
 
-                                // Update the cached epoch
-                                *entry.into_mut() = CachedImageInfo {
-                                    texture_cache_id: image_id,
-                                    epoch: image_template.epoch,
-                                };
-                            }
-                        }
-                        Vacant(entry) => {
-                            let image_id = self.texture_cache.new_item_id();
+        match image_template.data {
+            ImageData::ExternalHandle(..) => {
+                // external handle doesn't need to update the texture_cache.
+            }
+            ImageData::Raw(..) | ImageData::ExternalBuffer(..) | ImageData::Vector(..) => {
+                match self.cached_images.entry(request.clone(), self.current_frame_id) {
+                    Occupied(entry) => {
+                        let image_id = entry.get().texture_cache_id;
 
-                            let filter = match request.rendering {
-                                ImageRendering::Pixelated => TextureFilter::Nearest,
-                                ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
-                            };
-
-                            self.texture_cache.insert(image_id,
+                        if entry.get().epoch != image_template.epoch {
+                            self.texture_cache.update(image_id,
                                                       image_template.descriptor,
-                                                      filter,
                                                       image_data);
 
-                            entry.insert(CachedImageInfo {
+                            // Update the cached epoch
+                            *entry.into_mut() = CachedImageInfo {
                                 texture_cache_id: image_id,
                                 epoch: image_template.epoch,
-                            });
+                            };
                         }
+                    }
+                    Vacant(entry) => {
+                        let image_id = self.texture_cache.new_item_id();
+
+                        let filter = match request.rendering {
+                            ImageRendering::Pixelated => TextureFilter::Nearest,
+                            ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
+                        };
+
+                        self.texture_cache.insert(image_id,
+                                                  image_template.descriptor,
+                                                  filter,
+                                                  image_data);
+
+                        entry.insert(CachedImageInfo {
+                            texture_cache_id: image_id,
+                            epoch: image_template.epoch,
+                        });
                     }
                 }
             }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -714,6 +714,9 @@ impl TextureCache {
             ImageData::ExternalHandle(..) | ImageData::ExternalBuffer(..)=> {
                 panic!("Doesn't support Update() for external image.");
             }
+            ImageData::Vector(..) => {
+                panic!("The vector image should have been rasterized into a raw image.");
+            }
             ImageData::Raw(bytes) => {
                 TextureUpdateOp::Update {
                     page_pos_x: existing_item.allocated_rect.origin.x,
@@ -739,6 +742,10 @@ impl TextureCache {
                   descriptor: ImageDescriptor,
                   filter: TextureFilter,
                   data: ImageData) {
+        if let ImageData::Vector(..) = data {
+            panic!("must rasterize the vector image before adding to the cache");
+        }
+
         let width = descriptor.width;
         let height = descriptor.height;
         let format = descriptor.format;
@@ -755,6 +762,9 @@ impl TextureCache {
                 match data {
                     ImageData::ExternalHandle(..) => {
                         panic!("External handle should not go through texture_cache.");
+                    }
+                    ImageData::Vector(..) => {
+                        panic!("The vector image should have been rasterized.");
                     }
                     ImageData::Raw(bytes) => {
                         let update_op = TextureUpdate {

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -220,6 +220,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                     &ImageData::Raw(ref v) => { (**v).clone() }
                     &ImageData::ExternalHandle(_) => { return; }
                     &ImageData::ExternalBuffer(_) => { return; }
+                    &ImageData::Vector(_) => { return; }
                 };
                 self.images.insert(*key, CachedImage {
                     width: descriptor.width,

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -692,6 +692,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                     &ImageData::Raw(ref v) => { (**v).clone() }
                     &ImageData::ExternalHandle(_) => { return; }
                     &ImageData::ExternalBuffer(_) => { return; }
+                    &ImageData::Vector(_) => { return; }
                 };
                 self.frame_writer.images.insert(*key, CachedImage {
                     width: descriptor.width,


### PR DESCRIPTION
Here is a simple integration of a VectorImageRenderer abstraction that can be implemented to render vector graphics to an image.

The main ideas are that:
 - The interface should be implementable outside of WebRender in order for gecko to put in there things that WebRender cannot handle yet.
 - The result should be transparently usable as a regular image.
 - The intent is for the renderer to use the same thread pool as the glyph cache (an implementation detail of the vector renderer thanks to PR #855)
 - The interface should be extended to support some sort of sparse/tiled output for very large scrollable vector images.

The wr_sample implements a dummy vector renderer that always outputs a checkerboard pattern. You can have a look and see how it works.

Implementation-wise, vector images are treated like raw images, except that when an image is requested, if it is a vector image the resource cache asks the renderer to paint it asynchronously, and waits for the result at the end of the frame, just before inserting it into the texture cache. I am pretty happy with how simple it turns out (but I guess it will become a lot trickier with zoom support), it took me a few attempts, the first few implementations were a lot more complicated.

The VectorImageRenderer interface needs a bit of work. The request expects a certain size, which will probably not play well with the scaling factor that we should apply when zooming. It also passes an ImageDescriptor but it's not obvious to me whether we want to support anything other than RGBA8 (and maybe A8 for masks) and the stride member is also awkward.
I'm not sure what's best between VectorImageData being a ```Vec<u8>``` or a pointer-sized opaque handle like ExternalEvent (in which case we'd need to figure out who gets to delete the thing).

Feedback very welcome @kvark @glennw @jrmuizel @JerryShih

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/858)
<!-- Reviewable:end -->
