### PR TITLE
Use glBlend for certain mix-blend-mode types

### DIFF
--- a/webrender/res/ps_hardware_composite.fs.glsl
+++ b/webrender/res/ps_hardware_composite.fs.glsl
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void main(void) {
+    oFragColor = texture(sCache, vUv);
+}

--- a/webrender/res/ps_hardware_composite.glsl
+++ b/webrender/res/ps_hardware_composite.glsl
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+varying vec3 vUv;

--- a/webrender/res/ps_hardware_composite.vs.glsl
+++ b/webrender/res/ps_hardware_composite.vs.glsl
@@ -1,0 +1,25 @@
+#line 1
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+void main(void) {
+    PrimitiveInstance pi = fetch_prim_instance();
+    AlphaBatchTask dest_task = fetch_alpha_batch_task(pi.render_task_index);
+    AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.x);
+
+    vec2 dest_origin = dest_task.render_target_origin -
+                       dest_task.screen_space_origin +
+                       src_task.screen_space_origin;
+
+    vec2 local_pos = mix(dest_origin,
+                         dest_origin + src_task.size,
+                         aPosition.xy);
+
+    vec2 texture_size = vec2(textureSize(sCache, 0));
+    vec2 st0 = src_task.render_target_origin / texture_size;
+    vec2 st1 = (src_task.render_target_origin + src_task.size) / texture_size;
+    vUv = vec3(mix(st0, st1, aPosition.xy), src_task.render_target_layer_index);
+
+    gl_Position = uTransform * vec4(local_pos, pi.z, 1.0);
+}

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1937,6 +1937,16 @@ impl Device {
                                 gl::ZERO, gl::SRC_ALPHA);
         gl::blend_equation(gl::FUNC_ADD);
     }
+    pub fn set_blend_mode_max(&self) {
+        gl::blend_func_separate(gl::ONE, gl::ONE,
+                                gl::ONE, gl::ONE);
+        gl::blend_equation_separate(gl::MAX, gl::FUNC_ADD);
+    }
+    pub fn set_blend_mode_min(&self) {
+        gl::blend_func_separate(gl::ONE, gl::ONE,
+                                gl::ONE, gl::ONE);
+        gl::blend_equation_separate(gl::MIN, gl::FUNC_ADD);
+    }
 }
 
 impl Drop for Device {

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -18,8 +18,9 @@ use std::{i32, usize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tiling;
+use renderer::BlendMode;
 use webrender_traits::{Epoch, ColorF, PipelineId, DeviceIntSize};
-use webrender_traits::{ImageFormat, NativeFontHandle};
+use webrender_traits::{ImageFormat, NativeFontHandle, MixBlendMode};
 use webrender_traits::{ExternalImageId, ScrollLayerId, WebGLCommand};
 use webrender_traits::{ImageData};
 use webrender_traits::{DeviceUintRect};
@@ -486,4 +487,30 @@ pub enum LowLevelFilterOp {
     Opacity(Au),
     Saturate(Au),
     Sepia(Au),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum HardwareCompositeOp {
+    Multiply,
+    Max,
+    Min,
+}
+
+impl HardwareCompositeOp {
+    pub fn from_mix_blend_mode(mix_blend_mode: MixBlendMode) -> Option<HardwareCompositeOp> {
+        match mix_blend_mode {
+            MixBlendMode::Multiply => Some(HardwareCompositeOp::Multiply),
+            MixBlendMode::Lighten => Some(HardwareCompositeOp::Max),
+            MixBlendMode::Darken => Some(HardwareCompositeOp::Min),
+            _ => None,
+        }
+    }
+
+    pub fn to_blend_mode(&self) -> BlendMode {
+        match self {
+            &HardwareCompositeOp::Multiply => BlendMode::Multiply,
+            &HardwareCompositeOp::Max => BlendMode::Max,
+            &HardwareCompositeOp::Min => BlendMode::Min,
+        }
+    }
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use internal_types::LowLevelFilterOp;
+use internal_types::{HardwareCompositeOp, LowLevelFilterOp};
 use mask_cache::MaskCacheInfo;
 use prim_store::{PrimitiveCacheKey, PrimitiveIndex};
 use std::{cmp, f32, i32, mem, usize};
@@ -54,6 +54,7 @@ pub enum AlphaRenderItem {
     Primitive(StackingContextIndex, PrimitiveIndex, i32),
     Blend(StackingContextIndex, RenderTaskId, LowLevelFilterOp, i32),
     Composite(StackingContextIndex, RenderTaskId, RenderTaskId, MixBlendMode, i32),
+    HardwareComposite(StackingContextIndex, RenderTaskId, HardwareCompositeOp, i32),
 }
 
 #[derive(Debug, Clone)]

--- a/wrench/reftests/blend/multiply-2-ref.yaml
+++ b/wrench/reftests/blend/multiply-2-ref.yaml
@@ -1,0 +1,7 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: [0, 128, 0]

--- a/wrench/reftests/blend/multiply-2.yaml
+++ b/wrench/reftests/blend/multiply-2.yaml
@@ -1,0 +1,16 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: [0, 255, 0]
+        -
+          bounds: [0, 0, 100, 100]
+          type: stacking_context
+          mix-blend-mode: multiply
+          items:
+            -
+              bounds: [0, 0, 100, 100]
+              type: rect
+              color: [255, 128, 0]

--- a/wrench/reftests/blend/reftest.list
+++ b/wrench/reftests/blend/reftest.list
@@ -1,4 +1,5 @@
 == multiply.yaml multiply-ref.yaml
+== multiply-2.yaml multiply-2-ref.yaml
 == difference.yaml difference-ref.yaml
 == darken.yaml darken-ref.yaml
 == lighten.yaml lighten-ref.yaml


### PR DESCRIPTION
Certain mix-blend-mode types can be implemented with glBlend. This adds an AlphaRenderItem for a composite operation that doesn't need readback or processing in the shader, but instead uses glBlend. And then certain mix-blend-modes are expressed in this AlphaRenderItem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/867)
<!-- Reviewable:end -->
