### PR TITLE
Properly isolate stacking contexts with mix-blend-mode children

### DIFF
--- a/webrender/res/ps_composite.fs.glsl
+++ b/webrender/res/ps_composite.fs.glsl
@@ -229,7 +229,7 @@ void main(void) {
             break;
     }
 
-    result.rgb = (1 - Cb.a) * Cs.rgb + Cb.a * result.rgb;
+    result.rgb = (1.0 - Cb.a) * Cs.rgb + Cb.a * result.rgb;
     result.a = Cs.a;
 
     oFragColor = result;

--- a/webrender/res/ps_composite.fs.glsl
+++ b/webrender/res/ps_composite.fs.glsl
@@ -151,6 +151,22 @@ vec3 Luminosity(vec3 Cb, vec3 Cs) {
     return SetLum(Cb, Lum(Cs));
 }
 
+const int MixBlendMode_Multiply    = 1;
+const int MixBlendMode_Screen      = 2;
+const int MixBlendMode_Overlay     = 3;
+const int MixBlendMode_Darken      = 4;
+const int MixBlendMode_Lighten     = 5;
+const int MixBlendMode_ColorDodge  = 6;
+const int MixBlendMode_ColorBurn   = 7;
+const int MixBlendMode_HardLight   = 8;
+const int MixBlendMode_SoftLight   = 9;
+const int MixBlendMode_Difference  = 10;
+const int MixBlendMode_Exclusion   = 11;
+const int MixBlendMode_Hue         = 12;
+const int MixBlendMode_Saturation  = 13;
+const int MixBlendMode_Color       = 14;
+const int MixBlendMode_Luminosity  = 15;
+
 void main(void) {
     vec4 Cb = texture(sCache, vUv0);
     vec4 Cs = texture(sCache, vUv1);
@@ -159,60 +175,62 @@ void main(void) {
     vec4 result = vec4(1.0, 1.0, 0.0, 1.0);
 
     switch (vOp) {
-        case 1:
+        case MixBlendMode_Multiply:
             result.rgb = Multiply(Cb.rgb, Cs.rgb);
             break;
-        case 2:
+        case MixBlendMode_Screen:
             result.rgb = Screen(Cb.rgb, Cs.rgb);
             break;
-        case 3:
-            result.rgb = HardLight(Cs.rgb, Cb.rgb);        // Overlay is inverse of Hardlight
+        case MixBlendMode_Overlay:
+            // Overlay is inverse of Hardlight
+            result.rgb = HardLight(Cs.rgb, Cb.rgb);
             break;
-        case 4:
-            // mix-blend-mode: darken
+        case MixBlendMode_Darken:
             result.rgb = min(Cs.rgb, Cb.rgb);
             break;
-        case 5:
-            // mix-blend-mode: lighten
+        case MixBlendMode_Lighten:
             result.rgb = max(Cs.rgb, Cb.rgb);
             break;
-        case 6:
+        case MixBlendMode_ColorDodge:
             result.r = ColorDodge(Cb.r, Cs.r);
             result.g = ColorDodge(Cb.g, Cs.g);
             result.b = ColorDodge(Cb.b, Cs.b);
             break;
-        case 7:
+        case MixBlendMode_ColorBurn:
             result.r = ColorBurn(Cb.r, Cs.r);
             result.g = ColorBurn(Cb.g, Cs.g);
             result.b = ColorBurn(Cb.b, Cs.b);
             break;
-        case 8:
+        case MixBlendMode_HardLight:
             result.rgb = HardLight(Cb.rgb, Cs.rgb);
             break;
-        case 9:
+        case MixBlendMode_SoftLight:
             result.r = SoftLight(Cb.r, Cs.r);
             result.g = SoftLight(Cb.g, Cs.g);
             result.b = SoftLight(Cb.b, Cs.b);
             break;
-        case 10:
+        case MixBlendMode_Difference:
             result.rgb = Difference(Cb.rgb, Cs.rgb);
             break;
-        case 11:
+        case MixBlendMode_Exclusion:
             result.rgb = Exclusion(Cb.rgb, Cs.rgb);
             break;
-        case 12:
+        case MixBlendMode_Hue:
             result.rgb = Hue(Cb.rgb, Cs.rgb);
             break;
-        case 13:
+        case MixBlendMode_Saturation:
             result.rgb = Saturation(Cb.rgb, Cs.rgb);
             break;
-        case 14:
+        case MixBlendMode_Color:
             result.rgb = Color(Cb.rgb, Cs.rgb);
             break;
-        case 15:
+        case MixBlendMode_Luminosity:
             result.rgb = Luminosity(Cb.rgb, Cs.rgb);
             break;
     }
+
+    result.rgb = (1 - Cb.a) * Cs.rgb + Cb.a * result.rgb;
+    result.a = Cs.a;
 
     oFragColor = result;
 }

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -19,8 +19,8 @@ void main(void) {
 
     vec2 texture_size = vec2(textureSize(sCache, 0));
 
-    vec2 st0 = (backdrop_task.render_target_origin + vec2(0.0, backdrop_task.size.y)) / texture_size;
-    vec2 st1 = (backdrop_task.render_target_origin + vec2(backdrop_task.size.x, 0.0)) / texture_size;
+    vec2 st0 = backdrop_task.render_target_origin / texture_size;
+    vec2 st1 = (backdrop_task.render_target_origin + backdrop_task.size) / texture_size;
     vUv0 = vec3(mix(st0, st1, aPosition.xy), backdrop_task.render_target_layer_index);
 
     st0 = src_task.render_target_origin / texture_size;

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1886,6 +1886,30 @@ impl Device {
         }
     }
 
+    pub fn clear_target_rect(&self,
+                             color: Option<[f32; 4]>,
+                             depth: Option<f32>,
+                             rect: DeviceIntRect) {
+        let mut clear_bits = 0;
+
+        if let Some(color) = color {
+            gl::clear_color(color[0], color[1], color[2], color[3]);
+            clear_bits |= gl::COLOR_BUFFER_BIT;
+        }
+
+        if let Some(depth) = depth {
+            gl::clear_depth(depth as f64);
+            clear_bits |= gl::DEPTH_BUFFER_BIT;
+        }
+
+        if clear_bits != 0 {
+            gl::enable(gl::SCISSOR_TEST);
+            gl::scissor(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height);
+            gl::clear(clear_bits);
+            gl::disable(gl::SCISSOR_TEST);
+        }
+    }
+
     pub fn enable_depth(&self) {
         gl::enable(gl::DEPTH_TEST);
     }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -341,6 +341,7 @@ impl Frame {
                                               rect,
                                               pipeline_id,
                                               new_scroll_layer_id,
+                                              false,
                                               CompositeOps::empty());
 
 
@@ -428,6 +429,7 @@ impl Frame {
                                                           clip_region.main,
                                                           pipeline_id,
                                                           scroll_layer_id,
+                                                          false,
                                                           CompositeOps::empty());
 
                     // Note: we don't use the original clip region here,
@@ -448,6 +450,7 @@ impl Frame {
                                               clip_region.main,
                                               pipeline_id,
                                               scroll_layer_id,
+                                              level == 0,
                                               composition_operations);
 
         self.flatten_items(traversal,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tiling;
 use renderer::BlendMode;
 use webrender_traits::{Epoch, ColorF, PipelineId, DeviceIntSize};
-use webrender_traits::{ImageFormat, NativeFontHandle, MixBlendMode};
+use webrender_traits::{ImageFormat, NativeFontHandle};
 use webrender_traits::{ExternalImageId, ScrollLayerId, WebGLCommand};
 use webrender_traits::{ImageData};
 use webrender_traits::{DeviceUintRect};
@@ -492,26 +492,13 @@ pub enum LowLevelFilterOp {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum HardwareCompositeOp {
-    Multiply,
-    Max,
-    Min,
+    Alpha,
 }
 
 impl HardwareCompositeOp {
-    pub fn from_mix_blend_mode(mix_blend_mode: MixBlendMode) -> Option<HardwareCompositeOp> {
-        match mix_blend_mode {
-            MixBlendMode::Multiply => Some(HardwareCompositeOp::Multiply),
-            MixBlendMode::Lighten => Some(HardwareCompositeOp::Max),
-            MixBlendMode::Darken => Some(HardwareCompositeOp::Min),
-            _ => None,
-        }
-    }
-
     pub fn to_blend_mode(&self) -> BlendMode {
         match self {
-            &HardwareCompositeOp::Multiply => BlendMode::Multiply,
-            &HardwareCompositeOp::Max => BlendMode::Max,
-            &HardwareCompositeOp::Min => BlendMode::Min,
+            &HardwareCompositeOp::Alpha => BlendMode::Alpha,
         }
     }
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -62,6 +62,7 @@ pub struct AlphaRenderTask {
     screen_origin: DeviceIntPoint,
     pub opaque_items: Vec<AlphaRenderItem>,
     pub alpha_items: Vec<AlphaRenderItem>,
+    pub isolate_clear: bool,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -144,6 +145,7 @@ pub struct RenderTask {
 impl RenderTask {
     pub fn new_alpha_batch(task_index: RenderTaskIndex,
                            screen_origin: DeviceIntPoint,
+                           isolate_clear: bool,
                            location: RenderTaskLocation) -> RenderTask {
         RenderTask {
             id: RenderTaskId::Static(task_index),
@@ -153,6 +155,7 @@ impl RenderTask {
                 screen_origin: screen_origin,
                 alpha_items: Vec::new(),
                 opaque_items: Vec::new(),
+                isolate_clear: isolate_clear,
             }),
         }
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -80,10 +80,6 @@ pub enum BlendMode {
     None,
     Alpha,
 
-    Multiply,
-    Max,
-    Min,
-
     // Use the color of the text itself as a constant color blend factor.
     Subpixel(ColorF),
 }
@@ -1206,7 +1202,6 @@ impl Renderer {
                         let shader = match batch.key.blend_mode {
                             BlendMode::Subpixel(..) => self.ps_text_run_subpixel.get(&mut self.device, transform_kind),
                             BlendMode::Alpha | BlendMode::None => self.ps_text_run.get(&mut self.device, transform_kind),
-                            _ => unreachable!(),
                         };
                         (GPU_TAG_PRIM_TEXT_RUN, shader)
                     }
@@ -1290,20 +1285,18 @@ impl Renderer {
                 let width = readback.data[2];
                 let height = readback.data[3];
 
-                // Need to invert the y coordinates when reading back from
-                // the framebuffer.
-                let y0 = if render_target.is_some() {
-                    src_y as i32
-                } else {
-                    target_dimensions.height as i32 - height as i32 - src_y as i32
-                };
+                let mut src = DeviceIntRect::new(DeviceIntPoint::new(src_x as i32, src_y as i32),
+                                                 DeviceIntSize::new(width as i32, height as i32));
+                let mut dest = DeviceIntRect::new(DeviceIntPoint::new(dest_x as i32, dest_y as i32),
+                                                  DeviceIntSize::new(width as i32, height as i32));
 
-                let src = DeviceIntRect::new(DeviceIntPoint::new(src_x as i32,
-                                                                 y0),
-                                             DeviceIntSize::new(width as i32, height as i32));
-                let dest = DeviceIntRect::new(DeviceIntPoint::new(dest_x as i32,
-                                                                  dest_y as i32),
-                                              DeviceIntSize::new(width as i32, height as i32));
+                // Need to invert the y coordinates and flip the image vertically when
+                // reading back from the framebuffer.
+                if render_target.is_none() {
+                    src.origin.y = target_dimensions.height as i32 - src.size.height - src.origin.y;
+                    dest.origin.y += dest.size.height;
+                    dest.size.height = -dest.size.height;
+                }
 
                 self.device.blit_render_target(render_target,
                                                Some(src),
@@ -1380,6 +1373,11 @@ impl Renderer {
             };
 
             self.device.clear_target(clear_color, clear_depth);
+
+            let isolate_clear_color = Some([0.0, 0.0, 0.0, 0.0]);
+            for isolate_clear in &target.isolate_clears {
+                self.device.clear_target_rect(isolate_clear_color, None, *isolate_clear);
+            }
 
             projection
         };
@@ -1500,18 +1498,6 @@ impl Renderer {
                 match batch.key.blend_mode {
                     BlendMode::None => {
                         self.device.set_blend(false);
-                    }
-                    BlendMode::Multiply => {
-                        self.device.set_blend(true);
-                        self.device.set_blend_mode_multiply();
-                    }
-                    BlendMode::Max => {
-                        self.device.set_blend(true);
-                        self.device.set_blend_mode_max();
-                    }
-                    BlendMode::Min => {
-                        self.device.set_blend(true);
-                        self.device.set_blend_mode_min();
                     }
                     BlendMode::Alpha => {
                         self.device.set_blend(true);

--- a/wrench/reftests/blend/canvas-ref.yaml
+++ b/wrench/reftests/blend/canvas-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [0, 255, 0]

--- a/wrench/reftests/blend/canvas.yaml
+++ b/wrench/reftests/blend/canvas.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+        # the root stacking context should blend with the canvas background
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          mix-blend-mode: difference
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: [255, 0, 255]

--- a/wrench/reftests/blend/isolated-2-ref.yaml
+++ b/wrench/reftests/blend/isolated-2-ref.yaml
@@ -1,0 +1,21 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 130, 130]
+      color: [255, 255, 0]
+    - type: stacking_context
+      bounds: [10, 10, 130, 130]
+      items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [0, 255, 0]
+        - type: stacking_context
+          bounds: [20, 20, 100, 100]
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: [255, 0, 0]
+            - type: rect
+              bounds: [0, 0, 80, 80]
+              color: [0, 0, 0]

--- a/wrench/reftests/blend/isolated-2.yaml
+++ b/wrench/reftests/blend/isolated-2.yaml
@@ -1,0 +1,24 @@
+# translation of wpt/css-tests/compositing-1_dev/html/mix-blend-mode-stacking-context-creates-isolation.htm
+---
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 130, 130]
+      color: [255, 255, 0]
+      # this stacking context should create an isolated group for its children
+      # inside there should be overlapping red and green rects
+      # where they intersect should be a black rect
+      # the rects should not blend with the yellow backdrop
+    - type: stacking_context
+      bounds: [10, 10, 130, 130]
+      items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [0, 255, 0]
+        - type: stacking_context
+          bounds: [20, 20, 100, 100]
+          mix-blend-mode: multiply
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: [255, 0, 0]

--- a/wrench/reftests/blend/isolated-ref.yaml
+++ b/wrench/reftests/blend/isolated-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [255, 255, 0]

--- a/wrench/reftests/blend/isolated-with-filter.yaml
+++ b/wrench/reftests/blend/isolated-with-filter.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [255, 0, 0]
+          # the presence of this filter shouldn't break isolated groups
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          filters: opacity(1.0)
+          items:
+            - type: stacking_context
+              bounds: [0, 0, 100, 100]
+              mix-blend-mode: difference
+              items:
+                - type: rect
+                  bounds: [0, 0, 100, 100]
+                  color: [255, 255, 0]

--- a/wrench/reftests/blend/isolated.yaml
+++ b/wrench/reftests/blend/isolated.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [255, 0, 0]
+        # this stacking context should create an isolated group for its children
+        # causing the yellow rect to not blend with the green backdrop
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          items:
+            - type: stacking_context
+              bounds: [0, 0, 100, 100]
+              mix-blend-mode: difference
+              items:
+                - type: rect
+                  bounds: [0, 0, 100, 100]
+                  color: [255, 255, 0]

--- a/wrench/reftests/blend/reftest.list
+++ b/wrench/reftests/blend/reftest.list
@@ -3,3 +3,8 @@
 == difference.yaml difference-ref.yaml
 == darken.yaml darken-ref.yaml
 == lighten.yaml lighten-ref.yaml
+== repeated-difference.yaml repeated-difference-ref.yaml
+== canvas.yaml canvas-ref.yaml
+== isolated.yaml isolated-ref.yaml
+== isolated-2.yaml isolated-2-ref.yaml
+== isolated-with-filter.yaml isolated-ref.yaml

--- a/wrench/reftests/blend/repeated-difference-ref.yaml
+++ b/wrench/reftests/blend/repeated-difference-ref.yaml
@@ -1,0 +1,7 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: [0, 255, 0]

--- a/wrench/reftests/blend/repeated-difference.yaml
+++ b/wrench/reftests/blend/repeated-difference.yaml
@@ -1,0 +1,25 @@
+---
+root:
+  items:
+        -
+          bounds: [0, 0, 100, 100]
+          type: rect
+          color: [255, 255, 255]
+        -
+          bounds: [0, 0, 100, 100]
+          type: stacking_context
+          mix-blend-mode: difference
+          items:
+            -
+              bounds: [0, 0, 100, 100]
+              type: rect
+              color: [255, 255, 255]
+            -
+              bounds: [0, 0, 100, 100]
+              type: stacking_context
+              mix-blend-mode: difference
+              items:
+                -
+                  bounds: [0, 0, 100, 100]
+                  type: rect
+                  color: [0, 255, 0]

--- a/wrench/reftests/filters/isolated-ref.yaml
+++ b/wrench/reftests/filters/isolated-ref.yaml
@@ -1,0 +1,13 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [0, 0, 0]
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          filters: opacity(0.5)
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: [0, 255, 0]

--- a/wrench/reftests/filters/isolated.yaml
+++ b/wrench/reftests/filters/isolated.yaml
@@ -1,0 +1,17 @@
+# this tests that filters don't create isolated groups
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [0, 0, 0]
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          items:
+            - type: stacking_context
+              bounds: [0, 0, 100, 100]
+              filters: opacity(0.5)
+              items:
+                - type: rect
+                  bounds: [0, 0, 100, 100]
+                  color: [0, 255, 0]

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -1,1 +1,2 @@
 == filter-grayscale.yaml filter-grayscale-ref.yaml
+== isolated.yaml isolated-ref.yaml

--- a/wrench/res/composite.yaml
+++ b/wrench/res/composite.yaml
@@ -1,0 +1,28 @@
+# A sample page for spot checking if compositing is working, should be two gradients
+# overlaid on an image, the left with opacity, the right with mix-blend-mode
+---
+root:
+  items:
+    - type: image
+      bounds: 0 0 1024 768
+      src: "landscape.jpg"
+
+    - type: stacking_context
+      bounds: 100 100 412 568
+      filters: opacity(0.5)
+      items:
+        - type: gradient
+          bounds: 0 0 412 568
+          start: 0 0
+          end: 412 568
+          stops: [0.0, [255, 0, 0], 1.0, [0, 0, 255]]
+
+    - type: stacking_context
+      bounds: 512 100 412 568
+      mix-blend-mode: color-dodge
+      items:
+        - type: gradient
+          bounds: 0 0 412 568
+          start: 0 0
+          end: 412 568
+          stops: [0.0, [255, 0, 0], 1.0, [0, 0, 255]]


### PR DESCRIPTION
Anything in HTML that creates a stacking context must create an isolated group for mix-blend-mode. [1] This means that the initial backdrop for any children with mix-blend-mode must be transparent black. Currently stacking context's don't create isolated groups, and instead the backdrop can be from multiple parents up the stacking context tree.

This is a WIP that tries to implement the right behavior. When a stacking context has mix-blend-mode children, it's contents need to be drawn independently with the correct backdrop (transparent black), then composited.

It looks like the code works, but I'd like some feedback to see if this is an okay approach.

[1] https://www.w3.org/TR/compositing-1/#csscompositingrules_CSS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/868)
<!-- Reviewable:end -->
