### PR TITLE
Fix the image tex-coord clamping

### DIFF
--- a/webrender/res/ps_image.fs.glsl
+++ b/webrender/res/ps_image.fs.glsl
@@ -27,7 +27,7 @@ void main(void) {
     // We clamp the texture coordinates to the half-pixel offset from the borders
     // in order to avoid sampling outside of the texture area.
     vec2 st = vTextureOffset + ((position_in_tile / vStretchSize) * vTextureSize);
-    st = clamp(vStRect.xy, st, vStRect.zw);
+    st = clamp(st, vStRect.xy, vStRect.zw);
 
     alpha = alpha * float(all(bvec2(step(position_in_tile, vStretchSize))));
 


### PR DESCRIPTION
The invalid argument order we use now would still clip the lower bound but ignore the higher bound.

r? @glennw 
cc @jrmuizel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/871)
<!-- Reviewable:end -->
