### PR TITLE
Avoid the fractional GPU data in texture rows

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -40,8 +40,9 @@ varying vec3 vClipMaskUv;
 
 #ifdef WR_VERTEX_SHADER
 
-#define VECS_PER_LAYER             13
-#define VECS_PER_RENDER_TASK        3
+// These have to be multiples of WR_MAX_VERTEX_TEXTURE_WIDTH
+#define VECS_PER_LAYER             16
+#define VECS_PER_RENDER_TASK        4
 #define VECS_PER_PRIM_GEOM          2
 
 uniform sampler2D sLayers;

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -11,7 +11,7 @@ use tiling::StackingContextIndex;
 use webrender_traits::{DeviceIntLength, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use webrender_traits::MixBlendMode;
 
-const FLOATS_PER_RENDER_TASK_INFO: usize = 12;
+const FLOATS_PER_RENDER_TASK_INFO: usize = 16;
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct RenderTaskIndex(pub usize);
@@ -318,6 +318,7 @@ impl RenderTask {
                         0.0,
                         0.0,
                         0.0,
+                        0.0, 0.0, 0.0, 0.0,
                     ],
                 }
             }
@@ -332,10 +333,8 @@ impl RenderTask {
                         0.0,
                         0.0,
                         0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
+                        0.0, 0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0,
                     ],
                 }
             }
@@ -354,6 +353,7 @@ impl RenderTask {
                         task.inner_rect.origin.y as f32,
                         (task.inner_rect.origin.x + task.inner_rect.size.width) as f32,
                         (task.inner_rect.origin.y + task.inner_rect.size.height) as f32,
+                        0.0, 0.0, 0.0, 0.0,
                     ],
                 }
             }
@@ -369,10 +369,8 @@ impl RenderTask {
                         blur_radius.0 as f32,
                         0.0,
                         0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
+                        0.0, 0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0,
                     ]
                 }
             }
@@ -387,10 +385,8 @@ impl RenderTask {
                         0.0,
                         0.0,
                         0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
+                        0.0, 0.0, 0.0, 0.0,
+                        0.0, 0.0, 0.0, 0.0,
                     ]
                 }
             }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1273,6 +1273,7 @@ pub struct PackedLayer {
     pub inv_transform: WorldToLayerTransform,
     pub local_clip_rect: LayerRect,
     pub screen_vertices: [WorldPoint4D; 4],
+    _pad: [f32; 12], // round up to 16 vectors
 }
 
 impl Default for PackedLayer {
@@ -1282,6 +1283,7 @@ impl Default for PackedLayer {
             inv_transform: WorldToLayerTransform::identity(),
             local_clip_rect: LayerRect::zero(),
             screen_vertices: [WorldPoint4D::zero(); 4],
+            _pad: [0.0; 12],
         }
     }
 }


### PR DESCRIPTION
Fixes #865

r? @glennw 
cc @jrmuizel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/872)
<!-- Reviewable:end -->
