### PR TITLE
Make it possible to tweak the maximum texture size.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -42,12 +42,6 @@ const SHADER_VERSION: &'static str = "#version 300 es\n";
 
 static SHADER_PREAMBLE: &'static str = "shared";
 
-lazy_static! {
-    pub static ref MAX_TEXTURE_SIZE: gl::GLint = {
-        gl::get_integer_v(gl::MAX_TEXTURE_SIZE)
-    };
-}
-
 #[repr(u32)]
 pub enum DepthFunction {
     Less = gl::LESS,
@@ -825,6 +819,8 @@ pub struct Device {
     // Used on android only
     #[allow(dead_code)]
     next_vao_id: gl::GLuint,
+
+    max_texture_size: u32,
 }
 
 impl Device {
@@ -863,7 +859,13 @@ impl Device {
 
             next_vao_id: 1,
             //file_watcher: file_watcher,
+
+            max_texture_size: gl::get_integer_v(gl::MAX_TEXTURE_SIZE) as u32
         }
+    }
+
+    pub fn max_texture_size(&self) -> u32 {
+        self.max_texture_size
     }
 
     pub fn get_capabilities(&self) -> &Capabilities {

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -675,7 +675,10 @@ impl Renderer {
                                      options.precache_shaders)
         };
 
-        let mut texture_cache = TextureCache::new();
+        let device_max_size = device.max_texture_size();
+        let max_texture_size = cmp::min(device_max_size, options.max_texture_size.unwrap_or(device_max_size));
+
+        let mut texture_cache = TextureCache::new(max_texture_size);
 
         let white_pixels: Vec<u8> = vec![
             0xff, 0xff, 0xff, 0xff,
@@ -1770,6 +1773,7 @@ pub struct RendererOptions {
     pub clear_framebuffer: bool,
     pub clear_color: ColorF,
     pub render_target_debug: bool,
+    pub max_texture_size: Option<u32>,
     pub workers: Option<Arc<Mutex<ThreadPool>>>,
     pub recorder: Option<Box<ApiRecordingReceiver>>,
 }
@@ -1789,6 +1793,7 @@ impl Default for RendererOptions {
             clear_framebuffer: true,
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
             render_target_debug: false,
+            max_texture_size: None,
             workers: None,
             recorder: None,
         }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -235,6 +235,10 @@ impl ResourceCache {
         }
     }
 
+    pub fn max_texture_size(&self) -> u32 {
+        self.texture_cache.max_texture_size()
+    }
+
     pub fn add_font_template(&mut self, font_key: FontKey, template: FontTemplate) {
         // Push the new font to the glyph cache thread, and also store
         // it locally for glyph metric requests.
@@ -248,6 +252,12 @@ impl ResourceCache {
                               image_key: ImageKey,
                               descriptor: ImageDescriptor,
                               data: ImageData) {
+        if descriptor.width > self.max_texture_size() || descriptor.height > self.max_texture_size() {
+            // TODO: we need to support handle this case gracefully, cf. issue #620.
+            println!("Warning: texture size ({} {}) larger than the maximum size",
+                     descriptor.width, descriptor.height);
+        }
+
         let resource = ImageResource {
             descriptor: descriptor,
             data: data,

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use device::{MAX_TEXTURE_SIZE, TextureFilter};
+use device::TextureFilter;
 use fnv::FnvHasher;
 use freelist::{FreeList, FreeListItem, FreeListItemId};
 use internal_types::{TextureUpdate, TextureUpdateOp};
@@ -27,9 +27,6 @@ const MAX_RGBA_PIXELS_PER_TEXTURE: u32 = MAX_BYTES_PER_TEXTURE / 4;
 
 /// The desired initial size of each texture, in pixels.
 const INITIAL_TEXTURE_SIZE: u32 = 1024;
-
-/// The desired initial area of each texture, in pixels squared.
-const INITIAL_TEXTURE_AREA: u32 = INITIAL_TEXTURE_SIZE * INITIAL_TEXTURE_SIZE;
 
 /// The square root of the number of RGBA pixels we're allowed to use for a texture, rounded down.
 /// to the next power of two.
@@ -330,9 +327,8 @@ impl TexturePage {
         self.texture_size = new_texture_size
     }
 
-    fn can_grow(&self) -> bool {
-        self.texture_size.width < max_texture_size() ||
-        self.texture_size.height < max_texture_size()
+    fn can_grow(&self, max_size: u32) -> bool {
+        self.texture_size.width < max_size || self.texture_size.height < max_size
     }
 }
 
@@ -541,6 +537,7 @@ pub struct TextureCache {
     items: FreeList<TextureCacheItem>,
     arena: TextureCacheArena,
     pending_updates: TextureUpdateList,
+    max_texture_size: u32,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -556,14 +553,23 @@ pub struct AllocationResult {
 }
 
 impl TextureCache {
-    pub fn new() -> TextureCache {
+    pub fn new(mut max_texture_size: u32) -> TextureCache {
+        if max_texture_size * max_texture_size > MAX_RGBA_PIXELS_PER_TEXTURE {
+            max_texture_size = SQRT_MAX_RGBA_PIXELS_PER_TEXTURE;
+        }
+
         TextureCache {
             cache_id_list: CacheTextureIdList::new(),
             free_texture_levels: HashMap::with_hasher(Default::default()),
             items: FreeList::new(),
             pending_updates: TextureUpdateList::new(),
             arena: TextureCacheArena::new(),
+            max_texture_size: max_texture_size,
         }
+    }
+
+    pub fn max_texture_size(&self) -> u32 {
+        self.max_texture_size
     }
 
     pub fn pending_updates(&mut self) -> TextureUpdateList {
@@ -626,8 +632,8 @@ impl TextureCache {
         };
 
         // TODO(gw): Handle this sensibly (support failing to render items that can't fit?)
-        assert!(requested_size.width < max_texture_size());
-        assert!(requested_size.height < max_texture_size());
+        assert!(requested_size.width < self.max_texture_size);
+        assert!(requested_size.height < self.max_texture_size);
 
         // Loop until an allocation succeeds, growing or adding new
         // texture pages as required.
@@ -651,11 +657,11 @@ impl TextureCache {
                 }
             }
 
-            if !page_list.is_empty() && page_list.last().unwrap().can_grow() {
+            if !page_list.is_empty() && page_list.last().unwrap().can_grow(self.max_texture_size) {
                 let last_page = page_list.last_mut().unwrap();
                 // Grow the texture.
-                let new_width = cmp::min(last_page.texture_size.width * 2, max_texture_size());
-                let new_height = cmp::min(last_page.texture_size.height * 2, max_texture_size());
+                let new_width = cmp::min(last_page.texture_size.width * 2, self.max_texture_size);
+                let new_height = cmp::min(last_page.texture_size.height * 2, self.max_texture_size);
                 let texture_size = DeviceUintSize::new(new_width, new_height);
                 self.pending_updates.push(TextureUpdate {
                     id: last_page.texture_id,
@@ -673,7 +679,7 @@ impl TextureCache {
             }
 
             // We need a new page.
-            let texture_size = initial_texture_size();
+            let texture_size = initial_texture_size(self.max_texture_size);
             let free_texture_levels_entry = self.free_texture_levels.entry(format);
             let mut free_texture_levels = match free_texture_levels_entry {
                 Entry::Vacant(entry) => entry.insert(Vec::new()),
@@ -877,22 +883,7 @@ pub struct FreeTextureLevel {
 }
 
 /// Returns the number of pixels on a side we start out with for our texture atlases.
-fn initial_texture_size() -> DeviceUintSize {
-    let max_hardware_texture_size = *MAX_TEXTURE_SIZE as u32;
-    let initial_size = if max_hardware_texture_size * max_hardware_texture_size > INITIAL_TEXTURE_AREA {
-        INITIAL_TEXTURE_SIZE
-    } else {
-        max_hardware_texture_size
-    };
+fn initial_texture_size(max_texture_size: u32) -> DeviceUintSize {
+    let initial_size = cmp::min(max_texture_size, INITIAL_TEXTURE_SIZE);
     DeviceUintSize::new(initial_size, initial_size)
-}
-
-/// Returns the number of pixels on a side we're allowed to use for our texture atlases.
-fn max_texture_size() -> u32 {
-    let max_hardware_texture_size = *MAX_TEXTURE_SIZE as u32;
-    if max_hardware_texture_size * max_hardware_texture_size > MAX_RGBA_PIXELS_PER_TEXTURE {
-        SQRT_MAX_RGBA_PIXELS_PER_TEXTURE
-    } else {
-        max_hardware_texture_size
-    }
 }


### PR DESCRIPTION
As a prelude to the work on supporting very large images, this pull request makes it possible to lower the maximum texture size. By default the maximum size is the one reported by GL and we can lower it with a setting in the RendererOptions (but not increase it).

This should make it a lot easier to test support for large images, will give us the possibility to cap the maximum size for drivers that are too optimistic for their own sake, and also make it easier to reproduce bugs happening on hardware with lower capabilities.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/877)
<!-- Reviewable:end -->
