### PR TITLE
Add ClipScrollGroup

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -6,8 +6,8 @@ use internal_types::{HardwareCompositeOp, LowLevelFilterOp};
 use mask_cache::MaskCacheInfo;
 use prim_store::{PrimitiveCacheKey, PrimitiveIndex};
 use std::{cmp, f32, i32, mem, usize};
-use tiling::{PackedLayerIndex, RenderPass, RenderTargetIndex, ScrollLayerIndex};
-use tiling::StackingContextIndex;
+use tiling::{ClipScrollGroupIndex, PackedLayerIndex, RenderPass, RenderTargetIndex};
+use tiling::{ScrollLayerIndex, StackingContextIndex};
 use webrender_traits::{DeviceIntLength, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use webrender_traits::MixBlendMode;
 
@@ -51,7 +51,7 @@ pub enum RenderTaskLocation {
 
 #[derive(Debug, Clone)]
 pub enum AlphaRenderItem {
-    Primitive(StackingContextIndex, PrimitiveIndex, i32),
+    Primitive(ClipScrollGroupIndex, PrimitiveIndex, i32),
     Blend(StackingContextIndex, RenderTaskId, LowLevelFilterOp, i32),
     Composite(StackingContextIndex, RenderTaskId, RenderTaskId, MixBlendMode, i32),
     HardwareComposite(StackingContextIndex, RenderTaskId, HardwareCompositeOp, i32),


### PR DESCRIPTION
ClipScrollGroups represent a portion of a stacking context that is
clipped and scrolled. Before we thought of the entire contents of a
StackingContext as clipped and scrolled in the same way. This isn't the
case on the web, so we add preliminary support for the concept, while
maintaining the 1-to-1 relationship between them for the moment.

Parts of this PR are based on a proof of concept by Glenn Watson.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/890)
<!-- Reviewable:end -->
