### PR TITLE
Tiled image support

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
     let vector_img = api.generate_image_key();
     api.add_image(
         vector_img,
-        ImageDescriptor::new(100, 100, ImageFormat::RGBA8).with_opaque_flag(true),
+        ImageDescriptor::new(100, 100, ImageFormat::RGBA8, true),
         ImageData::new_blob_image(Vec::new()),
         None,
     );
@@ -143,7 +143,7 @@ fn main() {
         let mask_image = api.generate_image_key();
         api.add_image(
             mask_image,
-            ImageDescriptor::new(2, 2, ImageFormat::A8).with_opaque_flag(true),
+            ImageDescriptor::new(2, 2, ImageFormat::A8, true),
             ImageData::new(vec![0, 80, 180, 255]),
             None,
         );

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -107,6 +107,7 @@ fn main() {
         vector_img,
         ImageDescriptor::new(100, 100, ImageFormat::RGBA8).with_opaque_flag(true),
         ImageData::new_blob_image(Vec::new()),
+        None,
     );
 
     let pipeline_id = PipelineId(0, 0);
@@ -143,7 +144,8 @@ fn main() {
         api.add_image(
             mask_image,
             ImageDescriptor::new(2, 2, ImageFormat::A8).with_opaque_flag(true),
-            ImageData::new(vec![0, 80, 180, 255])
+            ImageData::new(vec![0, 80, 180, 255]),
+            None,
         );
         let mask = webrender_traits::ImageMask {
             image: mask_image,

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -111,6 +111,7 @@ fn main() {
             height: 100,
             stride: None,
             is_opaque: true,
+            offset: 0,
         },
         ImageData::new_blob_image(Vec::new()),
     );
@@ -154,6 +155,7 @@ fn main() {
                 stride: None,
                 format: ImageFormat::A8,
                 is_opaque: true,
+                offset: 0,
             },
             ImageData::new(vec![0, 80, 180, 255])
         );

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -105,14 +105,7 @@ fn main() {
     let vector_img = api.generate_image_key();
     api.add_image(
         vector_img,
-        ImageDescriptor {
-            format: ImageFormat::RGBA8,
-            width: 100,
-            height: 100,
-            stride: None,
-            is_opaque: true,
-            offset: 0,
-        },
+        ImageDescriptor::new(100, 100, ImageFormat::RGBA8).with_opaque_flag(true),
         ImageData::new_blob_image(Vec::new()),
     );
 
@@ -149,14 +142,7 @@ fn main() {
         let mask_image = api.generate_image_key();
         api.add_image(
             mask_image,
-            ImageDescriptor {
-                width: 2,
-                height: 2,
-                stride: None,
-                format: ImageFormat::A8,
-                is_opaque: true,
-                offset: 0,
-            },
+            ImageDescriptor::new(2, 2, ImageFormat::A8).with_opaque_flag(true),
             ImageData::new(vec![0, 80, 180, 255])
         );
         let mask = webrender_traits::ImageMask {

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1631,7 +1631,12 @@ impl Device {
             None => width,
         };
 
-        assert!(data.len() as u32 == bpp * row_length * height);
+        // Take the stride into account for all rows, except the last one.
+        let len = bpp * row_length * (height - 1)
+                + width * bpp;
+
+        assert!(data.len() as u32 >= len);
+        let data = &data[0..len as usize];
 
         if let Some(..) = stride {
             gl::pixel_store_i(gl::UNPACK_ROW_LENGTH, row_length as gl::GLint);

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -16,10 +16,10 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
 use webrender_traits::{AuxiliaryLists, ClipRegion, ColorF, DisplayItem, Epoch, FilterOp};
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform, TileOffset};
 use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerId, ScrollLayerState};
 use webrender_traits::{ScrollLocation, ScrollPolicy, ServoScrollRootId, SpecificDisplayItem};
-use webrender_traits::{StackingContext, WorldPoint};
+use webrender_traits::{StackingContext, WorldPoint, ImageDisplayItem, DeviceUintSize};
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct FrameId(pub u32);
@@ -226,7 +226,7 @@ impl Frame {
         self.clip_scroll_tree.discard_frame_state_for_pipeline(pipeline_id);
     }
 
-    pub fn create(&mut self, scene: &Scene) {
+    pub fn create(&mut self, scene: &Scene, resource_cache: &mut ResourceCache) {
         let root_pipeline_id = match scene.root_pipeline_id {
             Some(root_pipeline_id) => root_pipeline_id,
             None => return,
@@ -295,6 +295,7 @@ impl Frame {
                                                   &root_clip.main.size);
 
             self.flatten_stacking_context(&mut traversal,
+                                          resource_cache,
                                           root_pipeline_id,
                                           &mut context,
                                           reference_frame_id,
@@ -314,6 +315,7 @@ impl Frame {
 
     fn flatten_scroll_layer<'a>(&mut self,
                                 traversal: &mut DisplayListTraversal<'a>,
+                                resource_cache: &mut ResourceCache,
                                 pipeline_id: PipelineId,
                                 context: &mut FlattenContext,
                                 current_reference_frame_id: ScrollLayerId,
@@ -341,6 +343,7 @@ impl Frame {
                                               &content_size);
 
         self.flatten_items(traversal,
+                           resource_cache,
                            pipeline_id,
                            context,
                            current_reference_frame_id,
@@ -353,6 +356,7 @@ impl Frame {
 
     fn flatten_stacking_context<'a>(&mut self,
                                     traversal: &mut DisplayListTraversal<'a>,
+                                    resource_cache: &mut ResourceCache,
                                     pipeline_id: PipelineId,
                                     context: &mut FlattenContext,
                                     current_reference_frame_id: ScrollLayerId,
@@ -442,6 +446,7 @@ impl Frame {
                                               composition_operations);
 
         self.flatten_items(traversal,
+                           resource_cache,
                            pipeline_id,
                            context,
                            reference_frame_id,
@@ -462,6 +467,7 @@ impl Frame {
     }
 
     fn flatten_iframe<'a>(&mut self,
+                          resource_cache: &mut ResourceCache,
                           pipeline_id: PipelineId,
                           bounds: &LayerRect,
                           context: &mut FlattenContext,
@@ -519,6 +525,7 @@ impl Frame {
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
 
         self.flatten_stacking_context(&mut traversal,
+                                      resource_cache,
                                       pipeline_id,
                                       context,
                                       iframe_reference_frame_id,
@@ -534,6 +541,7 @@ impl Frame {
 
     fn flatten_items<'a>(&mut self,
                          traversal: &mut DisplayListTraversal<'a>,
+                         resource_cache: &mut ResourceCache,
                          pipeline_id: PipelineId,
                          context: &mut FlattenContext,
                          current_reference_frame_id: ScrollLayerId,
@@ -547,13 +555,22 @@ impl Frame {
                                                         &item.clip, info.context_id);
                 }
                 SpecificDisplayItem::Image(ref info) => {
-                    context.builder.add_image(item.rect,
-                                              &item.clip,
-                                              &info.stretch_size,
-                                              &info.tile_spacing,
-                                              None,
-                                              info.image_key,
-                                              info.image_rendering);
+                    let image = resource_cache.get_image_properties(info.image_key);
+                    if let Some(tile_size) = image.tiling {
+                        // The image resource is tiled. We have to generate an image primitive
+                        // for each tile.
+                        let image_size = DeviceUintSize::new(image.descriptor.width, image.descriptor.height);
+                        self.decompose_tiled_image(context, &item, info, image_size, tile_size as u32);
+                    } else {
+                        context.builder.add_image(item.rect,
+                                                  &item.clip,
+                                                  &info.stretch_size,
+                                                  &info.tile_spacing,
+                                                  None,
+                                                  info.image_key,
+                                                  info.image_rendering,
+                                                  None);
+                    }
                 }
                 SpecificDisplayItem::YuvImage(ref info) => {
                     context.builder.add_yuv_image(item.rect,
@@ -612,6 +629,7 @@ impl Frame {
                 }
                 SpecificDisplayItem::PushStackingContext(ref info) => {
                     self.flatten_stacking_context(traversal,
+                                                  resource_cache,
                                                   pipeline_id,
                                                   context,
                                                   current_reference_frame_id,
@@ -623,6 +641,7 @@ impl Frame {
                 }
                 SpecificDisplayItem::PushScrollLayer(ref info) => {
                     self.flatten_scroll_layer(traversal,
+                                              resource_cache,
                                               pipeline_id,
                                               context,
                                               current_reference_frame_id,
@@ -634,7 +653,8 @@ impl Frame {
                                               info.id);
                 }
                 SpecificDisplayItem::Iframe(ref info) => {
-                    self.flatten_iframe(info.pipeline_id,
+                    self.flatten_iframe(resource_cache,
+                                        info.pipeline_id,
                                         &item.rect,
                                         context,
                                         current_scroll_layer_id,
@@ -644,6 +664,206 @@ impl Frame {
                 SpecificDisplayItem::PopScrollLayer => return,
             }
         }
+    }
+
+    fn decompose_tiled_image(&mut self,
+                             context: &mut FlattenContext,
+                             item: &DisplayItem,
+                             info: &ImageDisplayItem,
+                             image_size: DeviceUintSize,
+                             tile_size: u32) {
+        // The image resource is tiled. We have to generate an image primitive
+        // for each tile.
+        // We need to do this because the image is borken up into smaller tiles in the texture
+        // cache and the image shader is not able to work with this type of sparse representation.
+
+        // The tiling logic works as follows:
+        //
+        //  ###################-+  -+
+        //  #    |    |    |//# |   | image size
+        //  #    |    |    |//# |   |
+        //  #----+----+----+--#-+   |  -+ 
+        //  #    |    |    |//# |   |   | regular tile size
+        //  #    |    |    |//# |   |   |
+        //  #----+----+----+--#-+   |  -+-+
+        //  #////|////|////|//# |   |     | "leftover" height
+        //  ################### |  -+  ---+
+        //  #----+----+----+----+
+        //
+        // In the ascii diagram above, a large image is plit into tiles of almost regular size.
+        // The tiles on the right and bottom edges (hatched in the diagram) are smaller than
+        // the regular tiles and are handled separately in the code see leftover_width/height.
+        // each generated image primitive corresponds to a tile in the texture cache, with the
+        // assumption that the smaller tiles with leftover sizes are sized to fit their own
+        // irregular size in the texture cache.
+
+        // TODO(nical) supporting tiled repeated images isn't implemented yet.
+        // One way to implement this is to have another level of decomposition on top of this one,
+        // and generate a set of image primitive per repetition just like we have a primitive
+        // per tile here.
+        //
+        // For the case where we don't tile along an axis, we can still perform the repetition in
+        // the shader (for this particular axis), and it is worth special-casing for this to avoid
+        // generating many primitives.
+        // This can happen with very tall and thin images used as a repeating background.
+        // Apparently web authors do that...
+
+        let mut stretch_size = info.stretch_size;
+
+        let mut repeat_x = false;
+        let mut repeat_y = false;
+
+        if stretch_size.width < item.rect.size.width {
+            if image_size.width < tile_size {
+                // we don't actually tile in this dimmension so repeating can be done in the shader.
+                repeat_x = true;
+            } else {
+                println!("Unimplemented! repeating a tiled image (x axis)");
+                stretch_size.width = item.rect.size.width;
+            }
+        }
+
+        if stretch_size.height < item.rect.size.height {
+                // we don't actually tile in this dimmension so repeating can be done in the shader.
+            if image_size.height < tile_size {
+                repeat_y = true;
+            } else {
+                println!("Unimplemented! repeating a tiled image (y axis)");
+                stretch_size.height = item.rect.size.height;
+            }
+        }
+
+        let tile_size_f32 = tile_size as f32;
+
+        // Note: this rounds down so it excludes the partially filled tiles on the right and
+        // bottom edges (we handle them separately below).
+        let num_tiles_x = (image_size.width / tile_size) as u16;
+        let num_tiles_y = (image_size.height / tile_size) as u16;
+
+        // Ratio between (image space) tile size and image size.
+        let img_dw = tile_size_f32 / (image_size.width as f32);
+        let img_dh = tile_size_f32 / (image_size.height as f32);
+
+        // Strected size of the tile in layout space.
+        let stretched_tile_size = LayerSize::new(
+            img_dw * stretch_size.width,
+            img_dh * stretch_size.height
+        );
+
+        // The size in pixels of the tiles on the right and bottom edges, smaller
+        // than the regular tile size if the image is not a multiple of the tile size.
+        // Zero means the image size is a multiple of the tile size.
+        let leftover = DeviceUintSize::new(image_size.width % tile_size, image_size.height % tile_size);
+
+        for ty in 0..num_tiles_y {
+            for tx in 0..num_tiles_x {
+                self.add_tile_primitive(context, item, info,
+                                        TileOffset::new(tx, ty),
+                                        stretched_tile_size,
+                                        1.0, 1.0,
+                                        repeat_x, repeat_y);
+            }
+            if leftover.width != 0 {
+                // Tiles on the right edge that are smaller than the tile size.
+                self.add_tile_primitive(context, item, info,
+                                        TileOffset::new(num_tiles_x, ty),
+                                        stretched_tile_size,
+                                        (leftover.width as f32) / tile_size_f32,
+                                        1.0,
+                                        repeat_x, repeat_y);
+            }
+        }
+
+        if leftover.height != 0 {
+            for tx in 0..num_tiles_x {
+                // Tiles on the bottom edge that are smaller than the tile size.
+                self.add_tile_primitive(context, item, info,
+                                        TileOffset::new(tx, num_tiles_y),
+                                        stretched_tile_size,
+                                        1.0,
+                                        (leftover.height as f32) / tile_size_f32,
+                                        repeat_x, repeat_y);
+            }
+
+            if leftover.width != 0 {
+                // Finally, the bottom-right tile with a "leftover" size.
+                self.add_tile_primitive(context, item, info,
+                                        TileOffset::new(num_tiles_x, num_tiles_y),
+                                        stretched_tile_size,
+                                        (leftover.width as f32) / tile_size_f32,
+                                        (leftover.height as f32) / tile_size_f32,
+                                        repeat_x, repeat_y);
+            }
+        }
+    }
+
+    fn add_tile_primitive(&mut self,
+                          context: &mut FlattenContext,
+                          item: &DisplayItem,
+                          info: &ImageDisplayItem,
+                          tile_offset: TileOffset,
+                          stretched_tile_size: LayerSize,
+                          tile_ratio_width: f32,
+                          tile_ratio_height: f32,
+                          repeat_x: bool,
+                          repeat_y: bool) {
+        // If the the image is tiled along a given axis, we can't have the shader compute
+        // the image repetition pattern. In this case we base the primitive's rectangle size
+        // on the stretched tile size which effectively cancels the repetion (and repetition
+        // has to be emulated by generating more primitives).
+        // If the image is not tiling along this axis, we can perform the repetition in the
+        // shader. in this case we use the item's size in the primitive (on that particular
+        // axis).
+        // See the repeat_x/y code below.
+
+        let stretched_size = LayerSize::new(
+            stretched_tile_size.width * tile_ratio_width,
+            stretched_tile_size.height * tile_ratio_height,
+        );
+
+        let mut prim_rect = LayerRect::new(
+            item.rect.origin + LayerPoint::new(
+                tile_offset.x as f32 * stretched_tile_size.width,
+                tile_offset.y as f32 * stretched_tile_size.height,
+            ),
+            stretched_size,
+        );
+
+        if !item.rect.contains(&prim_rect.origin) {
+            // Due to stretching, this tile is outside of the item's rectangle,
+            // so it isn't visible.
+            return;
+        }
+
+        if repeat_x {
+            assert_eq!(tile_offset.x, 0);
+            prim_rect.size.width = item.rect.size.width;
+        }
+
+        if repeat_y {
+            assert_eq!(tile_offset.y, 0);
+            prim_rect.size.height = item.rect.size.height;
+        }
+
+        // Fix up the primitive's rect if it overflows the original item rect.
+        let x_overflow = prim_rect.max_x() - item.rect.max_x();
+        if x_overflow > 0.0 {
+            prim_rect.size.width -= x_overflow;
+        }
+
+        let y_overflow = prim_rect.max_y() - item.rect.max_y();
+        if y_overflow > 0.0 {
+            prim_rect.size.height -= y_overflow;
+        }
+
+        context.builder.add_image(prim_rect,
+                                  &item.clip,
+                                  &stretched_size,
+                                  &info.tile_spacing,
+                                  None,
+                                  info.image_key,
+                                  info.image_rendering,
+                                  Some(tile_offset));
     }
 
     pub fn build(&mut self,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -28,7 +28,7 @@ use util::{self, pack_as_float, rect_from_points_f, subtract_rect, TransformedRe
 use util::{RectHelpers, TransformedRectKind};
 use webrender_traits::{as_scroll_parent_rect, BorderDetails, BorderDisplayItem, BorderSide, BorderStyle};
 use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, device_length, DeviceIntPoint};
-use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintSize, ExtendMode, FontKey};
+use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintSize, ExtendMode, FontKey, TileOffset};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
 use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
 use webrender_traits::{RepeatMode, ScrollLayerId, ScrollLayerPixel, WebGLContextId, YuvColorSpace};
@@ -417,7 +417,8 @@ impl FrameBuilder {
                                    &segment.tile_spacing,
                                    Some(segment.sub_rect),
                                    border.image_key,
-                                   ImageRendering::Auto);
+                                   ImageRendering::Auto,
+                                   None);
                 }
             }
             BorderDetails::Normal(ref border) => {
@@ -833,10 +834,12 @@ impl FrameBuilder {
                      tile_spacing: &LayerSize,
                      sub_rect: Option<TexelRect>,
                      image_key: ImageKey,
-                     image_rendering: ImageRendering) {
+                     image_rendering: ImageRendering,
+                     tile: Option<TileOffset>) {
         let prim_cpu = ImagePrimitiveCpu {
             kind: ImagePrimitiveKind::Image(image_key,
                                             image_rendering,
+                                            tile,
                                             *tile_spacing),
             color_texture_id: SourceTexture::Invalid,
             resource_address: GpuStoreAddress(0),
@@ -1361,7 +1364,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
 
         if let Some(mask) = scroll_layer.clip_source.image_mask() {
             // We don't add the image mask for resolution, because layer masks are resolved later.
-            self.resource_cache.request_image(mask.image, ImageRendering::Auto);
+            self.resource_cache.request_image(mask.image, ImageRendering::Auto, None);
         }
     }
 

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -387,6 +387,7 @@ pub enum TextureUpdateOp {
         height: u32,
         data: Arc<Vec<u8>>,
         stride: Option<u32>,
+        offset: u32,
     },
     UpdateForExternalBuffer {
         rect: DeviceUintRect,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -407,7 +407,7 @@ impl RenderBackend {
             webgl_context.unbind();
         }
 
-        self.frame.create(&self.scene);
+        self.frame.create(&self.scene, &mut self.resource_cache);
     }
 
     fn render(&mut self) -> RendererFrame {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -126,11 +126,11 @@ impl RenderBackend {
                             };
                             tx.send(glyph_dimensions).unwrap();
                         }
-                        ApiMsg::AddImage(id, descriptor, data) => {
+                        ApiMsg::AddImage(id, descriptor, data, tiling) => {
                             if let ImageData::Raw(ref bytes) = data {
                                 profile_counters.image_templates.inc(bytes.len());
                             }
-                            self.resource_cache.add_image_template(id, descriptor, data);
+                            self.resource_cache.add_image_template(id, descriptor, data, tiling);
                         }
                         ApiMsg::UpdateImage(id, descriptor, bytes) => {
                             self.resource_cache.update_image_template(id, descriptor, bytes);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -698,13 +698,13 @@ impl Renderer {
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
         let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
-                             ImageDescriptor::new(2, 2, ImageFormat::RGBA8),
+                             ImageDescriptor::new(2, 2, ImageFormat::RGBA8, false),
                              TextureFilter::Linear,
                              ImageData::Raw(Arc::new(white_pixels)));
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
-                             ImageDescriptor::new(2, 2, ImageFormat::A8),
+                             ImageDescriptor::new(2, 2, ImageFormat::A8, false),
                              TextureFilter::Linear,
                              ImageData::Raw(Arc::new(mask_pixels)));
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -698,27 +698,13 @@ impl Renderer {
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
         let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
-                             ImageDescriptor {
-                                width: 2,
-                                height: 2,
-                                stride: None,
-                                offset: 0,
-                                format: ImageFormat::RGBA8,
-                                is_opaque: false,
-                             },
+                             ImageDescriptor::new(2, 2, ImageFormat::RGBA8),
                              TextureFilter::Linear,
                              ImageData::Raw(Arc::new(white_pixels)));
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
-                             ImageDescriptor {
-                                width: 2,
-                                height: 2,
-                                stride: None,
-                                offset: 0,
-                                format: ImageFormat::A8,
-                                is_opaque: false,
-                             },
+                             ImageDescriptor::new(2, 2, ImageFormat::A8),
                              TextureFilter::Linear,
                              ImageData::Raw(Arc::new(mask_pixels)));
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -702,6 +702,7 @@ impl Renderer {
                                 width: 2,
                                 height: 2,
                                 stride: None,
+                                offset: 0,
                                 format: ImageFormat::RGBA8,
                                 is_opaque: false,
                              },
@@ -714,6 +715,7 @@ impl Renderer {
                                 width: 2,
                                 height: 2,
                                 stride: None,
+                                offset: 0,
                                 format: ImageFormat::A8,
                                 is_opaque: false,
                              },
@@ -1123,13 +1125,13 @@ impl Renderer {
                                                    filter,
                                                    mode);
                     }
-                    TextureUpdateOp::Update { page_pos_x, page_pos_y, width, height, data, stride } => {
+                    TextureUpdateOp::Update { page_pos_x, page_pos_y, width, height, data, stride, offset } => {
                         let texture_id = self.cache_texture_id_map[update.id.0];
                         self.device.update_texture(texture_id,
                                                    page_pos_x,
                                                    page_pos_y,
                                                    width, height, stride,
-                                                   data.as_slice());
+                                                   &data[offset as usize..]);
                     }
                     TextureUpdateOp::UpdateForExternalBuffer { rect, id, stride } => {
                         let handler = self.external_image_handler

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -262,7 +262,8 @@ impl ResourceCache {
     pub fn add_image_template(&mut self,
                               image_key: ImageKey,
                               descriptor: ImageDescriptor,
-                              data: ImageData) {
+                              data: ImageData,
+                              tiling: Option<u16>) {
         if descriptor.width > self.max_texture_size() || descriptor.height > self.max_texture_size() {
             // TODO: we need to support handle this case gracefully, cf. issue #620.
             println!("Warning: texture size ({} {}) larger than the maximum size",
@@ -273,7 +274,7 @@ impl ResourceCache {
             descriptor: descriptor,
             data: data,
             epoch: Epoch(0),
-            tiling: None,
+            tiling: tiling,
         };
 
         self.image_templates.insert(image_key, resource);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -23,7 +23,7 @@ use thread_profiler::register_thread_with_profiler;
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, ImageDescriptor, ColorF};
-use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance};
+use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance, TileOffset};
 use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError};
 use threadpool::ThreadPool;
 use euclid::Point2D;
@@ -92,6 +92,7 @@ impl RenderedGlyphKey {
 pub struct ImageProperties {
     pub descriptor: ImageDescriptor,
     pub external_id: Option<ExternalImageId>,
+    pub tiling: Option<u16>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -105,6 +106,7 @@ struct ImageResource {
     data: ImageData,
     descriptor: ImageDescriptor,
     epoch: Epoch,
+    tiling: Option<u16>,
 }
 
 struct CachedImageInfo {
@@ -177,6 +179,7 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
 struct ImageRequest {
     key: ImageKey,
     rendering: ImageRendering,
+    tile: Option<TileOffset>,
 }
 
 struct GlyphRasterJob {
@@ -270,6 +273,7 @@ impl ResourceCache {
             descriptor: descriptor,
             data: data,
             epoch: Epoch(0),
+            tiling: None,
         };
 
         self.image_templates.insert(image_key, resource);
@@ -301,6 +305,7 @@ impl ResourceCache {
             descriptor: descriptor,
             data: ImageData::new(bytes),
             epoch: next_epoch,
+            tiling: None,
         };
 
         self.image_templates.insert(image_key, resource);
@@ -339,11 +344,16 @@ impl ResourceCache {
         webgl_texture.size = size;
     }
 
-    pub fn request_image(&mut self, key: ImageKey, rendering: ImageRendering) {
+    pub fn request_image(&mut self,
+                         key: ImageKey,
+                         rendering: ImageRendering,
+                         tile: Option<TileOffset>) {
+
         debug_assert!(self.state == State::AddResources);
         let request = ImageRequest {
             key: key,
             rendering: rendering,
+            tile: tile,
         };
 
         let template = self.image_templates.get(&key).unwrap();
@@ -472,11 +482,13 @@ impl ResourceCache {
     #[inline]
     pub fn get_cached_image(&self,
                             image_key: ImageKey,
-                            image_rendering: ImageRendering) -> CacheItem {
+                            image_rendering: ImageRendering,
+                            tile: Option<TileOffset>) -> CacheItem {
         debug_assert!(self.state == State::QueryResources);
         let key = ImageRequest {
             key: image_key,
             rendering: image_rendering,
+            tile: tile,
         };
         let image_info = &self.cached_images.get(&key, self.current_frame_id);
         let item = self.texture_cache.get(image_info.texture_cache_id);
@@ -501,6 +513,7 @@ impl ResourceCache {
         ImageProperties {
             descriptor: image_template.descriptor,
             external_id: external_id,
+            tiling: image_template.tiling,
         }
     }
 
@@ -563,6 +576,7 @@ impl ResourceCache {
                                                               stride: None,
                                                               format: ImageFormat::RGBA8,
                                                               is_opaque: false,
+                                                              offset: 0,
                                                           },
                                                           TextureFilter::Linear,
                                                           ImageData::Raw(Arc::new(glyph.bytes)));
@@ -650,10 +664,48 @@ impl ResourceCache {
                             ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
                         };
 
-                        self.texture_cache.insert(image_id,
-                                                  image_template.descriptor,
-                                                  filter,
-                                                  image_data);
+                        if let Some(tile) = request.tile {
+                            let tile_size = image_template.tiling.unwrap() as u32;
+                            let image_descriptor = image_template.descriptor.clone();
+                            let stride = image_descriptor.compute_stride();
+                            let bpp = image_descriptor.format.bytes_per_pixel().unwrap();
+
+                            // Storage for the tiles on the right and bottom edges is shrunk to
+                            // fit the image data (See decompose_tiled_image in frame.rs).
+                            let actual_width = if (tile.x as u32) < image_descriptor.width / tile_size {
+                                tile_size
+                            } else {
+                                image_descriptor.width % tile_size
+                            };
+
+                            let actual_height = if (tile.y as u32) < image_descriptor.height / tile_size {
+                                tile_size
+                            } else {
+                                image_descriptor.height % tile_size
+                            };
+
+                            let offset = image_descriptor.offset + tile.y as u32 * tile_size * stride
+                                                                 + tile.x as u32 * tile_size * bpp;
+
+                            let tile_descriptor = ImageDescriptor {
+                                width: actual_width,
+                                height: actual_height,
+                                stride: Some(stride),
+                                offset: offset,
+                                format: image_descriptor.format,
+                                is_opaque: image_descriptor.is_opaque,
+                            };
+
+                            self.texture_cache.insert(image_id,
+                                                      tile_descriptor,
+                                                      filter,
+                                                      image_data);
+                        } else {
+                            self.texture_cache.insert(image_id,
+                                                      image_template.descriptor,
+                                                      filter,
+                                                      image_data);
+                        }
 
                         entry.insert(CachedImageInfo {
                             texture_cache_id: image_id,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -23,7 +23,7 @@ use thread_profiler::register_thread_with_profiler;
 use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, ImageDescriptor, ColorF};
-use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance, TileOffset};
+use webrender_traits::{ExternalImageId, GlyphOptions, GlyphInstance, TileOffset, TileSize};
 use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError};
 use threadpool::ThreadPool;
 use euclid::Point2D;
@@ -92,7 +92,7 @@ impl RenderedGlyphKey {
 pub struct ImageProperties {
     pub descriptor: ImageDescriptor,
     pub external_id: Option<ExternalImageId>,
-    pub tiling: Option<u16>,
+    pub tiling: Option<TileSize>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -106,7 +106,7 @@ struct ImageResource {
     data: ImageData,
     descriptor: ImageDescriptor,
     epoch: Epoch,
-    tiling: Option<u16>,
+    tiling: Option<TileSize>,
 }
 
 struct CachedImageInfo {
@@ -263,7 +263,7 @@ impl ResourceCache {
                               image_key: ImageKey,
                               descriptor: ImageDescriptor,
                               data: ImageData,
-                              mut tiling: Option<u16>) {
+                              mut tiling: Option<TileSize>) {
         if descriptor.width > self.max_texture_size() || descriptor.height > self.max_texture_size() {
             // We aren't going to be able to upload a texture this big, so tile it, even
             // if tiling was not requested.

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -263,11 +263,11 @@ impl ResourceCache {
                               image_key: ImageKey,
                               descriptor: ImageDescriptor,
                               data: ImageData,
-                              tiling: Option<u16>) {
+                              mut tiling: Option<u16>) {
         if descriptor.width > self.max_texture_size() || descriptor.height > self.max_texture_size() {
-            // TODO: we need to support handle this case gracefully, cf. issue #620.
-            println!("Warning: texture size ({} {}) larger than the maximum size",
-                     descriptor.width, descriptor.height);
+            // We aren't going to be able to upload a texture this big, so tile it, even
+            // if tiling was not requested.
+            tiling = Some(512);
         }
 
         let resource = ImageResource {

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -731,6 +731,7 @@ impl TextureCache {
                     height: descriptor.height,
                     data: bytes,
                     stride: descriptor.stride,
+                    offset: descriptor.offset,
                 }
             }
         };
@@ -782,6 +783,7 @@ impl TextureCache {
                                 height: result.item.allocated_rect.size.height,
                                 data: bytes,
                                 stride: stride,
+                                offset: descriptor.offset,
                             },
                         };
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -832,7 +832,7 @@ impl ClipBatcher {
             }
 
             if let Some((ref mask, address)) = info.image {
-                let cache_item = resource_cache.get_cached_image(mask.image, ImageRendering::Auto);
+                let cache_item = resource_cache.get_cached_image(mask.image, ImageRendering::Auto, None);
                 self.images.entry(cache_item.texture_id)
                            .or_insert(Vec::new())
                            .push(CacheClipInstance {

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -92,8 +92,9 @@ impl RenderApi {
     pub fn add_image(&self,
                      key: ImageKey,
                      descriptor: ImageDescriptor,
-                     data: ImageData) {
-        let msg = ApiMsg::AddImage(key, descriptor, data);
+                     data: ImageData,
+                     tiling: Option<u16>) {
+        let msg = ApiMsg::AddImage(key, descriptor, data, tiling);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -9,7 +9,7 @@ use std::cell::Cell;
 use {ApiMsg, ColorF, DisplayListBuilder, Epoch, ImageDescriptor};
 use {FontKey, IdNamespace, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLocation, ServoScrollRootId};
-use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand};
+use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand, TileSize};
 use {DeviceIntSize, DynamicProperties, LayoutPoint, LayoutSize, WorldPoint, PropertyBindingKey, PropertyBindingId};
 use VRCompositorCommand;
 use ExternalEvent;
@@ -93,7 +93,7 @@ impl RenderApi {
                      key: ImageKey,
                      descriptor: ImageDescriptor,
                      data: ImageData,
-                     tiling: Option<u16>) {
+                     tiling: Option<TileSize>) {
         let msg = ApiMsg::AddImage(key, descriptor, data, tiling);
         self.api_sender.send(msg).unwrap();
     }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -368,6 +368,27 @@ pub struct ImageDescriptor {
 }
 
 impl ImageDescriptor {
+    pub fn new(width: u32, height: u32, format: ImageFormat) -> Self {
+        ImageDescriptor {
+            width: width,
+            height: height,
+            format: format,
+            stride: None,
+            offset: 0,
+            is_opaque: format == ImageFormat::RGB8,
+        }
+    }
+
+    pub fn with_opaque_flag(mut self, is_opaque: bool) -> Self {
+        self.is_opaque = is_opaque;
+        return self;
+    }
+
+    pub fn with_stride(mut self, stride: u32) -> Self {
+        self.stride = Some(stride);
+        return self;
+    }
+
     pub fn compute_stride(&self) -> u32 {
         self.stride.unwrap_or(self.width * self.format.bytes_per_pixel().unwrap())
     }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -363,7 +363,14 @@ pub struct ImageDescriptor {
     pub width: u32,
     pub height: u32,
     pub stride: Option<u32>,
+    pub offset: u32,
     pub is_opaque: bool,
+}
+
+impl ImageDescriptor {
+    pub fn compute_stride(&self) -> u32 {
+        self.stride.unwrap_or(self.width * self.format.bytes_per_pixel().unwrap())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -31,7 +31,7 @@ pub enum ApiMsg {
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
-    AddImage(ImageKey, ImageDescriptor, ImageData),
+    AddImage(ImageKey, ImageDescriptor, ImageData, Option<u16>),
     /// Updates the the resource cache with the new image data.
     UpdateImage(ImageKey, ImageDescriptor, Vec<u8>),
     /// Drops an image from the resource cache.

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -24,6 +24,8 @@ pub enum RendererKind {
     OSMesa,
 }
 
+pub type TileSize = u16;
+
 #[derive(Clone, Deserialize, Serialize)]
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
@@ -31,7 +33,7 @@ pub enum ApiMsg {
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
-    AddImage(ImageKey, ImageDescriptor, ImageData, Option<u16>),
+    AddImage(ImageKey, ImageDescriptor, ImageData, Option<TileSize>),
     /// Updates the the resource cache with the new image data.
     UpdateImage(ImageKey, ImageDescriptor, Vec<u8>),
     /// Drops an image from the resource cache.
@@ -368,25 +370,15 @@ pub struct ImageDescriptor {
 }
 
 impl ImageDescriptor {
-    pub fn new(width: u32, height: u32, format: ImageFormat) -> Self {
+    pub fn new(width: u32, height: u32, format: ImageFormat, is_opaque: bool) -> Self {
         ImageDescriptor {
             width: width,
             height: height,
             format: format,
             stride: None,
             offset: 0,
-            is_opaque: format == ImageFormat::RGB8,
+            is_opaque: is_opaque,
         }
-    }
-
-    pub fn with_opaque_flag(mut self, is_opaque: bool) -> Self {
-        self.is_opaque = is_opaque;
-        return self;
-    }
-
-    pub fn with_stride(mut self, stride: u32) -> Self {
-        self.stride = Some(stride);
-        return self;
     }
 
     pub fn compute_stride(&self) -> u32 {

--- a/webrender_traits/src/units.rs
+++ b/webrender_traits/src/units.rs
@@ -73,6 +73,10 @@ pub type WorldPoint = TypedPoint2D<f32, WorldPixel>;
 pub type WorldSize = TypedSize2D<f32, WorldPixel>;
 pub type WorldPoint4D = TypedPoint4D<f32, WorldPixel>;
 
+/// Offset in number of tiles.
+#[derive(Hash, Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Tiles;
+pub type TileOffset = TypedPoint2D<u16, Tiles>;
 
 pub type LayoutTransform = TypedMatrix4D<f32, LayoutPixel, LayoutPixel>;
 pub type LayerTransform = TypedMatrix4D<f32, LayerPixel, LayerPixel>;

--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -1,0 +1,2 @@
+== tile-size.yaml tile-size-ref.yaml
+== very-big.yaml very-big-ref.yaml

--- a/wrench/reftests/image/tile-size-ref.yaml
+++ b/wrench/reftests/image/tile-size-ref.yaml
@@ -1,0 +1,14 @@
+root:
+  items:
+    - image: xy_gradient(512, 512)
+      bounds: 0 0 512 512
+      stretch_size: 512 512
+    - image: xy_gradient(512, 512)
+      bounds: 512 0 512 512
+      stretch_size: 512 512
+    - image: xy_gradient(512, 512)
+      bounds: 0 512 512 512
+      stretch_size: 512 512
+    - image: xy_gradient(512, 512)
+      bounds: 512 512 512 512
+      stretch_size: 512 512

--- a/wrench/reftests/image/tile-size.yaml
+++ b/wrench/reftests/image/tile-size.yaml
@@ -1,0 +1,19 @@
+root:
+  items:
+    - image: xy_gradient(512, 512)
+      bounds: 0 0 512 512
+      stretch_size: 512 512
+      tile-size: 64
+    - image: xy_gradient(512, 512)
+      bounds: 512 0 512 512
+      stretch_size: 512 512
+      tile-size: 128
+    - image: xy_gradient(512, 512)
+      bounds: 0 512 512 512
+      stretch_size: 512 512
+      tile-size: 256
+      # tile size bigger than the image itself
+    - image: xy_gradient(512, 512)
+      bounds: 512 512 512 512
+      stretch_size: 512 512
+      tile-size: 4096

--- a/wrench/reftests/image/very-big-ref.yaml
+++ b/wrench/reftests/image/very-big-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: 0 0 500 500
+      color: red

--- a/wrench/reftests/image/very-big.yaml
+++ b/wrench/reftests/image/very-big.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - image: solid_color(255, 0, 0, 255, 100000, 1000)
+      bounds: 0 0 500 500
+      stretch_size: 1000000 1000

--- a/wrench/reftests/reftest.list
+++ b/wrench/reftests/reftest.list
@@ -3,3 +3,4 @@ include mask/reftest.list
 include scrolling/reftest.list
 include filters/reftest.list
 include boxshadow/reftest.list
+include image/reftest.list

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -212,7 +212,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 self.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
             }
 
-            &ApiMsg::AddImage(ref key, ref descriptor, ref data) => {
+            &ApiMsg::AddImage(ref key, ref descriptor, ref data, _) => {
                 let stride = descriptor.stride.unwrap_or(
                     descriptor.width * descriptor.format.bytes_per_pixel().unwrap()
                 );

--- a/wrench/src/parse_function.rs
+++ b/wrench/src/parse_function.rs
@@ -37,7 +37,7 @@ pub fn parse_function(s: &str) -> (&str, Vec<&str>) {
 
     let mut end = p.start;
     while let Some(k) = p.o {
-        if !k.1.is_alphabetic() {
+        if !k.1.is_alphabetic() && k.1 != '_' {
             break;
         }
         end = k.0 + k.1.len_utf8();

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -308,8 +308,9 @@ impl Wrench {
             ImageDescriptor {
                 width: image_dims.0,
                 height: image_dims.1,
-                stride: None,
                 format: format,
+                stride: None,
+                offset: 0,
                 is_opaque: is_image_opaque(format, &bytes[..]),
             },
             ImageData::Raw(Arc::new(bytes)));

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -15,9 +15,9 @@ use glutin::WindowProxy;
 use image;
 use image::GenericImage;
 use json_frame_writer::JsonFrameWriter;
+use parse_function::parse_function;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use time;
 use webrender;
 use webrender_traits::*;
@@ -124,7 +124,7 @@ pub struct Wrench {
 
     window_title_to_set: Option<String>,
 
-    image_map: HashMap<PathBuf, (ImageKey, LayoutSize)>,
+    image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
     gl_renderer: String,
     gl_version: String,
@@ -287,35 +287,57 @@ impl Wrench {
         (key, None)
     }
 
-    pub fn add_or_get_image(&mut self, file: &Path) -> (ImageKey, LayoutSize) {
-        let key = file.to_owned();
+    pub fn add_or_get_image(&mut self, file: &Path, tiling: Option<i64>) -> (ImageKey, LayoutSize) {
+        let key = (file.to_owned(), tiling);
         if let Some(k) = self.image_map.get(&key) {
             return *k
         }
 
-        let image = image::open(file).unwrap();
-        let image_dims = image.dimensions();
-        let format = match image {
-            image::ImageLuma8(_) => ImageFormat::A8,
-            image::ImageRgb8(_) => ImageFormat::RGB8,
-            image::ImageRgba8(_) => ImageFormat::RGBA8,
-            _ => panic!("We don't support whatever your crazy image type is, come on"),
+        let (descriptor, image_data) = match image::open(file) {
+            Ok(image) => {
+                let image_dims = image.dimensions();
+                let format = match image {
+                    image::ImageLuma8(_) => ImageFormat::A8,
+                    image::ImageRgb8(_) => ImageFormat::RGB8,
+                    image::ImageRgba8(_) => ImageFormat::RGBA8,
+                    _ => panic!("We don't support whatever your crazy image type is, come on"),
+                };
+                let bytes = image.raw_pixels();
+                let descriptor = ImageDescriptor::new(image_dims.0, image_dims.1, format)
+                                    .with_opaque_flag(is_image_opaque(format, &bytes[..]));
+                let data = ImageData::new(bytes);
+                (descriptor, data)
+            }
+            _ => {
+                // This is a hack but it is convenient when generating test cases and avoids
+                // bloating the repository.
+                match parse_function(file.components().last().unwrap().as_os_str().to_str().unwrap()) {
+                    ("xy_gradient", args) => {
+                        generate_xy_gradient_image(
+                            args.get(0).unwrap_or(&"1000").parse::<u32>().unwrap(),
+                            args.get(1).unwrap_or(&"1000").parse::<u32>().unwrap()
+                        )
+                    }
+                    ("solid_color", args) => {
+                        generate_solid_color_image(
+                            args.get(0).unwrap_or(&"255").parse::<u8>().unwrap(),
+                            args.get(1).unwrap_or(&"255").parse::<u8>().unwrap(),
+                            args.get(2).unwrap_or(&"255").parse::<u8>().unwrap(),
+                            args.get(3).unwrap_or(&"255").parse::<u8>().unwrap(),
+                            args.get(4).unwrap_or(&"1000").parse::<u32>().unwrap(),
+                            args.get(5).unwrap_or(&"1000").parse::<u32>().unwrap()
+                        )
+                    }
+                    _ => {
+                        panic!("Failed to load image {:?}", file.to_str());
+                    }
+                }
+            }
         };
-        let bytes = image.raw_pixels();
+        let tiling = tiling.map(|tile_size|{ tile_size as u16 });
         let image_key = self.api.generate_image_key();
-        self.api.add_image(
-            image_key,
-            ImageDescriptor {
-                width: image_dims.0,
-                height: image_dims.1,
-                format: format,
-                stride: None,
-                offset: 0,
-                is_opaque: is_image_opaque(format, &bytes[..]),
-            },
-            ImageData::Raw(Arc::new(bytes)));
-
-        let val = (image_key, LayoutSize::new(image_dims.0 as f32, image_dims.1 as f32));
+        self.api.add_image(image_key, descriptor, image_data, tiling);
+        let val = (image_key, LayoutSize::new(descriptor.width as f32, descriptor.height as f32));
         self.image_map.insert(key, val);
         val
     }
@@ -400,4 +422,45 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
         ImageFormat::A8 => false,
         ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
     }
+}
+
+fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, ImageData) {
+    let mut pixels = Vec::with_capacity((w*h*4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let grid = if x % 100 < 3 || y % 100 < 3 { 0.9 } else { 1.0 };
+            pixels.push((y as f32 / h as f32 * 255.0 * grid) as u8);
+            pixels.push(0);
+            pixels.push((x as f32 / w as f32 * 255.0 * grid) as u8);
+            pixels.push(255);
+        }
+    }
+
+    return (
+        ImageDescriptor::new(w, h, ImageFormat::RGBA8).with_opaque_flag(true),
+        ImageData::new(pixels)
+    );
+}
+
+fn generate_solid_color_image(r: u8, g: u8, b: u8, a: u8, w: u32, h: u32) -> (ImageDescriptor, ImageData) {
+    let buf_size = (w*h*4) as usize;
+    let mut pixels = Vec::with_capacity(buf_size);
+    // Unsafely filling the buffer is horrible. Unfortunately doing this idiomatically
+    // is terribly slow in debug builds to the point that reftests/image/very-big.yaml
+    // takes more than 20 seconds to run on a recent laptop.
+    unsafe {
+        pixels.set_len(buf_size);
+        let color: u32 = ::std::mem::transmute([b,g,r,a]);
+        let mut ptr: *mut u32 = ::std::mem::transmute(&mut pixels[0]);
+        let end = ptr.offset((w*h) as isize);
+        while ptr < end {
+            *ptr = color;
+            ptr = ptr.offset(1);
+        }
+    }
+
+    return (
+        ImageDescriptor::new(w, h, ImageFormat::RGBA8).with_opaque_flag(a == 255),
+        ImageData::new(pixels)
+    );
 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -303,8 +303,10 @@ impl Wrench {
                     _ => panic!("We don't support whatever your crazy image type is, come on"),
                 };
                 let bytes = image.raw_pixels();
-                let descriptor = ImageDescriptor::new(image_dims.0, image_dims.1, format)
-                                    .with_opaque_flag(is_image_opaque(format, &bytes[..]));
+                let descriptor = ImageDescriptor::new(image_dims.0,
+                                                      image_dims.1,
+                                                      format,
+                                                      is_image_opaque(format, &bytes[..]));
                 let data = ImageData::new(bytes);
                 (descriptor, data)
             }
@@ -425,7 +427,7 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
 }
 
 fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, ImageData) {
-    let mut pixels = Vec::with_capacity((w*h*4) as usize);
+    let mut pixels = Vec::with_capacity((w * h * 4) as usize);
     for y in 0..h {
         for x in 0..w {
             let grid = if x % 100 < 3 || y % 100 < 3 { 0.9 } else { 1.0 };
@@ -437,22 +439,22 @@ fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, ImageData) {
     }
 
     return (
-        ImageDescriptor::new(w, h, ImageFormat::RGBA8).with_opaque_flag(true),
+        ImageDescriptor::new(w, h, ImageFormat::RGBA8, true),
         ImageData::new(pixels)
     );
 }
 
 fn generate_solid_color_image(r: u8, g: u8, b: u8, a: u8, w: u32, h: u32) -> (ImageDescriptor, ImageData) {
-    let buf_size = (w*h*4) as usize;
+    let buf_size = (w * h * 4) as usize;
     let mut pixels = Vec::with_capacity(buf_size);
     // Unsafely filling the buffer is horrible. Unfortunately doing this idiomatically
     // is terribly slow in debug builds to the point that reftests/image/very-big.yaml
     // takes more than 20 seconds to run on a recent laptop.
     unsafe {
         pixels.set_len(buf_size);
-        let color: u32 = ::std::mem::transmute([b,g,r,a]);
+        let color: u32 = ::std::mem::transmute([b, g, r, a]);
         let mut ptr: *mut u32 = ::std::mem::transmute(&mut pixels[0]);
-        let end = ptr.offset((w*h) as isize);
+        let end = ptr.offset((w * h) as isize);
         while ptr < end {
             *ptr = color;
             ptr = ptr.offset(1);
@@ -460,7 +462,7 @@ fn generate_solid_color_image(r: u8, g: u8, b: u8, a: u8, w: u32, h: u32) -> (Im
     }
 
     return (
-        ImageDescriptor::new(w, h, ImageFormat::RGBA8).with_opaque_flag(a == 255),
+        ImageDescriptor::new(w, h, ImageFormat::RGBA8, a == 255),
         ImageData::new(pixels)
     );
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -170,7 +170,7 @@ impl YamlFrameReader {
                 let image_mask = if item["image_mask"].as_hash().is_some() {
                     let image_mask = &item["image_mask"];
                     let (image_key, image_dims) =
-                        wrench.add_or_get_image(&self.rsrc_path(&image_mask["image"]));
+                        wrench.add_or_get_image(&self.rsrc_path(&image_mask["image"]), None);
                     let image_rect =
                         image_mask["rect"].as_rect().unwrap_or(LayoutRect::new(LayoutPoint::zero(),
                                                                                image_dims));
@@ -323,7 +323,8 @@ impl YamlFrameReader {
 
     fn handle_image(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {
         let filename = &item[if item["type"].is_badvalue() { "image" } else { "src" }];
-        let (image_key, image_dims) = wrench.add_or_get_image(&self.rsrc_path(filename));
+        let tiling = item["tile-size"].as_i64();
+        let (image_key, image_dims) = wrench.add_or_get_image(&self.rsrc_path(filename), tiling);
 
         let bounds_raws = item["bounds"].as_vec_f32().unwrap();
         let bounds = if bounds_raws.len() == 2 {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -85,7 +85,6 @@ fn matrix4d_node<U1, U2>(parent: &mut Table, key: &str, value: &TypedMatrix4D<f3
     f32_vec_node(parent, key, &value.to_row_major_array());
 }
 
-#[cfg(target_os = "windows")]
 fn u32_node(parent: &mut Table, key: &str, value: u32) {
     yaml_node(parent, key, Yaml::Integer(value as i64));
 }
@@ -228,6 +227,7 @@ struct CachedImage {
     format: ImageFormat,
     bytes: Option<Vec<u8>>,
     path: Option<PathBuf>,
+    tiling: Option<u16>,
 }
 
 pub struct YamlFrameWriter {
@@ -546,6 +546,9 @@ impl YamlFrameWriter {
                     if let Some(path) = self.path_for_image(&item.image_key) {
                         path_node(&mut v, "image", &path);
                     }
+                    if let Some(&CachedImage { tiling: Some(tile_size), .. }) = self.images.get(&item.image_key) {
+                        u32_node(&mut v, "tile-size", tile_size as u32);
+                    }
                     size_node(&mut v, "strech", &item.stretch_size);
                     size_node(&mut v, "spacing", &item.tile_spacing);
                     match item.image_rendering {
@@ -694,7 +697,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 self.frame_writer.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
             }
 
-            &ApiMsg::AddImage(ref key, ref descriptor, ref data) => {
+            &ApiMsg::AddImage(ref key, ref descriptor, ref data, ref tiling) => {
                 let stride = descriptor.stride.unwrap_or(
                     descriptor.width * descriptor.format.bytes_per_pixel().unwrap()
                 );
@@ -711,6 +714,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                     format: descriptor.format,
                     bytes: Some(bytes),
                     path: None,
+                    tiling: *tiling,
                 });
             }
 


### PR DESCRIPTION
Here is a pretty straightforward implementation of image tiling which aims at being able to render images (and vector images) that are larger than the maximum texture size.

The change mostly boils down to:
 - making it possible to upload textures with an offset in the source buffer
 - identifying individual tiles in the resource cache (See ```ImageRequest::tile```)
 - break up image display items into several primitives when the image is tiled

The current limitation is that repeating images isn't supported with tiling yet. That will need to be fixed. It should only be a matter of extending the code in frame.rs so that it generate a set of image primitive for each repetition.

I have been changing my mind regularly on the topic of whether tiling should be requested explicitly in the API or if it should be done somewhat automatically inside of WebRender. Currently I think that making this explicit in the API is simpler to implement and also simpler to test, so that's what I ended up implementing. It would probably make sense to also automatically tile images that are larger than the maximum texture size even if tiling isn't requested, because there isn't any way to render them otherwise.
I don't have a particular attachment to the way I exposed it in the api (added ```RenderApi::add_image_with_tiling``` rather than passing an extra parameter in add_image to avoid changing the api), let me know if you have a preference.

I am quite happy with how this works compared to what we have in gecko's layers, because tiles are uploaded on-demand which means we don't need to pay unnecessary cost for large images that are partially visible.

The separation between the commits isn't too bad so I kept it this way in case it helps with the review, but don't hesitate to ask me to squash it into one commit before the review if you prefer. Also the PR is rebased on top of PR #877 which makes more code appear here than it should, but this will clear out when the latter PR lands.

r? @glennw @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/897)
<!-- Reviewable:end -->
