### PR TITLE
Simplify ExternalImageId type.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -266,7 +266,7 @@ impl ResourceCache {
                 // This image should not be an external image.
                 match image.data {
                     ImageData::ExternalHandle(id) => {
-                        panic!("Update an external image with buffer, id={} image_key={:?}", id.0, image_key);
+                        panic!("Update an external image with buffer, id={} image_key={:?}", id, image_key);
                     },
                     _ => {},
                 }

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -602,8 +602,7 @@ pub enum YuvColorSpace {
 /// An arbitrary identifier for an external image provided by the
 /// application. It must be a unique identifier for each external
 /// image.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct ExternalImageId(pub u64);
+pub type ExternalImageId = u64;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ImageData {


### PR DESCRIPTION
The ExternalImageId only contains a u64 field. Use u64 directly instead of a struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/906)
<!-- Reviewable:end -->
