### PR TITLE
Refactored input handling in sample & wrench

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -279,12 +279,9 @@ fn main() {
         window.swap_buffers().ok();
 
         match event {
-            glutin::Event::Closed => break,
-            glutin::Event::KeyboardInput(_element_state, scan_code, _virtual_key_code) => {
-                if scan_code == 9 {
-                    break;
-                }
-            }
+            glutin::Event::Closed |
+            glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) |
+            glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Q)) => break,
             _ => ()
         }
     }

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -466,32 +466,28 @@ fn main() {
                     break 'outer;
                 }
 
-                glutin::Event::KeyboardInput(kstate, _scan_code, maybe_vk) => {
-                    if kstate == ElementState::Pressed {
-                        if let Some(vk) = maybe_vk {
-                            match vk {
-                                VirtualKeyCode::Escape | VirtualKeyCode::Q => {
-                                    break 'outer;
-                                },
-                                VirtualKeyCode::P => {
-                                    profiler = !profiler;
-                                    wrench.renderer.set_profiler_enabled(profiler);
-                                },
-                                VirtualKeyCode::L => {
-                                    do_loop = !do_loop;
-                                },
-                                VirtualKeyCode::Left => {
-                                    thing.prev_frame();
-                                },
-                                VirtualKeyCode::Right => {
-                                    thing.next_frame();
-                                },
-                                VirtualKeyCode::H => {
-                                    show_help = !show_help;
-                                },
-                                _ => ()
-                            }
-                        }
+                glutin::Event::KeyboardInput(ElementState::Pressed, _scan_code, Some(vk)) => {
+                    match vk {
+                        VirtualKeyCode::Escape | VirtualKeyCode::Q => {
+                            break 'outer;
+                        },
+                        VirtualKeyCode::P => {
+                            profiler = !profiler;
+                            wrench.renderer.set_profiler_enabled(profiler);
+                        },
+                        VirtualKeyCode::L => {
+                            do_loop = !do_loop;
+                        },
+                        VirtualKeyCode::Left => {
+                            thing.prev_frame();
+                        },
+                        VirtualKeyCode::Right => {
+                            thing.next_frame();
+                        },
+                        VirtualKeyCode::H => {
+                            show_help = !show_help;
+                        },
+                        _ => ()
                     }
                 }
                 _ => ()


### PR DESCRIPTION
After missing #915 due to being unable to escape the sample with "Esc", I figured this could be improved ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/917)
<!-- Reviewable:end -->
