### PR TITLE
Texture allocation refactoring

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -14,7 +14,7 @@ use prim_store::{ImagePrimitiveKind, PrimitiveContainer, PrimitiveGeometry, Prim
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu, RadialGradientPrimitiveGpu};
 use prim_store::{RectanglePrimitive, TextRunPrimitiveCpu, TextRunPrimitiveGpu};
 use prim_store::{TexelRect, YuvImagePrimitiveCpu, YuvImagePrimitiveGpu};
-use profiler::FrameProfileCounters;
+use profiler::{FrameProfileCounters, TextureCacheProfileCounters};
 use render_task::{AlphaRenderItem, MaskCacheKey, MaskResult, RenderTask, RenderTaskIndex};
 use render_task::RenderTaskLocation;
 use resource_cache::ResourceCache;
@@ -1087,7 +1087,9 @@ impl FrameBuilder {
                  frame_id: FrameId,
                  clip_scroll_tree: &ClipScrollTree,
                  auxiliary_lists_map: &AuxiliaryListsMap,
-                 device_pixel_ratio: f32) -> Frame {
+                 device_pixel_ratio: f32,
+                 texture_cache_profile: &mut TextureCacheProfileCounters)
+                 -> Frame {
         profile_scope!("build");
 
         let mut profile_counters = FrameProfileCounters::new();
@@ -1124,7 +1126,7 @@ impl FrameBuilder {
         let mut required_pass_count = 0;
         main_render_task.max_depth(0, &mut required_pass_count);
 
-        resource_cache.block_until_all_resources_added();
+        resource_cache.block_until_all_resources_added(texture_cache_profile);
 
         for scroll_layer in self.scroll_layer_store.iter() {
             if let Some(ref clip_info) = scroll_layer.clip_cache_info {

--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -15,14 +15,28 @@ impl FreeListItemId {
 
     #[inline]
     pub fn value(&self) -> u32 {
-        let FreeListItemId(value) = *self;
-        value
+        self.0
     }
 }
 
 pub trait FreeListItem {
     fn next_free_id(&self) -> Option<FreeListItemId>;
     fn set_next_free_id(&mut self, id: Option<FreeListItemId>);
+}
+
+struct FreeListIter<'a, T: 'a> {
+    items: &'a [T],
+    cur_index: Option<FreeListItemId>,
+}
+
+impl<'a, T: FreeListItem> Iterator for FreeListIter<'a, T> {
+    type Item = FreeListItemId;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cur_index.map(|free_id| {
+            self.cur_index = self.items[free_id.0 as usize].next_free_id();
+            free_id
+        })
+    }
 }
 
 pub struct FreeList<T> {
@@ -37,6 +51,13 @@ impl<T: FreeListItem> FreeList<T> {
             items: Vec::new(),
             first_free_index: None,
             alloc_count: 0,
+        }
+    }
+
+    fn free_iter(&self) -> FreeListIter<T> {
+        FreeListIter {
+            items: &self.items,
+            cur_index: self.first_free_index,
         }
     }
 
@@ -58,31 +79,14 @@ impl<T: FreeListItem> FreeList<T> {
         }
     }
 
-    #[allow(dead_code)]
-    fn assert_not_in_free_list(&self, id: FreeListItemId) {
-        let FreeListItemId(id) = id;
-        let mut next_free_id = self.first_free_index;
-
-        while let Some(free_id) = next_free_id {
-            let FreeListItemId(index) = free_id;
-            assert!(index != id);
-            let free_item = &self.items[index as usize];
-            next_free_id = free_item.next_free_id();
-        }
-    }
-
     pub fn get(&self, id: FreeListItemId) -> &T {
-        //self.assert_not_in_free_list(id);
-
-        let FreeListItemId(index) = id;
-        &self.items[index as usize]
+        debug_assert_eq!(self.free_iter().find(|&fid| fid==id), None);
+        &self.items[id.0 as usize]
     }
 
     pub fn get_mut(&mut self, id: FreeListItemId) -> &mut T {
-        //self.assert_not_in_free_list(id);
-
-        let FreeListItemId(index) = id;
-        &mut self.items[index as usize]
+        debug_assert_eq!(self.free_iter().find(|&fid| fid==id), None);
+        &mut self.items[id.0 as usize]
     }
 
     #[allow(dead_code)]
@@ -90,8 +94,6 @@ impl<T: FreeListItem> FreeList<T> {
         self.alloc_count
     }
 
-    // TODO(gw): Actually free items from the texture cache!!
-    #[allow(dead_code)]
     pub fn free(&mut self, id: FreeListItemId) {
         self.alloc_count -= 1;
         let FreeListItemId(index) = id;
@@ -101,19 +103,16 @@ impl<T: FreeListItem> FreeList<T> {
     }
 
     pub fn for_each_item<F>(&mut self, f: F) where F: Fn(&mut T) {
-        let mut free_ids = HashSet::new();
-
-        let mut next_free_id = self.first_free_index;
-        while let Some(free_id) = next_free_id {
-            free_ids.insert(free_id);
-            let FreeListItemId(index) = free_id;
-            let free_item = &self.items[index as usize];
-            next_free_id = free_item.next_free_id();
-        }
+        //TODO: this could be done much faster. Instead of gathering the free
+        // indices into a set, we could re-order the free list to be ascending.
+        // That is an one-time operation with at most O(nf^2), where
+        //    nf = number of elements in the free list
+        // Then this code would just walk both `items` and the ascending free
+        // list, essentially skipping the free indices for free.
+        let free_ids: HashSet<_> = self.free_iter().collect();
 
         for (index, mut item) in self.items.iter_mut().enumerate() {
-            let id = FreeListItemId(index as u32);
-            if !free_ids.contains(&id) {
+            if !free_ids.contains(&FreeListItemId(index as u32)) {
                 f(&mut item);
             }
         }

--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -20,6 +20,7 @@ impl FreeListItemId {
 }
 
 pub trait FreeListItem {
+    fn take(&mut self) -> Self;
     fn next_free_id(&self) -> Option<FreeListItemId>;
     fn set_next_free_id(&mut self, id: Option<FreeListItemId>);
 }
@@ -94,12 +95,14 @@ impl<T: FreeListItem> FreeList<T> {
         self.alloc_count
     }
 
-    pub fn free(&mut self, id: FreeListItemId) {
+    pub fn free(&mut self, id: FreeListItemId) -> T {
         self.alloc_count -= 1;
         let FreeListItemId(index) = id;
         let item = &mut self.items[index as usize];
+        let data = item.take();
         item.set_next_free_id(self.first_free_index);
         self.first_free_index = Some(id);
+        data
     }
 
     pub fn for_each_item<F>(&mut self, f: F) where F: Fn(&mut T) {

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -257,10 +257,28 @@ impl FrameProfileCounters {
 }
 
 #[derive(Clone)]
+pub struct TextureCacheProfileCounters {
+    pub pages_a8: ResourceProfileCounter,
+    pub pages_rgb8: ResourceProfileCounter,
+    pub pages_rgba8: ResourceProfileCounter,
+}
+
+impl TextureCacheProfileCounters {
+    pub fn new() -> TextureCacheProfileCounters {
+        TextureCacheProfileCounters {
+            pages_a8: ResourceProfileCounter::new("Texture A8 cached pages"),
+            pages_rgb8: ResourceProfileCounter::new("Texture RGB8 cached pages"),
+            pages_rgba8: ResourceProfileCounter::new("Texture RGBA8 cached pages"),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct BackendProfileCounters {
     pub font_templates: ResourceProfileCounter,
     pub image_templates: ResourceProfileCounter,
     pub total_time: TimeProfileCounter,
+    pub texture_cache: TextureCacheProfileCounters,
 }
 
 impl BackendProfileCounters {
@@ -269,6 +287,7 @@ impl BackendProfileCounters {
             font_templates: ResourceProfileCounter::new("Font Templates"),
             image_templates: ResourceProfileCounter::new("Image Templates"),
             total_time: TimeProfileCounter::new("Backend CPU Time", false),
+            texture_cache: TextureCacheProfileCounters::new(),
         }
     }
 
@@ -639,6 +658,12 @@ impl Profiler {
         self.draw_counters(&[
             &backend_profile.font_templates,
             &backend_profile.image_templates,
+        ], debug_renderer, true);
+
+        self.draw_counters(&[
+            &backend_profile.texture_cache.pages_a8,
+            &backend_profile.texture_cache.pages_rgb8,
+            &backend_profile.texture_cache.pages_rgba8,
         ], debug_renderer, true);
 
         self.draw_counters(&[

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -7,7 +7,7 @@ use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use internal_types::{FontTemplate, GLContextHandleWrapper, GLContextWrapper};
 use internal_types::{SourceTexture, ResultMsg, RendererFrame};
-use profiler::BackendProfileCounters;
+use profiler::{BackendProfileCounters, TextureCacheProfileCounters};
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
 use scene::Scene;
@@ -96,8 +96,7 @@ impl RenderBackend {
         }
     }
 
-    pub fn run(&mut self) {
-        let mut profile_counters = BackendProfileCounters::new();
+    pub fn run(&mut self, mut profile_counters: BackendProfileCounters) {
         let mut frame_counter: u32 = 0;
 
         loop {
@@ -213,13 +212,16 @@ impl RenderBackend {
                         }
                         ApiMsg::Scroll(delta, cursor, move_phase) => {
                             profile_scope!("Scroll");
-                            let frame = profile_counters.total_time.profile(|| {
-                                if self.frame.scroll(delta, cursor, move_phase) {
-                                    Some(self.render())
-                                } else {
-                                    None
-                                }
-                            });
+                            let frame = {
+                                let counters = &mut profile_counters.texture_cache;
+                                profile_counters.total_time.profile(|| {
+                                    if self.frame.scroll(delta, cursor, move_phase) {
+                                        Some(self.render(counters))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            };
 
                             match frame {
                                 Some(frame) => {
@@ -231,13 +233,16 @@ impl RenderBackend {
                         }
                         ApiMsg::ScrollLayersWithScrollId(origin, pipeline_id, scroll_root_id) => {
                             profile_scope!("ScrollLayersWithScrollId");
-                            let frame = profile_counters.total_time.profile(|| {
-                                if self.frame.scroll_nodes(origin, pipeline_id, scroll_root_id) {
-                                    Some(self.render())
-                                } else {
-                                    None
-                                }
-                            });
+                            let frame = {
+                                let counters = &mut profile_counters.texture_cache;
+                                profile_counters.total_time.profile(|| {
+                                    if self.frame.scroll_nodes(origin, pipeline_id, scroll_root_id) {
+                                        Some(self.render(counters))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            };
 
                             match frame {
                                 Some(frame) => {
@@ -250,10 +255,13 @@ impl RenderBackend {
                         }
                         ApiMsg::TickScrollingBounce => {
                             profile_scope!("TickScrollingBounce");
-                            let frame = profile_counters.total_time.profile(|| {
-                                self.frame.tick_scrolling_bounce_animations();
-                                self.render()
-                            });
+                            let frame = {
+                                let counters = &mut profile_counters.texture_cache;
+                                profile_counters.total_time.profile(|| {
+                                    self.frame.tick_scrolling_bounce_animations();
+                                    self.render(counters)
+                                })
+                            };
 
                             self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
                         }
@@ -346,9 +354,12 @@ impl RenderBackend {
                                 self.build_scene();
                             }
 
-                            let frame = profile_counters.total_time.profile(|| {
-                                self.render()
-                            });
+                            let frame = {
+                                let counters = &mut profile_counters.texture_cache;
+                                profile_counters.total_time.profile(|| {
+                                    self.render(counters)
+                                })
+                            };
                             if self.scene.root_pipeline_id.is_some() {
                                 self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
                                 frame_counter += 1;
@@ -410,10 +421,13 @@ impl RenderBackend {
         self.frame.create(&self.scene, &mut self.resource_cache);
     }
 
-    fn render(&mut self) -> RendererFrame {
+    fn render(&mut self,
+              texture_cache_profile: &mut TextureCacheProfileCounters)
+              -> RendererFrame {
         let frame = self.frame.build(&mut self.resource_cache,
                                      &self.scene.pipeline_auxiliary_lists,
-                                     self.device_pixel_ratio);
+                                     self.device_pixel_ratio,
+                                     texture_cache_profile);
 
         frame
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -684,6 +684,7 @@ impl Renderer {
         let max_texture_size = cmp::min(device_max_size, options.max_texture_size.unwrap_or(device_max_size));
 
         let mut texture_cache = TextureCache::new(max_texture_size);
+        let mut backend_profile_counters = BackendProfileCounters::new();
 
         let white_pixels: Vec<u8> = vec![
             0xff, 0xff, 0xff, 0xff,
@@ -700,13 +701,15 @@ impl Renderer {
         texture_cache.insert(white_image_id,
                              ImageDescriptor::new(2, 2, ImageFormat::RGBA8, false),
                              TextureFilter::Linear,
-                             ImageData::Raw(Arc::new(white_pixels)));
+                             ImageData::Raw(Arc::new(white_pixels)),
+                             &mut backend_profile_counters.texture_cache);
 
         let dummy_mask_image_id = texture_cache.new_item_id();
         texture_cache.insert(dummy_mask_image_id,
                              ImageDescriptor::new(2, 2, ImageFormat::A8, false),
                              TextureFilter::Linear,
-                             ImageData::Raw(Arc::new(mask_pixels)));
+                             ImageData::Raw(Arc::new(mask_pixels)),
+                             &mut backend_profile_counters.texture_cache);
 
         let dummy_cache_texture_id = device.create_texture_ids(1, TextureTarget::Array)[0];
         device.init_texture(dummy_cache_texture_id,
@@ -803,7 +806,7 @@ impl Renderer {
                                                  backend_main_thread_dispatcher,
                                                  blob_image_renderer,
                                                  backend_vr_compositor);
-            backend.run();
+            backend.run(backend_profile_counters);
         })};
 
         let renderer = Renderer {


### PR DESCRIPTION
Fixes #914

Note: the [comment](https://github.com/servo/webrender/issues/914#issuecomment-281816803) appears to be irrelevant, since the actual texture freeing happens in `texture_cache`, and the free list just contains texture items, which are plain old data (PODs).

@staktrace I suggest we proceed with this PR and check if it resolves your issue, then potentially come with a follow-up.
@glennw r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/919)
<!-- Reviewable:end -->
