### PR TITLE
Have ClipScrollTree use reference frame relative coordinates

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -5,10 +5,9 @@
 use euclid::Point3D;
 use geometry::ray_intersects_rect;
 use spring::{DAMPING, STIFFNESS, Spring};
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
+use webrender_traits::{LayerPixel, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
 use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollEventPhase, ScrollLayerId};
-use webrender_traits::{ScrollLayerRect, ScrollLocation, ScrollToWorldTransform, WorldPoint};
-use webrender_traits::{WorldPoint4D};
+use webrender_traits::{ScrollLayerRect, ScrollLocation, WorldPoint, WorldPoint4D};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -16,6 +15,15 @@ const CAN_OVERSCROLL: bool = true;
 #[cfg(not(target_os = "macos"))]
 const CAN_OVERSCROLL: bool = false;
 
+#[derive(Clone)]
+pub enum NodeType {
+    /// Transform for this layer, relative to parent reference frame. A reference
+    /// frame establishes a new coordinate space in the tree.
+    ReferenceFrame(LayerToScrollTransform),
+
+    /// Other nodes just do clipping, but no transformation.
+    ClipRect,
+}
 
 /// Contains scrolling and transform information stacking contexts.
 #[derive(Clone)]
@@ -26,32 +34,34 @@ pub struct ClipScrollNode {
     /// Size of the content inside the scroll region (in logical pixels)
     pub content_size: LayerSize,
 
-    /// Viewing rectangle
+    /// Viewing rectangle in the coordinate system of the parent reference frame.
     pub local_viewport_rect: LayerRect,
 
-    /// Viewing rectangle clipped against parent layer(s)
+    /// Viewport rectangle clipped against parent layer(s) viewport rectangles.
+    /// This is in the coordinate system of the parent reference frame.
     pub combined_local_viewport_rect: LayerRect,
 
-    /// World transform for the viewport rect itself.
+    /// World transform for the viewport rect itself. This is the parent
+    /// reference frame transformation plus the scrolling offsets provided by
+    /// the nodes in between the reference frame and this node.
     pub world_viewport_transform: LayerToWorldTransform,
 
-    /// World transform for content within this layer
+    /// World transform for content transformed by this node.
     pub world_content_transform: LayerToWorldTransform,
-
-    /// Transform for this layer, relative to parent scrollable layer.
-    pub local_transform: LayerToScrollTransform,
 
     /// Pipeline that this layer belongs to
     pub pipeline_id: PipelineId,
 
     /// Child layers
     pub children: Vec<ScrollLayerId>,
+
+    /// Whether or not this node is a reference frame.
+    pub node_type: NodeType,
 }
 
 impl ClipScrollNode {
     pub fn new(local_viewport_rect: &LayerRect,
                content_size: LayerSize,
-               local_transform: &LayerToScrollTransform,
                pipeline_id: PipelineId)
                -> ClipScrollNode {
         ClipScrollNode {
@@ -61,9 +71,27 @@ impl ClipScrollNode {
             combined_local_viewport_rect: *local_viewport_rect,
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),
-            local_transform: *local_transform,
             children: Vec::new(),
             pipeline_id: pipeline_id,
+            node_type: NodeType::ClipRect,
+        }
+    }
+
+    pub fn new_reference_frame(local_viewport_rect: &LayerRect,
+                               content_size: LayerSize,
+                               local_transform: &LayerToScrollTransform,
+                               pipeline_id: PipelineId)
+                               -> ClipScrollNode {
+        ClipScrollNode {
+            scrolling: ScrollingState::new(),
+            content_size: content_size,
+            local_viewport_rect: *local_viewport_rect,
+            combined_local_viewport_rect: *local_viewport_rect,
+            world_viewport_transform: LayerToWorldTransform::identity(),
+            world_content_transform: LayerToWorldTransform::identity(),
+            children: Vec::new(),
+            pipeline_id: pipeline_id,
+            node_type: NodeType::ReferenceFrame(*local_transform),
         }
     }
 
@@ -117,9 +145,16 @@ impl ClipScrollNode {
     }
 
     pub fn update_transform(&mut self,
-                            parent_world_transform: &ScrollToWorldTransform,
-                            parent_viewport_rect: &ScrollLayerRect) {
-        let inv_transform = match self.local_transform.inverse() {
+                            parent_reference_frame_transform: &LayerToWorldTransform,
+                            parent_combined_viewport_rect: &ScrollLayerRect,
+                            parent_accumulated_scroll_offset: LayerPoint) {
+
+        let local_transform = match self.node_type {
+            NodeType::ReferenceFrame(transform) => transform,
+            NodeType::ClipRect => LayerToScrollTransform::identity(),
+        };
+
+        let inv_transform = match local_transform.inverse() {
             Some(transform) => transform,
             None => {
                 // If a transform function causes the current transformation matrix of an object
@@ -129,18 +164,40 @@ impl ClipScrollNode {
             }
         };
 
-        let parent_viewport_rect_in_local_space = inv_transform.transform_rect(parent_viewport_rect)
-                                                               .translate(&-self.scrolling.offset);
-        let local_viewport_rect = self.local_viewport_rect.translate(&-self.scrolling.offset);
-        let viewport_rect = parent_viewport_rect_in_local_space.intersection(&local_viewport_rect)
-                                                               .unwrap_or(LayerRect::zero());
+        // We are trying to move the combined viewport rectangle of our parent nodes into the
+        // coordinate system of this node, so we must invert our transformation (only for
+        // reference frames) and then apply the scroll offset of all the parent layers.
+        let parent_combined_viewport_in_local_space =
+            inv_transform.pre_translated(-parent_accumulated_scroll_offset.x,
+                                         -parent_accumulated_scroll_offset.y,
+                                         0.0)
+                         .transform_rect(parent_combined_viewport_rect);
 
-        self.combined_local_viewport_rect = viewport_rect;
-        self.world_viewport_transform = parent_world_transform.pre_mul(&self.local_transform);
-        self.world_content_transform = self.world_viewport_transform
-                                                     .pre_translated(self.scrolling.offset.x,
-                                                                     self.scrolling.offset.y,
-                                                                     0.0);
+        // Now that we have the combined viewport rectangle of the parent nodes in local space,
+        // we do the intersection and get our combined viewport rect in the coordinate system
+        // starting from our origin.
+        self.combined_local_viewport_rect =
+            parent_combined_viewport_in_local_space.intersection(&self.local_viewport_rect)
+                                                    .unwrap_or(LayerRect::zero());
+
+        // The transformation for this viewport in world coordinates is the transformation for
+        // our parent reference frame, plus any accumulated scrolling offsets from nodes
+        // between our reference frame and this node. For reference frames, we also include
+        // whatever local transformation this reference frame provides. This can be combined
+        // with the local_viewport_rect to get its position in world space.
+        self.world_viewport_transform =
+            parent_reference_frame_transform
+                .pre_translated(parent_accumulated_scroll_offset.x,
+                                parent_accumulated_scroll_offset.y,
+                                0.0)
+                .pre_mul(&local_transform.with_destination::<LayerPixel>());
+
+        // The transformation for any content inside of us is the viewport transformation, plus
+        // whatever scrolling offset we supply as well.
+        self.world_content_transform =
+            self.world_viewport_transform.pre_translated(self.scrolling.offset.x,
+                                                         self.scrolling.offset.y,
+                                                         0.0);
     }
 
     pub fn scrollable_height(&self) -> f32 {

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use clip_scroll_node::{ClipScrollNode, NodeType, ScrollingState};
 use fnv::FnvHasher;
-use clip_scroll_node::{ClipScrollNode, ScrollingState};
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
-use webrender_traits::{ScrollEventPhase, ScrollLayerId, ScrollLayerInfo, ScrollLayerPixel};
-use webrender_traits::{ScrollLayerRect, ScrollLayerState, ScrollLocation, ScrollToWorldTransform};
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
+use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollEventPhase, ScrollLayerId};
+use webrender_traits::{ScrollLayerInfo, ScrollLayerRect, ScrollLayerState, ScrollLocation};
 use webrender_traits::{ServoScrollRootId, WorldPoint, as_scroll_parent_rect};
 
 pub type ScrollStates = HashMap<ScrollLayerId, ScrollingState, BuildHasherDefault<FnvHasher>>;
@@ -78,10 +78,13 @@ impl ClipScrollTree {
 
         let root_reference_frame_id = ScrollLayerId::root_reference_frame(pipeline_id);
         self.root_reference_frame_id = root_reference_frame_id;
-        let reference_frame = ClipScrollNode::new(&viewport, viewport.size, &identity, pipeline_id);
+        let reference_frame = ClipScrollNode::new_reference_frame(&viewport,
+                                                                  viewport.size,
+                                                                  &identity,
+                                                                  pipeline_id);
         self.nodes.insert(self.root_reference_frame_id, reference_frame);
 
-        let scroll_node = ClipScrollNode::new(&viewport, *content_size, &identity, pipeline_id);
+        let scroll_node = ClipScrollNode::new(&viewport, *content_size, pipeline_id);
         let topmost_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
         self.topmost_scroll_layer_id = topmost_scroll_layer_id;
         self.add_node(scroll_node, topmost_scroll_layer_id, root_reference_frame_id);
@@ -296,23 +299,41 @@ impl ClipScrollTree {
         let root_reference_frame_id = self.root_reference_frame_id();
         let root_viewport = self.nodes[&root_reference_frame_id].local_viewport_rect;
         self.update_node_transform(root_reference_frame_id,
-                                    &ScrollToWorldTransform::identity(),
-                                    &as_scroll_parent_rect(&root_viewport));
+                                   &LayerToWorldTransform::identity(),
+                                   &as_scroll_parent_rect(&root_viewport),
+                                   LayerPoint::zero());
     }
 
     fn update_node_transform(&mut self,
                              layer_id: ScrollLayerId,
-                             parent_world_transform: &ScrollToWorldTransform,
-                             parent_viewport_rect: &ScrollLayerRect) {
+                             parent_reference_frame_transform: &LayerToWorldTransform,
+                             parent_viewport_rect: &ScrollLayerRect,
+                             parent_accumulated_scroll_offset: LayerPoint) {
         // TODO(gw): This is an ugly borrow check workaround to clone these.
         //           Restructure this to avoid the clones!
-        let (node_transform_for_children, viewport_rect, node_children) = {
+        let (reference_frame_transform, viewport_rect, accumulated_scroll_offset, node_children) = {
             match self.nodes.get_mut(&layer_id) {
                 Some(node) => {
-                    node.update_transform(parent_world_transform, parent_viewport_rect);
+                    node.update_transform(parent_reference_frame_transform,
+                                          parent_viewport_rect,
+                                          parent_accumulated_scroll_offset);
 
-                    (node.world_content_transform.with_source::<ScrollLayerPixel>(),
+                    // The transformation we are passing is the transformation of the parent
+                    // reference frame and the offset is the accumulated offset of all the nodes
+                    // between us and the parent reference frame. If we are a reference frame,
+                    // we need to reset both these values.
+                    let (transform, offset) = match node.node_type {
+                        NodeType::ReferenceFrame(..) =>
+                            (node.world_viewport_transform, LayerPoint::zero()),
+                        NodeType::ClipRect => {
+                            (*parent_reference_frame_transform,
+                             parent_accumulated_scroll_offset + node.scrolling.offset)
+                        }
+                    };
+
+                    (transform,
                      as_scroll_parent_rect(&node.combined_local_viewport_rect),
+                     offset,
                      node.children.clone())
                 }
                 None => return,
@@ -321,8 +342,9 @@ impl ClipScrollTree {
 
         for child_layer_id in node_children {
             self.update_node_transform(child_layer_id,
-                                       &node_transform_for_children,
-                                       &viewport_rect);
+                                       &reference_frame_transform,
+                                       &viewport_rect,
+                                       accumulated_scroll_offset);
         }
     }
 
@@ -369,7 +391,7 @@ impl ClipScrollTree {
         };
         self.current_reference_frame_id += 1;
 
-        let node = ClipScrollNode::new(&rect, rect.size, &transform, pipeline_id);
+        let node = ClipScrollNode::new_reference_frame(&rect, rect.size, &transform, pipeline_id);
         self.add_node(node, reference_frame_id, parent_id);
         reference_frame_id
     }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -288,21 +288,15 @@ impl Frame {
 
             let viewport_rect = LayerRect::new(LayerPoint::zero(), root_pipeline.viewport_size);
             let clip = ClipRegion::simple(&viewport_rect);
-            context.builder.push_clip_scroll_node(reference_frame_id,
-                                                  &clip,
-                                                  &LayerPoint::zero(),
-                                                  &root_pipeline.viewport_size);
-            context.builder.push_clip_scroll_node(topmost_scroll_layer_id,
-                                                  &clip,
-                                                  &LayerPoint::zero(),
-                                                  &root_clip.main.size);
+            context.builder.push_clip_scroll_node(reference_frame_id, &clip);
+            context.builder.push_clip_scroll_node(topmost_scroll_layer_id, &clip);
 
             self.flatten_stacking_context(&mut traversal,
                                           root_pipeline_id,
                                           &mut context,
                                           reference_frame_id,
                                           topmost_scroll_layer_id,
-                                          LayerToScrollTransform::identity(),
+                                          LayerPoint::zero(),
                                           0,
                                           &root_stacking_context,
                                           root_clip);
@@ -321,7 +315,7 @@ impl Frame {
                                 context: &mut FlattenContext,
                                 current_reference_frame_id: ScrollLayerId,
                                 parent_scroll_layer_id: ScrollLayerId,
-                                layer_relative_transform: LayerToScrollTransform,
+                                reference_frame_relative_offset: LayerPoint,
                                 level: i32,
                                 clip: &ClipRegion,
                                 content_size: &LayerSize,
@@ -332,25 +326,33 @@ impl Frame {
             return;
         }
 
-        let clip_rect = clip.main;
-        let node = ClipScrollNode::new(&clip_rect,
-                                       *content_size,
-                                       &layer_relative_transform,
-                                       pipeline_id);
+        let clip_rect = clip.main.translate(&reference_frame_relative_offset);
+        let node = ClipScrollNode::new(&clip_rect, *content_size, pipeline_id);
         self.clip_scroll_tree.add_node(node, new_scroll_layer_id, parent_scroll_layer_id);
-        context.builder.push_clip_scroll_node(new_scroll_layer_id,
-                                              clip,
-                                              &clip_rect.origin,
-                                              &content_size);
+        context.builder.push_clip_scroll_node(new_scroll_layer_id, clip);
+
+        // We need to push a fake stacking context here, because primitives that are
+        // direct children of this stacking context, need to be adjusted by the scroll
+        // offset of this layer. Eventually we should be able to remove this.
+        let rect = LayerRect::new(LayerPoint::zero(),
+                                  LayerSize::new(content_size.width + clip_rect.origin.x,
+                                                 content_size.height + clip_rect.origin.y));
+        context.builder.push_stacking_context(reference_frame_relative_offset,
+                                              rect,
+                                              pipeline_id,
+                                              new_scroll_layer_id,
+                                              CompositeOps::empty());
+
 
         self.flatten_items(traversal,
                            pipeline_id,
                            context,
                            current_reference_frame_id,
                            new_scroll_layer_id,
-                           LayerToScrollTransform::identity(),
+                           reference_frame_relative_offset,
                            level);
 
+        context.builder.pop_stacking_context();
         context.builder.pop_clip_scroll_node();
     }
 
@@ -360,7 +362,7 @@ impl Frame {
                                     context: &mut FlattenContext,
                                     current_reference_frame_id: ScrollLayerId,
                                     current_scroll_layer_id: ScrollLayerId,
-                                    layer_relative_transform: LayerToScrollTransform,
+                                    mut reference_frame_relative_offset: LayerPoint,
                                     level: i32,
                                     stacking_context: &StackingContext,
                                     clip_region: &ClipRegion) {
@@ -384,16 +386,8 @@ impl Frame {
             return;
         }
 
-        let stacking_context_transform = context.scene
-                                                .properties
-                                                .resolve_layout_transform(&stacking_context.transform);
-
-        let mut transform =
-            layer_relative_transform.pre_translated(stacking_context.bounds.origin.x,
-                                                    stacking_context.bounds.origin.y,
-                                                    0.0)
-                                     .pre_mul(&stacking_context_transform)
-                                     .pre_mul(&stacking_context.perspective);
+        let stacking_context_transform =
+            context.scene.properties.resolve_layout_transform(&stacking_context.transform);
 
         let mut reference_frame_id = current_reference_frame_id;
         let mut scroll_layer_id = match stacking_context.scroll_policy {
@@ -405,30 +399,42 @@ impl Frame {
         // that fixed position stacking contexts are positioned relative to us.
         if stacking_context_transform != LayoutTransform::identity() ||
            stacking_context.perspective != LayoutTransform::identity() {
+            let transform =
+                LayerToScrollTransform::create_translation(reference_frame_relative_offset.x,
+                                                           reference_frame_relative_offset.y,
+                                                           0.0)
+                                        .pre_translated(stacking_context.bounds.origin.x,
+                                                        stacking_context.bounds.origin.y,
+                                                        0.0)
+                                        .pre_mul(&stacking_context_transform)
+                                        .pre_mul(&stacking_context.perspective);
             scroll_layer_id = self.clip_scroll_tree.add_reference_frame(clip_region.main,
                                                                         transform,
                                                                         pipeline_id,
                                                                         scroll_layer_id);
             reference_frame_id = scroll_layer_id;
-            transform = LayerToScrollTransform::identity();
+            reference_frame_relative_offset = LayerPoint::zero();
+        } else {
+            reference_frame_relative_offset = LayerPoint::new(
+                reference_frame_relative_offset.x + stacking_context.bounds.origin.x,
+                reference_frame_relative_offset.y + stacking_context.bounds.origin.y);
         }
 
         if level == 0 {
             if let Some(pipeline) = context.scene.pipeline_map.get(&pipeline_id) {
                 if let Some(bg_color) = pipeline.background_color {
-
                     // Adding a dummy layer for this rectangle in order to disable clipping.
-                    let no_clip = ClipRegion::simple(&clip_region.main);
-                    context.builder.push_stacking_context(clip_region.main,
-                                                          transform,
+                    context.builder.push_stacking_context(reference_frame_relative_offset,
+                                                          clip_region.main,
                                                           pipeline_id,
                                                           scroll_layer_id,
                                                           CompositeOps::empty());
 
-                    //Note: we don't use the original clip region here,
+                    // Note: we don't use the original clip region here,
                     // it's already processed by the node we just pushed.
+                    let background_rect = LayerRect::new(LayerPoint::zero(), clip_region.main.size);
                     context.builder.add_solid_rectangle(&clip_region.main,
-                                                        &no_clip,
+                                                        &ClipRegion::simple(&background_rect),
                                                         &bg_color,
                                                         PrimitiveFlags::None);
 
@@ -438,8 +444,8 @@ impl Frame {
         }
 
          // TODO(gw): Int with overflow etc
-        context.builder.push_stacking_context(clip_region.main,
-                                              transform,
+        context.builder.push_stacking_context(reference_frame_relative_offset,
+                                              clip_region.main,
                                               pipeline_id,
                                               scroll_layer_id,
                                               composition_operations);
@@ -449,7 +455,7 @@ impl Frame {
                            context,
                            reference_frame_id,
                            scroll_layer_id,
-                           transform,
+                           reference_frame_relative_offset,
                            level);
 
         if level == 0 && self.frame_builder_config.enable_scrollbars {
@@ -469,7 +475,7 @@ impl Frame {
                           bounds: &LayerRect,
                           context: &mut FlattenContext,
                           current_scroll_layer_id: ScrollLayerId,
-                          layer_relative_transform: LayerToScrollTransform) {
+                          reference_frame_relative_offset: LayerPoint) {
 
         let pipeline = match context.scene.pipeline_map.get(&pipeline_id) {
             Some(pipeline) => pipeline,
@@ -493,9 +499,10 @@ impl Frame {
         self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
 
         let iframe_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
-        let transform = layer_relative_transform.pre_translated(bounds.origin.x,
-                                                                bounds.origin.y,
-                                                                0.0);
+        let transform = LayerToScrollTransform::create_translation(
+            reference_frame_relative_offset.x + bounds.origin.x,
+            reference_frame_relative_offset.y + bounds.origin.y,
+            0.0);
         let iframe_reference_frame_id =
             self.clip_scroll_tree.add_reference_frame(iframe_rect,
                                                       transform,
@@ -504,20 +511,13 @@ impl Frame {
         let iframe_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
         let node = ClipScrollNode::new(&LayerRect::new(LayerPoint::zero(), iframe_rect.size),
                                        iframe_clip.main.size,
-                                       &LayerToScrollTransform::identity(),
                                        pipeline_id);
         self.clip_scroll_tree.add_node(node.clone(),
                                        iframe_scroll_layer_id,
                                        iframe_reference_frame_id);
 
-        context.builder.push_clip_scroll_node(iframe_reference_frame_id,
-                                              iframe_clip,
-                                              &LayerPoint::zero(),
-                                              &iframe_rect.size);
-        context.builder.push_clip_scroll_node(iframe_scroll_layer_id,
-                                              iframe_clip,
-                                              &LayerPoint::zero(),
-                                              &iframe_clip.main.size);
+        context.builder.push_clip_scroll_node(iframe_reference_frame_id, iframe_clip);
+        context.builder.push_clip_scroll_node(iframe_scroll_layer_id, iframe_clip);
 
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
 
@@ -526,7 +526,7 @@ impl Frame {
                                       context,
                                       iframe_reference_frame_id,
                                       iframe_scroll_layer_id,
-                                      LayerToScrollTransform::identity(),
+                                      LayerPoint::zero(),
                                       0,
                                       &iframe_stacking_context,
                                       iframe_clip);
@@ -541,7 +541,7 @@ impl Frame {
                          context: &mut FlattenContext,
                          current_reference_frame_id: ScrollLayerId,
                          current_scroll_layer_id: ScrollLayerId,
-                         layer_relative_transform: LayerToScrollTransform,
+                         reference_frame_relative_offset: LayerPoint,
                          level: i32) {
         while let Some(item) = traversal.next() {
             match item.item {
@@ -628,7 +628,7 @@ impl Frame {
                                                   context,
                                                   current_reference_frame_id,
                                                   current_scroll_layer_id,
-                                                  layer_relative_transform,
+                                                  reference_frame_relative_offset,
                                                   level + 1,
                                                   &info.stacking_context,
                                                   &item.clip);
@@ -639,7 +639,7 @@ impl Frame {
                                               context,
                                               current_reference_frame_id,
                                               current_scroll_layer_id,
-                                              layer_relative_transform,
+                                              reference_frame_relative_offset,
                                               level,
                                               &item.clip,
                                               &info.content_size,
@@ -650,7 +650,7 @@ impl Frame {
                                         &item.rect,
                                         context,
                                         current_scroll_layer_id,
-                                        layer_relative_transform);
+                                        reference_frame_relative_offset);
                 }
                 SpecificDisplayItem::PopStackingContext |
                 SpecificDisplayItem::PopScrollLayer => return,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -24,14 +24,14 @@ use tiling::{AuxiliaryListsMap, ClipScrollGroup, ClipScrollGroupIndex, Composite
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
 use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, ScrollLayer};
 use tiling::{ScrollLayerIndex, StackingContext, StackingContextIndex};
-use util::{self, pack_as_float, rect_from_points_f, subtract_rect, TransformedRect};
+use util::{self, pack_as_float, rect_from_points_f, subtract_rect};
 use util::{RectHelpers, TransformedRectKind};
-use webrender_traits::{as_scroll_parent_rect, BorderDetails, BorderDisplayItem, BorderSide, BorderStyle};
+use webrender_traits::{BorderDetails, BorderDisplayItem, BorderSide, BorderStyle};
 use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, device_length, DeviceIntPoint};
 use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintSize, ExtendMode, FontKey, TileOffset};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
-use webrender_traits::{RepeatMode, ScrollLayerId, ScrollLayerPixel, WebGLContextId, YuvColorSpace};
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, PipelineId, RepeatMode, ScrollLayerId};
+use webrender_traits::{WebGLContextId, YuvColorSpace};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -199,8 +199,8 @@ impl FrameBuilder {
     }
 
     pub fn push_stacking_context(&mut self,
+                                 reference_frame_offset: LayerPoint,
                                  rect: LayerRect,
-                                 transform: LayerToScrollTransform,
                                  pipeline_id: PipelineId,
                                  scroll_layer_id: ScrollLayerId,
                                  composite_ops: CompositeOps) {
@@ -209,7 +209,7 @@ impl FrameBuilder {
                                                         scroll_layer_id,
                                                         pipeline_id);
         self.stacking_context_store.push(StackingContext::new(pipeline_id,
-                                                              transform,
+                                                              reference_frame_offset,
                                                               rect,
                                                               composite_ops,
                                                               group_index));
@@ -222,9 +222,7 @@ impl FrameBuilder {
 
     pub fn push_clip_scroll_node(&mut self,
                                  scroll_layer_id: ScrollLayerId,
-                                 clip_region: &ClipRegion,
-                                 node_origin: &LayerPoint,
-                                 content_size: &LayerSize) {
+                                 clip_region: &ClipRegion) {
         let scroll_layer_index = ScrollLayerIndex(self.scroll_layer_store.len());
         let parent_index = *self.clip_scroll_node_stack.last().unwrap_or(&scroll_layer_index);
         self.clip_scroll_node_stack.push(scroll_layer_index);
@@ -246,24 +244,9 @@ impl FrameBuilder {
         });
         self.packed_layers.push(PackedLayer::empty());
         self.cmds.push(PrimitiveRunCmd::PushScrollLayer(scroll_layer_index));
-
-
-        // We need to push a fake stacking context here, because primitives that are
-        // direct children of this stacking context, need to be adjusted by the scroll
-        // offset of this layer. Eventually we should be able to remove this.
-        let rect = LayerRect::new(LayerPoint::zero(),
-                                  LayerSize::new(content_size.width + node_origin.x,
-                                                 content_size.height + node_origin.y));
-        self.push_stacking_context(rect,
-                                   LayerToScrollTransform::identity(),
-                                   scroll_layer_id.pipeline_id,
-                                   scroll_layer_id,
-                                   CompositeOps::empty());
-
     }
 
     pub fn pop_clip_scroll_node(&mut self) {
-        self.pop_stacking_context();
         self.cmds.push(PrimitiveRunCmd::PopScrollLayer);
         self.clip_scroll_node_stack.pop();
     }
@@ -1264,39 +1247,33 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             let stacking_context = &mut self.frame_builder
                                             .stacking_context_store[stacking_context_index.0];
 
-            let scroll_tree_layer = &self.clip_scroll_tree.nodes[&group.scroll_layer_id];
+            let node = &self.clip_scroll_tree.nodes[&group.scroll_layer_id];
             let packed_layer = &mut self.frame_builder.packed_layers[group.packed_layer_index.0];
-            packed_layer.transform = scroll_tree_layer.world_content_transform
-                                                      .with_source::<ScrollLayerPixel>()
-                                                      .pre_mul(&stacking_context.local_transform);
-            packed_layer.inv_transform = packed_layer.transform.inverse().unwrap();
+
+            // The world content transform is relative to the containing reference frame,
+            // so we translate into the origin of the stacking context itself.
+            let transform = node.world_content_transform
+                                .pre_translated(stacking_context.reference_frame_offset.x,
+                                                stacking_context.reference_frame_offset.y,
+                                                0.0);
+            packed_layer.set_transform(transform);
 
             if !stacking_context.can_contribute_to_scene() {
                 return;
             }
 
-            let inv_layer_transform = stacking_context.local_transform.inverse().unwrap();
-            let local_viewport_rect =
-                as_scroll_parent_rect(&scroll_tree_layer.combined_local_viewport_rect);
-            let viewport_rect = inv_layer_transform.transform_rect(&local_viewport_rect);
-            let layer_local_rect = stacking_context.local_rect.intersection(&viewport_rect);
+            // Here we want to find the intersection between the clipping region and the
+            // stacking context content, so we move the viewport rectangle into the coordinate
+            // system of the stacking context content.
+            let viewport_rect =
+                &node.combined_local_viewport_rect
+                     .translate(&-stacking_context.reference_frame_offset)
+                     .translate(&-node.scrolling.offset);
+            let intersected_rect = stacking_context.local_rect.intersection(viewport_rect);
 
-            group.xf_rect = None;
-
-            let layer_local_rect = match layer_local_rect {
-                Some(layer_local_rect) if !layer_local_rect.is_empty() => layer_local_rect,
-                _ => continue,
-            };
-
-            let layer_xf_rect = TransformedRect::new(&layer_local_rect,
-                                                     &packed_layer.transform,
-                                                     self.device_pixel_ratio);
-
-            if layer_xf_rect.bounding_rect.intersects(&self.screen_rect) {
-                packed_layer.screen_vertices = layer_xf_rect.vertices.clone();
-                packed_layer.local_clip_rect = layer_local_rect;
-                group.xf_rect = Some(layer_xf_rect);
-            }
+            group.xf_rect = packed_layer.set_rect(intersected_rect,
+                                                  self.screen_rect,
+                                                  self.device_pixel_ratio);
         }
     }
 
@@ -1334,26 +1311,15 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         self.scroll_layer_stack.push(scroll_layer_index);
 
         let scroll_layer = &mut self.frame_builder.scroll_layer_store[scroll_layer_index.0];
+        let node = &self.clip_scroll_tree.nodes[&scroll_layer.scroll_layer_id];
+
         let packed_layer_index = scroll_layer.packed_layer_index;
-        let scroll_tree_layer = &self.clip_scroll_tree.nodes[&scroll_layer.scroll_layer_id];
         let packed_layer = &mut self.frame_builder.packed_layers[packed_layer_index.0];
 
-        packed_layer.transform = scroll_tree_layer.world_viewport_transform;
-        packed_layer.inv_transform = packed_layer.transform.inverse().unwrap();
-
-        let local_rect = &scroll_tree_layer.combined_local_viewport_rect
-                                           .translate(&scroll_tree_layer.scrolling.offset);
-        if !local_rect.is_empty() {
-            let layer_xf_rect = TransformedRect::new(local_rect,
-                                                     &packed_layer.transform,
+        packed_layer.set_transform(node.world_viewport_transform);
+        scroll_layer.xf_rect = packed_layer.set_rect(Some(node.combined_local_viewport_rect),
+                                                     self.screen_rect,
                                                      self.device_pixel_ratio);
-
-            if layer_xf_rect.bounding_rect.intersects(&self.screen_rect) {
-                packed_layer.screen_vertices = layer_xf_rect.vertices.clone();
-                packed_layer.local_clip_rect = *local_rect;
-                scroll_layer.xf_rect = Some(layer_xf_rect);
-            }
-        }
 
         let clip_info = match scroll_layer.clip_cache_info {
             Some(ref mut clip_info) => clip_info,


### PR DESCRIPTION
Instead of assuming that ClipScrollNodes and stacking contexts exist in
a contiguous tree, make the coordinate system of the ClipScrollTree
independent of the one used for stacking contexts. Now all coordinates
are calculated relative to the parent reference frame of every node.

Additionally, stacking contexts no longer have a transformation,
since they already rely on reference frames to be positioned. Stacking
contexts still need a rectangle and an origin though, because display
items may not be positioned relative to the top left corner due to the
way that overflow is calculated in Servo.

This change is necessary in order to clip and transform arbitrary
stacking context items with arbitrary scrolling nodes (within the same
reference frame).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/922)
<!-- Reviewable:end -->
