### PR TITLE
Rustify MaskSegment enum names

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -67,13 +67,12 @@ pub struct AlphaRenderTask {
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub enum MaskSegment {
-    // This must match the SEGMENT_ values
-    // in clip_shared.glsl!
+    // This must match the SEGMENT_ values in clip_shared.glsl!
     All = 0,
-    Corner_TopLeft,
-    Corner_TopRight,
-    Corner_BottomLeft,
-    Corner_BottomRight,
+    TopLeftCorner,
+    TopRightCorner,
+    BottomLeftCorner,
+    BottomRightCorner,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -808,22 +808,22 @@ impl ClipBatcher {
                         self.rectangles.extend(&[
                             CacheClipInstance {
                                 address: GpuStoreAddress(offset),
-                                segment: MaskSegment::Corner_TopLeft as i32,
+                                segment: MaskSegment::TopLeftCorner as i32,
                                 ..instance
                             },
                             CacheClipInstance {
                                 address: GpuStoreAddress(offset),
-                                segment: MaskSegment::Corner_TopRight as i32,
+                                segment: MaskSegment::TopRightCorner as i32,
                                 ..instance
                             },
                             CacheClipInstance {
                                 address: GpuStoreAddress(offset),
-                                segment: MaskSegment::Corner_BottomLeft as i32,
+                                segment: MaskSegment::BottomLeftCorner as i32,
                                 ..instance
                             },
                             CacheClipInstance {
                                 address: GpuStoreAddress(offset),
-                                segment: MaskSegment::Corner_BottomRight as i32,
+                                segment: MaskSegment::BottomRightCorner as i32,
                                 ..instance
                             },
                         ]);


### PR DESCRIPTION
The current names cause compilation warnings because they are not
sufficiently rusty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/924)
<!-- Reviewable:end -->
