### PR TITLE
Support resizing an image in the texture cache.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -110,6 +110,13 @@ fn main() {
         None,
     );
 
+    let (desc, data) = generate_xy_gradient_image(100, 100);
+    let resized_img = api.generate_image_key();
+    api.add_image(
+        resized_img, desc, ImageData::new(data),
+        None,
+    );
+
     let pipeline_id = PipelineId(0, 0);
     let mut builder = webrender_traits::DisplayListBuilder::new(pipeline_id);
 
@@ -131,12 +138,12 @@ fn main() {
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
     builder.push_image(
-        LayoutRect::new(LayoutPoint::new(0.0, 0.0), LayoutSize::new(100.0, 100.0)),
+        LayoutRect::new(LayoutPoint::new(0.0, 0.0), LayoutSize::new(1000.0, 1000.0)),
         ClipRegion::simple(&bounds),
-        LayoutSize::new(100.0, 100.0),
+        LayoutSize::new(1000.0, 1000.0),
         LayoutSize::new(0.0, 0.0),
         ImageRendering::Auto,
-        vector_img,
+        resized_img,
     );
 
     let sub_clip = {
@@ -267,12 +274,23 @@ fn main() {
     api.set_root_pipeline(pipeline_id);
     api.generate_frame(None);
 
+    let mut x = 0.0;
+
     for event in window.wait_events() {
+
         renderer.update();
 
         renderer.render(DeviceUintSize::new(width, height));
 
         window.swap_buffers().ok();
+
+        x += 0.1f32;
+        let sz = (x.sin() * 40.0 + 200.0) as u32;
+        //let sz = 100;
+        let (desc, data) = generate_xy_gradient_image(sz, sz);
+        api.update_image(resized_img, desc, data);
+
+        api.generate_frame(None);
 
         match event {
             glutin::Event::Closed |
@@ -333,4 +351,22 @@ impl BlobImageRenderer for FakeBlobImageRenderer {
     fn resolve_blob_image(&mut self, key: ImageKey) -> BlobImageResult {
         self.images.remove(&key).unwrap_or(Err(BlobImageError::InvalidKey))
     }
+}
+
+fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, Vec<u8>) {
+    let mut pixels = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let grid = if x % 100 < 3 || y % 100 < 3 { 0.9 } else { 1.0 };
+            pixels.push((y as f32 / h as f32 * 255.0 * grid) as u8);
+            pixels.push(0);
+            pixels.push((x as f32 / w as f32 * 255.0 * grid) as u8);
+            pixels.push(255);
+        }
+    }
+
+    return (
+        ImageDescriptor::new(w, h, ImageFormat::RGBA8, true),
+        pixels
+    );
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -641,6 +641,11 @@ impl ResourceCache {
                 // external handle doesn't need to update the texture_cache.
             }
             ImageData::Raw(..) | ImageData::ExternalBuffer(..) | ImageData::Blob(..) => {
+                let filter = match request.rendering {
+                    ImageRendering::Pixelated => TextureFilter::Nearest,
+                    ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
+                };
+
                 match self.cached_images.entry(request.clone(), self.current_frame_id) {
                     Occupied(entry) => {
                         let image_id = entry.get().texture_cache_id;
@@ -648,6 +653,7 @@ impl ResourceCache {
                         if entry.get().epoch != image_template.epoch {
                             self.texture_cache.update(image_id,
                                                       image_template.descriptor,
+                                                      filter,
                                                       image_data);
 
                             // Update the cached epoch
@@ -659,11 +665,6 @@ impl ResourceCache {
                     }
                     Vacant(entry) => {
                         let image_id = self.texture_cache.new_item_id();
-
-                        let filter = match request.rendering {
-                            ImageRendering::Pixelated => TextureFilter::Nearest,
-                            ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
-                        };
 
                         if let Some(tile) = request.tile {
                             let tile_size = image_template.tiling.unwrap() as u32;


### PR DESCRIPTION
I was looking into something that I could do in an hour before taking a week off, and gave resizing images in update_image a shot.

It seems to work, except that I see some flickering when trying to continuously resize the image. I am not sure if it is because of logic itself or because of the hacky way I tested it. 
I accidentally committed my test code in the sample, I'll remove it if we want to land this.

There's no urgency to support this feature as far as I know so it's fine if we don't want to merge this. It's not complicated either so if this patch is correct, we might as well take it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/925)
<!-- Reviewable:end -->
