### PR TITLE
properly account for spread radius with inset box shadows

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -716,8 +716,13 @@ impl FrameBuilder {
         // The local space box shadow rect. It is the element rect
         // translated by the box shadow offset and inflated by the
         // box shadow spread.
+        let inflate_amount = match clip_mode {
+            BoxShadowClipMode::Outset | BoxShadowClipMode::None => spread_radius,
+            BoxShadowClipMode::Inset => -spread_radius,
+        };
+
         let bs_rect = box_bounds.translate(box_offset)
-                                .inflate(spread_radius, spread_radius);
+                                .inflate(inflate_amount, inflate_amount);
 
         // Get the outer rectangle, based on the blur radius.
         let outside_edge_size = 2.0 * blur_radius;

--- a/wrench/reftests/boxshadow/inset-spread-ref.yaml
+++ b/wrench/reftests/boxshadow/inset-spread-ref.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+        -
+          bounds: [50, 50, 100, 100]
+          type: stacking_context
+          items:
+            - type: rect
+              bounds: [ 10, 10, 80, 80 ]
+              color: [255, 255, 255]
+

--- a/wrench/reftests/boxshadow/inset-spread.yaml
+++ b/wrench/reftests/boxshadow/inset-spread.yaml
@@ -1,0 +1,13 @@
+---
+root:
+  items:
+        -
+          bounds: [50, 50, 100, 100]
+          type: stacking_context
+          items:
+            - type: box_shadow
+              bounds: [ 10, 10, 80, 80 ]
+              blur_radius: 5
+              clip_mode: inset
+              spread_radius: 20
+              color: [0, 0, 0]

--- a/wrench/reftests/boxshadow/reftest.list
+++ b/wrench/reftests/boxshadow/reftest.list
@@ -1,1 +1,2 @@
 != inset-simple.yaml inset-simple-ref.yaml
+!= inset-spread.yaml inset-spread-ref.yaml


### PR DESCRIPTION
Inset box shadow spread radius needs to deflate, not inflate the rect. Fixes https://github.com/servo/webrender/issues/921

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/926)
<!-- Reviewable:end -->
