### PR TITLE
Change set_root_display_list to accept built display lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "servo-dwrote 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.19.0",
- "webrender_traits 0.19.0",
+ "webrender_traits 0.20.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1230,12 +1230,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.19.0",
+ "webrender_traits 0.20.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1296,7 +1296,7 @@ dependencies = [
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.19.0",
- "webrender_traits 0.19.0",
+ "webrender_traits 0.20.0",
 ]
 
 [[package]]

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -262,7 +262,7 @@ fn main() {
         Some(root_background_color),
         epoch,
         LayoutSize::new(width as f32, height as f32),
-        builder,
+        builder.finalize(),
         true);
     api.set_root_pipeline(pipeline_id);
     api.generate_frame(None);

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -11,6 +11,7 @@ use {FontKey, IdNamespace, ImageKey, NativeFontHandle, PipelineId};
 use {RenderApiSender, ResourceId, ScrollEventPhase, ScrollLayerState, ScrollLocation, ServoScrollRootId};
 use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand, TileSize};
 use {DeviceIntSize, DynamicProperties, LayoutPoint, LayoutSize, WorldPoint, PropertyBindingKey, PropertyBindingId};
+use {BuiltDisplayList, AuxiliaryLists};
 use VRCompositorCommand;
 use ExternalEvent;
 use std::marker::PhantomData;
@@ -157,10 +158,8 @@ impl RenderApi {
                                  background_color: Option<ColorF>,
                                  epoch: Epoch,
                                  viewport_size: LayoutSize,
-                                 builder: DisplayListBuilder,
+                                 (pipeline_id, display_list, auxiliary_lists): (PipelineId, BuiltDisplayList, AuxiliaryLists),
                                  preserve_frame_state: bool) {
-        let pipeline_id = builder.pipeline_id;
-        let (display_list, auxiliary_lists) = builder.finalize();
         let msg = ApiMsg::SetRootDisplayList(background_color,
                                              epoch,
                                              pipeline_id,

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -363,12 +363,13 @@ impl DisplayListBuilder {
         ClipRegion::new(rect, complex, image_mask, &mut self.auxiliary_lists_builder)
     }
 
-    pub fn finalize(self) -> (BuiltDisplayList, AuxiliaryLists) {
+    pub fn finalize(self) -> (PipelineId, BuiltDisplayList, AuxiliaryLists) {
         unsafe {
             let blob = convert_pod_to_blob(&self.list).to_vec();
             let display_list_items_size = blob.len();
 
-            (BuiltDisplayList {
+            (self.pipeline_id,
+             BuiltDisplayList {
                  descriptor: BuiltDisplayListDescriptor {
                      display_list_items_size: display_list_items_size,
                  },

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -168,6 +168,7 @@ pub struct AuxiliaryLists {
 ///
 /// Auxiliary lists consist of some number of gradient stops, complex clip regions, filters, and
 /// glyph instances, in that order.
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct AuxiliaryListsDescriptor {
     gradient_stops_size: usize,
@@ -289,6 +290,7 @@ pub struct BuiltDisplayList {
 ///
 /// A display list consists of some number of display list items, followed by a number of display
 /// items.
+#[repr(C)]
 #[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct BuiltDisplayListDescriptor {
     /// The size in bytes of the display list items in this display list.

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -364,7 +364,7 @@ impl Wrench {
         self.api.set_root_display_list(root_background_color,
                                        Epoch(frame_number),
                                        self.window_size_f32(),
-                                       display_list,
+                                       display_list.finalize(),
                                        false);
 
         for (scroll_root_id, offset) in scroll_offsets {


### PR DESCRIPTION
This will let us build our display lists in the child process in Gecko,
transport them over Gecko IPC and send them into webrender in the
compositor process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/927)
<!-- Reviewable:end -->
