### PR TITLE
Implement support for page zoom.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -35,6 +35,7 @@ pub struct RenderBackend {
     result_tx: Sender<ResultMsg>,
 
     device_pixel_ratio: f32,
+    page_zoom_factor: f32,
     next_namespace_id: IdNamespace,
 
     resource_cache: ResourceCache,
@@ -81,6 +82,7 @@ impl RenderBackend {
             payload_tx: payload_tx,
             result_tx: result_tx,
             device_pixel_ratio: device_pixel_ratio,
+            page_zoom_factor: 1.0,
             resource_cache: resource_cache,
             scene: Scene::new(),
             frame: Frame::new(config),
@@ -136,6 +138,9 @@ impl RenderBackend {
                         }
                         ApiMsg::DeleteImage(id) => {
                             self.resource_cache.delete_image_template(id);
+                        }
+                        ApiMsg::SetPageZoom(factor) => {
+                            self.page_zoom_factor = factor.get();
                         }
                         ApiMsg::CloneApi(sender) => {
                             let result = self.next_namespace_id;
@@ -424,11 +429,11 @@ impl RenderBackend {
     fn render(&mut self,
               texture_cache_profile: &mut TextureCacheProfileCounters)
               -> RendererFrame {
+        let device_pixel_ratio = self.device_pixel_ratio * self.page_zoom_factor;
         let frame = self.frame.build(&mut self.resource_cache,
                                      &self.scene.pipeline_auxiliary_lists,
-                                     self.device_pixel_ratio,
+                                     device_pixel_ratio,
                                      texture_cache_profile);
-
         frame
     }
 

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -13,7 +13,7 @@ use {GlyphKey, GlyphDimensions, ImageData, WebGLContextId, WebGLCommand, TileSiz
 use {DeviceIntSize, DynamicProperties, LayoutPoint, LayoutSize, WorldPoint, PropertyBindingKey, PropertyBindingId};
 use {BuiltDisplayList, AuxiliaryLists};
 use VRCompositorCommand;
-use ExternalEvent;
+use {ExternalEvent, PageZoomFactor};
 use std::marker::PhantomData;
 
 impl RenderApiSender {
@@ -190,6 +190,11 @@ impl RenderApi {
                                              pipeline_id: PipelineId,
                                              scroll_root_id: ServoScrollRootId) {
         let msg = ApiMsg::ScrollLayersWithScrollId(new_scroll_origin, pipeline_id, scroll_root_id);
+        self.api_sender.send(msg).unwrap();
+    }
+
+    pub fn set_page_zoom(&self, page_zoom: PageZoomFactor) {
+        let msg = ApiMsg::SetPageZoom(page_zoom);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -50,6 +50,7 @@ pub enum ApiMsg {
                        BuiltDisplayListDescriptor,
                        AuxiliaryListsDescriptor,
                        bool),
+    SetPageZoom(PageZoomFactor),
     SetRootPipeline(PipelineId),
     Scroll(ScrollLocation, WorldPoint, ScrollEventPhase),
     ScrollLayersWithScrollId(LayoutPoint, PipelineId, ServoScrollRootId),
@@ -1186,6 +1187,22 @@ pub enum VRCompositorCommand {
     Release(VRCompositorId)
 }
 
+/// Represents a desktop style page zoom factor.
+#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+pub struct PageZoomFactor(f32);
+
+impl PageZoomFactor {
+    /// Construct a new page zoom factor.
+    pub fn new(scale: f32) -> PageZoomFactor {
+        PageZoomFactor(scale)
+    }
+
+    /// Get the page zoom factor as an untyped float.
+    pub fn get(&self) -> f32 {
+        self.0
+    }
+}
+
 // Trait object that handles WebVR commands.
 // Receives the texture_id associated to the WebGLContext.
 pub trait VRCompositorHandler: Send {
@@ -1216,6 +1233,7 @@ impl fmt::Debug for ApiMsg {
             &ApiMsg::VRCompositorCommand(..) => { write!(f, "ApiMsg::VRCompositorCommand") }
             &ApiMsg::ExternalEvent(..) => { write!(f, "ApiMsg::ExternalEvent") }
             &ApiMsg::ShutDown => { write!(f, "ApiMsg::ShutDown") }
+            &ApiMsg::SetPageZoom(..) => { write!(f, "ApiMsg::SetPageZoom") }
         }
     }
 }


### PR DESCRIPTION
This allows setting a page (desktop style) zoom factor. It is multiplied
by the hidpi-factor to give a css pixel -> device pixel scale factor.
This value is then used to select rasterization size for items such
as glyphs, box shadow caches etc to provide high resolution zoom support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/931)
<!-- Reviewable:end -->
