### PR TITLE
Modify run_tests.py for running any wrench command headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ script:
   - if [ $BUILD_KIND = DEBUG ]; then (cd sample && cargo test --verbose); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd sample && cargo build --verbose --features=profiler); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd wrench && cargo test --verbose); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && cargo build --release --verbose --features headless); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python run_tests.py res/rect.yaml); fi
+  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python headless.py reftest); fi

--- a/wrench/test.sh
+++ b/wrench/test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-cargo build --release --features headless && python run_tests.py res/rect.yaml
-rm screenshot.png


### PR DESCRIPTION
It would be nice to specify the command to run under OSMesa and not have to type `cargo build --release --features headless` so often.

@glennw does this seem like an ok change?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/940)
<!-- Reviewable:end -->
