### PR TITLE
Make perspective and transform Option types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ dependencies = [
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.21.0",
- "webrender_traits 0.22.0",
+ "webrender 0.22.0",
+ "webrender_traits 0.23.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1147,12 +1147,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.22.0",
+ "webrender_traits 0.23.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1211,8 +1211,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.21.0",
- "webrender_traits 0.22.0",
+ "webrender 0.22.0",
+ "webrender_traits 0.23.0",
 ]
 
 [[package]]

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -18,11 +18,10 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
-use webrender_traits::{BlobImageResult, BlobImageError, BlobImageDescriptor};
-use webrender_traits::{ColorF, Epoch, GlyphInstance, ClipRegion, ImageRendering};
-use webrender_traits::{ImageDescriptor, ImageData, ImageFormat, PipelineId};
-use webrender_traits::{ImageKey, BlobImageData, BlobImageRenderer, RasterizedBlobImage};
-use webrender_traits::{LayoutSize, LayoutPoint, LayoutRect, LayoutTransform, DeviceUintSize};
+use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer};
+use webrender_traits::{BlobImageResult, ClipRegion, ColorF, DeviceUintSize, Epoch, GlyphInstance};
+use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
+use webrender_traits::{LayoutPoint, LayoutRect, LayoutSize, PipelineId, RasterizedBlobImage};
 
 
 fn load_file(name: &str) -> Vec<u8> {
@@ -126,8 +125,8 @@ fn main() {
                                   bounds,
                                   clip_region,
                                   0,
-                                  LayoutTransform::identity().into(),
-                                  LayoutTransform::identity(),
+                                  None,
+                                  None,
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
     builder.push_image(

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -372,9 +372,6 @@ impl Frame {
             return;
         }
 
-        let stacking_context_transform =
-            context.scene.properties.resolve_layout_transform(&stacking_context.transform);
-
         let mut reference_frame_id = current_reference_frame_id;
         let mut scroll_layer_id = match stacking_context.scroll_policy {
             ScrollPolicy::Fixed => current_reference_frame_id,
@@ -383,8 +380,11 @@ impl Frame {
 
         // If we have a transformation, we establish a new reference frame. This means
         // that fixed position stacking contexts are positioned relative to us.
-        if stacking_context_transform != LayoutTransform::identity() ||
-           stacking_context.perspective != LayoutTransform::identity() {
+        if stacking_context.transform.is_some() || stacking_context.perspective.is_some() {
+            let transform = stacking_context.transform.as_ref();
+            let transform = context.scene.properties.resolve_layout_transform(transform);
+            let perspective =
+                stacking_context.perspective.unwrap_or_else(LayoutTransform::identity);
             let transform =
                 LayerToScrollTransform::create_translation(reference_frame_relative_offset.x,
                                                            reference_frame_relative_offset.y,
@@ -392,8 +392,8 @@ impl Frame {
                                         .pre_translated(stacking_context.bounds.origin.x,
                                                         stacking_context.bounds.origin.y,
                                                         0.0)
-                                        .pre_mul(&stacking_context_transform)
-                                        .pre_mul(&stacking_context.perspective);
+                                        .pre_mul(&transform)
+                                        .pre_mul(&perspective);
             scroll_layer_id = self.clip_scroll_tree.add_reference_frame(clip_region.main,
                                                                         transform,
                                                                         pipeline_id,

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -41,7 +41,14 @@ impl SceneProperties {
     }
 
     /// Get the current value for a transform property.
-    pub fn resolve_layout_transform(&self, property: &PropertyBinding<LayoutTransform>) -> LayoutTransform {
+    pub fn resolve_layout_transform(&self,
+                                    property: Option<&PropertyBinding<LayoutTransform>>)
+                                    -> LayoutTransform {
+        let property = match property {
+            Some(property) => property,
+            None => return LayoutTransform::identity(),
+        };
+
         match *property {
             PropertyBinding::Value(matrix) => matrix,
             PropertyBinding::Binding(ref key) => {

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -284,8 +284,8 @@ impl DisplayListBuilder {
                                  bounds: LayoutRect,
                                  clip: ClipRegion,
                                  z_index: i32,
-                                 transform: PropertyBinding<LayoutTransform>,
-                                 perspective: LayoutTransform,
+                                 transform: Option<PropertyBinding<LayoutTransform>>,
+                                 perspective: Option<LayoutTransform>,
                                  mix_blend_mode: MixBlendMode,
                                  filters: Vec<FilterOp>) {
         let stacking_context = StackingContext {

--- a/webrender_traits/src/stacking_context.rs
+++ b/webrender_traits/src/stacking_context.rs
@@ -10,8 +10,8 @@ impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
                bounds: LayoutRect,
                z_index: i32,
-               transform: PropertyBinding<LayoutTransform>,
-               perspective: LayoutTransform,
+               transform: Option<PropertyBinding<LayoutTransform>>,
+               perspective: Option<LayoutTransform>,
                mix_blend_mode: MixBlendMode,
                filters: Vec<FilterOp>,
                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -901,8 +901,8 @@ pub struct StackingContext {
     pub scroll_policy: ScrollPolicy,
     pub bounds: LayoutRect,
     pub z_index: i32,
-    pub transform: PropertyBinding<LayoutTransform>,
-    pub perspective: LayoutTransform,
+    pub transform: Option<PropertyBinding<LayoutTransform>>,
+    pub perspective: Option<LayoutTransform>,
     pub mix_blend_mode: MixBlendMode,
     pub filters: ItemRange,
 }

--- a/wrench/reftests/scrolling/fixed-position-ref.yaml
+++ b/wrench/reftests/scrolling/fixed-position-ref.yaml
@@ -6,3 +6,12 @@ root:
     - type: rect
       bounds: [60, 0, 50, 50]
       color: green
+    - type: rect
+      bounds: [120, 0, 50, 50]
+      color: green
+    - type: rect
+      bounds: [180, 0, 50, 50]
+      color: green
+    - type: rect
+      bounds: [240, 0, 50, 50]
+      color: green

--- a/wrench/reftests/scrolling/fixed-position.yaml
+++ b/wrench/reftests/scrolling/fixed-position.yaml
@@ -17,10 +17,48 @@ root:
     # a transformation.
     - type: stacking_context
       bounds: [0, 0, 50, 50]
-      transform: translate(60, 100),
+      transform: translate(60, 100)
       items:
         - type: stacking_context
           bounds: [0, 0, 50, 50]
+          scroll-policy: fixed
+          items:
+            - type: rect
+              bounds: [0, 0, 50, 50]
+              color: green
+    # This is similar to the previous case, but ensures that this still works
+    # even with an identity transform.
+    - type: stacking_context
+      bounds: [120, 0, 50, 200]
+      transform: translate(0, 0)
+      items:
+        - type: stacking_context
+          bounds: [0, 0, 50, 200]
+          scroll-policy: fixed
+          items:
+            - type: rect
+              bounds: [0, 100, 50, 50]
+              color: green
+    # This is similar to the previous case, but for perspective.
+    - type: stacking_context
+      bounds: [180, 0, 50, 200]
+      perspective: 1
+      items:
+        - type: stacking_context
+          bounds: [0, 0, 50, 200]
+          scroll-policy: fixed
+          items:
+            - type: rect
+              bounds: [0, 100, 50, 50]
+              color: green
+    # This is similar to the previous case, but since the perspective is
+    # 0 (equivalent to none), it shouldn't scroll.
+    - type: stacking_context
+      bounds: [240, 0, 50, 200]
+      perspective: 0
+      items:
+        - type: stacking_context
+          bounds: [0, 0, 50, 200]
           scroll-policy: fixed
           items:
             - type: rect

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -177,16 +177,16 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
     scroll_policy_node(parent, "scroll-policy", sc.scroll_policy);
     i32_node(parent, "z_index", sc.z_index);
 
-    let transform = match sc.transform {
-        PropertyBinding::Value(m) => m,
-        PropertyBinding::Binding(..) => panic!("TODO: Handle property bindings in wrench!"),
+    match sc.transform {
+        Some(PropertyBinding::Value(transform)) => matrix4d_node(parent, "transform", &transform),
+        Some(PropertyBinding::Binding(..)) => panic!("TODO: Handle property bindings in wrench!"),
+        None => {}
     };
-    if transform != LayoutTransform::identity() {
-        matrix4d_node(parent, "transform", &transform);
+
+    if let Some(perspective) = sc.perspective {
+        matrix4d_node(parent, "perspective", &perspective);
     }
-    if sc.perspective != LayoutTransform::identity() {
-        matrix4d_node(parent, "perspective", &sc.perspective);
-    }
+
     // mix_blend_mode
     if sc.mix_blend_mode != MixBlendMode::Normal {
         mix_blend_mode_node(parent, "mix-blend-mode", sc.mix_blend_mode)


### PR DESCRIPTION
CSS makes a distinction between an identity transform and an empty
transform. For instance, stacking contexts with identity
transformations still create what we call reference frames, which means
they serve as coordinates spaces for fixed position elements. This will
also help us to properly assign ScrollLayerIds during display list
construction if we want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/945)
<!-- Reviewable:end -->
