### PR TITLE
Use correct yaml keys for image stretch_size and tile_spacing

### DIFF
--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -549,8 +549,8 @@ impl YamlFrameWriter {
                     if let Some(&CachedImage { tiling: Some(tile_size), .. }) = self.images.get(&item.image_key) {
                         u32_node(&mut v, "tile-size", tile_size as u32);
                     }
-                    size_node(&mut v, "strech", &item.stretch_size);
-                    size_node(&mut v, "spacing", &item.tile_spacing);
+                    size_node(&mut v, "stretch_size", &item.stretch_size);
+                    size_node(&mut v, "tile_spacing", &item.tile_spacing);
                     match item.image_rendering {
                         ImageRendering::Auto => (),
                         ImageRendering::CrispEdges => str_node(&mut v, "rendering", "crisp-edges"),


### PR DESCRIPTION
We weren't being consistent between writing and reading.

Keep the read keys the same so as to not break existing yaml files, plus I think they're the better keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/946)
<!-- Reviewable:end -->
