### PR TITLE
add delete_font API for deleting fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ dependencies = [
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.22.0",
- "webrender_traits 0.23.0",
+ "webrender 0.22.1",
+ "webrender_traits 0.23.1",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1147,12 +1147,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.23.0",
+ "webrender_traits 0.23.1",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1211,8 +1211,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.22.0",
- "webrender_traits 0.23.0",
+ "webrender 0.22.1",
+ "webrender_traits 0.23.1",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -147,6 +147,18 @@ impl FontContext {
         self.cg_fonts.insert((*font_key).clone(), native_font_handle);
     }
 
+    pub fn delete_font(&mut self, font_key: &FontKey) {
+        if let Some(cg_font) = self.cg_fonts.remove(font_key) {
+            let ct_font_keys = self.ct_fonts.keys()
+                                            .filter(|k| k.0 == *font_key)
+                                            .cloned()
+                                            .collect::<Vec<_>>();
+            for ct_font_key in ct_font_keys {
+                self.ct_fonts.remove(&ct_font_key);
+            }
+        }
+    }
+
     fn get_ct_font(&mut self,
                    font_key: FontKey,
                    size: Au) -> Option<CTFont> {

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -13,6 +13,7 @@ use freetype::freetype::{FT_Library, FT_Set_Char_Size};
 use freetype::freetype::{FT_Face, FT_Long, FT_UInt, FT_F26Dot6};
 use freetype::freetype::{FT_Init_FreeType, FT_Load_Glyph, FT_Render_Glyph};
 use freetype::freetype::{FT_New_Memory_Face, FT_GlyphSlot, FT_LcdFilter};
+use freetype::freetype::{FT_Done_Face};
 
 use std::{mem, ptr, slice};
 use std::collections::HashMap;
@@ -86,6 +87,15 @@ impl FontContext {
 
     pub fn add_native_font(&mut self, _font_key: &FontKey, _native_font_handle: NativeFontHandle) {
         panic!("TODO: Not supported on Linux");
+    }
+
+    pub fn delete_font(&mut self, font_key: &FontKey) {
+        if let Some(face) = self.faces.remove(font_key) {
+            let result = unsafe {
+                FT_Done_Face(face.face)
+            };
+            assert!(result.succeeded());
+        }
     }
 
     fn load_glyph(&self,

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -143,6 +143,10 @@ impl FontContext {
         self.fonts.insert((*font_key).clone(), face);
     }
 
+    pub fn delete_font(&mut self, font_key: &FontKey) {
+        self.fonts.remove(font_key);
+    }
+
     // Assumes RGB format from dwrite, which is 3 bytes per pixel as dwrite
     // doesn't output an alpha value via GlyphRunAnalysis::CreateAlphaTexture
     #[allow(dead_code)]

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -66,6 +66,7 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
     match msg {
         &ApiMsg::AddRawFont(..) |
         &ApiMsg::AddNativeFont(..) |
+        &ApiMsg::DeleteFont(..) |
         &ApiMsg::AddImage(..) |
         &ApiMsg::GenerateFrame(..) |
         &ApiMsg::UpdateImage(..) |

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -119,6 +119,9 @@ impl RenderBackend {
                             self.resource_cache
                                 .add_font_template(id, FontTemplate::Native(native_font_handle));
                         }
+                        ApiMsg::DeleteFont(id) => {
+                            self.resource_cache.delete_font_template(id);
+                        }
                         ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
                             let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
                             for glyph_key in &glyph_keys {

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -70,6 +70,11 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
+    pub fn delete_font(&self, key: FontKey) {
+        let msg = ApiMsg::DeleteFont(key);
+        self.api_sender.send(msg).unwrap();
+    }
+
     /// Gets the dimensions for the supplied glyph keys
     ///
     /// Note: Internally, the internal texture cache doesn't store

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -30,6 +30,7 @@ pub type TileSize = u16;
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>),
     AddNativeFont(FontKey, NativeFontHandle),
+    DeleteFont(FontKey),
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Adds an image from the resource cache.
@@ -1214,6 +1215,7 @@ impl fmt::Debug for ApiMsg {
         match self {
             &ApiMsg::AddRawFont(..) => { write!(f, "ApiMsg::AddRawFont") }
             &ApiMsg::AddNativeFont(..) => { write!(f, "ApiMsg::AddNativeFont") }
+            &ApiMsg::DeleteFont(..) => { write!(f, "ApiMsg::DeleteFont") }
             &ApiMsg::GetGlyphDimensions(..) => { write!(f, "ApiMsg::GetGlyphDimensions") }
             &ApiMsg::AddImage(..) => { write!(f, "ApiMsg::AddImage") }
             &ApiMsg::UpdateImage(..) => { write!(f, "ApiMsg::UpdateImage") }


### PR DESCRIPTION
This allows us to better synchronize font lifetimes with gecko, so that when we delete fonts in gecko we can ensure WebRender is no longer keeping them around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/947)
<!-- Reviewable:end -->
