### PR TITLE
Fix typo transforming clip masks incorrectly

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1388,7 +1388,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         // The coordinates of the mask are relative to the origin of the node itself,
         // so we need to account for that origin in the transformation we assign to
         // the packed layer.
-        let transform = node.world_content_transform
+        let transform = node.world_viewport_transform
                             .pre_translated(node.local_viewport_rect.origin.x,
                                             node.local_viewport_rect.origin.y,
                                             0.0);

--- a/wrench/reftests/scrolling/scroll-layer-with-mask-ref.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask-ref.yaml
@@ -3,3 +3,6 @@ root:
     - type: rect
       bounds: [20, 20, 80, 80]
       color: green
+    - type: rect
+      bounds: [120, 20, 80, 80]
+      color: green

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -22,3 +22,24 @@ root:
           - type: rect
             bounds: [0, 0, 100, 100]
             color: green
+
+    # The same test, but this time ensure that scroll offsets don't affect the masking.
+    -
+      type: stacking_context
+      bounds: [100, 0, 100, 100]
+      clip: [0, 0, 100, 300]
+      scroll-policy: scrollable
+      items:
+      - type: scroll_layer
+        bounds: [10, 10, 100, 100]
+        content-size: [100, 300]
+        scroll-offset: [0, 100]
+        clip:
+          image_mask:
+            image: "mask.png"
+            rect: [0, 0, 100, 100]
+            repeat: false
+        items:
+        - type: rect
+          bounds: [0, 0, 100, 200]
+          color: green


### PR DESCRIPTION
I recently made a typo when fixing a bug, meaning that clip masks where
transformed as if they were content of their scroll nodes. Instead we
should transform using the viewport transform. Also add test coverage
for this bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/954)
<!-- Reviewable:end -->
