### PR TITLE
Assign ScrollLayerId per primitive

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -4,10 +4,16 @@
 
 use euclid::Point3D;
 use geometry::ray_intersects_rect;
+use mask_cache::{ClipSource, MaskCacheInfo};
+use prim_store::GpuBlock32;
+use renderer::VertexDataStore;
 use spring::{DAMPING, STIFFNESS, Spring};
-use webrender_traits::{LayerPixel, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
-use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollEventPhase, ScrollLayerId};
-use webrender_traits::{ScrollLayerRect, ScrollLocation, WorldPoint, WorldPoint4D};
+use tiling::PackedLayerIndex;
+use util::TransformedRect;
+use webrender_traits::{ClipRegion, LayerPixel, LayerPoint, LayerRect, LayerSize};
+use webrender_traits::{LayerToScrollTransform, LayerToWorldTransform, PipelineId};
+use webrender_traits::{ScrollEventPhase, ScrollLayerId, ScrollLayerRect, ScrollLocation};
+use webrender_traits::{WorldPoint, WorldPoint4D};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -15,18 +21,61 @@ const CAN_OVERSCROLL: bool = true;
 #[cfg(not(target_os = "macos"))]
 const CAN_OVERSCROLL: bool = false;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+pub struct ClipInfo {
+    /// The ClipSource for this node, which is used to generate mask_cache_info.
+    pub clip_source: ClipSource,
+
+    /// The MaskCacheInfo for this node, which is produced by processing the
+    /// provided ClipSource.
+    pub mask_cache_info: Option<MaskCacheInfo>,
+
+    /// The packed layer index for this node, which is used to render a clip mask
+    /// for it, if necessary.
+    pub packed_layer_index: PackedLayerIndex,
+
+    /// The final transformed rectangle of this clipping region for this node,
+    /// which depends on the screen rectangle and the transformation of all of
+    /// the parents.
+    pub xf_rect: Option<TransformedRect>,
+}
+
+impl ClipInfo {
+    pub fn new(clip_region: &ClipRegion,
+               clip_store: &mut VertexDataStore<GpuBlock32>,
+               packed_layer_index: PackedLayerIndex)
+               -> ClipInfo {
+        // We pass true here for the MaskCacheInfo because this type of
+        // mask needs an extra clip for the clip rectangle.
+        let clip_source = ClipSource::Region(clip_region.clone());
+        ClipInfo {
+            mask_cache_info: MaskCacheInfo::new(&clip_source, true, clip_store),
+            clip_source: clip_source,
+            packed_layer_index: packed_layer_index,
+            xf_rect: None,
+        }
+    }
+
+    pub fn is_masking(&self) -> bool {
+        match self.mask_cache_info {
+            Some(ref info) => info.is_masking(),
+            _ => false,
+        }
+    }
+
+}
+#[derive(Clone, Debug)]
 pub enum NodeType {
     /// Transform for this layer, relative to parent reference frame. A reference
     /// frame establishes a new coordinate space in the tree.
     ReferenceFrame(LayerToScrollTransform),
 
     /// Other nodes just do clipping, but no transformation.
-    ClipRect,
+    Clip(ClipInfo),
 }
 
 /// Contains scrolling and transform information stacking contexts.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ClipScrollNode {
     /// Manages scrolling offset, overscroll state etc.
     pub scrolling: ScrollingState,
@@ -56,6 +105,9 @@ pub struct ClipScrollNode {
     /// Pipeline that this layer belongs to
     pub pipeline_id: PipelineId,
 
+    /// Parent layer. If this is None, we are the root node.
+    pub parent: Option<ScrollLayerId>,
+
     /// Child layers
     pub children: Vec<ScrollLayerId>,
 
@@ -64,27 +116,29 @@ pub struct ClipScrollNode {
 }
 
 impl ClipScrollNode {
-    pub fn new(local_viewport_rect: &LayerRect,
-               local_clip_rect: &LayerRect,
+    pub fn new(pipeline_id: PipelineId,
+               parent_id: ScrollLayerId,
+               local_viewport_rect: &LayerRect,
                content_size: LayerSize,
-               pipeline_id: PipelineId)
+               clip_info: ClipInfo)
                -> ClipScrollNode {
         ClipScrollNode {
             scrolling: ScrollingState::new(),
             content_size: content_size,
             local_viewport_rect: *local_viewport_rect,
-            local_clip_rect: *local_clip_rect,
-            combined_local_viewport_rect: *local_clip_rect,
+            local_clip_rect: *local_viewport_rect,
+            combined_local_viewport_rect: LayerRect::zero(),
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),
+            parent: Some(parent_id),
             children: Vec::new(),
             pipeline_id: pipeline_id,
-            node_type: NodeType::ClipRect,
+            node_type: NodeType::Clip(clip_info),
         }
     }
 
-    pub fn new_reference_frame(local_viewport_rect: &LayerRect,
-                               local_clip_rect: &LayerRect,
+    pub fn new_reference_frame(parent_id: Option<ScrollLayerId>,
+                               local_viewport_rect: &LayerRect,
                                content_size: LayerSize,
                                local_transform: &LayerToScrollTransform,
                                pipeline_id: PipelineId)
@@ -93,10 +147,11 @@ impl ClipScrollNode {
             scrolling: ScrollingState::new(),
             content_size: content_size,
             local_viewport_rect: *local_viewport_rect,
-            local_clip_rect: *local_clip_rect,
-            combined_local_viewport_rect: *local_clip_rect,
+            local_clip_rect: *local_viewport_rect,
+            combined_local_viewport_rect: LayerRect::zero(),
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),
+            parent: parent_id,
             children: Vec::new(),
             pipeline_id: pipeline_id,
             node_type: NodeType::ReferenceFrame(*local_transform),
@@ -159,7 +214,7 @@ impl ClipScrollNode {
 
         let local_transform = match self.node_type {
             NodeType::ReferenceFrame(transform) => transform,
-            NodeType::ClipRect => LayerToScrollTransform::identity(),
+            NodeType::Clip(_) => LayerToScrollTransform::identity(),
         };
 
         let inv_transform = match local_transform.inverse() {
@@ -330,7 +385,7 @@ impl ClipScrollNode {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ScrollingState {
     pub offset: LayerPoint,
     pub spring: Spring,

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -6,10 +6,10 @@ use clip_scroll_node::{ClipScrollNode, NodeType, ScrollingState};
 use fnv::FnvHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
-use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollEventPhase, ScrollLayerId};
-use webrender_traits::{ScrollLayerInfo, ScrollLayerRect, ScrollLayerState, ScrollLocation};
-use webrender_traits::{ServoScrollRootId, WorldPoint, as_scroll_parent_rect};
+use webrender_traits::{LayerPoint, LayerRect, LayerToScrollTransform, LayerToWorldTransform};
+use webrender_traits::{PipelineId, ScrollEventPhase, ScrollLayerId, ScrollLayerInfo};
+use webrender_traits::{ScrollLayerRect, ScrollLayerState, ScrollLocation, ServoScrollRootId};
+use webrender_traits::{WorldPoint, as_scroll_parent_rect};
 
 pub type ScrollStates = HashMap<ScrollLayerId, ScrollingState, BuildHasherDefault<FnvHasher>>;
 
@@ -48,7 +48,7 @@ impl ClipScrollTree {
             current_scroll_layer_id: None,
             root_reference_frame_id: ScrollLayerId::root_reference_frame(dummy_pipeline),
             topmost_scroll_layer_id: ScrollLayerId::root_scroll_layer(dummy_pipeline),
-            current_reference_frame_id: 1,
+            current_reference_frame_id: 0,
             pipelines_to_discard: HashSet::new(),
         }
     }
@@ -65,33 +65,6 @@ impl ClipScrollTree {
         debug_assert!(!self.nodes.is_empty());
         debug_assert!(self.nodes.contains_key(&self.topmost_scroll_layer_id));
         self.topmost_scroll_layer_id
-    }
-
-    pub fn establish_root(&mut self,
-                          pipeline_id: PipelineId,
-                          viewport_size: &LayerSize,
-                          viewport_offset: LayerPoint,
-                          clip_size: LayerSize,
-                          content_size: &LayerSize) {
-        debug_assert!(self.nodes.is_empty());
-
-        let transform = LayerToScrollTransform::create_translation(viewport_offset.x, viewport_offset.y, 0.0);
-        let viewport = LayerRect::new(LayerPoint::zero(), *viewport_size);
-        let clip = LayerRect::new(LayerPoint::new(-viewport_offset.x, -viewport_offset.y),
-                                  LayerSize::new(clip_size.width, clip_size.height));
-        let root_reference_frame_id = ScrollLayerId::root_reference_frame(pipeline_id);
-        self.root_reference_frame_id = root_reference_frame_id;
-        let reference_frame = ClipScrollNode::new_reference_frame(&viewport,
-                                                                  &clip,
-                                                                  viewport.size,
-                                                                  &transform,
-                                                                  pipeline_id);
-        self.nodes.insert(self.root_reference_frame_id, reference_frame);
-
-        let scroll_node = ClipScrollNode::new(&viewport, &clip, *content_size, pipeline_id);
-        let topmost_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
-        self.topmost_scroll_layer_id = topmost_scroll_layer_id;
-        self.add_node(scroll_node, topmost_scroll_layer_id, root_reference_frame_id);
     }
 
     pub fn collect_nodes_bouncing_back(&self)
@@ -329,7 +302,7 @@ impl ClipScrollTree {
                     let (transform, offset) = match node.node_type {
                         NodeType::ReferenceFrame(..) =>
                             (node.world_viewport_transform, LayerPoint::zero()),
-                        NodeType::ClipRect => {
+                        NodeType::Clip(_) => {
                             (*parent_reference_frame_transform,
                              parent_accumulated_scroll_offset + node.scrolling.offset)
                         }
@@ -385,27 +358,35 @@ impl ClipScrollTree {
     }
 
     pub fn add_reference_frame(&mut self,
-                               rect: LayerRect,
-                               transform: LayerToScrollTransform,
+                               rect: &LayerRect,
+                               transform: &LayerToScrollTransform,
                                pipeline_id: PipelineId,
-                               parent_id: ScrollLayerId) -> ScrollLayerId {
+                               parent_id: Option<ScrollLayerId>)
+                               -> ScrollLayerId {
         let reference_frame_id = ScrollLayerId {
             pipeline_id: pipeline_id,
             info: ScrollLayerInfo::ReferenceFrame(self.current_reference_frame_id),
         };
         self.current_reference_frame_id += 1;
 
-        let node = ClipScrollNode::new_reference_frame(&rect, &rect, rect.size, &transform, pipeline_id);
-        self.add_node(node, reference_frame_id, parent_id);
+        let node = ClipScrollNode::new_reference_frame(parent_id,
+                                                       &rect,
+                                                       rect.size,
+                                                       &transform,
+                                                       pipeline_id);
+        self.add_node(node, reference_frame_id);
         reference_frame_id
     }
 
-    pub fn add_node(&mut self, node: ClipScrollNode, id: ScrollLayerId, parent_id: ScrollLayerId) {
+    pub fn add_node(&mut self, node: ClipScrollNode, id: ScrollLayerId) {
+        // When the parent node is None this means we are adding the root.
+        match node.parent {
+            Some(parent_id) => self.nodes.get_mut(&parent_id).unwrap().add_child(id),
+            None => self.root_reference_frame_id = id,
+        }
+
         debug_assert!(!self.nodes.contains_key(&id));
         self.nodes.insert(id, node);
-
-        debug_assert!(parent_id != id);
-        self.nodes.get_mut(&parent_id).unwrap().add_child(id);
     }
 
     pub fn discard_frame_state_for_pipeline(&mut self, pipeline_id: PipelineId) {

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -18,20 +18,21 @@ use profiler::{FrameProfileCounters, TextureCacheProfileCounters};
 use render_task::{AlphaRenderItem, MaskCacheKey, MaskResult, RenderTask, RenderTaskIndex};
 use render_task::RenderTaskLocation;
 use resource_cache::ResourceCache;
+use clip_scroll_node::{ClipInfo, ClipScrollNode, NodeType};
 use clip_scroll_tree::ClipScrollTree;
 use std::{cmp, f32, i32, mem, usize};
+use tiling::StackingContextIndex;
 use tiling::{AuxiliaryListsMap, ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, Frame};
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
-use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, ScrollLayer};
-use tiling::{ScrollLayerIndex, StackingContext, StackingContextIndex};
+use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
 use util::{self, pack_as_float, rect_from_points_f, subtract_rect};
 use util::{RectHelpers, TransformedRectKind};
 use webrender_traits::{BorderDetails, BorderDisplayItem, BorderSide, BorderStyle};
-use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, DeviceIntPoint};
-use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintSize, ExtendMode, FontKey, TileOffset};
+use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, DeviceIntPoint, DeviceIntRect};
+use webrender_traits::{DeviceIntSize, DeviceUintRect, DeviceUintSize, ExtendMode, FontKey};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
-use webrender_traits::{LayerPoint, LayerRect, LayerSize, PipelineId, RepeatMode, ScrollLayerId};
-use webrender_traits::{WebGLContextId, YuvColorSpace};
+use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
+use webrender_traits::{RepeatMode, ScrollLayerId, TileOffset, WebGLContextId, YuvColorSpace};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -109,7 +110,6 @@ pub struct FrameBuilder {
     config: FrameBuilderConfig,
 
     stacking_context_store: Vec<StackingContext>,
-    scroll_layer_store: Vec<ScrollLayer>,
     clip_scroll_group_store: Vec<ClipScrollGroup>,
     packed_layers: Vec<PackedLayer>,
 
@@ -117,7 +117,7 @@ pub struct FrameBuilder {
 
     /// A stack of scroll nodes used during display list processing to properly
     /// parent new scroll nodes.
-    clip_scroll_node_stack: Vec<ScrollLayerIndex>,
+    clip_scroll_node_stack: Vec<ScrollLayerId>,
 
     /// A stack of stacking contexts used for creating ClipScrollGroups as
     /// primitives are added to the frame.
@@ -132,7 +132,6 @@ impl FrameBuilder {
             screen_size: screen_size,
             background_color: background_color,
             stacking_context_store: Vec::new(),
-            scroll_layer_store: Vec::new(),
             clip_scroll_group_store: Vec::new(),
             prim_store: PrimitiveStore::new(),
             cmds: Vec::new(),
@@ -152,7 +151,7 @@ impl FrameBuilder {
                      -> PrimitiveIndex {
         let stacking_context_index = *self.stacking_context_stack.last().unwrap();
         if !self.stacking_context_store[stacking_context_index.0]
-                 .has_clip_scroll_group(scroll_layer_id) {
+                .has_clip_scroll_group(scroll_layer_id) {
             let group_index = self.create_clip_scroll_group(stacking_context_index,
                                                             scroll_layer_id);
             let stacking_context = &mut self.stacking_context_store[stacking_context_index.0];
@@ -178,19 +177,18 @@ impl FrameBuilder {
                                                        container);
 
         match self.cmds.last_mut().unwrap() {
-            &mut PrimitiveRunCmd::PrimitiveRun(_run_prim_index, ref mut count, _) => {
-                debug_assert!(_run_prim_index.0 + *count == prim_index.0);
-                *count += 1;
-                return prim_index;
+            &mut PrimitiveRunCmd::PrimitiveRun(_run_prim_index, ref mut count, run_layer_id)
+                if run_layer_id == scroll_layer_id => {
+                    debug_assert!(_run_prim_index.0 + *count == prim_index.0);
+                    *count += 1;
+                    return prim_index;
             }
+            &mut PrimitiveRunCmd::PrimitiveRun(..) |
             &mut PrimitiveRunCmd::PushStackingContext(..) |
-            &mut PrimitiveRunCmd::PopStackingContext |
-            &mut PrimitiveRunCmd::PushScrollLayer(..) |
-            &mut PrimitiveRunCmd::PopScrollLayer => {}
+            &mut PrimitiveRunCmd::PopStackingContext => {}
         }
 
         self.cmds.push(PrimitiveRunCmd::PrimitiveRun(prim_index, 1, scroll_layer_id));
-
         prim_index
     }
 
@@ -243,35 +241,105 @@ impl FrameBuilder {
         self.stacking_context_stack.pop();
     }
 
+    pub fn push_reference_frame(&mut self,
+                                parent_id: Option<ScrollLayerId>,
+                                pipeline_id: PipelineId,
+                                rect: &LayerRect,
+                                transform: &LayerToScrollTransform,
+                                clip_scroll_tree: &mut ClipScrollTree)
+                                -> ScrollLayerId {
+        let new_id = clip_scroll_tree.add_reference_frame(rect, transform, pipeline_id, parent_id);
+        self.clip_scroll_node_stack.push(new_id);
+        new_id
+    }
+
+    pub fn current_reference_frame_id(&self) -> ScrollLayerId {
+        *self.clip_scroll_node_stack.iter().rev().find(|id| id.is_reference_frame()).unwrap()
+    }
+
+    pub fn setup_viewport_offset(&mut self,
+                                 window_size: DeviceUintSize,
+                                 inner_rect: DeviceUintRect,
+                                 device_pixel_ratio: f32,
+                                 clip_scroll_tree: &mut ClipScrollTree) {
+        let inner_origin = inner_rect.origin.to_f32();
+        let viewport_offset = LayerPoint::new((inner_origin.x / device_pixel_ratio).round(),
+                                              (inner_origin.y / device_pixel_ratio).round());
+        let outer_size = window_size.to_f32();
+        let outer_size = LayerSize::new((outer_size.width / device_pixel_ratio).round(),
+                                        (outer_size.height / device_pixel_ratio).round());
+        let clip_size = LayerSize::new(outer_size.width + 2.0 * viewport_offset.x,
+                                       outer_size.height + 2.0 * viewport_offset.y);
+
+        let viewport_clip = LayerRect::new(LayerPoint::new(-viewport_offset.x, -viewport_offset.y),
+                                           LayerSize::new(clip_size.width, clip_size.height));
+
+        let root_id = clip_scroll_tree.root_reference_frame_id();
+        if let Some(root_node) = clip_scroll_tree.nodes.get_mut(&root_id) {
+            if let NodeType::ReferenceFrame(ref mut transform) = root_node.node_type {
+                *transform = LayerToScrollTransform::create_translation(viewport_offset.x,
+                                                                        viewport_offset.y,
+                                                                        0.0);
+            }
+            root_node.local_clip_rect = viewport_clip;
+        }
+
+        let scroll_layer_id = clip_scroll_tree.topmost_scroll_layer_id();
+        if let Some(root_node) = clip_scroll_tree.nodes.get_mut(&scroll_layer_id) {
+            root_node.local_clip_rect = viewport_clip;
+        }
+    }
+
+    pub fn push_root(&mut self,
+                     pipeline_id: PipelineId,
+                     viewport_size: &LayerSize,
+                     content_size: &LayerSize,
+                     clip_scroll_tree: &mut ClipScrollTree)
+                     -> ScrollLayerId {
+        let viewport_rect = LayerRect::new(LayerPoint::zero(), *viewport_size);
+        let identity = &LayerToScrollTransform::identity();
+        self.push_reference_frame(None, pipeline_id, &viewport_rect, identity, clip_scroll_tree);
+
+        let topmost_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
+        clip_scroll_tree.topmost_scroll_layer_id = topmost_scroll_layer_id;
+        self.push_clip_scroll_node(topmost_scroll_layer_id,
+                                   clip_scroll_tree.root_reference_frame_id,
+                                   pipeline_id,
+                                   &viewport_rect,
+                                   content_size,
+                                   &ClipRegion::simple(&viewport_rect),
+                                   clip_scroll_tree);
+        topmost_scroll_layer_id
+    }
+
     pub fn push_clip_scroll_node(&mut self,
-                                 scroll_layer_id: ScrollLayerId,
-                                 clip_region: &ClipRegion) {
-        let scroll_layer_index = ScrollLayerIndex(self.scroll_layer_store.len());
-        let parent_index = *self.clip_scroll_node_stack.last().unwrap_or(&scroll_layer_index);
-        self.clip_scroll_node_stack.push(scroll_layer_index);
+                                 new_node_id: ScrollLayerId,
+                                 parent_id: ScrollLayerId,
+                                 pipeline_id: PipelineId,
+                                 local_viewport_rect: &LayerRect,
+                                 content_size: &LayerSize,
+                                 clip_region: &ClipRegion,
+                                 clip_scroll_tree: &mut ClipScrollTree) {
+        let clip_info = ClipInfo::new(clip_region,
+                                      &mut self.prim_store.gpu_data32,
+                                      PackedLayerIndex(self.packed_layers.len()));
+        let node = ClipScrollNode::new(pipeline_id,
+                                       parent_id,
+                                       local_viewport_rect,
+                                       *content_size,
+                                       clip_info);
 
-        let packed_layer_index = PackedLayerIndex(self.packed_layers.len());
-
-        let clip_source = ClipSource::Region(clip_region.clone());
-        let clip_info = MaskCacheInfo::new(&clip_source,
-                                           true, // needs an extra clip for the clip rectangle
-                                           &mut self.prim_store.gpu_data32);
-
-        self.scroll_layer_store.push(ScrollLayer {
-            scroll_layer_id: scroll_layer_id,
-            parent_index: parent_index,
-            clip_source: clip_source,
-            clip_cache_info: clip_info,
-            xf_rect: None,
-            packed_layer_index: packed_layer_index,
-        });
+        clip_scroll_tree.add_node(node, new_node_id);
         self.packed_layers.push(PackedLayer::empty());
-        self.cmds.push(PrimitiveRunCmd::PushScrollLayer(scroll_layer_index));
+        self.clip_scroll_node_stack.push(new_node_id);
     }
 
     pub fn pop_clip_scroll_node(&mut self) {
-        self.cmds.push(PrimitiveRunCmd::PopScrollLayer);
         self.clip_scroll_node_stack.pop();
+    }
+
+    pub fn current_clip_scroll_node_id(&mut self) -> ScrollLayerId {
+        *self.clip_scroll_node_stack.last().unwrap()
     }
 
     pub fn add_solid_rectangle(&mut self,
@@ -917,7 +985,7 @@ impl FrameBuilder {
     /// primitives in screen space.
     fn build_layer_screen_rects_and_cull_layers(&mut self,
                                                 screen_rect: &DeviceIntRect,
-                                                clip_scroll_tree: &ClipScrollTree,
+                                                clip_scroll_tree: &mut ClipScrollTree,
                                                 auxiliary_lists_map: &AuxiliaryListsMap,
                                                 resource_cache: &mut ResourceCache,
                                                 profile_counters: &mut FrameProfileCounters,
@@ -1120,7 +1188,6 @@ impl FrameBuilder {
                         }
                     }
                 }
-                PrimitiveRunCmd::PushScrollLayer(_) | PrimitiveRunCmd::PopScrollLayer => { }
             }
         }
 
@@ -1131,7 +1198,7 @@ impl FrameBuilder {
     pub fn build(&mut self,
                  resource_cache: &mut ResourceCache,
                  frame_id: FrameId,
-                 clip_scroll_tree: &ClipScrollTree,
+                 clip_scroll_tree: &mut ClipScrollTree,
                  auxiliary_lists_map: &AuxiliaryListsMap,
                  device_pixel_ratio: f32,
                  texture_cache_profile: &mut TextureCacheProfileCounters)
@@ -1172,9 +1239,11 @@ impl FrameBuilder {
 
         resource_cache.block_until_all_resources_added(texture_cache_profile);
 
-        for scroll_layer in self.scroll_layer_store.iter() {
-            if let Some(ref clip_info) = scroll_layer.clip_cache_info {
-                self.prim_store.resolve_clip_cache(clip_info, resource_cache);
+        for node in clip_scroll_tree.nodes.values() {
+            if let NodeType::Clip(ref clip_info) = node.node_type {
+                if let Some(ref mask_info) = clip_info.mask_cache_info {
+                    self.prim_store.resolve_clip_cache(mask_info, resource_cache);
+                }
             }
         }
 
@@ -1234,27 +1303,27 @@ impl FrameBuilder {
 struct LayerRectCalculationAndCullingPass<'a> {
     frame_builder: &'a mut FrameBuilder,
     screen_rect: &'a DeviceIntRect,
-    clip_scroll_tree: &'a ClipScrollTree,
+    clip_scroll_tree: &'a mut ClipScrollTree,
     auxiliary_lists_map: &'a AuxiliaryListsMap,
     resource_cache: &'a mut ResourceCache,
     profile_counters: &'a mut FrameProfileCounters,
     device_pixel_ratio: f32,
     stacking_context_stack: Vec<StackingContextIndex>,
-    scroll_layer_stack: Vec<ScrollLayerIndex>,
 
     /// A cached clip info stack, which should handle the most common situation,
     /// which is that we are using the same clip info stack that we were using
     /// previously.
     current_clip_stack: Vec<(PackedLayerIndex, MaskCacheInfo)>,
 
-    /// The scroll layer that defines the previous scroll layer info stack.
-    current_clip_stack_scroll_layer: Option<ScrollLayerIndex>
+    /// Information about the cached clip stack, which is used to avoid having
+    /// to recalculate it for every primitive.
+    current_clip_info: Option<(ScrollLayerId, DeviceIntRect)>
 }
 
 impl<'a> LayerRectCalculationAndCullingPass<'a> {
     fn create_and_run(frame_builder: &'a mut FrameBuilder,
                       screen_rect: &'a DeviceIntRect,
-                      clip_scroll_tree: &'a ClipScrollTree,
+                      clip_scroll_tree: &'a mut ClipScrollTree,
                       auxiliary_lists_map: &'a AuxiliaryListsMap,
                       resource_cache: &'a mut ResourceCache,
                       profile_counters: &'a mut FrameProfileCounters,
@@ -1269,15 +1338,15 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             profile_counters: profile_counters,
             device_pixel_ratio: device_pixel_ratio,
             stacking_context_stack: Vec::new(),
-            scroll_layer_stack: Vec::new(),
             current_clip_stack: Vec::new(),
-            current_clip_stack_scroll_layer: None,
+            current_clip_info: None,
         };
         pass.run();
     }
 
     fn run(&mut self) {
         self.recalculate_clip_scroll_groups();
+        self.recalculate_clip_scroll_nodes();
         self.compute_stacking_context_visibility();
 
         let commands = mem::replace(&mut self.frame_builder.cmds, Vec::new());
@@ -1285,16 +1354,63 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             match cmd {
                 &PrimitiveRunCmd::PushStackingContext(stacking_context_index) =>
                     self.handle_push_stacking_context(stacking_context_index),
-                &PrimitiveRunCmd::PushScrollLayer(scroll_layer_index) =>
-                    self.handle_push_scroll_layer(scroll_layer_index),
                 &PrimitiveRunCmd::PrimitiveRun(prim_index, prim_count, scroll_layer_id) =>
                     self.handle_primitive_run(prim_index, prim_count, scroll_layer_id),
                 &PrimitiveRunCmd::PopStackingContext => self.handle_pop_stacking_context(),
-                &PrimitiveRunCmd::PopScrollLayer => self.handle_pop_scroll_layer(),
             }
         }
 
         mem::replace(&mut self.frame_builder.cmds, commands);
+    }
+
+    fn recalculate_clip_scroll_nodes(&mut self) {
+        for (_, ref mut node) in self.clip_scroll_tree.nodes.iter_mut() {
+            let node_clip_info = match node.node_type {
+                NodeType::Clip(ref mut clip_info) => clip_info,
+                NodeType::ReferenceFrame(_) => continue,
+            };
+
+            let packed_layer_index = node_clip_info.packed_layer_index;
+            let packed_layer = &mut self.frame_builder.packed_layers[packed_layer_index.0];
+
+            // The coordinates of the mask are relative to the origin of the node itself,
+            // so we need to account for that origin in the transformation we assign to
+            // the packed layer.
+            let transform = node.world_viewport_transform
+                                .pre_translated(node.local_viewport_rect.origin.x,
+                                                node.local_viewport_rect.origin.y,
+                                                0.0);
+            packed_layer.set_transform(transform);
+
+            // Meanwhile, the combined viewport rect is relative to the reference frame, so
+            // we move it into the local coordinate system of the node.
+            let local_viewport_rect =
+                node.combined_local_viewport_rect.translate(&-node.local_viewport_rect.origin);
+
+            node_clip_info.xf_rect = packed_layer.set_rect(Some(local_viewport_rect),
+                                                           self.screen_rect,
+                                                           self.device_pixel_ratio);
+
+            let mask_info = match node_clip_info.mask_cache_info {
+                Some(ref mut mask_info) => mask_info,
+                _ => continue,
+            };
+
+            let auxiliary_lists = self.auxiliary_lists_map.get(&node.pipeline_id)
+                                                          .expect("No auxiliary lists?");
+
+            mask_info.update(&node_clip_info.clip_source,
+                             &packed_layer.transform,
+                             &mut self.frame_builder.prim_store.gpu_data32,
+                             self.device_pixel_ratio,
+                             auxiliary_lists);
+
+            if let Some(mask) = node_clip_info.clip_source.image_mask() {
+                // We don't add the image mask for resolution, because
+                // layer masks are resolved later.
+                self.resource_cache.request_image(mask.image, ImageRendering::Auto, None);
+            }
+        }
     }
 
     fn recalculate_clip_scroll_groups(&mut self) {
@@ -1369,53 +1485,6 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         }
     }
 
-    fn handle_push_scroll_layer(&mut self, scroll_layer_index: ScrollLayerIndex) {
-        self.scroll_layer_stack.push(scroll_layer_index);
-
-        let scroll_layer = &mut self.frame_builder.scroll_layer_store[scroll_layer_index.0];
-        let node = &self.clip_scroll_tree.nodes[&scroll_layer.scroll_layer_id];
-
-        let packed_layer_index = scroll_layer.packed_layer_index;
-        let packed_layer = &mut self.frame_builder.packed_layers[packed_layer_index.0];
-
-        // The coordinates of the mask are relative to the origin of the node itself,
-        // so we need to account for that origin in the transformation we assign to
-        // the packed layer.
-        let transform = node.world_viewport_transform
-                            .pre_translated(node.local_viewport_rect.origin.x,
-                                            node.local_viewport_rect.origin.y,
-                                            0.0);
-        packed_layer.set_transform(transform);
-
-        // Meanwhile, the combined viewport rect is relative to the reference frame, so
-        // we move it into the local coordinate system of the node.
-        let local_viewport_rect =
-            node.combined_local_viewport_rect.translate(&-node.local_viewport_rect.origin);
-
-        scroll_layer.xf_rect = packed_layer.set_rect(Some(local_viewport_rect),
-                                                     self.screen_rect,
-                                                     self.device_pixel_ratio);
-
-        let clip_info = match scroll_layer.clip_cache_info {
-            Some(ref mut clip_info) => clip_info,
-            None => return,
-        };
-
-        let pipeline_id = scroll_layer.scroll_layer_id.pipeline_id;
-        let auxiliary_lists = self.auxiliary_lists_map.get(&pipeline_id)
-                                                       .expect("No auxiliary lists?");
-        clip_info.update(&scroll_layer.clip_source,
-                         &packed_layer.transform,
-                         &mut self.frame_builder.prim_store.gpu_data32,
-                         self.device_pixel_ratio,
-                         auxiliary_lists);
-
-        if let Some(mask) = scroll_layer.clip_source.image_mask() {
-            // We don't add the image mask for resolution, because layer masks are resolved later.
-            self.resource_cache.request_image(mask.image, ImageRendering::Auto, None);
-        }
-    }
-
     fn handle_push_stacking_context(&mut self, stacking_context_index: StackingContextIndex) {
         self.stacking_context_stack.push(stacking_context_index);
 
@@ -1429,33 +1498,39 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         stacking_context.bounding_rect = DeviceIntRect::zero();
     }
 
-    fn rebuild_clip_info_stack_if_necessary(&mut self, mut scroll_layer_index: ScrollLayerIndex) {
-        if let Some(previous_scroll_layer) = self.current_clip_stack_scroll_layer {
-            if previous_scroll_layer == scroll_layer_index {
-                return;
+    fn rebuild_clip_info_stack_if_necessary(&mut self, id: ScrollLayerId) -> DeviceIntRect {
+        if let Some((current_scroll_id, bounding_rect)) = self.current_clip_info {
+            if current_scroll_id == id {
+                return bounding_rect;
             }
         }
 
         // TODO(mrobinson): If we notice that this process is expensive, we can special-case
         // more common situations, such as moving from a child or a parent.
-        self.current_clip_stack_scroll_layer = Some(scroll_layer_index);
         self.current_clip_stack.clear();
-        loop {
-            let scroll_layer = &self.frame_builder.scroll_layer_store[scroll_layer_index.0];
-            match scroll_layer.clip_cache_info {
-                Some(ref clip_info) if clip_info.is_masking() =>
-                    self.current_clip_stack.push((scroll_layer.packed_layer_index,
-                                                  clip_info.clone())),
-                _ => {},
+        let mut bounding_rect = None;
+
+        let mut current_id = Some(id);
+        while let Some(id) = current_id {
+            let node = &self.clip_scroll_tree.nodes.get(&id).unwrap();
+            current_id = node.parent;
+
+            let clip_info = match node.node_type {
+                NodeType::Clip(ref clip) if clip.is_masking() => clip,
+                _ => continue,
             };
 
-            if scroll_layer.parent_index == scroll_layer_index {
-                break;
+            if bounding_rect.is_none() {
+                bounding_rect = Some(clip_info.xf_rect.as_ref().unwrap().bounding_rect);
             }
-            scroll_layer_index = scroll_layer.parent_index;
+            self.current_clip_stack.push((clip_info.packed_layer_index,
+                                          clip_info.mask_cache_info.clone().unwrap()))
         }
-
         self.current_clip_stack.reverse();
+
+        let bounding_rect = bounding_rect.unwrap_or_else(DeviceIntRect::zero);
+        self.current_clip_info = Some((id, bounding_rect));
+        bounding_rect
     }
 
     fn handle_primitive_run(&mut self,
@@ -1476,12 +1551,10 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             (clip_scroll_group.packed_layer_index, stacking_context.pipeline_id)
         };
 
-        let scroll_layer_index = *self.scroll_layer_stack.last().unwrap();
-        self.rebuild_clip_info_stack_if_necessary(scroll_layer_index);
+        let node_clip_bounds = self.rebuild_clip_info_stack_if_necessary(scroll_layer_id);
 
         let stacking_context =
             &mut self.frame_builder.stacking_context_store[stacking_context_index.0];
-
         let packed_layer = &self.frame_builder.packed_layers[packed_layer_index.0];
         let auxiliary_lists = self.auxiliary_lists_map.get(&pipeline_id)
                                                       .expect("No auxiliary lists?");
@@ -1532,12 +1605,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                     // assignment to targets.
                     let (mask_key, mask_rect) = match prim_clip_info {
                         Some(..) => (MaskCacheKey::Primitive(prim_index), prim_bounding_rect),
-                        None => {
-                            let scroll_layer =
-                                &self.frame_builder.scroll_layer_store[scroll_layer_index.0];
-                            (MaskCacheKey::ScrollLayer(scroll_layer_index),
-                             scroll_layer.xf_rect.as_ref().unwrap().bounding_rect)
-                        }
+                        None => (MaskCacheKey::ScrollLayer(scroll_layer_id), node_clip_bounds)
                     };
                     let mask_opt =
                         RenderTask::new_mask(mask_rect, mask_key, &self.current_clip_stack);
@@ -1560,9 +1628,5 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 }
             }
         }
-    }
-
-    fn handle_pop_scroll_layer(&mut self) {
-        self.scroll_layer_stack.pop();
     }
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -7,9 +7,9 @@ use mask_cache::MaskCacheInfo;
 use prim_store::{PrimitiveCacheKey, PrimitiveIndex};
 use std::{cmp, f32, i32, mem, usize};
 use tiling::{ClipScrollGroupIndex, PackedLayerIndex, RenderPass, RenderTargetIndex};
-use tiling::{ScrollLayerIndex, StackingContextIndex};
+use tiling::{StackingContextIndex};
 use webrender_traits::{DeviceIntLength, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use webrender_traits::MixBlendMode;
+use webrender_traits::{MixBlendMode, ScrollLayerId};
 
 const FLOATS_PER_RENDER_TASK_INFO: usize = 12;
 
@@ -33,7 +33,7 @@ pub enum RenderTaskKey {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum MaskCacheKey {
     Primitive(PrimitiveIndex),
-    ScrollLayer(ScrollLayerIndex),
+    ScrollLayer(ScrollLayerId),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -7,7 +7,7 @@ use fnv::FnvHasher;
 use gpu_store::GpuStoreAddress;
 use internal_types::{ANGLE_FLOAT_TO_FIXED, BatchTextures, CacheTextureId, LowLevelFilterOp};
 use internal_types::SourceTexture;
-use mask_cache::{ClipSource, MaskCacheInfo};
+use mask_cache::MaskCacheInfo;
 use prim_store::{CLIP_DATA_GPU_SIZE, DeferredResolve, GpuBlock128, GpuBlock16, GpuBlock32};
 use prim_store::{GpuBlock64, GradientData, PrimitiveCacheKey, PrimitiveGeometry, PrimitiveIndex};
 use prim_store::{PrimitiveKind, PrimitiveMetadata, PrimitiveStore, TexelRect};
@@ -391,13 +391,10 @@ pub struct ScrollbarPrimitive {
     pub border_radius: f32,
 }
 
+#[derive(Debug)]
 pub enum PrimitiveRunCmd {
     PushStackingContext(StackingContextIndex),
     PopStackingContext,
-
-    PushScrollLayer(ScrollLayerIndex),
-    PopScrollLayer,
-
     PrimitiveRun(PrimitiveIndex, usize, ScrollLayerId),
 }
 
@@ -1395,18 +1392,6 @@ impl ClipScrollGroup {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ScrollLayerIndex(pub usize);
-
-pub struct ScrollLayer {
-    pub scroll_layer_id: ScrollLayerId,
-    pub parent_index: ScrollLayerIndex,
-    pub clip_source: ClipSource,
-    pub clip_cache_info: Option<MaskCacheInfo>,
-    pub packed_layer_index: PackedLayerIndex,
-    pub xf_rect: Option<TransformedRect>,
-}
-
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct PackedLayer {
@@ -1472,13 +1457,6 @@ impl CompositeOps {
         CompositeOps {
             filters: filters,
             mix_blend_mode: mix_blend_mode
-        }
-    }
-
-    pub fn empty() -> CompositeOps {
-        CompositeOps {
-            filters: Vec::new(),
-            mix_blend_mode: None,
         }
     }
 

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -3,10 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use display_list::AuxiliaryListsBuilder;
-use {BorderRadius, ClipRegion, ColorF, ComplexClipRegion};
-use {FontKey, ImageKey, PipelineId, ScrollLayerId, ScrollLayerInfo, ServoScrollRootId};
-use {ImageMask, ItemRange};
-use {LayoutSize, LayoutPoint, LayoutRect};
+use {BorderRadius, ClipRegion, ColorF, ComplexClipRegion, FontKey, ImageKey, ImageMask, ItemRange};
+use {LayoutPoint, LayoutRect, LayoutSize};
 
 impl BorderRadius {
     pub fn zero() -> BorderRadius {
@@ -150,17 +148,5 @@ impl FontKey {
 impl ImageKey {
     pub fn new(key0: u32, key1: u32) -> ImageKey {
         ImageKey(key0, key1)
-    }
-}
-
-impl ScrollLayerId {
-    pub fn new(pipeline_id: PipelineId,
-               index: usize,
-               scroll_root_id: ServoScrollRootId)
-               -> ScrollLayerId {
-        ScrollLayerId {
-            pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Scrollable(index, scroll_root_id),
-        }
     }
 }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -51,6 +51,7 @@ pub struct DisplayListBuilder {
     pub list: Vec<DisplayItem>,
     auxiliary_lists_builder: AuxiliaryListsBuilder,
     pub pipeline_id: PipelineId,
+    scroll_layer_stack: Vec<ScrollLayerId>,
     next_scroll_layer_id: usize,
 }
 
@@ -60,7 +61,10 @@ impl DisplayListBuilder {
             list: Vec::new(),
             auxiliary_lists_builder: AuxiliaryListsBuilder::new(),
             pipeline_id: pipeline_id,
-            next_scroll_layer_id: 0,
+            scroll_layer_stack: vec![ScrollLayerId::root_scroll_layer(pipeline_id)],
+
+            // We start at 1 here, because the root scroll id is always 0.
+            next_scroll_layer_id: 1,
         }
     }
 
@@ -70,21 +74,33 @@ impl DisplayListBuilder {
         }
     }
 
+    fn push_item(&mut self, item: SpecificDisplayItem, rect: LayoutRect, clip: ClipRegion) {
+        self.list.push(DisplayItem {
+            item: item,
+            rect: rect,
+            clip: clip,
+            scroll_layer_id: *self.scroll_layer_stack.last().unwrap(),
+        });
+    }
+
+    fn push_new_empty_item(&mut self, item: SpecificDisplayItem) {
+        self.list.push(DisplayItem {
+            item: item,
+            rect: LayoutRect::zero(),
+            clip: ClipRegion::simple(&LayoutRect::zero()),
+            scroll_layer_id: *self.scroll_layer_stack.last().unwrap(),
+        });
+    }
+
     pub fn push_rect(&mut self,
                      rect: LayoutRect,
                      clip: ClipRegion,
                      color: ColorF) {
-        let item = RectangleDisplayItem {
+        let item = SpecificDisplayItem::Rectangle(RectangleDisplayItem {
             color: color,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::Rectangle(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_image(&mut self,
@@ -94,20 +110,14 @@ impl DisplayListBuilder {
                       tile_spacing: LayoutSize,
                       image_rendering: ImageRendering,
                       key: ImageKey) {
-        let item = ImageDisplayItem {
+        let item = SpecificDisplayItem::Image(ImageDisplayItem {
             image_key: key,
             stretch_size: stretch_size,
             tile_spacing: tile_spacing,
             image_rendering: image_rendering,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::Image(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_yuv_image(&mut self,
@@ -117,33 +127,23 @@ impl DisplayListBuilder {
                           u_key: ImageKey,
                           v_key: ImageKey,
                           color_space: YuvColorSpace) {
-        self.list.push(DisplayItem {
-            item: SpecificDisplayItem::YuvImage(YuvImageDisplayItem {
+        let item = SpecificDisplayItem::YuvImage(YuvImageDisplayItem {
                 y_image_key: y_key,
                 u_image_key: u_key,
                 v_image_key: v_key,
                 color_space: color_space,
-            }),
-            rect: rect,
-            clip: clip,
         });
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_webgl_canvas(&mut self,
                              rect: LayoutRect,
                              clip: ClipRegion,
                              context_id: WebGLContextId) {
-        let item = WebGLDisplayItem {
+        let item = SpecificDisplayItem::WebGL(WebGLDisplayItem {
             context_id: context_id,
-        };
-
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::WebGL(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        });
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_text(&mut self,
@@ -162,22 +162,16 @@ impl DisplayListBuilder {
         // font as a crash test - the rendering is also ignored
         // by the azure renderer.
         if size < Au::from_px(4096) {
-            let item = TextDisplayItem {
+            let item = SpecificDisplayItem::Text(TextDisplayItem {
                 color: color,
                 glyphs: self.auxiliary_lists_builder.add_glyph_instances(&glyphs),
                 font_key: font_key,
                 size: size,
                 blur_radius: blur_radius,
                 glyph_options: glyph_options,
-            };
+            });
 
-            let display_item = DisplayItem {
-                item: SpecificDisplayItem::Text(item),
-                rect: rect,
-                clip: clip,
-            };
-
-            self.list.push(display_item);
+            self.push_item(item, rect, clip);
         }
     }
 
@@ -186,18 +180,12 @@ impl DisplayListBuilder {
                        clip: ClipRegion,
                        widths: BorderWidths,
                        details: BorderDetails) {
-        let item = BorderDisplayItem {
+        let item = SpecificDisplayItem::Border(BorderDisplayItem {
             details: details,
             widths: widths,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::Border(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_box_shadow(&mut self,
@@ -210,7 +198,7 @@ impl DisplayListBuilder {
                            spread_radius: f32,
                            border_radius: f32,
                            clip_mode: BoxShadowClipMode) {
-        let item = BoxShadowDisplayItem {
+        let item = SpecificDisplayItem::BoxShadow(BoxShadowDisplayItem {
             box_bounds: box_bounds,
             offset: offset,
             color: color,
@@ -218,15 +206,9 @@ impl DisplayListBuilder {
             spread_radius: spread_radius,
             border_radius: border_radius,
             clip_mode: clip_mode,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::BoxShadow(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_gradient(&mut self,
@@ -236,20 +218,14 @@ impl DisplayListBuilder {
                          end_point: LayoutPoint,
                          stops: Vec<GradientStop>,
                          extend_mode: ExtendMode) {
-        let item = GradientDisplayItem {
+        let item = SpecificDisplayItem::Gradient(GradientDisplayItem {
             start_point: start_point,
             end_point: end_point,
             stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
             extend_mode: extend_mode,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::Gradient(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_radial_gradient(&mut self,
@@ -261,22 +237,16 @@ impl DisplayListBuilder {
                                 end_radius: f32,
                                 stops: Vec<GradientStop>,
                                 extend_mode: ExtendMode) {
-        let item = RadialGradientDisplayItem {
+        let item = SpecificDisplayItem::RadialGradient(RadialGradientDisplayItem {
             start_center: start_center,
             start_radius: start_radius,
             end_center: end_center,
             end_radius: end_radius,
             stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
             extend_mode: extend_mode,
-        };
+        });
 
-        let display_item = DisplayItem {
-            item: SpecificDisplayItem::RadialGradient(item),
-            rect: rect,
-            clip: clip,
-        };
-
-        self.list.push(display_item);
+        self.push_item(item, rect, clip);
     }
 
     pub fn push_stacking_context(&mut self,
@@ -288,33 +258,23 @@ impl DisplayListBuilder {
                                  perspective: Option<LayoutTransform>,
                                  mix_blend_mode: MixBlendMode,
                                  filters: Vec<FilterOp>) {
-        let stacking_context = StackingContext {
-            scroll_policy: scroll_policy,
-            bounds: bounds,
-            z_index: z_index,
-            transform: transform,
-            perspective: perspective,
-            mix_blend_mode: mix_blend_mode,
-            filters: self.auxiliary_lists_builder.add_filters(&filters),
-        };
+        let item = SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
+            stacking_context: StackingContext {
+                scroll_policy: scroll_policy,
+                bounds: bounds,
+                z_index: z_index,
+                transform: transform,
+                perspective: perspective,
+                mix_blend_mode: mix_blend_mode,
+                filters: self.auxiliary_lists_builder.add_filters(&filters),
+            }
+        });
 
-        let item = DisplayItem {
-            item: SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
-                stacking_context: stacking_context
-            }),
-            rect: LayoutRect::zero(),
-            clip: clip,
-        };
-        self.list.push(item);
+        self.push_item(item, LayoutRect::zero(), clip);
     }
 
     pub fn pop_stacking_context(&mut self) {
-        let item = DisplayItem {
-            item: SpecificDisplayItem::PopStackingContext,
-            rect: LayoutRect::zero(),
-            clip: ClipRegion::simple(&LayoutRect::zero()),
-        };
-        self.list.push(item);
+        self.push_new_empty_item(SpecificDisplayItem::PopStackingContext);
     }
 
     pub fn push_scroll_layer(&mut self,
@@ -324,35 +284,25 @@ impl DisplayListBuilder {
         let scroll_layer_id = self.next_scroll_layer_id;
         self.next_scroll_layer_id += 1;
 
-        let item = PushScrollLayerItem {
+        let scroll_layer_id = ScrollLayerId::new(self.pipeline_id, scroll_layer_id, scroll_root_id);
+        let item = SpecificDisplayItem::PushScrollLayer(PushScrollLayerItem {
             content_size: content_size,
-            id: ScrollLayerId::new(self.pipeline_id, scroll_layer_id, scroll_root_id),
-        };
+            id: scroll_layer_id,
+        });
 
-        let item = DisplayItem {
-            item: SpecificDisplayItem::PushScrollLayer(item),
-            rect: clip.main,
-            clip: clip,
-        };
-        self.list.push(item);
+        self.push_item(item, clip.main, clip);
+        self.scroll_layer_stack.push(scroll_layer_id);
     }
 
     pub fn pop_scroll_layer(&mut self) {
-        let item = DisplayItem {
-            item: SpecificDisplayItem::PopScrollLayer,
-            rect: LayoutRect::zero(),
-            clip: ClipRegion::simple(&LayoutRect::zero()),
-        };
-        self.list.push(item);
+        self.push_new_empty_item(SpecificDisplayItem::PopScrollLayer);
+        self.scroll_layer_stack.pop();
+        assert!(self.scroll_layer_stack.len() > 0);
     }
 
     pub fn push_iframe(&mut self, rect: LayoutRect, clip: ClipRegion, pipeline_id: PipelineId) {
-        let item = DisplayItem {
-            item: SpecificDisplayItem::Iframe(IframeDisplayItem { pipeline_id: pipeline_id }),
-            rect: rect,
-            clip: clip,
-        };
-        self.list.push(item);
+        let item = SpecificDisplayItem::Iframe(IframeDisplayItem { pipeline_id: pipeline_id });
+        self.push_item(item, rect, clip);
     }
 
     pub fn new_clip_region(&mut self,

--- a/webrender_traits/src/types.rs
+++ b/webrender_traits/src/types.rs
@@ -414,6 +414,7 @@ pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: LayoutRect,
     pub clip: ClipRegion,
+    pub scroll_layer_id: ScrollLayerId,
 }
 
 #[repr(C)]
@@ -840,6 +841,23 @@ impl ScrollLayerId {
         match self.info {
             ScrollLayerInfo::Scrollable(_, scroll_root_id) => Some(scroll_root_id),
             ScrollLayerInfo::ReferenceFrame(..) => None,
+        }
+    }
+
+    pub fn is_reference_frame(&self) -> bool {
+        match self.info {
+            ScrollLayerInfo::Scrollable(..) => false,
+            ScrollLayerInfo::ReferenceFrame(..) => true,
+        }
+    }
+
+    pub fn new(pipeline_id: PipelineId,
+               index: usize,
+               scroll_root_id: ServoScrollRootId)
+               -> ScrollLayerId {
+        ScrollLayerId {
+            pipeline_id: pipeline_id,
+            info: ScrollLayerInfo::Scrollable(index, scroll_root_id),
         }
     }
 }


### PR DESCRIPTION
Allow assigning a ScrollLayerId directly to a primitive. In the future,
this will allow API users to assign primitive to arbitrary scroll
layers. As part of this work we collapse the scroll_layer_store in
FrameBuilder into the ClipScrollTree itself, making the architecture
a bit less complicated. The biggest potential change here is that
changing between clipping layers requires HashMap lookups instead of
array indexing. If this proves to be a performance issue, it is
possible to optimize this code at the cost of simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/959)
<!-- Reviewable:end -->
