### PR TITLE
Properly skip invisible stacking contexts

### DIFF
--- a/wrench/reftests/filters/invisible-ref.yaml
+++ b/wrench/reftests/filters/invisible-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 50, 50]
+      color: green

--- a/wrench/reftests/filters/invisible.yaml
+++ b/wrench/reftests/filters/invisible.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    - type: stacking_context
+      bounds: [0, 0, 100, 100]
+      filters: opacity(0.0),
+      items:
+      - type: stacking_context
+        bounds: [0, 0, 100, 100]
+        items:
+        - type: stacking_context
+          bounds: [0, 0, 100, 100]
+          items:
+          - type: stacking_context
+            bounds: [0, 0, 100, 100]
+            items:
+            - type: stacking_context
+              bounds: [0, 0, 100, 100]
+              items:
+              - type: rect
+                bounds: [70, 70, 50, 50]
+                color: green
+    # This display item ensures that the stacking context is skipped, but
+    # later items are not.
+    - type: rect
+      bounds: [10, 10, 50, 50]
+      color: green

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -1,2 +1,3 @@
 == filter-grayscale.yaml filter-grayscale-ref.yaml
 == isolated.yaml isolated-ref.yaml
+== invisible.yaml invisible-ref.yaml


### PR DESCRIPTION
Previously, we tried to skip invisible stacking contexts, but the logic
for that was very broken, because it did not take into account nested
stacking contexts. We fix that issue as well as removing code for
skipping empty scroll layers (which could never work for properly
formed display lists). Finally, we add a test for this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/967)
<!-- Reviewable:end -->
