### PR TITLE
Add a benchmarking module to wrench.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,8 @@ dependencies = [
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.22.1",

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -24,6 +24,8 @@ osmesa-sys = { version = "0.1.2", optional = true }
 osmesa-src = { git = "https://github.com/servo/osmesa-src", optional = true }
 webrender = {path = "../webrender"}
 webrender_traits = {path = "../webrender_traits"}
+serde_derive = "0.9"
+serde = "0.9"
 
 [features]
 headless = [ "osmesa-sys", "osmesa-src" ]

--- a/wrench/benchmarks/benchmarks.list
+++ b/wrench/benchmarks/benchmarks.list
@@ -1,0 +1,3 @@
+simple-batching.yaml
+large-clip-rect.yaml
+

--- a/wrench/benchmarks/large-clip-rect.yaml
+++ b/wrench/benchmarks/large-clip-rect.yaml
@@ -1,0 +1,59 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16
+        - type: rect
+          bounds: [0, 0, 1024, 1024]
+          color: red
+          clip:
+            complex:
+              - rect: [0, 0, 1024, 1024]
+                radius: 16

--- a/wrench/benchmarks/simple-batching.yaml
+++ b/wrench/benchmarks/simple-batching.yaml
@@ -1,0 +1,45 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green
+        - type: rect
+          bounds: [0, 0, 512, 512]
+          color: green

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -103,3 +103,21 @@ subcommands:
               help: a specific reftest or directory to run
               required: false
               index: 1
+    - perf:
+        about: run benchmarks
+        args:
+          - filename:
+              help: name of the file to save benchmarks to
+              required: true
+              index: 1
+    - compare_perf:
+        about: compare two benchmark files
+        args:
+          - first_filename:
+              help: first benchmark file to compare
+              required: true
+              index: 1
+          - second_filename:
+              help: second benchmark file to compare
+              required: true
+              index: 2

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -21,6 +21,8 @@ extern crate image;
 extern crate lazy_static;
 #[cfg(feature = "headless")]
 extern crate osmesa_sys;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate time;
 extern crate webrender;
@@ -30,6 +32,7 @@ extern crate yaml_rust;
 mod binary_frame_reader;
 mod json_frame_writer;
 mod parse_function;
+mod perf;
 mod png;
 mod reftest;
 mod scene;
@@ -43,6 +46,7 @@ use gleam::gl;
 use glutin::{ElementState, VirtualKeyCode, WindowProxy};
 use image::ColorType;
 use image::png::PNGEncoder;
+use perf::PerfHarness;
 use reftest::ReftestHarness;
 use std::cmp::{max, min};
 #[cfg(feature = "headless")]
@@ -323,6 +327,17 @@ fn main() {
             let base_manifest = Path::new("reftests/reftest.list");
             let specific_reftest = subargs.value_of("REFTEST").map(|x| Path::new(x));
             harness.run(&base_manifest, specific_reftest);
+            return;
+        } else if let Some(subargs) = args.subcommand_matches("perf") {
+            let harness = PerfHarness::new(&mut wrench, &mut window);
+            let base_manifest = Path::new("benchmarks/benchmarks.list");
+            let filename = subargs.value_of("filename").unwrap();
+            harness.run(&base_manifest, filename);
+            return;
+        } else if let Some(subargs) = args.subcommand_matches("compare_perf") {
+            let first_filename = subargs.value_of("first_filename").unwrap();
+            let second_filename = subargs.value_of("second_filename").unwrap();
+            perf::compare(first_filename, second_filename);
             return;
         } else {
             panic!("Should never have gotten here");

--- a/wrench/src/perf.rs
+++ b/wrench/src/perf.rs
@@ -1,0 +1,281 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use WindowWrapper;
+use serde_json;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use webrender_traits::*;
+use wrench::{Wrench, WrenchThing};
+use yaml_frame_reader::YamlFrameReader;
+
+const COLOR_DEFAULT: &'static str = "\x1b[0m";
+const COLOR_RED: &'static str = "\x1b[31m";
+const COLOR_GREEN: &'static str = "\x1b[32m";
+const COLOR_MAGENTA: &'static str = "\x1b[95m";
+
+pub struct Benchmark {
+    pub test: PathBuf,
+}
+
+pub struct BenchmarkManifest {
+    pub benchmarks: Vec<Benchmark>,
+}
+
+impl BenchmarkManifest {
+    pub fn new(manifest: &Path) -> BenchmarkManifest {
+        let dir = manifest.parent().unwrap();
+        let f = File::open(manifest).expect(&format!("couldn't open manifest: {}", manifest.display()));
+        let file = BufReader::new(&f);
+
+        let mut benchmarks = Vec::new();
+
+        for line in file.lines() {
+            let l = line.unwrap();
+
+            // strip the comments
+            let s = &l[0..l.find("#").unwrap_or(l.len())];
+            let s = s.trim();
+            if s.len() == 0 {
+                continue;
+            }
+
+            let mut items = s.split_whitespace();
+
+            match items.next() {
+                Some("include") => {
+                    let include = dir.join(items.next().unwrap());
+
+                    benchmarks.append(&mut BenchmarkManifest::new(include.as_path()).benchmarks);
+                }
+                Some(name) => {
+                    let test = dir.join(name);
+                    benchmarks.push(Benchmark {
+                        test: test,
+                    });
+                }
+                _ => panic!(),
+            };
+        }
+
+        BenchmarkManifest {
+            benchmarks: benchmarks
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TestProfile {
+    name: String,
+    composite_time_ns: u64,
+    paint_time_ns: u64,
+    draw_calls: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Profile {
+    tests: Vec<TestProfile>,
+}
+
+impl Profile {
+    fn new() -> Profile {
+        Profile {
+            tests: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, profile: TestProfile) {
+        self.tests.push(profile);
+    }
+
+    fn save(&self, filename: &str) {
+        let mut file = File::create(&filename).unwrap();
+        let s = serde_json::to_string_pretty(self).unwrap();
+        file.write_all(&s.into_bytes()).unwrap();
+        file.write_all(b"\n").unwrap();
+    }
+
+    fn load(filename: &str) -> Profile {
+        let mut file = File::open(&filename).unwrap();
+        let mut string = String::new();
+        file.read_to_string(&mut string).unwrap();
+        serde_json::from_str(&string).expect("Unable to load profile!")
+    }
+
+    fn build_set_and_map_of_tests(&self) -> (HashSet<String>, HashMap<String, TestProfile>) {
+        let mut hash_set = HashSet::new();
+        let mut hash_map = HashMap::new();
+
+        for test in &self.tests {
+            hash_set.insert(test.name.clone());
+            hash_map.insert(test.name.clone(), test.clone());
+        }
+
+        (hash_set, hash_map)
+    }
+}
+
+pub struct PerfHarness<'a> {
+    wrench: &'a mut Wrench,
+    window: &'a mut WindowWrapper,
+    rx: Receiver<()>,
+}
+
+impl<'a> PerfHarness<'a> {
+    pub fn new(wrench: &'a mut Wrench,
+               window: &'a mut WindowWrapper) -> PerfHarness<'a>
+    {
+        // setup a notifier so we can wait for frames to be finished
+        struct Notifier {
+            tx: Sender<()>,
+        };
+        impl RenderNotifier for Notifier {
+            fn new_frame_ready(&mut self) {
+                self.tx.send(()).unwrap();
+            }
+            fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
+        }
+        let (tx, rx) = channel();
+        wrench.renderer.set_render_notifier(Box::new(Notifier { tx: tx }));
+
+        PerfHarness {
+            wrench: wrench,
+            window: window,
+            rx: rx,
+        }
+    }
+
+    pub fn run(mut self, base_manifest: &Path, filename: &str) {
+        let manifest = BenchmarkManifest::new(base_manifest);
+
+        let mut profile = Profile::new();
+
+        for t in manifest.benchmarks {
+            let stats = self.render_yaml(t.test.as_path());
+            profile.add(stats);
+        }
+
+        profile.save(filename);
+    }
+
+    fn render_yaml(&mut self, filename: &Path) -> TestProfile {
+        let mut reader = YamlFrameReader::new(filename);
+        reader.do_frame(self.wrench);
+
+        // wait for the frame
+        self.rx.recv().unwrap();
+
+        // Loop until we get a reasonable number of CPU and GPU
+        // frame profiles. Then take the mean.
+        let mut cpu_frame_profiles = Vec::new();
+        let mut gpu_frame_profiles = Vec::new();
+
+        while cpu_frame_profiles.len() < 10 ||
+              gpu_frame_profiles.len() < 10 {
+            self.wrench.render();
+            self.window.swap_buffers();
+            let (cpu_profiles, gpu_profiles) = self.wrench.get_frame_profiles();
+            cpu_frame_profiles.extend(cpu_profiles);
+            gpu_frame_profiles.extend(gpu_profiles);
+        }
+
+        // Ensure the draw calls match in every sample.
+        let draw_calls = cpu_frame_profiles[0].draw_calls;
+        assert!(cpu_frame_profiles.iter().all(|s| s.draw_calls == draw_calls));
+
+        cpu_frame_profiles.sort_by_key(|a| a.composite_time_ns);
+        gpu_frame_profiles.sort_by_key(|a| a.paint_time_ns);
+
+        // Remove the two slowest and fastest frames.
+        let cpu_samples = &cpu_frame_profiles[2..cpu_frame_profiles.len() - 2];
+        let gpu_samples = &gpu_frame_profiles[2..gpu_frame_profiles.len() - 2];
+
+        // Use the mean value from the remaining frames.
+        let composite_time: u64 = cpu_samples.iter()
+                                             .map(|s| s.composite_time_ns)
+                                             .sum();
+        let paint_time: u64 = gpu_samples.iter()
+                                         .map(|s| s.paint_time_ns)
+                                         .sum();
+
+        TestProfile {
+            name: filename.to_str().unwrap().to_string(),
+            composite_time_ns: composite_time / cpu_samples.len() as u64,
+            paint_time_ns: paint_time / gpu_samples.len() as u64,
+            draw_calls: draw_calls,
+        }
+    }
+}
+
+fn select_color(base: f32, value: f32) -> &'static str {
+    let tolerance = base * 0.1;
+    if (value - base).abs() < tolerance {
+        COLOR_DEFAULT
+    } else if value > base {
+        COLOR_RED
+    } else {
+        COLOR_GREEN
+    }
+}
+
+pub fn compare(first_filename: &str, second_filename: &str) {
+    let profile0 = Profile::load(first_filename);
+    let profile1 = Profile::load(second_filename);
+
+    let (set0, map0) = profile0.build_set_and_map_of_tests();
+    let (set1, map1) = profile1.build_set_and_map_of_tests();
+
+    println!("+------------------------------------------------+--------------+------------------+------------------+");
+    println!("|  Test name                                     | Draw Calls   | Composite (ms)   | Paint (ms)       |");
+    println!("+------------------------------------------------+--------------+------------------+------------------+");
+
+    for test_name in set0.symmetric_difference(&set1) {
+        println!("| {}{:47}{}|{:14}|{:18}|{:18}|", COLOR_MAGENTA, test_name, COLOR_DEFAULT, " -", " -", " -");
+    }
+
+    for test_name in set0.intersection(&set1) {
+        let test0 = &map0[test_name];
+        let test1 = &map1[test_name];
+
+        let composite_time0 = test0.composite_time_ns as f32 / 1000000.0;
+        let composite_time1 = test1.composite_time_ns as f32 / 1000000.0;
+
+        let paint_time0 = test0.paint_time_ns as f32 / 1000000.0;
+        let paint_time1 = test1.paint_time_ns as f32 / 1000000.0;
+
+        let draw_calls_color = if test0.draw_calls == test1.draw_calls {
+            COLOR_DEFAULT
+        } else if test0.draw_calls > test1.draw_calls {
+            COLOR_GREEN
+        } else {
+            COLOR_RED
+        };
+
+        let composite_time_color = select_color(composite_time0, composite_time1);
+        let paint_time_color = select_color(paint_time0, paint_time1);
+
+        let draw_call_string = format!(" {} -> {}", test0.draw_calls, test1.draw_calls);
+        let composite_time_string = format!(" {:.2} -> {:.2}", composite_time0,
+                                                               composite_time1);
+        let paint_time_string = format!(" {:.2} -> {:.2}", paint_time0,
+                                                           paint_time1);
+
+        println!("| {:47}|{}{:14}{}|{}{:18}{}|{}{:18}{}|", test_name,
+                                                           draw_calls_color,
+                                                           draw_call_string,
+                                                           COLOR_DEFAULT,
+                                                           composite_time_color,
+                                                           composite_time_string,
+                                                           COLOR_DEFAULT,
+                                                           paint_time_color,
+                                                           paint_time_string,
+                                                           COLOR_DEFAULT);
+    }
+
+    println!("+------------------------------------------------+--------------+------------------+------------------+");
+}

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use time;
 use webrender;
+use webrender::renderer::{CpuProfile, GpuProfile};
 use webrender_traits::*;
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use yaml_rust::Yaml;
@@ -169,6 +170,7 @@ impl Wrench {
             recorder: recorder,
             enable_subpixel_aa: subpixel_aa,
             debug: debug,
+            max_recorded_profiles: 16,
             .. Default::default()
         };
 
@@ -374,6 +376,10 @@ impl Wrench {
         }
 
         self.api.generate_frame(None);
+    }
+
+    pub fn get_frame_profiles(&mut self) -> (Vec<CpuProfile>, Vec<GpuProfile>) {
+        self.renderer.get_frame_profiles()
     }
 
     pub fn render(&mut self) {


### PR DESCRIPTION
This adds two new commands to wrench:

perf - This runs all the benchmarks in the benchmarks manifest, and records
the timing of various profile counters into a JSON file. This is
very similar to how the reftest code works.

compare_perf - This allows comparing two files output from the perf command above.

There are two new workflows enabled by this change:

(1) Working locally:
 - Run `perf` to get a baseline benchmark.
 - Develop new feature or optimization.
 - Run `perf` to get new results, and use `compare_perf` to compare to baseline.

(2) Automated performance measurement:
 - This is not available yet, but the idea is to upload the results
   of the perf command to a web server, which graphs the results
   over time.

New benchmarks can be added to the benchmarks/ directory, in a similar
way to adding reftests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/969)
<!-- Reviewable:end -->
