### PR TITLE
Use gpu_resource_rects for yuv image.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -625,12 +625,9 @@ struct YuvImage {
 YuvImage fetch_yuv_image(int index) {
     YuvImage image;
 
-    ivec2 uv = get_fetch_uv_4(index);
+    ivec2 uv = get_fetch_uv_1(index);
 
-    image.y_st_rect = texelFetchOffset(sData64, uv, 0, ivec2(0, 0));
-    image.u_st_rect = texelFetchOffset(sData64, uv, 0, ivec2(1, 0));
-    image.v_st_rect = texelFetchOffset(sData64, uv, 0, ivec2(2, 0));
-    vec4 size_color_space = texelFetchOffset(sData64, uv, 0, ivec2(3, 0));
+    vec4 size_color_space = texelFetchOffset(sData16, uv, 0, ivec2(0, 0));
     image.size = size_color_space.xy;
     image.color_space = int(size_color_space.z);
 

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -23,20 +23,23 @@ void main(void) {
 #endif
 
     YuvImage image = fetch_yuv_image(prim.prim_index);
+    ResourceRect y_rect = fetch_resource_rect(prim.user_data.x);
+    ResourceRect u_rect = fetch_resource_rect(prim.user_data.x + 1);
+    ResourceRect v_rect = fetch_resource_rect(prim.user_data.x + 2);
 
     vec2 y_texture_size = vec2(textureSize(sColor0, 0));
-    vec2 y_st0 = image.y_st_rect.xy / y_texture_size;
-    vec2 y_st1 = image.y_st_rect.zw / y_texture_size;
+    vec2 y_st0 = y_rect.uv_rect.xy / y_texture_size;
+    vec2 y_st1 = y_rect.uv_rect.zw / y_texture_size;
 
     vTextureSizeY = y_st1 - y_st0;
     vTextureOffsetY = y_st0;
 
     vec2 uv_texture_size = vec2(textureSize(sColor1, 0));
-    vec2 u_st0 = image.u_st_rect.xy / uv_texture_size;
-    vec2 u_st1 = image.u_st_rect.zw / uv_texture_size;
+    vec2 u_st0 = u_rect.uv_rect.xy / uv_texture_size;
+    vec2 u_st1 = u_rect.uv_rect.zw / uv_texture_size;
 
-    vec2 v_st0 = image.v_st_rect.xy / uv_texture_size;
-    vec2 v_st1 = image.v_st_rect.zw / uv_texture_size;
+    vec2 v_st0 = v_rect.uv_rect.xy / uv_texture_size;
+    vec2 v_st1 = v_rect.uv_rect.zw / uv_texture_size;
 
     // This assumes the U and V surfaces have the same size.
     vTextureSizeUv = u_st1 - u_st0;

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -965,12 +965,9 @@ impl FrameBuilder {
                          color_space: YuvColorSpace) {
 
         let prim_cpu = YuvImagePrimitiveCpu {
-            y_key: y_image_key,
-            u_key: u_image_key,
-            v_key: v_image_key,
-            y_texture_id: SourceTexture::Invalid,
-            u_texture_id: SourceTexture::Invalid,
-            v_texture_id: SourceTexture::Invalid,
+            yuv_key: [y_image_key, u_image_key, v_image_key],
+            yuv_texture_id: [SourceTexture::Invalid, SourceTexture::Invalid, SourceTexture::Invalid],
+            yuv_resource_address: GpuStoreAddress(0),
         };
 
         let prim_gpu = YuvImagePrimitiveGpu::new(rect.size, color_space);

--- a/webrender/src/gpu_store.rs
+++ b/webrender/src/gpu_store.rs
@@ -5,10 +5,20 @@
 use device::TextureFilter;
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::Add;
 use webrender_traits::ImageFormat;
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct GpuStoreAddress(pub i32);
+
+
+impl Add<i32> for GpuStoreAddress {
+    type Output = GpuStoreAddress;
+
+    fn add(self, other: i32) -> GpuStoreAddress {
+        GpuStoreAddress(self.0 + other)
+    }
+}
 
 pub trait GpuStoreLayout {
     fn image_format() -> ImageFormat;

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -105,7 +105,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
             }
             PrimitiveKind::YuvImage => {
                 let image_cpu = &self.cpu_yuv_images[metadata.cpu_prim_index.0];
-                [image_cpu.y_texture_id, image_cpu.u_texture_id, image_cpu.v_texture_id]
+                image_cpu.yuv_texture_id
             }
             PrimitiveKind::TextRun => {
                 let text_run_cpu = &self.cpu_text_runs[metadata.cpu_prim_index.0];
@@ -277,6 +277,8 @@ impl AlphaBatchHelpers for PrimitiveStore {
                         });
                     }
                     AlphaBatchKind::YuvImage => {
+                        let image_yuv_cpu = &self.cpu_yuv_images[metadata.cpu_prim_index.0];
+
                         data.push(PrimitiveInstance {
                             task_index: task_index,
                             clip_task_index: clip_task_index,
@@ -284,7 +286,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
                             global_prim_id: global_prim_id,
                             prim_address: prim_address,
                             sub_index: 0,
-                            user_data: [ 0, 0 ],
+                            user_data: [ image_yuv_cpu.yuv_resource_address.0, 0 ],
                             z_sort_index: z_sort_index,
                         });
                     }


### PR DESCRIPTION
@nical @glennw 
This is the initial work for #952.
Remove the usage of gpu64 data. Turn to use gpu_resource_rects for yuv uv coordinates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/970)
<!-- Reviewable:end -->
