### PR TITLE
Move ServoScrollRootId to ClipInfo and make it optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.22.1",
- "webrender_traits 0.23.1",
+ "webrender 0.23.0",
+ "webrender_traits 0.24.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1149,12 +1149,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.23.1",
+ "webrender_traits 0.24.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1213,8 +1213,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.22.1",
- "webrender_traits 0.23.1",
+ "webrender 0.23.0",
+ "webrender_traits 0.24.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -13,7 +13,7 @@ use util::TransformedRect;
 use webrender_traits::{ClipRegion, LayerPixel, LayerPoint, LayerRect, LayerSize};
 use webrender_traits::{LayerToScrollTransform, LayerToWorldTransform, PipelineId};
 use webrender_traits::{ScrollEventPhase, ScrollLayerId, ScrollLayerRect, ScrollLocation};
-use webrender_traits::{WorldPoint, WorldPoint4D};
+use webrender_traits::{ServoScrollRootId, WorldPoint, WorldPoint4D};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -38,12 +38,17 @@ pub struct ClipInfo {
     /// which depends on the screen rectangle and the transformation of all of
     /// the parents.
     pub xf_rect: Option<TransformedRect>,
+
+    /// An external identifier that is used to scroll this clipping node
+    /// from the API.
+    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 impl ClipInfo {
     pub fn new(clip_region: &ClipRegion,
                clip_store: &mut VertexDataStore<GpuBlock32>,
-               packed_layer_index: PackedLayerIndex)
+               packed_layer_index: PackedLayerIndex,
+               scroll_root_id: Option<ServoScrollRootId>)
                -> ClipInfo {
         // We pass true here for the MaskCacheInfo because this type of
         // mask needs an extra clip for the clip rectangle.
@@ -53,6 +58,7 @@ impl ClipInfo {
             clip_source: clip_source,
             packed_layer_index: packed_layer_index,
             xf_rect: None,
+            scroll_root_id: scroll_root_id,
         }
     }
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -32,7 +32,8 @@ use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, DeviceIntPoint, De
 use webrender_traits::{DeviceIntSize, DeviceUintRect, DeviceUintSize, ExtendMode, FontKey};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
 use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
-use webrender_traits::{RepeatMode, ScrollLayerId, TileOffset, WebGLContextId, YuvColorSpace};
+use webrender_traits::{RepeatMode, ScrollLayerId, ServoScrollRootId, TileOffset, WebGLContextId};
+use webrender_traits::YuvColorSpace;
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -307,6 +308,7 @@ impl FrameBuilder {
                                    pipeline_id,
                                    &viewport_rect,
                                    content_size,
+                                   Some(ServoScrollRootId(0)),
                                    &ClipRegion::simple(&viewport_rect),
                                    clip_scroll_tree);
         topmost_scroll_layer_id
@@ -318,11 +320,13 @@ impl FrameBuilder {
                                  pipeline_id: PipelineId,
                                  local_viewport_rect: &LayerRect,
                                  content_size: &LayerSize,
+                                 scroll_root_id: Option<ServoScrollRootId>,
                                  clip_region: &ClipRegion,
                                  clip_scroll_tree: &mut ClipScrollTree) {
         let clip_info = ClipInfo::new(clip_region,
                                       &mut self.prim_store.gpu_data32,
-                                      PackedLayerIndex(self.packed_layers.len()));
+                                      PackedLayerIndex(self.packed_layers.len()),
+                                      scroll_root_id);
         let node = ClipScrollNode::new(pipeline_id,
                                        parent_id,
                                        local_viewport_rect,

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -268,6 +268,7 @@ pub enum FilterOp {
 pub struct PushScrollLayerItem {
     pub content_size: LayoutSize,
     pub id: ScrollLayerId,
+    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -498,7 +499,7 @@ impl ScrollLayerId {
     pub fn root_scroll_layer(pipeline_id: PipelineId) -> ScrollLayerId {
         ScrollLayerId {
             pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Scrollable(0, ServoScrollRootId(0)),
+            info: ScrollLayerInfo::Scrollable(0),
         }
     }
 
@@ -509,13 +510,6 @@ impl ScrollLayerId {
         }
     }
 
-    pub fn scroll_root_id(&self) -> Option<ServoScrollRootId> {
-        match self.info {
-            ScrollLayerInfo::Scrollable(_, scroll_root_id) => Some(scroll_root_id),
-            ScrollLayerInfo::ReferenceFrame(..) => None,
-        }
-    }
-
     pub fn is_reference_frame(&self) -> bool {
         match self.info {
             ScrollLayerInfo::Scrollable(..) => false,
@@ -523,19 +517,16 @@ impl ScrollLayerId {
         }
     }
 
-    pub fn new(pipeline_id: PipelineId,
-               index: usize,
-               scroll_root_id: ServoScrollRootId)
-               -> ScrollLayerId {
+    pub fn new(pipeline_id: PipelineId, index: usize) -> ScrollLayerId {
         ScrollLayerId {
             pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Scrollable(index, scroll_root_id),
+            info: ScrollLayerInfo::Scrollable(index),
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ScrollLayerInfo {
-    Scrollable(usize, ServoScrollRootId),
+    Scrollable(usize),
     ReferenceFrame(usize),
 }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -318,14 +318,15 @@ impl DisplayListBuilder {
     pub fn push_scroll_layer(&mut self,
                              clip: ClipRegion,
                              content_size: LayoutSize,
-                             scroll_root_id: ServoScrollRootId) {
+                             scroll_root_id: Option<ServoScrollRootId>) {
         let scroll_layer_id = self.next_scroll_layer_id;
         self.next_scroll_layer_id += 1;
 
-        let scroll_layer_id = ScrollLayerId::new(self.pipeline_id, scroll_layer_id, scroll_root_id);
+        let scroll_layer_id = ScrollLayerId::new(self.pipeline_id, scroll_layer_id);
         let item = SpecificDisplayItem::PushScrollLayer(PushScrollLayerItem {
             content_size: content_size,
             id: scroll_layer_id,
+            scroll_root_id: scroll_root_id,
         });
 
         self.push_item(item, clip.main, clip);

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -499,7 +499,7 @@ impl YamlFrameReader {
             *entry = LayerPoint::new(size.x, size.y);
         }
 
-        self.builder().push_scroll_layer(clip, content_size, scroll_root_id);
+        self.builder().push_scroll_layer(clip, content_size, Some(scroll_root_id));
 
         if !yaml["items"].is_badvalue() {
             self.add_display_list_items_from_yaml(wrench, &yaml["items"]);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -196,9 +196,9 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
 
 fn write_scroll_layer(parent: &mut Table, scroll_layer: &PushScrollLayerItem) {
     size_node(parent, "content-size", &scroll_layer.content_size);
-    match scroll_layer.id.info {
-        ScrollLayerInfo::Scrollable(_, id) => usize_node(parent, "id", id.0),
-        ScrollLayerInfo::ReferenceFrame(..) => unreachable!("Scroll layer had reference frame id"),
+    match scroll_layer.scroll_root_id {
+        Some(id) => usize_node(parent, "id", id.0),
+        None => {}
     }
 }
 


### PR DESCRIPTION
This will make it easier to write ScrollLayerIds in wrench, which is
necessary for exposing arbitrary clip node selection in the API. It
will also eventually allow us to more naturally generate ScrollLayerIds
for both reference frame and clip nodes at the same time, eliminating
the distinction in the ScrollLayerId itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/971)
<!-- Reviewable:end -->
