### PR TITLE
Implement repetition and spacing for tiled images.

### DIFF
--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -1,4 +1,4 @@
 == tile-size.yaml tile-size-ref.yaml
 == very-big.yaml very-big-ref.yaml
 == tile-with-spacing.yaml tile-with-spacing-ref.yaml
-== tile-repeat-prim-or-decompose.yaml tile-repeat-prim-or-decompose-ref.yaml
+fuzzy(1,250000) == tile-repeat-prim-or-decompose.yaml tile-repeat-prim-or-decompose-ref.yaml

--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -1,2 +1,4 @@
 == tile-size.yaml tile-size-ref.yaml
 == very-big.yaml very-big-ref.yaml
+== tile-with-spacing.yaml tile-with-spacing-ref.yaml
+== tile-repeat-prim-or-decompose.yaml tile-repeat-prim-or-decompose-ref.yaml

--- a/wrench/reftests/image/tile-repeat-prim-or-decompose-ref.yaml
+++ b/wrench/reftests/image/tile-repeat-prim-or-decompose-ref.yaml
@@ -1,0 +1,8 @@
+root:
+  items:
+    - image: xy_gradient(500, 50)
+      bounds: 0 0 800 800
+      stretch_size: 50 50
+    - image: xy_gradient(50, 500)
+      bounds: 800 0 800 800
+      stretch_size: 50 50

--- a/wrench/reftests/image/tile-repeat-prim-or-decompose.yaml
+++ b/wrench/reftests/image/tile-repeat-prim-or-decompose.yaml
@@ -1,0 +1,17 @@
+# This test aims at exercising the different ways we handle repetition of tiled images.
+root:
+  items:
+    # This should cause the primitive repetition to be decomposed on the cpu along the x axis
+    # but perform the repetition along the y axis on the image shader because the image width
+    # fits within the tile size.
+    - image: xy_gradient(500, 50)
+      bounds: 0 0 800 800
+      stretch_size: 50 50
+      tile-size: 50
+    # This should cause the primitive repetition to be decomposed on the cpu along the y axis
+    # but perform the repetition along the x axis in the image shader because the image height
+    # fits within the tile size.
+    - image: xy_gradient(50, 500)
+      bounds: 800 0 800 800
+      stretch_size: 50 50
+      tile-size: 50

--- a/wrench/reftests/image/tile-with-spacing-ref.yaml
+++ b/wrench/reftests/image/tile-with-spacing-ref.yaml
@@ -1,0 +1,6 @@
+root:
+  items:
+    - image: solid_color(255, 0, 0, 255, 300, 300)
+      bounds: 0 0 800 800
+      stretch_size: 200 200
+      tile_spacing: 10 10

--- a/wrench/reftests/image/tile-with-spacing.yaml
+++ b/wrench/reftests/image/tile-with-spacing.yaml
@@ -1,0 +1,12 @@
+root:
+  items:
+    # TODO: This test would be more useful if we used an image with variations instead
+    # of a solid color. To do this we first need to change the way pixel snapping is
+    # applied so that when an image is split into several primitives, so that the latter
+    # all get snapped the same way rather than independently.
+    #- image: xy_gradient(300, 300)
+    - image: solid_color(255, 0, 0, 255, 300, 300)
+      bounds: 0 0 800 800
+      stretch_size: 200 200
+      tile_spacing: 10 10
+      tile-size: 64


### PR DESCRIPTION
Followup of PR #897. This should cover the all of the remaining cases when rendering tiled images (image display item specifically).
If the image is tiled and repeated along the same dimension it is decomposed into a primitive for each repetition, taking spacing into account. These primitives are then split in a per tile basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/972)
<!-- Reviewable:end -->
