### PR TITLE
Allow API clients to specify arbitrary clip primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_derive 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.23.0",
- "webrender_traits 0.24.0",
+ "webrender 0.24.0",
+ "webrender_traits 0.25.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1149,12 +1149,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.24.0",
+ "webrender_traits 0.25.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1213,8 +1213,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.23.0",
- "webrender_traits 0.24.0",
+ "webrender 0.24.0",
+ "webrender_traits 0.25.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -15,10 +15,10 @@ use scene::{Scene, SceneProperties};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
-use webrender_traits::{AuxiliaryLists, ClipRegion, ColorF, DeviceUintRect, DeviceUintSize};
-use webrender_traits::{DisplayItem, Epoch, FilterOp, ImageDisplayItem, LayerPoint, LayerRect};
-use webrender_traits::{LayerSize, LayerToScrollTransform, LayoutTransform, MixBlendMode};
-use webrender_traits::{PipelineId, PushScrollLayerItem, ScrollEventPhase, ScrollLayerId};
+use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipRegion, ColorF, DeviceUintRect};
+use webrender_traits::{DeviceUintSize, DisplayItem, Epoch, FilterOp, ImageDisplayItem, LayerPoint};
+use webrender_traits::{LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
+use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerId};
 use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, ServoScrollRootId};
 use webrender_traits::{SpecificDisplayItem, StackingContext, TileOffset, WorldPoint};
 
@@ -335,34 +335,23 @@ impl Frame {
         self.clip_scroll_tree.finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
     }
 
-    fn flatten_scroll_layer<'a>(&mut self,
-                                traversal: &mut DisplayListTraversal<'a>,
-                                pipeline_id: PipelineId,
-                                context: &mut FlattenContext,
-                                reference_frame_relative_offset: LayerPoint,
-                                level: i32,
-                                clip: &ClipRegion,
-                                item: &PushScrollLayerItem) {
-        let parent_id = context.builder.current_clip_scroll_node_id();
-        let parent_id = context.scroll_layer_id_with_replacement(parent_id);
-
+    fn flatten_clip<'a>(&mut self,
+                        context: &mut FlattenContext,
+                        pipeline_id: PipelineId,
+                        parent_id: ScrollLayerId,
+                        item: &ClipDisplayItem,
+                        reference_frame_relative_offset: LayerPoint,
+                        clip: &ClipRegion) {
         let clip_rect = clip.main.translate(&reference_frame_relative_offset);
-        context.builder.push_clip_scroll_node(item.id,
-                                              parent_id,
-                                              pipeline_id,
-                                              &clip_rect,
-                                              &item.content_size,
-                                              item.scroll_root_id,
-                                              clip,
-                                              &mut self.clip_scroll_tree);
+        context.builder.add_clip_scroll_node(item.id,
+                                             parent_id,
+                                             pipeline_id,
+                                             &clip_rect,
+                                             &item.content_size,
+                                             item.scroll_root_id,
+                                             clip,
+                                             &mut self.clip_scroll_tree);
 
-        self.flatten_items(traversal,
-                           pipeline_id,
-                           context,
-                           reference_frame_relative_offset,
-                           level);
-
-        context.builder.pop_clip_scroll_node();
     }
 
     fn flatten_stacking_context<'a>(&mut self,
@@ -478,7 +467,7 @@ impl Frame {
 
         if is_reference_frame {
             context.replacements.pop();
-            context.builder.pop_clip_scroll_node();
+            context.builder.pop_reference_frame();
         }
 
         context.builder.pop_stacking_context();
@@ -486,6 +475,7 @@ impl Frame {
 
     fn flatten_iframe<'a>(&mut self,
                           pipeline_id: PipelineId,
+                          parent_id: ScrollLayerId,
                           bounds: &LayerRect,
                           context: &mut FlattenContext,
                           reference_frame_relative_offset: LayerPoint) {
@@ -517,9 +507,6 @@ impl Frame {
             reference_frame_relative_offset.y + bounds.origin.y,
             0.0);
 
-        let parent_id = context.builder.current_clip_scroll_node_id();
-        let parent_id = context.scroll_layer_id_with_replacement(parent_id);
-
         let iframe_reference_frame_id =
             context.builder.push_reference_frame(Some(parent_id),
                                                  pipeline_id,
@@ -528,7 +515,7 @@ impl Frame {
                                                  &mut self.clip_scroll_tree);
 
         let iframe_scroll_layer_id = ScrollLayerId::root_scroll_layer(pipeline_id);
-        context.builder.push_clip_scroll_node(
+        context.builder.add_clip_scroll_node(
             iframe_scroll_layer_id,
             iframe_reference_frame_id,
             pipeline_id,
@@ -548,8 +535,7 @@ impl Frame {
                                       &iframe_stacking_context,
                                       iframe_clip);
 
-        context.builder.pop_clip_scroll_node();
-        context.builder.pop_clip_scroll_node();
+        context.builder.pop_reference_frame();
     }
 
     fn flatten_items<'a>(&mut self,
@@ -665,23 +651,22 @@ impl Frame {
                                                   &info.stacking_context,
                                                   &item.clip);
                 }
-                SpecificDisplayItem::PushScrollLayer(ref info) => {
-                    self.flatten_scroll_layer(traversal,
-                                              pipeline_id,
-                                              context,
-                                              reference_frame_relative_offset,
-                                              level,
-                                              &item.clip,
-                                              info);
-                }
                 SpecificDisplayItem::Iframe(ref info) => {
                     self.flatten_iframe(info.pipeline_id,
+                                        scroll_layer_id,
                                         &item.rect,
                                         context,
                                         reference_frame_relative_offset);
                 }
-                SpecificDisplayItem::PopStackingContext |
-                SpecificDisplayItem::PopScrollLayer => return,
+                SpecificDisplayItem::Clip(ref info) => {
+                    self.flatten_clip(context,
+                                      pipeline_id,
+                                      scroll_layer_id,
+                                      &info,
+                                      reference_frame_relative_offset,
+                                      &item.clip);
+                }
+                SpecificDisplayItem::PopStackingContext => return,
             }
         }
     }

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -19,6 +19,7 @@ pub struct DisplayItem {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum SpecificDisplayItem {
+    Clip(ClipDisplayItem),
     Rectangle(RectangleDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),
@@ -31,8 +32,6 @@ pub enum SpecificDisplayItem {
     Iframe(IframeDisplayItem),
     PushStackingContext(PushStackingContextDisplayItem),
     PopStackingContext,
-    PushScrollLayer(PushScrollLayerItem),
-    PopScrollLayer,
 }
 
 #[repr(C)]
@@ -40,6 +39,14 @@ pub enum SpecificDisplayItem {
 pub struct ItemRange {
     pub start: usize,
     pub length: usize,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ClipDisplayItem {
+    pub content_size: LayoutSize,
+    pub id: ScrollLayerId,
+    pub parent_id: ScrollLayerId,
+    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -286,13 +293,6 @@ pub enum FilterOp {
     Opacity(PropertyBinding<f32>),
     Saturate(f32),
     Sepia(f32),
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct PushScrollLayerItem {
-    pub content_size: LayoutSize,
-    pub id: ScrollLayerId,
-    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
Modify the API to a transitionally state allowing clients to select
their containing clip/scroll. This will allow Servo and Gecko to
transition to the new style API while maintaining backward compatibility
for a small performance cost. Eventually we will remove the old API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/978)
<!-- Reviewable:end -->
