### PR TITLE
Correct scroll layer id in push_built_display_list.

### DIFF
--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -414,6 +414,7 @@ impl DisplayListBuilder {
                 _ => {}
             }
             i.clip.complex = self.auxiliary_lists_builder.add_complex_clip_regions(aux.complex_clip_regions(&i.clip.complex));
+            i.scroll_layer_id = *self.clip_stack.last().unwrap();
             self.list.push(i);
         }
     }


### PR DESCRIPTION
There is an issue[1] about using push_built_display_list in gecko. Setting current scroll_layer_id to the items in built display list can fix the problem.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1346915

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/982)
<!-- Reviewable:end -->
