### PR TITLE
Remove ServoScrollRootId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.24.0",
- "webrender_traits 0.25.0",
+ "webrender 0.25.0",
+ "webrender_traits 0.26.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,12 +909,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.25.0",
+ "webrender_traits 0.26.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,8 +947,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.24.0",
- "webrender_traits 0.25.0",
+ "webrender 0.25.0",
+ "webrender_traits 0.26.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -13,7 +13,7 @@ use util::TransformedRect;
 use webrender_traits::{ClipRegion, LayerPixel, LayerPoint, LayerRect, LayerSize};
 use webrender_traits::{LayerToScrollTransform, LayerToWorldTransform, PipelineId};
 use webrender_traits::{ScrollEventPhase, ScrollLayerId, ScrollLayerRect, ScrollLocation};
-use webrender_traits::{ServoScrollRootId, WorldPoint, WorldPoint4D};
+use webrender_traits::{WorldPoint, WorldPoint4D};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -38,17 +38,12 @@ pub struct ClipInfo {
     /// which depends on the screen rectangle and the transformation of all of
     /// the parents.
     pub xf_rect: Option<TransformedRect>,
-
-    /// An external identifier that is used to scroll this clipping node
-    /// from the API.
-    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 impl ClipInfo {
     pub fn new(clip_region: &ClipRegion,
                clip_store: &mut VertexDataStore<GpuBlock32>,
-               packed_layer_index: PackedLayerIndex,
-               scroll_root_id: Option<ServoScrollRootId>)
+               packed_layer_index: PackedLayerIndex,)
                -> ClipInfo {
         // We pass true here for the MaskCacheInfo because this type of
         // mask needs an extra clip for the clip rectangle.
@@ -58,7 +53,6 @@ impl ClipInfo {
             clip_source: clip_source,
             packed_layer_index: packed_layer_index,
             xf_rect: None,
-            scroll_root_id: scroll_root_id,
         }
     }
 
@@ -195,6 +189,15 @@ impl ClipScrollNode {
     }
 
     pub fn set_scroll_origin(&mut self, origin: &LayerPoint) -> bool {
+        match self.node_type {
+            NodeType::ReferenceFrame(_) => {
+                warn!("Tried to scroll a reference frame.");
+                return false;
+            }
+            NodeType::Clip(_) => {}
+        };
+
+
         let scrollable_height = self.scrollable_height();
         let scrollable_width = self.scrollable_width();
         if scrollable_height <= 0. && scrollable_width <= 0. {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -20,8 +20,8 @@ use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipRegion, ColorF, Devi
 use webrender_traits::{DeviceUintSize, DisplayItem, Epoch, FilterOp, ImageDisplayItem, LayerPoint};
 use webrender_traits::{LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
 use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerId};
-use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, ServoScrollRootId};
-use webrender_traits::{SpecificDisplayItem, StackingContext, TileOffset, WorldPoint};
+use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, SpecificDisplayItem};
+use webrender_traits::{StackingContext, TileOffset, WorldPoint};
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct FrameId(pub u32);
@@ -231,12 +231,8 @@ impl Frame {
     }
 
     /// Returns true if any nodes actually changed position or false otherwise.
-    pub fn scroll_nodes(&mut self,
-                        origin: LayerPoint,
-                        pipeline_id: PipelineId,
-                        scroll_root_id: ServoScrollRootId)
-                         -> bool {
-        self.clip_scroll_tree.scroll_nodes(origin, pipeline_id, scroll_root_id)
+    pub fn scroll_nodes(&mut self, origin: LayerPoint, id: ScrollLayerId) -> bool {
+        self.clip_scroll_tree.scroll_nodes(origin, id)
     }
 
     /// Returns true if any nodes actually changed position or false otherwise.
@@ -349,7 +345,6 @@ impl Frame {
                                              pipeline_id,
                                              &clip_rect,
                                              &item.content_size,
-                                             item.scroll_root_id,
                                              clip,
                                              &mut self.clip_scroll_tree);
 
@@ -522,7 +517,6 @@ impl Frame {
             pipeline_id,
             &LayerRect::new(LayerPoint::zero(), iframe_rect.size),
             &iframe_clip.main.size,
-            Some(ServoScrollRootId(0)),
             iframe_clip,
             &mut self.clip_scroll_tree);
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -33,8 +33,7 @@ use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, DeviceIntPoint, De
 use webrender_traits::{DeviceIntSize, DeviceUintRect, DeviceUintSize, ExtendMode, FontKey};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
 use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
-use webrender_traits::{RepeatMode, ScrollLayerId, ServoScrollRootId, TileOffset, WebGLContextId};
-use webrender_traits::YuvColorSpace;
+use webrender_traits::{RepeatMode, ScrollLayerId, TileOffset, WebGLContextId, YuvColorSpace};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -309,7 +308,6 @@ impl FrameBuilder {
                                    pipeline_id,
                                    &viewport_rect,
                                    content_size,
-                                   Some(ServoScrollRootId(0)),
                                    &ClipRegion::simple(&viewport_rect),
                                    clip_scroll_tree);
         topmost_scroll_layer_id
@@ -321,13 +319,11 @@ impl FrameBuilder {
                                 pipeline_id: PipelineId,
                                 local_viewport_rect: &LayerRect,
                                 content_size: &LayerSize,
-                                scroll_root_id: Option<ServoScrollRootId>,
                                 clip_region: &ClipRegion,
                                 clip_scroll_tree: &mut ClipScrollTree) {
         let clip_info = ClipInfo::new(clip_region,
                                       &mut self.prim_store.gpu_data32,
-                                      PackedLayerIndex(self.packed_layers.len()),
-                                      scroll_root_id);
+                                      PackedLayerIndex(self.packed_layers.len()));
         let node = ClipScrollNode::new(pipeline_id,
                                        parent_id,
                                        local_viewport_rect,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -260,12 +260,12 @@ impl RenderBackend {
                                 None => self.notify_compositor_of_new_scroll_frame(false),
                             }
                         }
-                        ApiMsg::ScrollLayersWithScrollId(origin, pipeline_id, scroll_root_id) => {
-                            profile_scope!("ScrollLayersWithScrollId");
+                        ApiMsg::ScrollLayerWithId(origin, id) => {
+                            profile_scope!("ScrollLayerWithScrollId");
                             let frame = {
                                 let counters = &mut profile_counters.texture_cache;
                                 profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll_nodes(origin, pipeline_id, scroll_root_id) {
+                                    if self.frame.scroll_nodes(origin, id) {
                                         Some(self.render(counters))
                                     } else {
                                         None

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -46,7 +46,6 @@ pub struct ClipDisplayItem {
     pub content_size: LayoutSize,
     pub id: ScrollLayerId,
     pub parent_id: ScrollLayerId,
-    pub scroll_root_id: Option<ServoScrollRootId>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -509,48 +508,45 @@ impl ComplexClipRegion {
     }
 }
 
-#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ServoScrollRootId(pub usize);
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ScrollLayerId {
-    pub pipeline_id: PipelineId,
-    pub info: ScrollLayerInfo,
+pub enum ScrollLayerId {
+    Clip(usize, PipelineId),
+    ClipExternalId(usize, PipelineId),
+    ReferenceFrame(usize, PipelineId),
 }
 
 impl ScrollLayerId {
     pub fn root_scroll_layer(pipeline_id: PipelineId) -> ScrollLayerId {
-        ScrollLayerId {
-            pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Scrollable(0),
-        }
+        ScrollLayerId::Clip(0, pipeline_id)
     }
 
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ScrollLayerId {
-        ScrollLayerId {
-            pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::ReferenceFrame(0),
+        ScrollLayerId::ReferenceFrame(0, pipeline_id)
+    }
+
+    pub fn new(id: usize, pipeline_id: PipelineId) -> ScrollLayerId {
+        ScrollLayerId::ClipExternalId(id, pipeline_id)
+    }
+
+    pub fn pipeline_id(&self) -> PipelineId {
+        match *self {
+            ScrollLayerId::Clip(_, pipeline_id) => pipeline_id,
+            ScrollLayerId::ClipExternalId(_, pipeline_id) => pipeline_id,
+            ScrollLayerId::ReferenceFrame(_, pipeline_id) => pipeline_id,
         }
     }
 
     pub fn is_reference_frame(&self) -> bool {
-        match self.info {
-            ScrollLayerInfo::Scrollable(..) => false,
-            ScrollLayerInfo::ReferenceFrame(..) => true,
+        match *self {
+            ScrollLayerId::ReferenceFrame(..) => true,
+            _ => false,
         }
     }
 
-    pub fn new(pipeline_id: PipelineId, index: usize) -> ScrollLayerId {
-        ScrollLayerId {
-            pipeline_id: pipeline_id,
-            info: ScrollLayerInfo::Scrollable(index),
+    pub fn external_id(&self) -> Option<usize> {
+        match *self {
+            ScrollLayerId::ClipExternalId(id, _) => Some(id),
+            _ => None,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum ScrollLayerInfo {
-    Scrollable(usize),
-    ReferenceFrame(usize),
 }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -11,8 +11,8 @@ use {FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem, Gradie
 use {IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering, ItemRange};
 use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, MixBlendMode, PipelineId};
 use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
-use {RectangleDisplayItem, ScrollLayerId, ScrollPolicy, ServoScrollRootId, SpecificDisplayItem};
-use {StackingContext, TextDisplayItem, WebGLContextId, WebGLDisplayItem, YuvColorSpace};
+use {RectangleDisplayItem, ScrollLayerId, ScrollPolicy, SpecificDisplayItem, StackingContext};
+use {TextDisplayItem, WebGLContextId, WebGLDisplayItem, YuvColorSpace};
 use YuvImageDisplayItem;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -341,17 +341,20 @@ impl DisplayListBuilder {
     pub fn define_clip(&mut self,
                        clip: ClipRegion,
                        content_size: LayoutSize,
-                       scroll_root_id: Option<ServoScrollRootId>)
+                       id: Option<ScrollLayerId>)
                        -> ScrollLayerId {
-        let scroll_layer_id = self.next_scroll_layer_id;
-        self.next_scroll_layer_id += 1;
+        let id = match id {
+            Some(id) => id,
+            None => {
+                self.next_scroll_layer_id += 1;
+                ScrollLayerId::Clip(self.next_scroll_layer_id - 1, self.pipeline_id)
+            }
+        };
 
-        let id = ScrollLayerId::new(self.pipeline_id, scroll_layer_id);
         let item = SpecificDisplayItem::Clip(ClipDisplayItem {
             content_size: content_size,
             id: id,
             parent_id: *self.clip_stack.last().unwrap(),
-            scroll_root_id: scroll_root_id,
         });
 
         self.push_item(item, clip.main, clip);
@@ -361,8 +364,8 @@ impl DisplayListBuilder {
     pub fn push_scroll_layer(&mut self,
                              clip: ClipRegion,
                              content_size: LayoutSize,
-                             scroll_root_id: Option<ServoScrollRootId>) {
-        let id = self.define_clip(clip, content_size, scroll_root_id);
+                             id: Option<ScrollLayerId>) {
+        let id = self.define_clip(clip, content_size, id);
         self.clip_stack.push(id);
     }
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -364,8 +364,7 @@ impl Wrench {
     pub fn send_lists(&mut self,
                       frame_number: u32,
                       display_list: DisplayListBuilder,
-                      scroll_offsets: &HashMap<ServoScrollRootId, LayerPoint>) {
-        let pipeline_id = display_list.pipeline_id;
+                      scroll_offsets: &HashMap<ScrollLayerId, LayerPoint>) {
         let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
         self.api.set_root_display_list(root_background_color,
                                        Epoch(frame_number),
@@ -373,10 +372,8 @@ impl Wrench {
                                        display_list.finalize(),
                                        false);
 
-        for (scroll_root_id, offset) in scroll_offsets {
-            self.api.scroll_layers_with_scroll_root_id(*offset,
-                                                       pipeline_id,
-                                                       *scroll_root_id);
+        for (id, offset) in scroll_offsets {
+            self.api.scroll_layer_with_id(*offset, *id);
         }
 
         self.api.generate_frame(None);


### PR DESCRIPTION
Remove the concept of ServoScrollRootId and just wrap up external ids
into ScrollLayerId. This will allow API clients to specify ids without
having to do complicated bookkeeping when building display lists. In
addition, this makes the code much simpler. This is a major API break
because clips cannot share the same id. This is only possible because
now Servo does not need to split scroll layers / clips.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/983)
<!-- Reviewable:end -->
