### PR TITLE
Remove extra repr markers and mark BlobImageDescriptor reprc(C)

### DIFF
--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -86,6 +86,7 @@ pub struct NormalBorder {
     pub radius: BorderRadius,
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RepeatMode {
     Stretch,
@@ -193,6 +194,7 @@ pub struct BoxShadowDisplayItem {
     pub clip_mode: BoxShadowClipMode,
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ExtendMode {
     Clamp,
@@ -251,7 +253,6 @@ pub struct StackingContext {
     pub filters: ItemRange,
 }
 
-#[repr(C)]
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ScrollPolicy {

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -20,7 +20,6 @@ impl ImageKey {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ExternalImageId(pub u64);
 
-#[repr(C)]
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ImageFormat {
@@ -108,6 +107,7 @@ pub type BlobImageData = Vec<u8>;
 
 pub type BlobImageResult = Result<RasterizedBlobImage, BlobImageError>;
 
+#[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct BlobImageDescriptor {
     pub width: u32,


### PR DESCRIPTION
Having both repr(C) and repr(u32) on an enum is valid but will generate a warning that breaks in the gecko's webrender bindings in some cases.
It would also be convenient to have BlobImageDescriptor ffi-compatible.

r? @mrobinson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/986)
<!-- Reviewable:end -->
