### PR TITLE
Ensure that inset box shadows don't fetch texels outside cache rect.

### DIFF
--- a/webrender/res/ps_box_shadow.fs.glsl
+++ b/webrender/res/ps_box_shadow.fs.glsl
@@ -3,7 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    vec2 uv = min(vec2(1.0), vMirrorPoint - abs(vUv.xy - vMirrorPoint));
+    // Mirror and stretch the box shadow corner over the entire
+    // primitives.
+    vec2 uv = vMirrorPoint - abs(vUv.xy - vMirrorPoint);
+
+    // Ensure that we don't fetch texels outside the box
+    // shadow corner. This can happen, for example, when
+    // drawing the outer parts of an inset box shadow.
+    uv = clamp(uv, vec2(0.0), vec2(1.0));
+
+    // Map the unit UV to the actual UV rect in the cache.
     uv = mix(vCacheUvRectCoords.xy, vCacheUvRectCoords.zw, uv);
+
+    // Modulate the box shadow by the color.
     oFragColor = vColor * texture(sCache, vec3(uv, vUv.z));
 }


### PR DESCRIPTION
Fixes #990.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/992)
<!-- Reviewable:end -->
