### PR TITLE
Fix groove and ridge while there is no border radii

### DIFF
--- a/webrender/res/ps_border.fs.glsl
+++ b/webrender/res/ps_border.fs.glsl
@@ -366,10 +366,24 @@ void draw_mixed_border(float distanceFromMixLine, float distanceFromMiddle, vec2
       float pixelsPerFragment = length(fwidth(localPos.xy));
       vec4 color = get_fragment_color(distanceFromMixLine, pixelsPerFragment);
 
-      float distance = distance(vRefPoint, localPos) - vRadii.z;
-      float length = vRadii.x - vRadii.z;
-      if (distanceFromMiddle < 0.0) {
-        distance = length - distance;
+      if (vRadii.x > 0.0) {
+        float distance = distance(vRefPoint, localPos) - vRadii.z;
+        float length = vRadii.x - vRadii.z;
+        if (distanceFromMiddle < 0.0) {
+          distance = length - distance;
+        }
+
+        oFragColor = 0.0 <= distance && distance <= length ?
+          draw_mixed_edge(distance, length, color, brightness_mod) : vec4(0.0, 0.0, 0.0, 0.0);
+        break;
+      }
+
+      bool is_vertical = (vBorderPart == PST_TOP_LEFT) ? distanceFromMixLine < 0.0 :
+                                                         distanceFromMixLine >= 0.0;
+      float distance = is_vertical ? abs(localPos.x - vRefPoint.x) : abs(localPos.y - vRefPoint.y);
+      float length = is_vertical ? abs(vPieceRect.z) : abs(vPieceRect.w);
+      if (distanceFromMiddle > 0.0) {
+          distance = length - distance;
       }
 
       oFragColor = 0.0 <= distance && distance <= length ?

--- a/wrench/reftests/border/border-groove-simple-ref.yaml
+++ b/wrench/reftests/border/border-groove-simple-ref.yaml
@@ -1,0 +1,21 @@
+---
+root:
+  items:
+    - type: stacking_context
+      bounds: [0, 0, 50, 50]
+      items:
+        - type: border
+          bounds: [ 0, 0, 50, 50 ]
+          width: [ 6, 6, 6, 6 ]
+          border-type: normal
+          style: [ solid, solid, solid, solid ]
+          color: [ 0 0 178 1.0, 0 0 178 1.0, 0 0 255 1.0, 0 0 255 1.0 ]
+    - type: stacking_context
+      bounds: [6, 6, 38, 38]
+      items:
+        - type: border
+          bounds: [ 0, 0, 38, 38 ]
+          width: [ 6, 6, 6, 6 ]
+          border-type: normal
+          style: [ solid, solid, solid, solid ]
+          color: [ 0 0 255 1.0, 0 0 255 1.0, 0 0 178 1.0, 0 0 178 1.0 ]

--- a/wrench/reftests/border/border-groove-simple.yaml
+++ b/wrench/reftests/border/border-groove-simple.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: stacking_context
+      bounds: [0, 0, 500, 500]
+      items:
+        - type: border
+          bounds: [ 0, 0, 50, 50 ]
+          width: [ 12, 12, 12, 12 ]
+          border-type: normal
+          style: [ groove, groove, groove, groove ]
+          color: [ blue, blue, blue, blue ]

--- a/wrench/reftests/border/border-ridge-simple-ref.yaml
+++ b/wrench/reftests/border/border-ridge-simple-ref.yaml
@@ -1,0 +1,21 @@
+---
+root:
+  items:
+    - type: stacking_context
+      bounds: [0, 0, 50, 50]
+      items:
+        - type: border
+          bounds: [ 0, 0, 50, 50 ]
+          width: [ 6, 6, 6, 6 ]
+          border-type: normal
+          style: [ solid, solid, solid, solid ]
+          color: [ 0 0 255 1.0, 0 0 255 1.0, 0 0 178 1.0, 0 0 178 1.0 ]
+    - type: stacking_context
+      bounds: [6, 6, 38, 38]
+      items:
+        - type: border
+          bounds: [ 0, 0, 38, 38 ]
+          width: [ 6, 6, 6, 6 ]
+          border-type: normal
+          style: [ solid, solid, solid, solid ]
+          color: [ 0 0 178 1.0, 0 0 178 1.0, 0 0 255 1.0, 0 0 255 1.0 ]

--- a/wrench/reftests/border/border-ridge-simple.yaml
+++ b/wrench/reftests/border/border-ridge-simple.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: stacking_context
+      bounds: [0, 0, 500, 500]
+      items:
+        - type: border
+          bounds: [ 0, 0, 50, 50 ]
+          width: [ 12, 12, 12, 12 ]
+          border-type: normal
+          style: [ ridge, ridge, ridge, ridge ]
+          color: [ blue, blue, blue, blue ]

--- a/wrench/reftests/border/reftest.list
+++ b/wrench/reftests/border/reftest.list
@@ -1,3 +1,5 @@
 == border-gradient-simple.yaml border-gradient-simple-ref.yaml
 == border-radial-gradient-simple.yaml border-radial-gradient-simple-ref.yaml
 fuzzy(255,610) == border-double-simple.yaml border-double-simple-ref.yaml
+fuzzy(255,24) == border-groove-simple.yaml border-groove-simple-ref.yaml
+fuzzy(255,24) == border-ridge-simple.yaml border-ridge-simple-ref.yaml


### PR DESCRIPTION
Currently draw_mixed_border seems to only consider radii case. I add some code to handle non-radii case. I still need fuzzy for the reftests since in the test I set different border color to solid border and we'll  mix the color for the corner. I haven't figured out an easy way to handle it for groove/ridge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/998)
<!-- Reviewable:end -->
