### PR TITLE
Use hyphens instead of underscores for wrench keys

### DIFF
--- a/wrench/benchmarks/transforms-simple.yaml
+++ b/wrench/benchmarks/transforms-simple.yaml
@@ -1,10 +1,10 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 1024, 1024]
       items:
-      - type: stacking_context
+      - type: stacking-context
         bounds: [0, 0, 1024, 1024]
         transform: rotate(45)
         items:

--- a/wrench/reftests/blend/canvas.yaml
+++ b/wrench/reftests/blend/canvas.yaml
@@ -2,7 +2,7 @@
 root:
   items:
         # the root stacking context should blend with the canvas background
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           mix-blend-mode: difference
           items:

--- a/wrench/reftests/blend/darken.yaml
+++ b/wrench/reftests/blend/darken.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [10, 20, 30]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           mix-blend-mode: darken
           items:

--- a/wrench/reftests/blend/difference.yaml
+++ b/wrench/reftests/blend/difference.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: green
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           mix-blend-mode: difference
           items:

--- a/wrench/reftests/blend/isolated-2-ref.yaml
+++ b/wrench/reftests/blend/isolated-2-ref.yaml
@@ -4,13 +4,13 @@ root:
     - type: rect
       bounds: [10, 10, 130, 130]
       color: [255, 255, 0]
-    - type: stacking_context
+    - type: stacking-context
       bounds: [10, 10, 130, 130]
       items:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [0, 255, 0]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [20, 20, 100, 100]
           items:
             - type: rect

--- a/wrench/reftests/blend/isolated-2.yaml
+++ b/wrench/reftests/blend/isolated-2.yaml
@@ -9,13 +9,13 @@ root:
       # inside there should be overlapping red and green rects
       # where they intersect should be a black rect
       # the rects should not blend with the yellow backdrop
-    - type: stacking_context
+    - type: stacking-context
       bounds: [10, 10, 130, 130]
       items:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [0, 255, 0]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [20, 20, 100, 100]
           mix-blend-mode: multiply
           items:

--- a/wrench/reftests/blend/isolated-with-filter.yaml
+++ b/wrench/reftests/blend/isolated-with-filter.yaml
@@ -5,11 +5,11 @@ root:
           bounds: [0, 0, 100, 100]
           color: [255, 0, 0]
           # the presence of this filter shouldn't break isolated groups
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           filters: opacity(1.0)
           items:
-            - type: stacking_context
+            - type: stacking-context
               bounds: [0, 0, 100, 100]
               mix-blend-mode: difference
               items:

--- a/wrench/reftests/blend/isolated.yaml
+++ b/wrench/reftests/blend/isolated.yaml
@@ -6,10 +6,10 @@ root:
           color: [255, 0, 0]
         # this stacking context should create an isolated group for its children
         # causing the yellow rect to not blend with the green backdrop
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           items:
-            - type: stacking_context
+            - type: stacking-context
               bounds: [0, 0, 100, 100]
               mix-blend-mode: difference
               items:

--- a/wrench/reftests/blend/lighten.yaml
+++ b/wrench/reftests/blend/lighten.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [10, 20, 30]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           mix-blend-mode: lighten
           items:

--- a/wrench/reftests/blend/multiply-2.yaml
+++ b/wrench/reftests/blend/multiply-2.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [0, 255, 0]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           mix-blend-mode: multiply
           items:

--- a/wrench/reftests/blend/multiply.yaml
+++ b/wrench/reftests/blend/multiply.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: green
-        - type: stacking_context
+        - type: stacking-context
           bounds: [25, 25, 50, 50]
           mix-blend-mode: multiply
           items:

--- a/wrench/reftests/blend/repeated-difference.yaml
+++ b/wrench/reftests/blend/repeated-difference.yaml
@@ -7,7 +7,7 @@ root:
           color: [255, 255, 255]
         -
           bounds: [0, 0, 100, 100]
-          type: stacking_context
+          type: stacking-context
           mix-blend-mode: difference
           items:
             -
@@ -16,7 +16,7 @@ root:
               color: [255, 255, 255]
             -
               bounds: [0, 0, 100, 100]
-              type: stacking_context
+              type: stacking-context
               mix-blend-mode: difference
               items:
                 -

--- a/wrench/reftests/border/border-double-simple-ref.yaml
+++ b/wrench/reftests/border/border-double-simple-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: border
@@ -10,7 +10,7 @@ root:
           border-type: normal
           style: [ solid, solid, solid, solid ]
           color: [ blue, blue, blue, blue ]
-    - type: stacking_context
+    - type: stacking-context
       bounds: [8, 8, 34, 34]
       items:
         - type: border

--- a/wrench/reftests/border/border-double-simple.yaml
+++ b/wrench/reftests/border/border-double-simple.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 500, 500]
       items:
         - type: border

--- a/wrench/reftests/border/border-gradient-simple-ref.yaml
+++ b/wrench/reftests/border/border-gradient-simple-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: gradient # top left

--- a/wrench/reftests/border/border-gradient-simple.yaml
+++ b/wrench/reftests/border/border-gradient-simple.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: border

--- a/wrench/reftests/border/border-radial-gradient-simple-ref.yaml
+++ b/wrench/reftests/border/border-radial-gradient-simple-ref.yaml
@@ -1,70 +1,70 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
-        - type: radial_gradient # top left
+        - type: radial-gradient # top left
           bounds: [ 0, 0, 10, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # top right
+        - type: radial-gradient # top right
           bounds: [ 40, 0, 10, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # bottom left
+        - type: radial-gradient # bottom left
           bounds: [ 0, 40, 10, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # bottom right
+        - type: radial-gradient # bottom right
           bounds: [ 40, 40, 10, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # top
+        - type: radial-gradient # top
           bounds: [ 10, 0, 30, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # right
+        - type: radial-gradient # right
           bounds: [ 40, 10, 10, 30]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # bottom
+        - type: radial-gradient # bottom
           bounds: [ 10, 40, 30, 10]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
-        - type: radial_gradient # left
+        - type: radial-gradient # left
           bounds: [ 0, 10, 10, 30]
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false

--- a/wrench/reftests/border/border-radial-gradient-simple.yaml
+++ b/wrench/reftests/border/border-radial-gradient-simple.yaml
@@ -1,16 +1,16 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: border
           bounds: [ 0, 0, 50, 50 ]
           width: [ 10, 10, 10, 10 ]
           border-type: radial-gradient
-          start_center: [ 25, 25 ]
-          start_radius: 15
-          end_center: [ 25, 25 ]
-          end_radius: 35
+          start-center: [ 25, 25 ]
+          start-radius: 15
+          end-center: [ 25, 25 ]
+          end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           outset: [ 0, 0, 0, 0 ]

--- a/wrench/reftests/boxshadow/inset-simple-ref.yaml
+++ b/wrench/reftests/boxshadow/inset-simple-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [50, 50, 100, 100]
           items:
             - type: rect

--- a/wrench/reftests/boxshadow/inset-simple.yaml
+++ b/wrench/reftests/boxshadow/inset-simple.yaml
@@ -1,13 +1,13 @@
 ---
 root:
   items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [50, 50, 100, 100]
           items:
             - type: rect
               bounds: [ 10, 10, 80, 80 ]
               color: [0, 255, 0]
-            - type: box_shadow
+            - type: box-shadow
               bounds: [ 10, 10, 80, 80 ]
-              blur_radius: 25
-              clip_mode: inset
+              blur-radius: 25
+              clip-mode: inset

--- a/wrench/reftests/boxshadow/inset-spread-ref.yaml
+++ b/wrench/reftests/boxshadow/inset-spread-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [50, 50, 100, 100]
           items:
             - type: rect

--- a/wrench/reftests/boxshadow/inset-spread.yaml
+++ b/wrench/reftests/boxshadow/inset-spread.yaml
@@ -1,12 +1,12 @@
 ---
 root:
   items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [50, 50, 100, 100]
           items:
-            - type: box_shadow
+            - type: box-shadow
               bounds: [ 10, 10, 80, 80 ]
-              blur_radius: 5
-              clip_mode: inset
-              spread_radius: 20
+              blur-radius: 5
+              clip-mode: inset
+              spread-radius: 20
               color: [0, 0, 0]

--- a/wrench/reftests/filters/filter-grayscale.yaml
+++ b/wrench/reftests/filters/filter-grayscale.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [10, 10, 200, 200]
           filters: grayscale(1)
           items:

--- a/wrench/reftests/filters/invisible.yaml
+++ b/wrench/reftests/filters/invisible.yaml
@@ -1,20 +1,20 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 100, 100]
       filters: opacity(0.0),
       items:
-      - type: stacking_context
+      - type: stacking-context
         bounds: [0, 0, 100, 100]
         items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           items:
-          - type: stacking_context
+          - type: stacking-context
             bounds: [0, 0, 100, 100]
             items:
-            - type: stacking_context
+            - type: stacking-context
               bounds: [0, 0, 100, 100]
               items:
               - type: rect

--- a/wrench/reftests/filters/isolated-ref.yaml
+++ b/wrench/reftests/filters/isolated-ref.yaml
@@ -4,7 +4,7 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [0, 0, 0]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           filters: opacity(0.5)
           items:

--- a/wrench/reftests/filters/isolated.yaml
+++ b/wrench/reftests/filters/isolated.yaml
@@ -5,10 +5,10 @@ root:
         - type: rect
           bounds: [0, 0, 100, 100]
           color: [0, 0, 0]
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 100, 100]
           items:
-            - type: stacking_context
+            - type: stacking-context
               bounds: [0, 0, 100, 100]
               filters: opacity(0.5)
               items:

--- a/wrench/reftests/image/tile-repeat-prim-or-decompose-ref.yaml
+++ b/wrench/reftests/image/tile-repeat-prim-or-decompose-ref.yaml
@@ -1,8 +1,8 @@
 root:
   items:
-    - image: xy_gradient(500, 50)
+    - image: xy-gradient(500, 50)
       bounds: 0 0 800 800
-      stretch_size: 50 50
-    - image: xy_gradient(50, 500)
+      stretch-size: 50 50
+    - image: xy-gradient(50, 500)
       bounds: 800 0 800 800
-      stretch_size: 50 50
+      stretch-size: 50 50

--- a/wrench/reftests/image/tile-repeat-prim-or-decompose.yaml
+++ b/wrench/reftests/image/tile-repeat-prim-or-decompose.yaml
@@ -4,14 +4,14 @@ root:
     # This should cause the primitive repetition to be decomposed on the cpu along the x axis
     # but perform the repetition along the y axis on the image shader because the image width
     # fits within the tile size.
-    - image: xy_gradient(500, 50)
+    - image: xy-gradient(500, 50)
       bounds: 0 0 800 800
-      stretch_size: 50 50
+      stretch-size: 50 50
       tile-size: 50
     # This should cause the primitive repetition to be decomposed on the cpu along the y axis
     # but perform the repetition along the x axis in the image shader because the image height
     # fits within the tile size.
-    - image: xy_gradient(50, 500)
+    - image: xy-gradient(50, 500)
       bounds: 800 0 800 800
-      stretch_size: 50 50
+      stretch-size: 50 50
       tile-size: 50

--- a/wrench/reftests/image/tile-size-ref.yaml
+++ b/wrench/reftests/image/tile-size-ref.yaml
@@ -1,14 +1,14 @@
 root:
   items:
-    - image: xy_gradient(512, 512)
+    - image: xy-gradient(512, 512)
       bounds: 0 0 512 512
-      stretch_size: 512 512
-    - image: xy_gradient(512, 512)
+      stretch-size: 512 512
+    - image: xy-gradient(512, 512)
       bounds: 512 0 512 512
-      stretch_size: 512 512
-    - image: xy_gradient(512, 512)
+      stretch-size: 512 512
+    - image: xy-gradient(512, 512)
       bounds: 0 512 512 512
-      stretch_size: 512 512
-    - image: xy_gradient(512, 512)
+      stretch-size: 512 512
+    - image: xy-gradient(512, 512)
       bounds: 512 512 512 512
-      stretch_size: 512 512
+      stretch-size: 512 512

--- a/wrench/reftests/image/tile-size.yaml
+++ b/wrench/reftests/image/tile-size.yaml
@@ -1,19 +1,19 @@
 root:
   items:
-    - image: xy_gradient(512, 512)
+    - image: xy-gradient(512, 512)
       bounds: 0 0 512 512
-      stretch_size: 512 512
+      stretch-size: 512 512
       tile-size: 64
-    - image: xy_gradient(512, 512)
+    - image: xy-gradient(512, 512)
       bounds: 512 0 512 512
-      stretch_size: 512 512
+      stretch-size: 512 512
       tile-size: 128
-    - image: xy_gradient(512, 512)
+    - image: xy-gradient(512, 512)
       bounds: 0 512 512 512
-      stretch_size: 512 512
+      stretch-size: 512 512
       tile-size: 256
       # tile size bigger than the image itself
-    - image: xy_gradient(512, 512)
+    - image: xy-gradient(512, 512)
       bounds: 512 512 512 512
-      stretch_size: 512 512
+      stretch-size: 512 512
       tile-size: 4096

--- a/wrench/reftests/image/tile-with-spacing-ref.yaml
+++ b/wrench/reftests/image/tile-with-spacing-ref.yaml
@@ -1,6 +1,6 @@
 root:
   items:
-    - image: solid_color(255, 0, 0, 255, 300, 300)
+    - image: solid-color(255, 0, 0, 255, 300, 300)
       bounds: 0 0 800 800
-      stretch_size: 200 200
-      tile_spacing: 10 10
+      stretch-size: 200 200
+      tile-spacing: 10 10

--- a/wrench/reftests/image/tile-with-spacing.yaml
+++ b/wrench/reftests/image/tile-with-spacing.yaml
@@ -4,9 +4,9 @@ root:
     # of a solid color. To do this we first need to change the way pixel snapping is
     # applied so that when an image is split into several primitives, so that the latter
     # all get snapped the same way rather than independently.
-    #- image: xy_gradient(300, 300)
-    - image: solid_color(255, 0, 0, 255, 300, 300)
+    #- image: xy-gradient(300, 300)
+    - image: solid-color(255, 0, 0, 255, 300, 300)
       bounds: 0 0 800 800
-      stretch_size: 200 200
-      tile_spacing: 10 10
+      stretch-size: 200 200
+      tile-spacing: 10 10
       tile-size: 64

--- a/wrench/reftests/image/very-big.yaml
+++ b/wrench/reftests/image/very-big.yaml
@@ -1,5 +1,5 @@
 root:
   items:
-    - image: solid_color(255, 0, 0, 255, 100000, 1000)
+    - image: solid-color(255, 0, 0, 255, 100000, 1000)
       bounds: 0 0 500 500
-      stretch_size: 1000000 1000
+      stretch-size: 1000000 1000

--- a/wrench/reftests/mask/aligned-layer-rect-ref.yaml
+++ b/wrench/reftests/mask/aligned-layer-rect-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       items:
         - type: rect
           bounds: [9, 9, 10, 10]

--- a/wrench/reftests/mask/aligned-layer-rect.yaml
+++ b/wrench/reftests/mask/aligned-layer-rect.yaml
@@ -1,13 +1,13 @@
 ---
 root:
   items:
-    - type: scroll_layer
+    - type: scroll-layer
       bounds: [0, 0, 95, 88]
       content-size: [95, 88]
       clip:
         rect: [9, 9, 10, 10]
       items:
-        - type: scroll_layer
+        - type: scroll-layer
           bounds: [0, 0, 95, 88]
           content-size: [95, 88]
           clip:

--- a/wrench/reftests/mask/mask-ref.yaml
+++ b/wrench/reftests/mask/mask-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 95, 88]
       items:
         - type: rect

--- a/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
+++ b/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
@@ -1,18 +1,18 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       clip: [0, 0, 300, 300]
       bounds: [0, 0, 300, 300]
       "scroll-policy": scrollable
-      z_index: 4
+      z-index: 4
       transform: [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 150, -150, 1]
       items:
-        - type: scroll_layer
+        - type: scroll-layer
           bounds: [0, 0, 300, 300]
           clip:
             rect: [0, 0, 300, 300]
-            image_mask:
+            image-mask:
               # This image mask here assures that we will be forced to try to
               # mask instead of skipping it due to the mask rect becoming a
               # zero rect.

--- a/wrench/reftests/mask/mask.yaml
+++ b/wrench/reftests/mask/mask.yaml
@@ -5,7 +5,7 @@ root:
       bounds: [0, 0, 95, 88]
       color: blue
       clip:
-        image_mask:
+        image-mask:
           image: "mask.png"
           rect: [0, 0, 35, 35]
           repeat: false

--- a/wrench/reftests/mask/nested-mask-ref.yaml
+++ b/wrench/reftests/mask/nested-mask-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 95, 88]
       items:
         - type: rect

--- a/wrench/reftests/mask/nested-mask.yaml
+++ b/wrench/reftests/mask/nested-mask.yaml
@@ -1,21 +1,21 @@
 ---
 root:
   items:
-    - type: scroll_layer
+    - type: scroll-layer
       bounds: [0, 0, 95, 88]
       content-size: [95, 88]
       clip:
-        image_mask:
+        image-mask:
           image: "mask.png"
           rect: [0, 0, 35, 35]
           repeat: false
         rect: [0, 0, 95, 88]
       items:
-        - type: scroll_layer
+        - type: scroll-layer
           bounds: [0, 0, 95, 88]
           content-size: [95, 88]
           clip:
-            image_mask:
+            image-mask:
               image: "mask.png"
               rect: [4, 4, 35, 35]
               repeat: false

--- a/wrench/reftests/scrolling/fixed-position.yaml
+++ b/wrench/reftests/scrolling/fixed-position.yaml
@@ -4,7 +4,7 @@ root:
   scroll-offset: [0, 100]
   items:
     # This stacking context should not scroll out of view because it is fixed position.
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       scroll-policy: fixed
       items:
@@ -15,11 +15,11 @@ root:
     # because it is fixed relative to its reference frame. The reference frame
     # of this stacking context is the stacking context parent because it has
     # a transformation.
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       transform: translate(60, 100)
       items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 50, 50]
           scroll-policy: fixed
           items:
@@ -28,11 +28,11 @@ root:
               color: green
     # This is similar to the previous case, but ensures that this still works
     # even with an identity transform.
-    - type: stacking_context
+    - type: stacking-context
       bounds: [120, 0, 50, 200]
       transform: translate(0, 0)
       items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 50, 200]
           scroll-policy: fixed
           items:
@@ -40,11 +40,11 @@ root:
               bounds: [0, 100, 50, 50]
               color: green
     # This is similar to the previous case, but for perspective.
-    - type: stacking_context
+    - type: stacking-context
       bounds: [180, 0, 50, 200]
       perspective: 1
       items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 50, 200]
           scroll-policy: fixed
           items:
@@ -53,11 +53,11 @@ root:
               color: green
     # This is similar to the previous case, but since the perspective is
     # 0 (equivalent to none), it shouldn't scroll.
-    - type: stacking_context
+    - type: stacking-context
       bounds: [240, 0, 50, 200]
       perspective: 0
       items:
-        - type: stacking_context
+        - type: stacking-context
           bounds: [0, 0, 50, 200]
           scroll-policy: fixed
           items:

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -2,19 +2,19 @@ root:
   items:
     -
       clip: [0, 0, 100, 100]
-      type: stacking_context
+      type: stacking-context
       # We give this stacking context a little offset here to
       # ensure that offsets within reference frames are handled
       # properly when drawing the mask.
       bounds: [10, 10, 100, 100]
       scroll-policy: scrollable
       items:
-      - type: scroll_layer
+      - type: scroll-layer
         bounds: [0, 0, 100, 100]
         content-size: [100, 100]
         clip:
           rect: [0, 0, 100, 100]
-          image_mask:
+          image-mask:
             image: "mask.png"
             rect: [0, 0, 100, 100]
             repeat: false
@@ -25,17 +25,17 @@ root:
 
     # The same test, but this time ensure that scroll offsets don't affect the masking.
     -
-      type: stacking_context
+      type: stacking-context
       bounds: [100, 0, 100, 100]
       clip: [0, 0, 100, 300]
       scroll-policy: scrollable
       items:
-      - type: scroll_layer
+      - type: scroll-layer
         bounds: [10, 10, 100, 100]
         content-size: [100, 300]
         scroll-offset: [0, 100]
         clip:
-          image_mask:
+          image-mask:
             image: "mask.png"
             rect: [0, 0, 100, 100]
             repeat: false

--- a/wrench/reftests/scrolling/scroll-layer.yaml
+++ b/wrench/reftests/scrolling/scroll-layer.yaml
@@ -1,6 +1,6 @@
 root:
   items:
-    - type: scroll_layer
+    - type: scroll-layer
       bounds: [0, 0, 100, 100]
       content-size: [1000, 1000]
       scroll-offset: [50, 50]

--- a/wrench/reftests/scrolling/simple.yaml
+++ b/wrench/reftests/scrolling/simple.yaml
@@ -1,13 +1,13 @@
 root:
   items:
-    - type: scroll_layer
+    - type: scroll-layer
       bounds: [10, 10, 50, 50]
       content-size: [100, 100]
       items:
         - type: rect
           bounds: [10, 10, 500, 500]
           color: green
-    - type: scroll_layer
+    - type: scroll-layer
       bounds: [70, 10, 50, 50]
       content-size: [100, 100]
       items:

--- a/wrench/res/composite.yaml
+++ b/wrench/res/composite.yaml
@@ -7,7 +7,7 @@ root:
       bounds: 0 0 1024 768
       src: "landscape.jpg"
 
-    - type: stacking_context
+    - type: stacking-context
       bounds: 100 100 412 568
       filters: opacity(0.5)
       items:
@@ -17,7 +17,7 @@ root:
           end: 412 568
           stops: [0.0, [255, 0, 0], 1.0, [0, 0, 255]]
 
-    - type: stacking_context
+    - type: stacking-context
       bounds: 512 100 412 568
       mix-blend-mode: color-dodge
       items:

--- a/wrench/res/rect.yaml
+++ b/wrench/res/rect.yaml
@@ -8,5 +8,5 @@ root:
           bounds: 0 0 1024 768
           color: green
           type: rect
-      type: stacking_context
-      z_index: 1
+      type: stacking-context
+      z-index: 1

--- a/wrench/res/rotate.yaml
+++ b/wrench/res/rotate.yaml
@@ -9,5 +9,5 @@ root:
           bounds: [100, 100, 100, 100]
           type: rect
           color: blue
-      type: stacking_context
+      type: stacking-context
 

--- a/wrench/res/test.yaml
+++ b/wrench/res/test.yaml
@@ -35,10 +35,10 @@ root:
       size: 64
   
     - type: border
-    - type: box_shadow
+    - type: box-shadow
     - type: gradient
   
-    - type: box_shadow
+    - type: box-shadow
       bounds: [ rect ]
       clip: ..
       offset: point2d (default 0 0)
@@ -46,7 +46,7 @@ root:
       blur: f32 (default 0)
       spread: f32 (default 0)
       border: f32 (default 0)
-      clip_mode: none, outset, inset (default none)
+      clip-mode: none, outset, inset (default none)
       
     - glyphs: [ 65, 66, 67 ]
       positions: [ 0.2, 0.3, 0.4, 0.5, 0.6, 0.7 ]

--- a/wrench/src/parse_function.rs
+++ b/wrench/src/parse_function.rs
@@ -37,7 +37,7 @@ pub fn parse_function(s: &str) -> (&str, Vec<&str>) {
 
     let mut end = p.start;
     while let Some(k) = p.o {
-        if !k.1.is_alphabetic() && k.1 != '_' {
+        if !k.1.is_alphabetic() && k.1 != '_' && k.1 != '-' {
             break;
         }
         end = k.0 + k.1.len_utf8();

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -320,13 +320,13 @@ impl Wrench {
                 // This is a hack but it is convenient when generating test cases and avoids
                 // bloating the repository.
                 match parse_function(file.components().last().unwrap().as_os_str().to_str().unwrap()) {
-                    ("xy_gradient", args) => {
+                    ("xy-gradient", args) => {
                         generate_xy_gradient_image(
                             args.get(0).unwrap_or(&"1000").parse::<u32>().unwrap(),
                             args.get(1).unwrap_or(&"1000").parse::<u32>().unwrap()
                         )
                     }
-                    ("solid_color", args) => {
+                    ("solid-color", args) => {
                         generate_solid_color_image(
                             args.get(0).unwrap_or(&"255").parse::<u8>().unwrap(),
                             args.get(1).unwrap_or(&"255").parse::<u8>().unwrap(),

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -167,8 +167,8 @@ impl YamlFrameReader {
                     }
                 ).collect();
 
-                let image_mask = if item["image_mask"].as_hash().is_some() {
-                    let image_mask = &item["image_mask"];
+                let image_mask = if item["image-mask"].as_hash().is_some() {
+                    let image_mask = &item["image-mask"];
                     let (image_key, image_dims) =
                         wrench.add_or_get_image(&self.rsrc_path(&image_mask["image"]), None);
                     let image_rect =
@@ -221,12 +221,12 @@ impl YamlFrameReader {
     }
 
     fn handle_radial_gradient(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {
-        let bounds_key = if item["type"].is_badvalue() { "radial_gradient" } else { "bounds" };
+        let bounds_key = if item["type"].is_badvalue() { "radial-gradient" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("radial gradient must have bounds");
-        let start_center = item["start_center"].as_point().expect("radial gradient must have start center");
-        let start_radius = item["start_radius"].as_force_f32().expect("radial gradient must have start radius");
-        let end_center = item["end_center"].as_point().expect("radial gradient must have end center");
-        let end_radius = item["end_radius"].as_force_f32().expect("radial gradient must have end radius");
+        let start_center = item["start-center"].as_point().expect("radial gradient must have start center");
+        let start_radius = item["start-radius"].as_force_f32().expect("radial gradient must have start radius");
+        let end_center = item["end-center"].as_point().expect("radial gradient must have end center");
+        let end_radius = item["end-radius"].as_force_f32().expect("radial gradient must have end radius");
         let stops = item["stops"].as_vec().expect("radial gradient must have stops")
             .chunks(2).map(|chunk| GradientStop {
                 offset: chunk[0].as_force_f32().expect("gradient stop offset is not f32"),
@@ -345,11 +345,11 @@ impl YamlFrameReader {
                     }))
                 },
                 "radial-gradient" => {
-                    let start_center = item["start_center"].as_point().expect("radial gradient must have start center");
+                    let start_center = item["start-center"].as_point().expect("radial gradient must have start center");
                     let start_radius =
-                        item["start_radius"].as_force_f32().expect("radial gradient must have start radius");
-                    let end_center = item["end_center"].as_point().expect("radial gradient must have end center");
-                    let end_radius = item["end_radius"].as_force_f32().expect("radial gradient must have end radius");
+                        item["start-radius"].as_force_f32().expect("radial gradient must have start radius");
+                    let end_center = item["end-center"].as_point().expect("radial gradient must have end center");
+                    let end_radius = item["end-radius"].as_force_f32().expect("radial gradient must have end radius");
                     let stops = item["stops"].as_vec().expect("radial gradient must have stops")
                         .chunks(2).map(|chunk| GradientStop {
                             offset: chunk[0].as_force_f32().expect("gradient stop offset is not f32"),
@@ -388,15 +388,15 @@ impl YamlFrameReader {
     }
 
     fn handle_box_shadow(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {
-        let bounds_key = if item["type"].is_badvalue() { "box_shadow" } else { "bounds" };
+        let bounds_key = if item["type"].is_badvalue() { "box-shadow" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("box shadow must have bounds");
-        let box_bounds = item["box_bounds"].as_rect().unwrap_or(bounds);
+        let box_bounds = item["box-bounds"].as_rect().unwrap_or(bounds);
         let offset = item["offset"].as_point().unwrap_or(TypedPoint2D::zero());
         let color = item["color"].as_colorf().unwrap_or(ColorF::new(0.0, 0.0, 0.0, 1.0));
-        let blur_radius = item["blur_radius"].as_force_f32().unwrap_or(0.0);
-        let spread_radius = item["spread_radius"].as_force_f32().unwrap_or(0.0);
-        let border_radius = item["border_radius"].as_force_f32().unwrap_or(0.0);
-        let clip_mode = if let Some(mode) = item["clip_mode"].as_str() {
+        let blur_radius = item["blur-radius"].as_force_f32().unwrap_or(0.0);
+        let spread_radius = item["spread-radius"].as_force_f32().unwrap_or(0.0);
+        let border_radius = item["border-radius"].as_force_f32().unwrap_or(0.0);
+        let clip_mode = if let Some(mode) = item["clip-mode"].as_str() {
             match mode {
                 "none" => BoxShadowClipMode::None,
                 "outset" => BoxShadowClipMode::Outset,
@@ -435,15 +435,15 @@ impl YamlFrameReader {
             panic!("image expected 2 or 4 values in bounds, got '{:?}'", item["bounds"]);
         };
 
-        let stretch_size = item["stretch_size"].as_size()
+        let stretch_size = item["stretch-size"].as_size()
             .unwrap_or(image_dims);
-        let tile_spacing = item["tile_spacing"].as_size()
+        let tile_spacing = item["tile-spacing"].as_size()
             .unwrap_or(LayoutSize::new(0.0, 0.0));
         let rendering = match item["rendering"].as_str() {
             Some("auto") | None => ImageRendering::Auto,
-            Some("crisp_edges") => ImageRendering::CrispEdges,
+            Some("crisp-edges") => ImageRendering::CrispEdges,
             Some("pixelated") => ImageRendering::Pixelated,
-            Some(_) => panic!("ImageRendering can be auto, crisp_edges, or pixelated -- got {:?}", item),
+            Some(_) => panic!("ImageRendering can be auto, crisp-edges, or pixelated -- got {:?}", item),
         };
         let clip = self.to_clip_region(&item["clip"], &bounds, wrench).unwrap_or(*clip_region);
         self.builder().push_image(bounds, clip, stretch_size, tile_spacing, rendering, image_key);
@@ -452,7 +452,7 @@ impl YamlFrameReader {
     fn handle_text(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
-        let blur_radius = item["blur_radius"].as_px_to_au().unwrap_or(Au::from_f32_px(0.0));
+        let blur_radius = item["blur-radius"].as_px_to_au().unwrap_or(Au::from_f32_px(0.0));
 
         let (font_key, native_key) = if !item["family"].is_badvalue() {
             wrench.font_key_from_yaml_table(item)
@@ -547,20 +547,20 @@ impl YamlFrameReader {
                      "text"
                 } else if !item["glyphs"].is_badvalue() {
                     "glyphs"
-                } else if !item["box_shadow"].is_badvalue() {
+                } else if !item["box-shadow"].is_badvalue() {
                     // Note: box_shadow shorthand check has to come before border.
-                    "box_shadow"
+                    "box-shadow"
                 } else if !item["border"].is_badvalue() {
                     "border"
                 } else if !item["gradient"].is_badvalue() {
                     "gradient"
-                } else if !item["radial_gradient"].is_badvalue() {
-                    "radial_gradient"
+                } else if !item["radial-gradient"].is_badvalue() {
+                    "radial-gradient"
                 } else {
                     item["type"].as_str().unwrap_or("unknown")
                 };
 
-            if item_type == "stacking_context" {
+            if item_type == "stacking-context" {
                 self.add_stacking_context_from_yaml(wrench, &item, false);
                 continue;
             }
@@ -570,7 +570,7 @@ impl YamlFrameReader {
                 continue;
             }
 
-            let yaml_clip_id = item["clip_id"].as_i64();
+            let yaml_clip_id = item["clip-id"].as_i64();
             if let Some(yaml_id) = yaml_clip_id {
                 let id = ScrollLayerId::new(yaml_id as usize, self.builder().pipeline_id);
                 self.builder().push_clip_id(id);
@@ -580,14 +580,14 @@ impl YamlFrameReader {
                 "rect" => self.handle_rect(wrench, &full_clip_region, &item),
                 "image" => self.handle_image(wrench, &full_clip_region, &item),
                 "text" | "glyphs" => self.handle_text(wrench, &full_clip_region, &item),
-                "scroll_layer" => self.add_scroll_layer_from_yaml(wrench, &item),
+                "scroll-layer" => self.add_scroll_layer_from_yaml(wrench, &item),
                 "clip" => { self.handle_clip_from_yaml(wrench, &item); }
                 "border" => self.handle_border(wrench, &full_clip_region, &item),
                 "gradient" => self.handle_gradient(wrench, &full_clip_region, &item),
-                "radial_gradient" => self.handle_radial_gradient(wrench, &full_clip_region, &item),
-                "box_shadow" => self.handle_box_shadow(wrench, &full_clip_region, &item),
+                "radial-gradient" => self.handle_radial_gradient(wrench, &full_clip_region, &item),
+                "box-shadow" => self.handle_box_shadow(wrench, &full_clip_region, &item),
                 "iframe" => self.handle_iframe(wrench, &full_clip_region, &item),
-                "stacking_context" => { },
+                "stacking-context" => { },
                 _ => println!("Skipping unknown item type: {:?}", item),
             }
 
@@ -631,7 +631,7 @@ impl YamlFrameReader {
                                           is_root: bool) {
         let default_bounds = LayoutRect::new(LayoutPoint::new(0.0, 0.0), wrench.window_size_f32());
         let bounds = yaml["bounds"].as_rect().unwrap_or(default_bounds);
-        let z_index = yaml["z_index"].as_i64().unwrap_or(0);
+        let z_index = yaml["z-index"].as_i64().unwrap_or(0);
         // TODO(gw): Add support for specifying the transform origin in yaml.
         let transform_origin = LayoutPoint::new(bounds.origin.x + bounds.size.width * 0.5,
                                                 bounds.origin.y + bounds.size.height * 0.5);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -164,10 +164,10 @@ fn maybe_radius_yaml(radius: &BorderRadius) -> Option<Yaml> {
         }
     } else {
         let mut table = new_table();
-        size_node(&mut table, "top_left", &radius.top_left);
-        size_node(&mut table, "top_right", &radius.top_right);
-        size_node(&mut table, "bottom_left", &radius.bottom_left);
-        size_node(&mut table, "bottom_right", &radius.bottom_right);
+        size_node(&mut table, "top-left", &radius.top_left);
+        size_node(&mut table, "top-right", &radius.top_right);
+        size_node(&mut table, "bottom-left", &radius.bottom_left);
+        size_node(&mut table, "bottom-right", &radius.bottom_right);
         Some(Yaml::Hash(table))
     }
 }
@@ -177,7 +177,7 @@ fn write_sc(parent: &mut Table, sc: &StackingContext) {
     rect_node(parent, "bounds", &sc.bounds);
 
     scroll_policy_node(parent, "scroll-policy", sc.scroll_policy);
-    i32_node(parent, "z_index", sc.z_index);
+    i32_node(parent, "z-index", sc.z_index);
 
     match sc.transform {
         Some(PropertyBinding::Value(transform)) => matrix4d_node(parent, "transform", &transform),
@@ -481,7 +481,7 @@ impl YamlFrameWriter {
                 rect_node(&mut mask_table, "rect", &mask.rect);
                 bool_node(&mut mask_table, "repeat", mask.repeat);
 
-                table_node(&mut complex_table, "image_mask", mask_table);
+                table_node(&mut complex_table, "image-mask", mask_table);
             }
 
             Yaml::Hash(complex_table)
@@ -499,7 +499,7 @@ impl YamlFrameWriter {
             let mut v = new_table();
             rect_node(&mut v, "bounds", &base.rect);
             yaml_node(&mut v, "clip", self.make_clip_node(&base.clip, aux));
-            usize_node(&mut v, "clip_id", clip_id_mapper.map(&base.scroll_layer_id));
+            usize_node(&mut v, "clip-id", clip_id_mapper.map(&base.scroll_layer_id));
 
             match base.item {
                 Rectangle(item) => {
@@ -553,8 +553,8 @@ impl YamlFrameWriter {
                     if let Some(&CachedImage { tiling: Some(tile_size), .. }) = self.images.get(&item.image_key) {
                         u32_node(&mut v, "tile-size", tile_size as u32);
                     }
-                    size_node(&mut v, "stretch_size", &item.stretch_size);
-                    size_node(&mut v, "tile_spacing", &item.tile_spacing);
+                    size_node(&mut v, "stretch-size", &item.stretch_size);
+                    size_node(&mut v, "tile-spacing", &item.tile_spacing);
                     match item.image_rendering {
                         ImageRendering::Auto => (),
                         ImageRendering::CrispEdges => str_node(&mut v, "rendering", "crisp-edges"),
@@ -671,10 +671,10 @@ impl YamlFrameWriter {
                                                          details.outset.left];
                             yaml_node(&mut v, "width", f32_vec_yaml(&widths, true));
                             str_node(&mut v, "border-type", "radial-gradient");
-                            point_node(&mut v, "start_center", &details.gradient.start_center);
-                            f32_node(&mut v, "start_radius", details.gradient.start_radius);
-                            point_node(&mut v, "end_center", &details.gradient.end_center);
-                            f32_node(&mut v, "end_radius", details.gradient.end_radius);
+                            point_node(&mut v, "start-center", &details.gradient.start_center);
+                            f32_node(&mut v, "start-radius", details.gradient.start_radius);
+                            point_node(&mut v, "end-center", &details.gradient.end_center);
+                            f32_node(&mut v, "end-radius", details.gradient.end_radius);
                             let mut stops = vec![];
                             for stop in aux.gradient_stops(&details.gradient.stops) {
                                 stops.push(Yaml::Real(stop.offset.to_string()));
@@ -688,18 +688,18 @@ impl YamlFrameWriter {
                 },
                 BoxShadow(item) => {
                     str_node(&mut v, "type", "box-shadow");
-                    rect_node(&mut v, "box_bounds", &item.box_bounds);
+                    rect_node(&mut v, "box-bounds", &item.box_bounds);
                     point_node(&mut v, "offset", &item.offset);
                     color_node(&mut v, "color", item.color);
-                    f32_node(&mut v, "blur_radius", item.blur_radius);
-                    f32_node(&mut v, "spread_radius", item.spread_radius);
-                    f32_node(&mut v, "border_radius", item.border_radius);
+                    f32_node(&mut v, "blur-radius", item.blur_radius);
+                    f32_node(&mut v, "spread-radius", item.spread_radius);
+                    f32_node(&mut v, "border-radius", item.border_radius);
                     let clip_mode = match item.clip_mode {
                         BoxShadowClipMode::None => "none",
                         BoxShadowClipMode::Outset => "outset",
                         BoxShadowClipMode::Inset => "inset"
                     };
-                    str_node(&mut v, "clip_mode", clip_mode);
+                    str_node(&mut v, "clip-mode", clip_mode);
                 },
                 Gradient(item) => {
                     str_node(&mut v, "type", "gradient");
@@ -714,11 +714,11 @@ impl YamlFrameWriter {
                     bool_node(&mut v, "repeat", item.gradient.extend_mode == ExtendMode::Repeat);
                 },
                 RadialGradient(item) => {
-                    str_node(&mut v, "type", "radial_gradient");
-                    point_node(&mut v, "start_center", &item.gradient.start_center);
-                    f32_node(&mut v, "start_radius", item.gradient.start_radius);
-                    point_node(&mut v, "end_center", &item.gradient.end_center);
-                    f32_node(&mut v, "end_radius", item.gradient.end_radius);
+                    str_node(&mut v, "type", "radial-gradient");
+                    point_node(&mut v, "start-center", &item.gradient.start_center);
+                    f32_node(&mut v, "start-radius", item.gradient.start_radius);
+                    point_node(&mut v, "end-center", &item.gradient.end_center);
+                    f32_node(&mut v, "end-radius", item.gradient.end_radius);
                     let mut stops = vec![];
                     for stop in aux.gradient_stops(&item.gradient.stops) {
                         stops.push(Yaml::Real(stop.offset.to_string()));
@@ -732,7 +732,7 @@ impl YamlFrameWriter {
                     u32_vec_node(&mut v, "id", &vec![item.pipeline_id.0, item.pipeline_id.1]);
                 },
                 PushStackingContext(item) => {
-                    str_node(&mut v, "type", "stacking_context");
+                    str_node(&mut v, "type", "stacking-context");
                     write_sc(&mut v, &item.stacking_context);
                     self.write_display_list(&mut v, list_iterator, aux, clip_id_mapper);
                 },

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -310,10 +310,10 @@ impl YamlHelper for Yaml {
                 Some(BorderRadius::uniform(v as f32))
             }
             Yaml::Hash(_) => {
-                let top_left = self["top_left"].as_size().unwrap_or(TypedSize2D::zero());
-                let top_right = self["top_right"].as_size().unwrap_or(TypedSize2D::zero());
-                let bottom_left = self["bottom_left"].as_size().unwrap_or(TypedSize2D::zero());
-                let bottom_right = self["bottom_right"].as_size().unwrap_or(TypedSize2D::zero());
+                let top_left = self["top-left"].as_size().unwrap_or(TypedSize2D::zero());
+                let top_right = self["top-right"].as_size().unwrap_or(TypedSize2D::zero());
+                let bottom_left = self["bottom-left"].as_size().unwrap_or(TypedSize2D::zero());
+                let bottom_right = self["bottom-right"].as_size().unwrap_or(TypedSize2D::zero());
                 Some(BorderRadius {
                     top_left: top_left,
                     top_right: top_right,


### PR DESCRIPTION
Right now it's a bit of a mess. I propose we standardize on hypens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/999)
<!-- Reviewable:end -->
