### PR TITLE
Stop clipping on stacking context boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.25.0",
- "webrender_traits 0.26.0",
+ "webrender 0.26.0",
+ "webrender_traits 0.27.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,12 +909,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.26.0",
+ "webrender_traits 0.27.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,8 +947,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.25.0",
- "webrender_traits 0.26.0",
+ "webrender 0.26.0",
+ "webrender_traits 0.27.0",
 ]
 
 [[package]]

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -255,18 +255,9 @@ fn main() {
     let pipeline_id = PipelineId(0, 0);
     let mut builder = webrender_traits::DisplayListBuilder::new(pipeline_id);
 
-    let bounds = LayoutRect::new(LayoutPoint::new(0.0, 0.0), LayoutSize::new(width as f32, height as f32));
-    let clip_region = {
-        let complex = webrender_traits::ComplexClipRegion::new(
-            LayoutRect::new(LayoutPoint::new(50.0, 50.0), LayoutSize::new(100.0, 100.0)),
-            webrender_traits::BorderRadius::uniform(20.0));
-
-        builder.new_clip_region(&bounds, vec![complex], None)
-    };
-
+    let bounds = LayoutRect::new(LayoutPoint::zero(), LayoutSize::new(width as f32, height as f32));
     builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
                                   bounds,
-                                  clip_region,
                                   0,
                                   None,
                                   None,

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -248,9 +248,13 @@ impl ClipScrollNode {
         // Now that we have the combined viewport rectangle of the parent nodes in local space,
         // we do the intersection and get our combined viewport rect in the coordinate system
         // starting from our origin.
-        self.combined_local_viewport_rect =
-            parent_combined_viewport_in_local_space.intersection(&self.local_clip_rect)
-                                                    .unwrap_or(LayerRect::zero());
+        self.combined_local_viewport_rect = match self.node_type {
+            NodeType::Clip(_) => {
+                parent_combined_viewport_in_local_space.intersection(&self.local_clip_rect)
+                                                       .unwrap_or(LayerRect::zero())
+            }
+            NodeType::ReferenceFrame(_) => parent_combined_viewport_in_local_space,
+        };
 
         // The transformation for this viewport in world coordinates is the transformation for
         // our parent reference frame, plus any accumulated scrolling offsets from nodes

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -18,7 +18,7 @@ use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
 use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipRegion, ColorF, DeviceUintRect};
 use webrender_traits::{DeviceUintSize, DisplayItem, Epoch, FilterOp, ImageDisplayItem, LayerPoint};
-use webrender_traits::{LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
+use webrender_traits::{LayerRect, LayerSize, LayerToScrollTransform, LayoutRect, LayoutTransform};
 use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerId};
 use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, SpecificDisplayItem};
 use webrender_traits::{StackingContext, TileOffset, WorldPoint};
@@ -67,14 +67,14 @@ pub struct Frame {
 }
 
 trait DisplayListHelpers {
-    fn starting_stacking_context<'a>(&'a self) -> Option<(&'a StackingContext, &'a ClipRegion)>;
+    fn starting_stacking_context<'a>(&'a self) -> Option<(&'a StackingContext, &'a LayoutRect)>;
 }
 
 impl DisplayListHelpers for Vec<DisplayItem> {
-    fn starting_stacking_context<'a>(&'a self) -> Option<(&'a StackingContext, &'a ClipRegion)> {
+    fn starting_stacking_context<'a>(&'a self) -> Option<(&'a StackingContext, &'a LayoutRect)> {
         self.first().and_then(|item| match item.item {
             SpecificDisplayItem::PushStackingContext(ref specific_item) => {
-                Some((&specific_item.stacking_context, &item.clip))
+                Some((&specific_item.stacking_context, &item.rect))
             },
             _ => None,
         })
@@ -284,7 +284,7 @@ impl Frame {
 
         self.pipeline_epoch_map.insert(root_pipeline_id, root_pipeline.epoch);
 
-        let (root_stacking_context, root_clip) = match display_list.starting_stacking_context() {
+        let (root_stacking_context, root_bounds) = match display_list.starting_stacking_context() {
             Some(some) => some,
             None => {
                 warn!("Pipeline display list does not start with a stacking context.");
@@ -309,7 +309,7 @@ impl Frame {
 
             let scroll_layer_id = context.builder.push_root(root_pipeline_id,
                                                             &root_pipeline.viewport_size,
-                                                            &root_clip.main.size,
+                                                            &root_bounds.size,
                                                             &mut self.clip_scroll_tree);
 
             context.builder.setup_viewport_offset(window_size,
@@ -324,8 +324,8 @@ impl Frame {
                                           scroll_layer_id,
                                           LayerPoint::zero(),
                                           0,
-                                          &root_stacking_context,
-                                          root_clip);
+                                          &root_bounds,
+                                          &root_stacking_context);
         }
 
         self.frame_builder = Some(frame_builder);
@@ -357,8 +357,8 @@ impl Frame {
                                     context_scroll_layer_id: ScrollLayerId,
                                     mut reference_frame_relative_offset: LayerPoint,
                                     level: i32,
-                                    stacking_context: &StackingContext,
-                                    clip_region: &ClipRegion) {
+                                    bounds: &LayerRect,
+                                    stacking_context: &StackingContext) {
         // Avoid doing unnecessary work for empty stacking contexts.
         if traversal.current_stacking_context_empty() {
             traversal.skip_current_stacking_context();
@@ -400,28 +400,26 @@ impl Frame {
                 LayerToScrollTransform::create_translation(reference_frame_relative_offset.x,
                                                            reference_frame_relative_offset.y,
                                                            0.0)
-                                        .pre_translated(stacking_context.bounds.origin.x,
-                                                        stacking_context.bounds.origin.y,
-                                                        0.0)
+                                        .pre_translated(bounds.origin.x, bounds.origin.y, 0.0)
                                         .pre_mul(&transform)
                                         .pre_mul(&perspective);
 
+            let reference_frame_bounds = LayerRect::new(LayerPoint::zero(), bounds.size);
             scroll_layer_id = context.builder.push_reference_frame(Some(scroll_layer_id),
                                                                    pipeline_id,
-                                                                   &clip_region.main,
+                                                                   &reference_frame_bounds,
                                                                    &transform,
                                                                    &mut self.clip_scroll_tree);
             context.replacements.push((context_scroll_layer_id, scroll_layer_id));
             reference_frame_relative_offset = LayerPoint::zero();
         } else {
             reference_frame_relative_offset = LayerPoint::new(
-                reference_frame_relative_offset.x + stacking_context.bounds.origin.x,
-                reference_frame_relative_offset.y + stacking_context.bounds.origin.y);
+                reference_frame_relative_offset.x + bounds.origin.x,
+                reference_frame_relative_offset.y + bounds.origin.y);
         }
 
         // TODO(gw): Int with overflow etc
-        context.builder.push_stacking_context(reference_frame_relative_offset,
-                                              clip_region.main,
+        context.builder.push_stacking_context(&reference_frame_relative_offset,
                                               pipeline_id,
                                               level == 0,
                                               composition_operations);
@@ -431,9 +429,9 @@ impl Frame {
                 if let Some(bg_color) = pipeline.background_color {
                     // Note: we don't use the original clip region here,
                     // it's already processed by the node we just pushed.
-                    let background_rect = LayerRect::new(LayerPoint::zero(), clip_region.main.size);
+                    let background_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
                     context.builder.add_solid_rectangle(scroll_layer_id,
-                                                        &clip_region.main,
+                                                        &bounds,
                                                         &ClipRegion::simple(&background_rect),
                                                         &bg_color,
                                                         PrimitiveFlags::None);
@@ -487,7 +485,8 @@ impl Frame {
             None => return,
         };
 
-        let (iframe_stacking_context, iframe_clip) = match display_list.starting_stacking_context() {
+        let (iframe_stacking_context,
+             iframe_stacking_context_bounds) = match display_list.starting_stacking_context() {
             Some(some) => some,
             None => {
                 warn!("Pipeline display list does not start with a stacking context.");
@@ -516,8 +515,8 @@ impl Frame {
             iframe_reference_frame_id,
             pipeline_id,
             &LayerRect::new(LayerPoint::zero(), iframe_rect.size),
-            &iframe_clip.main.size,
-            iframe_clip,
+            &iframe_stacking_context_bounds.size,
+            &ClipRegion::simple(&iframe_stacking_context_bounds),
             &mut self.clip_scroll_tree);
 
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
@@ -527,8 +526,8 @@ impl Frame {
                                       iframe_scroll_layer_id,
                                       LayerPoint::zero(),
                                       0,
-                                      &iframe_stacking_context,
-                                      iframe_clip);
+                                      &iframe_stacking_context_bounds,
+                                      &iframe_stacking_context);
 
         context.builder.pop_reference_frame();
     }
@@ -644,8 +643,8 @@ impl Frame {
                                                   item.scroll_layer_id,
                                                   reference_frame_relative_offset,
                                                   level + 1,
-                                                  &info.stacking_context,
-                                                  &item.clip);
+                                                  &item.rect,
+                                                  &info.stacking_context);
                 }
                 SpecificDisplayItem::Iframe(ref info) => {
                     self.flatten_iframe(info.pipeline_id,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -211,8 +211,7 @@ impl FrameBuilder {
     }
 
     pub fn push_stacking_context(&mut self,
-                                 reference_frame_offset: LayerPoint,
-                                 rect: LayerRect,
+                                 reference_frame_offset: &LayerPoint,
                                  pipeline_id: PipelineId,
                                  is_page_root: bool,
                                  composite_ops: CompositeOps) {
@@ -229,8 +228,7 @@ impl FrameBuilder {
 
         let stacking_context_index = StackingContextIndex(self.stacking_context_store.len());
         self.stacking_context_store.push(StackingContext::new(pipeline_id,
-                                                              reference_frame_offset,
-                                                              rect,
+                                                              *reference_frame_offset,
                                                               is_page_root,
                                                               composite_ops));
         self.cmds.push(PrimitiveRunCmd::PushStackingContext(stacking_context_index));
@@ -1446,7 +1444,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             let local_viewport_rect =
                 node.combined_local_viewport_rect.translate(&-node.local_viewport_rect.origin);
 
-            node_clip_info.xf_rect = packed_layer.set_rect(Some(local_viewport_rect),
+            node_clip_info.xf_rect = packed_layer.set_rect(&local_viewport_rect,
                                                            self.screen_rect,
                                                            self.device_pixel_ratio);
 
@@ -1493,16 +1491,13 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 return;
             }
 
-            // Here we want to find the intersection between the clipping region and the
-            // stacking context content, so we move the viewport rectangle into the coordinate
-            // system of the stacking context content.
+            // Here we move the viewport rectangle into the coordinate system
+            // of the stacking context content.
             let viewport_rect =
                 &node.combined_local_viewport_rect
                      .translate(&-stacking_context.reference_frame_offset)
                      .translate(&-node.scrolling.offset);
-            let intersected_rect = stacking_context.local_rect.intersection(viewport_rect);
-
-            group.xf_rect = packed_layer.set_rect(intersected_rect,
+            group.xf_rect = packed_layer.set_rect(viewport_rect,
                                                   self.screen_rect,
                                                   self.device_pixel_ratio);
         }

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -244,7 +244,6 @@ pub struct PushStackingContextDisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StackingContext {
     pub scroll_policy: ScrollPolicy,
-    pub bounds: LayoutRect,
     pub z_index: i32,
     pub transform: Option<PropertyBinding<LayoutTransform>>,
     pub perspective: Option<LayoutTransform>,
@@ -356,7 +355,6 @@ pub struct ComplexClipRegion {
 
 impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
-               bounds: LayoutRect,
                z_index: i32,
                transform: Option<PropertyBinding<LayoutTransform>>,
                perspective: Option<LayoutTransform>,
@@ -366,7 +364,6 @@ impl StackingContext {
                -> StackingContext {
         StackingContext {
             scroll_policy: scroll_policy,
-            bounds: bounds,
             z_index: z_index,
             transform: transform,
             perspective: perspective,

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -313,7 +313,6 @@ impl DisplayListBuilder {
     pub fn push_stacking_context(&mut self,
                                  scroll_policy: ScrollPolicy,
                                  bounds: LayoutRect,
-                                 clip: ClipRegion,
                                  z_index: i32,
                                  transform: Option<PropertyBinding<LayoutTransform>>,
                                  perspective: Option<LayoutTransform>,
@@ -322,7 +321,6 @@ impl DisplayListBuilder {
         let item = SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
             stacking_context: StackingContext {
                 scroll_policy: scroll_policy,
-                bounds: bounds,
                 z_index: z_index,
                 transform: transform,
                 perspective: perspective,
@@ -331,7 +329,7 @@ impl DisplayListBuilder {
             }
         });
 
-        self.push_item(item, LayoutRect::zero(), clip);
+        self.push_item(item, bounds, ClipRegion::simple(&LayoutRect::zero()));
     }
 
     pub fn pop_stacking_context(&mut self) {

--- a/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
+++ b/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
@@ -2,7 +2,6 @@
 root:
   items:
     - type: stacking-context
-      clip: [0, 0, 300, 300]
       bounds: [0, 0, 300, 300]
       "scroll-policy": scrollable
       z-index: 4

--- a/wrench/reftests/scrolling/fixed-position.yaml
+++ b/wrench/reftests/scrolling/fixed-position.yaml
@@ -1,6 +1,5 @@
 root:
   bounds: [0, 0, 1024, 10000]
-  clip: [0, 0, 1024, 10000]
   scroll-offset: [0, 100]
   items:
     # This stacking context should not scroll out of view because it is fixed position.

--- a/wrench/reftests/scrolling/root-scroll-ref.yaml
+++ b/wrench/reftests/scrolling/root-scroll-ref.yaml
@@ -1,6 +1,5 @@
 root:
   bounds: [0, 0, 1024, 10000]
-  clip: [0, 0, 1024, 10000]
   items:
     - type: rect
       bounds: [10, 10, 50, 50]

--- a/wrench/reftests/scrolling/root-scroll.yaml
+++ b/wrench/reftests/scrolling/root-scroll.yaml
@@ -1,6 +1,5 @@
 root:
   bounds: [0, 0, 1024, 10000]
-  clip: [0, 0, 1024, 10000]
   scroll-offset: [0, 100]
   items:
     - type: rect

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -1,7 +1,6 @@
 root:
   items:
     -
-      clip: [0, 0, 100, 100]
       type: stacking-context
       # We give this stacking context a little offset here to
       # ensure that offsets within reference frames are handled
@@ -27,7 +26,6 @@ root:
     -
       type: stacking-context
       bounds: [100, 0, 100, 100]
-      clip: [0, 0, 100, 300]
       scroll-policy: scrollable
       items:
       - type: scroll-layer

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -629,9 +629,10 @@ impl YamlFrameReader {
                                           wrench: &mut Wrench,
                                           yaml: &Yaml,
                                           is_root: bool) {
-        let default_bounds = LayoutRect::new(LayoutPoint::new(0.0, 0.0), wrench.window_size_f32());
+        let default_bounds = LayoutRect::new(LayoutPoint::zero(), wrench.window_size_f32());
         let bounds = yaml["bounds"].as_rect().unwrap_or(default_bounds);
         let z_index = yaml["z-index"].as_i64().unwrap_or(0);
+
         // TODO(gw): Add support for specifying the transform origin in yaml.
         let transform_origin = LayoutPoint::new(bounds.origin.x + bounds.size.width * 0.5,
                                                 bounds.origin.y + bounds.size.height * 0.5);
@@ -646,11 +647,8 @@ impl YamlFrameReader {
             None => None,
         };
 
-        let mix_blend_mode = yaml["mix-blend-mode"].as_mix_blend_mode().unwrap_or(MixBlendMode::Normal);
-        let sc_full_rect = LayoutRect::new(LayoutPoint::new(0.0, 0.0), bounds.size);
-        let clip = self.to_clip_region(&yaml["clip"], &sc_full_rect, wrench)
-                       .unwrap_or(ClipRegion::simple(&sc_full_rect));
-
+        let mix_blend_mode = yaml["mix-blend-mode"].as_mix_blend_mode()
+                                                   .unwrap_or(MixBlendMode::Normal);
         let scroll_policy = yaml["scroll-policy"].as_scroll_policy()
                                                  .unwrap_or(ScrollPolicy::Scrollable);
 
@@ -665,7 +663,6 @@ impl YamlFrameReader {
 
         self.builder().push_stacking_context(scroll_policy,
                                              bounds,
-                                             clip,
                                              z_index as i32,
                                              transform.into(),
                                              perspective,

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -173,9 +173,6 @@ fn maybe_radius_yaml(radius: &BorderRadius) -> Option<Yaml> {
 }
 
 fn write_sc(parent: &mut Table, sc: &StackingContext) {
-    // overwrite "bounds" with the proper one
-    rect_node(parent, "bounds", &sc.bounds);
-
     scroll_policy_node(parent, "scroll-policy", sc.scroll_policy);
     i32_node(parent, "z-index", sc.z_index);
 


### PR DESCRIPTION
Now that clipping regions are first-class elements in the display list,
it doesn't make as much sense to clip along stacking context
boundaries. Additionally, this removes a lot of complexity around the
difference between stacking context bounds and overflow.

Using the transparent rectangle test, I couldn't detect a difference in
performance, and that creates a lot of stacking contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1002)
<!-- Reviewable:end -->
