### PR TITLE
Implement sub-image updates.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -147,8 +147,8 @@ impl RenderBackend {
                             }
                             self.resource_cache.add_image_template(id, descriptor, data, tiling);
                         }
-                        ApiMsg::UpdateImage(id, descriptor, bytes) => {
-                            self.resource_cache.update_image_template(id, descriptor, bytes);
+                        ApiMsg::UpdateImage(id, descriptor, bytes, dirty_rect) => {
+                            self.resource_cache.update_image_template(id, descriptor, bytes, dirty_rect);
                         }
                         ApiMsg::DeleteImage(id) => {
                             self.resource_cache.delete_image_template(id);

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -25,7 +25,7 @@ pub enum ApiMsg {
     /// Adds an image from the resource cache.
     AddImage(ImageKey, ImageDescriptor, ImageData, Option<TileSize>),
     /// Updates the the resource cache with the new image data.
-    UpdateImage(ImageKey, ImageDescriptor, Vec<u8>),
+    UpdateImage(ImageKey, ImageDescriptor, Vec<u8>, Option<DeviceUintRect>),
     /// Drops an image from the resource cache.
     DeleteImage(ImageKey),
     CloneApi(MsgSender<IdNamespace>),
@@ -229,8 +229,9 @@ impl RenderApi {
     pub fn update_image(&self,
                         key: ImageKey,
                         descriptor: ImageDescriptor,
-                        bytes: Vec<u8>) {
-        let msg = ApiMsg::UpdateImage(key, descriptor, bytes);
+                        bytes: Vec<u8>,
+                        dirty_rect: Option<DeviceUintRect>) {
+        let msg = ApiMsg::UpdateImage(key, descriptor, bytes, dirty_rect);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -234,7 +234,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, descriptor, ref bytes) => {
+            &ApiMsg::UpdateImage(ref key, descriptor, ref bytes, _dirty_rect) => {
                 if let Some(ref mut data) = self.images.get_mut(key) {
                     assert!(data.width == descriptor.width);
                     assert!(data.height == descriptor.height);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -800,7 +800,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, ref descriptor, ref bytes) => {
+            &ApiMsg::UpdateImage(ref key, ref descriptor, ref bytes, _dirty_rect) => {
                 if let Some(ref mut data) = self.frame_writer.images.get_mut(key) {
                     assert!(data.width == descriptor.width);
                     assert!(data.height == descriptor.height);


### PR DESCRIPTION
Add an optional dirty rect to the update_image command (None means invalidate all), and only upload the required part of the image if the image was already in the texture cache. This will become more important when used with blob images since the blob image renderer will use this information to avoid repainting the entire image when possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1003)
<!-- Reviewable:end -->
