### PR TITLE
Allow updating images that are not raw buffers

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -20,9 +20,10 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer};
-use webrender_traits::{BlobImageResult, ClipRegion, ColorF, DeviceIntPoint, DeviceUintSize, Epoch, GlyphInstance};
+use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
+use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
-use webrender_traits::{LayoutPoint, LayoutRect, LayoutSize, PipelineId, RasterizedBlobImage};
+use webrender_traits::{PipelineId, RasterizedBlobImage};
 
 #[derive(Debug)]
 enum Gesture {
@@ -455,7 +456,11 @@ impl FakeBlobImageRenderer {
 }
 
 impl BlobImageRenderer for FakeBlobImageRenderer {
-    fn request_blob_image(&mut self, key: ImageKey, _: Arc<BlobImageData>, descriptor: &BlobImageDescriptor) {
+    fn request_blob_image(&mut self,
+                          key: ImageKey,
+                          _: Arc<BlobImageData>,
+                          descriptor: &BlobImageDescriptor,
+                          _dirty_rect: Option<DeviceUintRect>) {
         let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
         for y in 0..descriptor.height {
             for x in 0..descriptor.width {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -295,16 +295,14 @@ impl ResourceCache {
     pub fn update_image_template(&mut self,
                                  image_key: ImageKey,
                                  descriptor: ImageDescriptor,
-                                 bytes: Vec<u8>,
+                                 data: ImageData,
                                  dirty_rect: Option<DeviceUintRect>) {
         let (next_epoch, prev_dirty_rect) = match self.image_templates.get(&image_key) {
             Some(image) => {
                 // This image should not be an external image.
-                match image.data {
-                    ImageData::ExternalHandle(id) => {
-                        panic!("Update an external image with buffer, id={} image_key={:?}", id.0, image_key);
-                    },
-                    _ => {},
+                // TODO: Why?
+                if let ImageData::ExternalHandle(id) = image.data {
+                    panic!("Update an external image with buffer, id={} image_key={:?}", id.0, image_key);
                 }
 
                 let Epoch(current_epoch) = image.epoch;
@@ -317,7 +315,7 @@ impl ResourceCache {
 
         let resource = ImageResource {
             descriptor: descriptor,
-            data: ImageData::new(bytes),
+            data: data,
             epoch: next_epoch,
             tiling: None,
             dirty_rect: match (dirty_rect, prev_dirty_rect) {
@@ -394,6 +392,7 @@ impl ResourceCache {
                             // TODO(nical): figure out the scale factor (should change with zoom).
                             scale_factor: 1.0,
                         },
+                        template.dirty_rect,
                     );
                 }
             }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -722,27 +722,30 @@ impl TextureCache {
                 panic!("The vector image should have been rasterized into a raw image.");
             }
             ImageData::Raw(bytes) => {
-                if let Some(dirty) = dirty_rect {
-                    let stride = descriptor.compute_stride();
-                    let offset = descriptor.offset + dirty.origin.y * stride + dirty.origin.x;
-                    TextureUpdateOp::Update {
-                        page_pos_x: existing_item.allocated_rect.origin.x + dirty.origin.x,
-                        page_pos_y: existing_item.allocated_rect.origin.y + dirty.origin.y,
-                        width: dirty.size.width,
-                        height: dirty.size.height,
-                        data: bytes,
-                        stride: Some(stride),
-                        offset: offset,
+                match dirty_rect {
+                    Some(dirty) => {
+                        let stride = descriptor.compute_stride();
+                        let offset = descriptor.offset + dirty.origin.y * stride + dirty.origin.x;
+                        TextureUpdateOp::Update {
+                            page_pos_x: existing_item.allocated_rect.origin.x + dirty.origin.x,
+                            page_pos_y: existing_item.allocated_rect.origin.y + dirty.origin.y,
+                            width: dirty.size.width,
+                            height: dirty.size.height,
+                            data: bytes,
+                            stride: Some(stride),
+                            offset: offset,
+                        }
                     }
-                } else {
-                    TextureUpdateOp::Update {
-                        page_pos_x: existing_item.allocated_rect.origin.x,
-                        page_pos_y: existing_item.allocated_rect.origin.y,
-                        width: descriptor.width,
-                        height: descriptor.height,
-                        data: bytes,
-                        stride: descriptor.stride,
-                        offset: descriptor.offset,
+                    None => {
+                        TextureUpdateOp::Update {
+                            page_pos_x: existing_item.allocated_rect.origin.x,
+                            page_pos_y: existing_item.allocated_rect.origin.y,
+                            width: descriptor.width,
+                            height: descriptor.height,
+                            data: bytes,
+                            stride: descriptor.stride,
+                            offset: descriptor.offset,
+                        }
                     }
                 }
             }

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -25,7 +25,7 @@ pub enum ApiMsg {
     /// Adds an image from the resource cache.
     AddImage(ImageKey, ImageDescriptor, ImageData, Option<TileSize>),
     /// Updates the the resource cache with the new image data.
-    UpdateImage(ImageKey, ImageDescriptor, Vec<u8>, Option<DeviceUintRect>),
+    UpdateImage(ImageKey, ImageDescriptor, ImageData, Option<DeviceUintRect>),
     /// Drops an image from the resource cache.
     DeleteImage(ImageKey),
     CloneApi(MsgSender<IdNamespace>),
@@ -229,9 +229,9 @@ impl RenderApi {
     pub fn update_image(&self,
                         key: ImageKey,
                         descriptor: ImageDescriptor,
-                        bytes: Vec<u8>,
+                        data: ImageData,
                         dirty_rect: Option<DeviceUintRect>) {
-        let msg = ApiMsg::UpdateImage(key, descriptor, bytes, dirty_rect);
+        let msg = ApiMsg::UpdateImage(key, descriptor, data, dirty_rect);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::sync::Arc;
+use DeviceUintRect;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -99,7 +100,8 @@ pub trait BlobImageRenderer: Send {
     fn request_blob_image(&mut self,
                             key: ImageKey,
                             data: Arc<BlobImageData>,
-                            descriptor: &BlobImageDescriptor);
+                            descriptor: &BlobImageDescriptor,
+                            dirty_rect: Option<DeviceUintRect>);
     fn resolve_blob_image(&mut self, key: ImageKey) -> BlobImageResult;
 }
 

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -234,14 +234,19 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, descriptor, ref bytes, _dirty_rect) => {
+            &ApiMsg::UpdateImage(ref key, descriptor, ref img_data, _dirty_rect) => {
                 if let Some(ref mut data) = self.images.get_mut(key) {
                     assert!(data.width == descriptor.width);
                     assert!(data.height == descriptor.height);
                     assert!(data.format == descriptor.format);
 
-                    *data.path.borrow_mut() = None;
-                    *data.bytes.borrow_mut() = Some(bytes.clone());
+                    if let &ImageData::Raw(ref bytes) = img_data {
+                        *data.path.borrow_mut() = None;
+                        *data.bytes.borrow_mut() = Some((**bytes).clone());
+                    } else {
+                        // Other existing image types only make sense within the gecko integration.
+                        println!("Wrench only supports updating buffer images (ignoring update command).");
+                    }
                 }
             }
 

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -797,14 +797,19 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 });
             }
 
-            &ApiMsg::UpdateImage(ref key, ref descriptor, ref bytes, _dirty_rect) => {
+            &ApiMsg::UpdateImage(ref key, ref descriptor, ref img_data, _dirty_rect) => {
                 if let Some(ref mut data) = self.frame_writer.images.get_mut(key) {
                     assert!(data.width == descriptor.width);
                     assert!(data.height == descriptor.height);
                     assert!(data.format == descriptor.format);
 
-                    *data.path.borrow_mut() = None;
-                    *data.bytes.borrow_mut() = Some(bytes.clone());
+                    if let &ImageData::Raw(ref bytes) = img_data {
+                        *data.path.borrow_mut() = None;
+                        *data.bytes.borrow_mut() = Some((**bytes).clone());
+                    } else {
+                        // Other existing image types only make sense within the gecko integration.
+                        println!("Wrench only supports updating buffer images (ignoring update command).");
+                    }
                 }
             }
 


### PR DESCRIPTION
```update_image``` currently takes a vector of bytes and the implementation expects this vector to be regular image data. We need to be able to update blob images as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1004)
<!-- Reviewable:end -->
