### PR TITLE
Splitting the clipped rectangles into opaque/transparent sub-parts

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -16,6 +16,7 @@ use scene::{Scene, SceneProperties};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
+use util::subtract_rect;
 use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipRegion, ColorF, DeviceUintRect};
 use webrender_traits::{DeviceUintSize, DisplayItem, Epoch, FilterOp, ImageDisplayItem, LayerPoint};
 use webrender_traits::{LayerRect, LayerSize, LayerToScrollTransform, LayoutTransform};
@@ -203,6 +204,22 @@ impl<'a> Iterator for DisplayListTraversal<'a> {
         self.next_item_index += 1;
         Some(item)
     }
+}
+
+fn clip_intersection(original_rect: &LayerRect,
+                     region: &ClipRegion,
+                     aux_lists: &AuxiliaryLists)
+                     -> Option<LayerRect> {
+    if region.image_mask.is_some() {
+        return None;
+    }
+    let clips = aux_lists.complex_clip_regions(&region.complex);
+    let base_rect = region.main.intersection(original_rect);
+    clips.iter().fold(base_rect, |inner_combined, ccr| {
+        inner_combined.and_then(|combined| {
+            ccr.get_inner_rect().and_then(|ir| ir.intersection(&combined))
+        })
+    })
 }
 
 impl Frame {
@@ -594,11 +611,34 @@ impl Frame {
                                              text_info.glyph_options);
                 }
                 SpecificDisplayItem::Rectangle(ref info) => {
-                    context.builder.add_solid_rectangle(scroll_layer_id,
-                                                        &item.rect,
-                                                        &item.clip,
-                                                        &info.color,
-                                                        PrimitiveFlags::None);
+                    let auxiliary_lists = self.pipeline_auxiliary_lists
+                                              .get(&pipeline_id)
+                                              .expect("No auxiliary lists?!");
+                    // Try to extract the opaque inner rectangle out of the clipped primitive.
+                    if let Some(opaque_rect) = clip_intersection(&item.rect, &item.clip, &auxiliary_lists) {
+                        let mut results = Vec::new();
+                        subtract_rect(&item.rect, &opaque_rect, &mut results);
+                        // The inner rectangle is considered opaque within this layer.
+                        // It may still inherit some masking from the clip stack.
+                        context.builder.add_solid_rectangle(scroll_layer_id,
+                                                            &opaque_rect,
+                                                            &ClipRegion::simple(&item.clip.main),
+                                                            &info.color,
+                                                            PrimitiveFlags::None);
+                        for transparent_rect in &results {
+                            context.builder.add_solid_rectangle(scroll_layer_id,
+                                                                transparent_rect,
+                                                                &item.clip,
+                                                                &info.color,
+                                                                PrimitiveFlags::None);
+                        }
+                    } else {
+                        context.builder.add_solid_rectangle(scroll_layer_id,
+                                                            &item.rect,
+                                                            &item.clip,
+                                                            &info.color,
+                                                            PrimitiveFlags::None);
+                    }
                 }
                 SpecificDisplayItem::Gradient(ref info) => {
                     context.builder.add_gradient(scroll_layer_id,


### PR DESCRIPTION
This is a simple optimization targeted at the case of large rectangles with rounded cornered clips. Instead of moving it into the transparent bin and rendering late, we are computing the inner intersection of the clip items and splitting the rectangle into opaque/transparent parts.

On my machine, this reduces the GPU time of https://github.com/servo/servo by approximately 10%: from 4.6ms to 3.9ms. More profiling might be needed, especially on windows.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1005)
<!-- Reviewable:end -->
