### PR TITLE
Fix incorrect yaml type in wrench reftests

### DIFF
--- a/wrench/reftests/border/border-groove-simple-ref.yaml
+++ b/wrench/reftests/border/border-groove-simple-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: border
@@ -10,7 +10,7 @@ root:
           border-type: normal
           style: [ solid, solid, solid, solid ]
           color: [ 0 0 178 1.0, 0 0 178 1.0, 0 0 255 1.0, 0 0 255 1.0 ]
-    - type: stacking_context
+    - type: stacking-context
       bounds: [6, 6, 38, 38]
       items:
         - type: border

--- a/wrench/reftests/border/border-groove-simple.yaml
+++ b/wrench/reftests/border/border-groove-simple.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 500, 500]
       items:
         - type: border

--- a/wrench/reftests/border/border-ridge-simple-ref.yaml
+++ b/wrench/reftests/border/border-ridge-simple-ref.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 50, 50]
       items:
         - type: border
@@ -10,7 +10,7 @@ root:
           border-type: normal
           style: [ solid, solid, solid, solid ]
           color: [ 0 0 255 1.0, 0 0 255 1.0, 0 0 178 1.0, 0 0 178 1.0 ]
-    - type: stacking_context
+    - type: stacking-context
       bounds: [6, 6, 38, 38]
       items:
         - type: border

--- a/wrench/reftests/border/border-ridge-simple.yaml
+++ b/wrench/reftests/border/border-ridge-simple.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: stacking_context
+    - type: stacking-context
       bounds: [0, 0, 500, 500]
       items:
         - type: border


### PR DESCRIPTION
Looks like a couple of tests were merged with underscores. I think they are passing because wrench will skip over the incorrect node, leaving just a blank page for the ref and test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1008)
<!-- Reviewable:end -->
