### PR TITLE
Adjust stops colors for aligned gradients relative to segment_rect

### DIFF
--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -15,31 +15,43 @@ void main(void) {
     vec4 adjusted_color_g0 = g0.color;
     vec4 adjusted_color_g1 = g1.color;
     if (gradient.start_end_point.y == gradient.start_end_point.w) {
-        vec2 x = mix(gradient.start_end_point.xx, gradient.start_end_point.zz,
-                     vec2(g0.offset.x, g1.offset.x));
+        // Calculate the x coord of the gradient stops
+        vec2 g01_x = mix(gradient.start_end_point.xx, gradient.start_end_point.zz,
+                         vec2(g0.offset.x, g1.offset.x));
+
         // The start and end point of gradient might exceed the geometry rect. So clamp
         // it to the geometry rect.
-        x = clamp(x, prim.local_rect.p0.xx, prim.local_rect.p0.xx + prim.local_rect.size.xx);
-        vec2 adjusted_offset =
-            (x - gradient.start_end_point.xx) / (gradient.start_end_point.zz - gradient.start_end_point.xx);
-        adjusted_color_g0 = mix(g0.color, g1.color, adjusted_offset.x);
-        adjusted_color_g1 = mix(g0.color, g1.color, adjusted_offset.y);
-        segment_rect.p0 = vec2(x.x, prim.local_rect.p0.y);
-        segment_rect.size = vec2(x.y - x.x, prim.local_rect.size.y);
+        g01_x = clamp(g01_x, prim.local_rect.p0.xx, prim.local_rect.p0.xx + prim.local_rect.size.xx);
+
+        // Calculate the rect using the clamped coords
+        segment_rect.p0 = vec2(g01_x.x, prim.local_rect.p0.y);
+        segment_rect.size = vec2(g01_x.y - g01_x.x, prim.local_rect.size.y);
         axis = vec2(1.0, 0.0);
-    } else {
-        vec2 y = mix(gradient.start_end_point.yy, gradient.start_end_point.ww,
-                     vec2(g0.offset.x, g1.offset.x));
-        // The start and end point of gradient might exceed the geometry rect. So clamp
-        // it to the geometry rect.
-        y = clamp(y, prim.local_rect.p0.yy, prim.local_rect.p0.yy + prim.local_rect.size.yy);
+
+        // We need to adjust the colors of the stops because they may have been clamped
         vec2 adjusted_offset =
-            (y - gradient.start_end_point.yy) / (gradient.start_end_point.ww - gradient.start_end_point.yy);
+            (g01_x - segment_rect.p0.xx) / segment_rect.size.xx;
         adjusted_color_g0 = mix(g0.color, g1.color, adjusted_offset.x);
         adjusted_color_g1 = mix(g0.color, g1.color, adjusted_offset.y);
-        segment_rect.p0 = vec2(prim.local_rect.p0.x, y.x);
-        segment_rect.size = vec2(prim.local_rect.size.x, y.y - y.x);
+    } else {
+        // Calculate the y coord of the gradient stops
+        vec2 g01_y = mix(gradient.start_end_point.yy, gradient.start_end_point.ww,
+                         vec2(g0.offset.x, g1.offset.x));
+
+        // The start and end point of gradient might exceed the geometry rect. So clamp
+        // it to the geometry rect.
+        g01_y = clamp(g01_y, prim.local_rect.p0.yy, prim.local_rect.p0.yy + prim.local_rect.size.yy);
+
+        // Calculate the rect using the clamped coords
+        segment_rect.p0 = vec2(prim.local_rect.p0.x, g01_y.x);
+        segment_rect.size = vec2(prim.local_rect.size.x, g01_y.y - g01_y.x);
         axis = vec2(0.0, 1.0);
+
+        // We need to adjust the colors of the stops because they may have been clamped
+        vec2 adjusted_offset =
+            (g01_y - segment_rect.p0.yy) / segment_rect.size.yy;
+        adjusted_color_g0 = mix(g0.color, g1.color, adjusted_offset.x);
+        adjusted_color_g1 = mix(g0.color, g1.color, adjusted_offset.y);
     }
 
 #ifdef WR_FEATURE_TRANSFORM


### PR DESCRIPTION
When there are multiple gradient stops for an aligned gradient,
the gradient stop colors are incorrectly adjusted. The weights
should be relative to the current segment rect not the entire
gradient rect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1010)
<!-- Reviewable:end -->
