### PR TITLE
Expose images to the BlobImageRenderer.

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -22,7 +22,7 @@ use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobI
 use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
-use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle, BoxShadowClipMode};
+use webrender_traits::{PipelineId, RasterizedBlobImage, ImageStore, TransformStyle, BoxShadowClipMode};
 
 #[derive(Debug)]
 enum Gesture {
@@ -482,7 +482,8 @@ impl BlobImageRenderer for FakeBlobImageRenderer {
                           key: ImageKey,
                           _: Arc<BlobImageData>,
                           descriptor: &BlobImageDescriptor,
-                          _dirty_rect: Option<DeviceUintRect>) {
+                          _dirty_rect: Option<DeviceUintRect>,
+                          _images: &ImageStore) {
         let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
         for y in 0..descriptor.height {
             for x in 0..descriptor.width {

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -115,10 +115,11 @@ impl ImageData {
 
 pub trait BlobImageRenderer: Send {
     fn request_blob_image(&mut self,
-                            key: ImageKey,
-                            data: Arc<BlobImageData>,
-                            descriptor: &BlobImageDescriptor,
-                            dirty_rect: Option<DeviceUintRect>);
+                          key: ImageKey,
+                          data: Arc<BlobImageData>,
+                          descriptor: &BlobImageDescriptor,
+                          dirty_rect: Option<DeviceUintRect>,
+                          images: &ImageStore);
     fn resolve_blob_image(&mut self, key: ImageKey) -> BlobImageResult;
 }
 
@@ -147,4 +148,8 @@ pub enum BlobImageError {
     InvalidKey,
     InvalidData,
     Other(String),
+}
+
+pub trait ImageStore {
+    fn get_image(&self, key: ImageKey) -> Option<(&ImageData, &ImageDescriptor)>;
 }


### PR DESCRIPTION
See issue #1017. The idea would be to do the same for fonts and paths.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1018)
<!-- Reviewable:end -->
