### PR TITLE
Add a into_data() method for built display lists

### DIFF
--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -68,6 +68,10 @@ impl BuiltDisplayList {
         }
     }
 
+    pub fn into_data(self) -> (Vec<u8>, BuiltDisplayListDescriptor) {
+        (self.data, self.descriptor)
+    }
+
     pub fn data(&self) -> &[u8] {
         &self.data[..]
     }
@@ -562,6 +566,10 @@ impl AuxiliaryLists {
             data: data,
             descriptor: descriptor,
         }
+    }
+
+    pub fn into_data(self) -> (Vec<u8>, AuxiliaryListsDescriptor) {
+        (self.data, self.descriptor)
     }
 
     pub fn data(&self) -> &[u8] {


### PR DESCRIPTION
This let's Gecko avoid a copy of the display because we can
move the Vec out into C++ instead of needing to copy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1019)
<!-- Reviewable:end -->
