### PR TITLE
Remove a redundant full screen rectangle being drawn each frame.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -441,7 +441,9 @@ impl Frame {
                                               level == 0,
                                               composition_operations);
 
-        if level == 0 {
+        // For the root pipeline, there's no need to add a full screen rectangle
+        // here, as it's handled by the framebuffer clear.
+        if level == 0 && context.scene.root_pipeline_id.unwrap() != pipeline_id {
             if let Some(pipeline) = context.scene.pipeline_map.get(&pipeline_id) {
                 if let Some(bg_color) = pipeline.background_color {
                     // Note: we don't use the original clip region here,


### PR DESCRIPTION
The root pipeline doesn't need to draw a rectangle for background
color, as this is handled by the framebuffer clear.

In some pages, this saves ~0.4ms GPU time per frame for the test
setup I am using (Intel HD530 @ 2048x2048). Other pages typically
see a gain of around 0.2ms / frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1021)
<!-- Reviewable:end -->
