### PR TITLE
Have ScrollLayerId use u64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.26.0",
- "webrender_traits 0.27.0",
+ "webrender 0.27.0",
+ "webrender_traits 0.28.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,12 +909,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.27.0",
+ "webrender_traits 0.28.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,8 +947,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.26.0",
- "webrender_traits 0.27.0",
+ "webrender 0.27.0",
+ "webrender_traits 0.28.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -23,7 +23,7 @@ pub struct ClipScrollTree {
     /// The current reference frame id, used for giving a unique id to all new
     /// reference frames. The ClipScrollTree increments this by one every time a
     /// reference frame is created.
-    current_reference_frame_id: usize,
+    current_reference_frame_id: u64,
 
     /// The root reference frame, which is the true root of the ClipScrollTree. Initially
     /// this ID is not valid, which is indicated by ```node``` being empty.

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -508,9 +508,9 @@ impl ComplexClipRegion {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ScrollLayerId {
-    Clip(usize, PipelineId),
-    ClipExternalId(usize, PipelineId),
-    ReferenceFrame(usize, PipelineId),
+    Clip(u64, PipelineId),
+    ClipExternalId(u64, PipelineId),
+    ReferenceFrame(u64, PipelineId),
 }
 
 impl ScrollLayerId {
@@ -522,7 +522,7 @@ impl ScrollLayerId {
         ScrollLayerId::ReferenceFrame(0, pipeline_id)
     }
 
-    pub fn new(id: usize, pipeline_id: PipelineId) -> ScrollLayerId {
+    pub fn new(id: u64, pipeline_id: PipelineId) -> ScrollLayerId {
         ScrollLayerId::ClipExternalId(id, pipeline_id)
     }
 
@@ -541,7 +541,7 @@ impl ScrollLayerId {
         }
     }
 
-    pub fn external_id(&self) -> Option<usize> {
+    pub fn external_id(&self) -> Option<u64> {
         match *self {
             ScrollLayerId::ClipExternalId(id, _) => Some(id),
             _ => None,

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -93,7 +93,7 @@ pub struct DisplayListBuilder {
     auxiliary_lists_builder: AuxiliaryListsBuilder,
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ScrollLayerId>,
-    next_scroll_layer_id: usize,
+    next_scroll_layer_id: u64,
 }
 
 impl DisplayListBuilder {

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -572,7 +572,7 @@ impl YamlFrameReader {
 
             let yaml_clip_id = item["clip-id"].as_i64();
             if let Some(yaml_id) = yaml_clip_id {
-                let id = ScrollLayerId::new(yaml_id as usize, self.builder().pipeline_id);
+                let id = ScrollLayerId::new(yaml_id as u64, self.builder().pipeline_id);
                 self.builder().push_clip_id(id);
             }
 
@@ -614,7 +614,7 @@ impl YamlFrameReader {
         let clip = self.to_clip_region(&yaml["clip"], &bounds, wrench)
                        .unwrap_or(ClipRegion::simple(&bounds));
         let id = yaml["id"].as_i64().map(|id|
-            ScrollLayerId::new(id as usize, self.builder().pipeline_id));
+            ScrollLayerId::new(id as u64, self.builder().pipeline_id));
 
         let id = self.builder().define_clip(clip, content_size, id);
 


### PR DESCRIPTION
This makes the size of the id platform independent and matches what
Gecko uses.

Fixes #489.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1022)
<!-- Reviewable:end -->
