### PR TITLE
Fix the `max_texture_size` checks

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -611,8 +611,8 @@ impl TextureCache {
         };
 
         // TODO(gw): Handle this sensibly (support failing to render items that can't fit?)
-        assert!(requested_size.width < self.max_texture_size);
-        assert!(requested_size.height < self.max_texture_size);
+        assert!(requested_size.width <= self.max_texture_size);
+        assert!(requested_size.height <= self.max_texture_size);
 
         let mut page_id = None; //using ID here to please the borrow checker
         for (i, page) in page_list.iter_mut().enumerate() {


### PR DESCRIPTION
The size of `max_texture_size` should still be allowed, and that's what the rest of the code assumes.
potentially fixes https://treeherder.mozilla.org/logviewer.html#?job_id=87300231&repo=try&lineNumber=3307
cc @staktrace 
r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1025)
<!-- Reviewable:end -->
