### PR TITLE
Tile external buffer images when they exceed the maximum texture size.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -259,10 +259,15 @@ impl ResourceCache {
 
     fn should_tile(&self, descriptor: &ImageDescriptor, data: &ImageData) -> bool {
         let limit = self.max_texture_size();
+        let size_check = descriptor.width > limit || descriptor.height > limit;
         return match data {
-            // Tiled external images are not implemented.
-            &ImageData::External(_) => false,
-            _ => { descriptor.width > limit || descriptor.height > limit }
+            &ImageData::Raw(_) => { size_check }
+            &ImageData::Blob(_) => { size_check }
+            &ImageData::External(info) => {
+                // External handles already represent existing textures so it does
+                // not make sense to tile them into smaller ones.
+                info.image_type == ExternalImageType::ExternalBuffer && size_check
+            },
         };
     }
 


### PR DESCRIPTION
Fixes issue #1027, and addresses a review comment from PR #1004 about explicitly enumerating all variants instead of using ```_ => { ... }``` in this match expression.

r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1036)
<!-- Reviewable:end -->
