### PR TITLE
Don't panic when dealing with empty masks

### DIFF
--- a/wrench/reftests/scrolling/empty-mask-ref.yaml
+++ b/wrench/reftests/scrolling/empty-mask-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: [0, 0, 100, 100]
+      color: green

--- a/wrench/reftests/scrolling/empty-mask.yaml
+++ b/wrench/reftests/scrolling/empty-mask.yaml
@@ -1,0 +1,17 @@
+root:
+  items:
+    - type: rect
+      bounds: [0, 0, 100, 100]
+      color: green
+    - type: scroll-layer
+      bounds: [0, 0, 100, 100]
+      content-size: [100, 100]
+      clip:
+        rect: [0, 0, 0, 0]
+        complex:
+          - rect: [0, 0, 100, 100]
+            radius: 20
+      items:
+        - type: rect
+          bounds: [0, 0, 500, 500]
+          color: red

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -3,3 +3,4 @@
 == fixed-position.yaml fixed-position-ref.yaml
 == scroll-layer.yaml scroll-layer-ref.yaml
 == scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
+== empty-mask.yaml empty-mask-ref.yaml


### PR DESCRIPTION
An empty mask shouldn't cause a panic. Instead we should use it as an
opportunity to optimize away the contents of that ClipScrollGroup. In
the future, perhaps this optimization can be extended to other kind of
empty ClipScrollGroups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1039)
<!-- Reviewable:end -->
