### PR TITLE
Temporarily disable dither on gradients, so we can update WR.

### DIFF
--- a/webrender/res/ps_gradient.fs.glsl
+++ b/webrender/res/ps_gradient.fs.glsl
@@ -12,5 +12,9 @@ void main(void) {
 #endif
 
     alpha = min(alpha, do_clip());
-    oFragColor = dither(vColor * vec4(1.0, 1.0, 1.0, alpha));
+
+    // TODO(gw): Re-enable the gradient dither once we get the
+    //           reftests passing.
+    //oFragColor = dither(vColor * vec4(1.0, 1.0, 1.0, alpha));
+    oFragColor = vColor * vec4(1.0, 1.0, 1.0, alpha);
 }

--- a/wrench/reftests/gradient/reftest.list
+++ b/wrench/reftests/gradient/reftest.list
@@ -2,9 +2,9 @@
 == premultiplied-angle.yaml blank.yaml
 == premultiplied-radial.yaml blank.yaml
 
-== linear.yaml linear-ref.png
-== linear-reverse.yaml linear-ref.png
-fuzzy(1,300) == linear-stops.yaml linear-stops-ref.png
+fuzzy(1,20000) == linear.yaml linear-ref.png
+fuzzy(1,20000) == linear-reverse.yaml linear-ref.png
+fuzzy(1,29300) == linear-stops.yaml linear-stops-ref.png
 
 # dithering requires us to fuzz here
 fuzzy(1,20000) == linear.yaml linear-ref.yaml


### PR DESCRIPTION
There are a number of WPT/CSS tests that break with the current
gradient dither code. For now, disable dither on gradients so that
we can land a WR update in Servo. We can re-enable the dither
once the reftest bug is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1042)
<!-- Reviewable:end -->
