### PR TITLE
Rename set_root_display_list to set_display_list.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.29.0",
- "webrender_traits 0.30.0",
+ "webrender 0.30.0",
+ "webrender_traits 0.31.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,12 +909,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.30.0",
+ "webrender_traits 0.31.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,8 +947,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.29.0",
- "webrender_traits 0.30.0",
+ "webrender 0.30.0",
+ "webrender_traits 0.31.0",
 ]
 
 [[package]]

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -392,7 +392,7 @@ fn main() {
 
     builder.pop_stacking_context();
 
-    api.set_root_display_list(
+    api.set_display_list(
         Some(root_background_color),
         epoch,
         LayoutSize::new(width as f32, height as f32),

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -24,18 +24,18 @@
 //! to make better use of multicore systems.
 //!
 //! What is referred to as a `frame`, is the current geometry on the screen.
-//! A new Frame is created by calling [`set_root_display_list()`][newframe] on the `RenderApi`.
+//! A new Frame is created by calling [`set_display_list()`][newframe] on the `RenderApi`.
 //! When the geometry is processed, the application will be informed via a `RenderNotifier`,
 //! a callback which you employ with [set_render_notifier][notifier] on the `Renderer`
 //! More information about [stacking contexts][stacking_contexts].
 //!
-//! `set_root_display_list()` also needs to be supplied with `BuiltDisplayList`s.
+//! `set_display_list()` also needs to be supplied with `BuiltDisplayList`s.
 //! These are obtained by finalizing a `DisplayListBuilder`. These are used to draw your geometry.
 //! But it doesn't only contain trivial geometry, it can also store another StackingContext, as
 //! they're nestable.
 //!
 //! [stacking_contexts]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-//! [newframe]: ../webrender_traits/struct.RenderApi.html#method.set_root_display_list
+//! [newframe]: ../webrender_traits/struct.RenderApi.html#method.set_display_list
 //! [notifier]: renderer/struct.Renderer.html#method.set_render_notifier
 
 #[macro_use]

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -71,7 +71,7 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         &ApiMsg::GenerateFrame(..) |
         &ApiMsg::UpdateImage(..) |
         &ApiMsg::DeleteImage(..) |
-        &ApiMsg::SetRootDisplayList(..) |
+        &ApiMsg::SetDisplayList(..) |
         &ApiMsg::SetRootPipeline(..) |
         &ApiMsg::Scroll(..) |
         &ApiMsg::TickScrollingBounce |

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -175,14 +175,14 @@ impl RenderBackend {
 
                             sender.send(result).unwrap();
                         }
-                        ApiMsg::SetRootDisplayList(background_color,
-                                                   epoch,
-                                                   pipeline_id,
-                                                   viewport_size,
-                                                   display_list_descriptor,
-                                                   auxiliary_lists_descriptor,
-                                                   preserve_frame_state) => {
-                            profile_scope!("SetRootDisplayList");
+                        ApiMsg::SetDisplayList(background_color,
+                                               epoch,
+                                               pipeline_id,
+                                               viewport_size,
+                                               display_list_descriptor,
+                                               auxiliary_lists_descriptor,
+                                               preserve_frame_state) => {
+                            profile_scope!("SetDisplayList");
                             let mut leftover_auxiliary_data = vec![];
                             let mut auxiliary_data;
                             loop {
@@ -213,12 +213,12 @@ impl RenderBackend {
                                 self.discard_frame_state_for_pipeline(pipeline_id);
                             }
                             profile_counters.total_time.profile(|| {
-                                self.scene.set_root_display_list(pipeline_id,
-                                                                 epoch,
-                                                                 built_display_list,
-                                                                 background_color,
-                                                                 viewport_size,
-                                                                 auxiliary_lists);
+                                self.scene.set_display_list(pipeline_id,
+                                                            epoch,
+                                                            built_display_list,
+                                                            background_color,
+                                                            viewport_size,
+                                                            auxiliary_lists);
                                 self.build_scene();
                             })
                         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1076,8 +1076,8 @@ impl Renderer {
 
     /// Renders the current frame.
     ///
-    /// A Frame is supplied by calling [`set_root_display_list()`][newframe].
-    /// [newframe]: ../../webrender_traits/struct.RenderApi.html#method.set_root_display_list
+    /// A Frame is supplied by calling [`set_display_list()`][newframe].
+    /// [newframe]: ../../webrender_traits/struct.RenderApi.html#method.set_display_list
     pub fn render(&mut self, framebuffer_size: DeviceUintSize) {
         profile_scope!("render");
 

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -113,13 +113,13 @@ impl Scene {
         self.root_pipeline_id = Some(pipeline_id);
     }
 
-    pub fn set_root_display_list(&mut self,
-                                 pipeline_id: PipelineId,
-                                 epoch: Epoch,
-                                 built_display_list: BuiltDisplayList,
-                                 background_color: Option<ColorF>,
-                                 viewport_size: LayerSize,
-                                 auxiliary_lists: AuxiliaryLists) {
+    pub fn set_display_list(&mut self,
+                            pipeline_id: PipelineId,
+                            epoch: Epoch,
+                            built_display_list: BuiltDisplayList,
+                            background_color: Option<ColorF>,
+                            viewport_size: LayerSize,
+                            auxiliary_lists: AuxiliaryLists) {
         self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
         self.display_lists.insert(pipeline_id, built_display_list.into_display_items());
 

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -35,13 +35,13 @@ pub enum ApiMsg {
     ///
     /// After receiving this message, WebRender will read the display list, followed by the
     /// auxiliary lists, from the payload channel.
-    SetRootDisplayList(Option<ColorF>,
-                       Epoch,
-                       PipelineId,
-                       LayoutSize,
-                       BuiltDisplayListDescriptor,
-                       AuxiliaryListsDescriptor,
-                       bool),
+    SetDisplayList(Option<ColorF>,
+                   Epoch,
+                   PipelineId,
+                   LayoutSize,
+                   BuiltDisplayListDescriptor,
+                   AuxiliaryListsDescriptor,
+                   bool),
     SetPageZoom(ZoomFactor),
     SetPinchZoom(ZoomFactor),
     SetPan(DeviceIntPoint),
@@ -76,7 +76,7 @@ impl fmt::Debug for ApiMsg {
             &ApiMsg::UpdateImage(..) => { write!(f, "ApiMsg::UpdateImage") }
             &ApiMsg::DeleteImage(..) => { write!(f, "ApiMsg::DeleteImage") }
             &ApiMsg::CloneApi(..) => { write!(f, "ApiMsg::CloneApi") }
-            &ApiMsg::SetRootDisplayList(..) => { write!(f, "ApiMsg::SetRootDisplayList") }
+            &ApiMsg::SetDisplayList(..) => { write!(f, "ApiMsg::SetDisplayList") }
             &ApiMsg::SetRootPipeline(..) => { write!(f, "ApiMsg::SetRootPipeline") }
             &ApiMsg::Scroll(..) => { write!(f, "ApiMsg::Scroll") }
             &ApiMsg::ScrollLayerWithId(..) => { write!(f, "ApiMsg::ScrollLayerWithId") }
@@ -298,15 +298,15 @@ impl RenderApi {
     ///                           position) should be preserved for this new display list.
     ///
     /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
-    pub fn set_root_display_list(&self,
-                                 background_color: Option<ColorF>,
-                                 epoch: Epoch,
-                                 viewport_size: LayoutSize,
-                                 (pipeline_id, display_list, auxiliary_lists): (PipelineId, BuiltDisplayList, AuxiliaryLists),
-                                 preserve_frame_state: bool) {
+    pub fn set_display_list(&self,
+                            background_color: Option<ColorF>,
+                            epoch: Epoch,
+                            viewport_size: LayoutSize,
+                            (pipeline_id, display_list, auxiliary_lists): (PipelineId, BuiltDisplayList, AuxiliaryLists),
+                            preserve_frame_state: bool) {
         let (dl_data, dl_desc) = display_list.into_data();
         let (aux_data, aux_desc) = auxiliary_lists.into_data();
-        let msg = ApiMsg::SetRootDisplayList(background_color,
+        let msg = ApiMsg::SetDisplayList(background_color,
                                              epoch,
                                              pipeline_id,
                                              viewport_size,

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -71,13 +71,13 @@ impl JsonFrameWriter {
         }
     }
 
-    pub fn begin_write_root_display_list(&mut self,
-                                         _: &Option<ColorF>,
-                                         _: &Epoch,
-                                         _: &PipelineId,
-                                         _: &LayoutSize,
-                                         display_list: &BuiltDisplayListDescriptor,
-                                         auxiliary_lists: &AuxiliaryListsDescriptor)
+    pub fn begin_write_display_list(&mut self,
+                                    _: &Option<ColorF>,
+                                    _: &Epoch,
+                                    _: &PipelineId,
+                                    _: &LayoutSize,
+                                    display_list: &BuiltDisplayListDescriptor,
+                                    auxiliary_lists: &AuxiliaryListsDescriptor)
     {
         unsafe {
             if CURRENT_FRAME_NUMBER == self.last_frame_written {
@@ -90,9 +90,9 @@ impl JsonFrameWriter {
         self.aux_descriptor = Some(auxiliary_lists.clone());
     }
 
-    pub fn finish_write_root_display_list(&mut self,
-                                          frame: u32,
-                                          data: &[u8])
+    pub fn finish_write_display_list(&mut self,
+                                     frame: u32,
+                                     data: &[u8])
     {
         let dl_desc = self.dl_descriptor.take().unwrap();
         let aux_desc = self.aux_descriptor.take().unwrap();
@@ -253,19 +253,19 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 self.images.remove(key);
             }
 
-            &ApiMsg::SetRootDisplayList(ref background_color,
-                                        ref epoch,
-                                        ref pipeline_id,
-                                        ref viewport_size,
-                                        ref display_list,
-                                        ref auxiliary_lists,
-                                        _preserve_frame_state) => {
-                self.begin_write_root_display_list(background_color,
-                                                   epoch,
-                                                   pipeline_id,
-                                                   viewport_size,
-                                                   display_list,
-                                                   auxiliary_lists);
+            &ApiMsg::SetDisplayList(ref background_color,
+                                    ref epoch,
+                                    ref pipeline_id,
+                                    ref viewport_size,
+                                    ref display_list,
+                                    ref auxiliary_lists,
+                                    _preserve_frame_state) => {
+                self.begin_write_display_list(background_color,
+                                              epoch,
+                                              pipeline_id,
+                                              viewport_size,
+                                              display_list,
+                                              auxiliary_lists);
             }
             _ => {}
         }
@@ -273,7 +273,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
 
     fn write_payload(&mut self, frame: u32, data: &[u8]) {
         if self.dl_descriptor.is_some() {
-            self.finish_write_root_display_list(frame, data);
+            self.finish_write_display_list(frame, data);
         }
     }
 }

--- a/wrench/src/scene.rs
+++ b/wrench/src/scene.rs
@@ -36,11 +36,11 @@ impl Scene {
         self.root_pipeline_id = Some(pipeline_id);
     }
 
-    pub fn begin_root_display_list(&mut self,
-                                   pipeline_id: &PipelineId,
-                                   epoch: &Epoch,
-                                   background_color: &Option<ColorF>,
-                                   viewport_size: &LayerSize) {
+    pub fn begin_display_list(&mut self,
+                              pipeline_id: &PipelineId,
+                              epoch: &Epoch,
+                              background_color: &Option<ColorF>,
+                              viewport_size: &LayerSize) {
         let new_pipeline = ScenePipeline {
              epoch: epoch.clone(),
              viewport_size: viewport_size.clone(),
@@ -50,10 +50,10 @@ impl Scene {
         self.pipeline_map.insert(pipeline_id.clone(), new_pipeline);
     }
 
-    pub fn finish_root_display_list(&mut self,
-                                    pipeline_id: PipelineId,
-                                    built_display_list: BuiltDisplayList,
-                                    auxiliary_lists: AuxiliaryLists) {
+    pub fn finish_display_list(&mut self,
+                               pipeline_id: PipelineId,
+                               built_display_list: BuiltDisplayList,
+                               auxiliary_lists: AuxiliaryLists) {
         self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
         self.display_lists.insert(pipeline_id, built_display_list.all_display_items().to_vec());
     }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -366,11 +366,11 @@ impl Wrench {
                       display_list: DisplayListBuilder,
                       scroll_offsets: &HashMap<ScrollLayerId, LayerPoint>) {
         let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
-        self.api.set_root_display_list(root_background_color,
-                                       Epoch(frame_number),
-                                       self.window_size_f32(),
-                                       display_list.finalize(),
-                                       false);
+        self.api.set_display_list(root_background_color,
+                                  Epoch(frame_number),
+                                  self.window_size_f32(),
+                                  display_list.finalize(),
+                                  false);
 
         for (id, offset) in scroll_offsets {
             self.api.scroll_layer_with_id(*offset, *id);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -281,14 +281,14 @@ impl YamlFrameWriter {
         }
     }
 
-    pub fn begin_write_root_display_list(&mut self,
-                                         scene: &mut Scene,
-                                         background_color: &Option<ColorF>,
-                                         epoch: &Epoch,
-                                         pipeline_id: &PipelineId,
-                                         viewport_size: &LayoutSize,
-                                         display_list: &BuiltDisplayListDescriptor,
-                                         auxiliary_lists: &AuxiliaryListsDescriptor)
+    pub fn begin_write_display_list(&mut self,
+                                    scene: &mut Scene,
+                                    background_color: &Option<ColorF>,
+                                    epoch: &Epoch,
+                                    pipeline_id: &PipelineId,
+                                    viewport_size: &LayoutSize,
+                                    display_list: &BuiltDisplayListDescriptor,
+                                    auxiliary_lists: &AuxiliaryListsDescriptor)
     {
         unsafe {
             if CURRENT_FRAME_NUMBER == self.last_frame_written {
@@ -301,12 +301,12 @@ impl YamlFrameWriter {
         self.aux_descriptor = Some(auxiliary_lists.clone());
         self.pipeline_id = Some(pipeline_id.clone());
 
-        scene.begin_root_display_list(pipeline_id, epoch,
-                                      background_color,
-                                      viewport_size);
+        scene.begin_display_list(pipeline_id, epoch,
+                                 background_color,
+                                 viewport_size);
     }
 
-    pub fn finish_write_root_display_list(&mut self, scene: &mut Scene, data: &[u8]) {
+    pub fn finish_write_display_list(&mut self, scene: &mut Scene, data: &[u8]) {
         let dl_desc = self.dl_descriptor.take().unwrap();
         let aux_desc = self.aux_descriptor.take().unwrap();
 
@@ -374,7 +374,7 @@ impl YamlFrameWriter {
 
         }
 
-        scene.finish_root_display_list(self.pipeline_id.unwrap(), dl, aux);
+        scene.finish_display_list(self.pipeline_id.unwrap(), dl, aux);
     }
 
     fn next_rsrc_paths(prefix: &str, counter: &mut u32, base_path: &Path, base: &str, ext: &str) -> (PathBuf, PathBuf) {
@@ -818,20 +818,20 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 self.frame_writer.images.remove(key);
             }
 
-            &ApiMsg::SetRootDisplayList(ref background_color,
-                                        ref epoch,
-                                        ref pipeline_id,
-                                        ref viewport_size,
-                                        ref display_list,
-                                        ref auxiliary_lists,
-                                        _preserve_frame_state) => {
-                self.frame_writer.begin_write_root_display_list(&mut self.scene,
-                                                                background_color,
-                                                                epoch,
-                                                                pipeline_id,
-                                                                viewport_size,
-                                                                display_list,
-                                                                auxiliary_lists);
+            &ApiMsg::SetDisplayList(ref background_color,
+                                    ref epoch,
+                                    ref pipeline_id,
+                                    ref viewport_size,
+                                    ref display_list,
+                                    ref auxiliary_lists,
+                                    _preserve_frame_state) => {
+                self.frame_writer.begin_write_display_list(&mut self.scene,
+                                                           background_color,
+                                                           epoch,
+                                                           pipeline_id,
+                                                           viewport_size,
+                                                           display_list,
+                                                           auxiliary_lists);
             }
             _ => {}
         }
@@ -839,7 +839,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
 
     fn write_payload(&mut self, _frame: u32, data: &[u8]) {
         if self.frame_writer.dl_descriptor.is_some() {
-            self.frame_writer.finish_write_root_display_list(&mut self.scene, data);
+            self.frame_writer.finish_write_display_list(&mut self.scene, data);
         }
     }
 }


### PR DESCRIPTION
The naming of this was confusing as it wasn't just for root display
lists, but all display lists. (And then you set the one that is the
root via `set_root_pipeline_id`.)

This was a artifact of an older design according to @glennw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1053)
<!-- Reviewable:end -->
