### PR TITLE
Fix the way that clip positioning is specified

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -118,15 +118,18 @@ pub struct ClipScrollNode {
 impl ClipScrollNode {
     pub fn new(pipeline_id: PipelineId,
                parent_id: ScrollLayerId,
-               local_viewport_rect: &LayerRect,
-               content_size: LayerSize,
+               content_rect: &LayerRect,
+               clip_rect: &LayerRect,
                clip_info: ClipInfo)
                -> ClipScrollNode {
+        // FIXME(mrobinson): We don't yet handle clipping rectangles that don't start at the origin
+        // of the node.
+        let local_viewport_rect = LayerRect::new(content_rect.origin, clip_rect.size);
         ClipScrollNode {
             scrolling: ScrollingState::new(),
-            content_size: content_size,
-            local_viewport_rect: *local_viewport_rect,
-            local_clip_rect: *local_viewport_rect,
+            content_size: content_rect.size,
+            local_viewport_rect: local_viewport_rect,
+            local_clip_rect: local_viewport_rect,
             combined_local_viewport_rect: LayerRect::zero(),
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -354,14 +354,12 @@ impl Frame {
                         pipeline_id: PipelineId,
                         parent_id: ScrollLayerId,
                         item: &ClipDisplayItem,
-                        reference_frame_relative_offset: LayerPoint,
+                        content_rect: &LayerRect,
                         clip: &ClipRegion) {
-        let clip_rect = clip.main.translate(&reference_frame_relative_offset);
         context.builder.add_clip_scroll_node(item.id,
                                              parent_id,
                                              pipeline_id,
-                                             &clip_rect,
-                                             &item.content_size,
+                                             &content_rect,
                                              clip,
                                              &mut self.clip_scroll_tree);
 
@@ -492,7 +490,6 @@ impl Frame {
                           bounds: &LayerRect,
                           context: &mut FlattenContext,
                           reference_frame_relative_offset: LayerPoint) {
-
         let pipeline = match context.scene.pipeline_map.get(&pipeline_id) {
             Some(pipeline) => pipeline,
             None => return,
@@ -533,9 +530,8 @@ impl Frame {
             iframe_scroll_layer_id,
             iframe_reference_frame_id,
             pipeline_id,
-            &LayerRect::new(LayerPoint::zero(), iframe_rect.size),
-            &iframe_stacking_context_bounds.size,
-            &ClipRegion::simple(&iframe_stacking_context_bounds),
+            &LayerRect::new(LayerPoint::zero(), iframe_stacking_context_bounds.size),
+            &ClipRegion::simple(&iframe_rect),
             &mut self.clip_scroll_tree);
 
         let mut traversal = DisplayListTraversal::new_skipping_first(display_list);
@@ -697,11 +693,12 @@ impl Frame {
                                         reference_frame_relative_offset);
                 }
                 SpecificDisplayItem::Clip(ref info) => {
+                    let content_rect = &item.rect.translate(&reference_frame_relative_offset);
                     self.flatten_clip(context,
                                       pipeline_id,
                                       scroll_layer_id,
                                       &info,
-                                      reference_frame_relative_offset,
+                                      &content_rect,
                                       &item.clip);
                 }
                 SpecificDisplayItem::PopStackingContext => return,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -309,8 +309,7 @@ impl FrameBuilder {
         self.add_clip_scroll_node(topmost_scroll_layer_id,
                                    clip_scroll_tree.root_reference_frame_id,
                                    pipeline_id,
-                                   &viewport_rect,
-                                   content_size,
+                                   &LayerRect::new(LayerPoint::zero(), *content_size),
                                    &ClipRegion::simple(&viewport_rect),
                                    clip_scroll_tree);
         topmost_scroll_layer_id
@@ -320,8 +319,7 @@ impl FrameBuilder {
                                 new_node_id: ScrollLayerId,
                                 parent_id: ScrollLayerId,
                                 pipeline_id: PipelineId,
-                                local_viewport_rect: &LayerRect,
-                                content_size: &LayerSize,
+                                content_rect: &LayerRect,
                                 clip_region: &ClipRegion,
                                 clip_scroll_tree: &mut ClipScrollTree) {
         let clip_info = ClipInfo::new(clip_region,
@@ -329,8 +327,8 @@ impl FrameBuilder {
                                       PackedLayerIndex(self.packed_layers.len()));
         let node = ClipScrollNode::new(pipeline_id,
                                        parent_id,
-                                       local_viewport_rect,
-                                       *content_size,
+                                       content_rect,
+                                       &clip_region.main,
                                        clip_info);
 
         clip_scroll_tree.add_node(node, new_node_id);

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -43,7 +43,6 @@ pub struct ItemRange {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ClipDisplayItem {
-    pub content_size: LayoutSize,
     pub id: ScrollLayerId,
     pub parent_id: ScrollLayerId,
 }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -441,8 +441,8 @@ impl DisplayListBuilder {
     }
 
     pub fn define_clip(&mut self,
+                       content_rect: LayoutRect,
                        clip: ClipRegion,
-                       content_size: LayoutSize,
                        id: Option<ScrollLayerId>)
                        -> ScrollLayerId {
         let id = match id {
@@ -454,20 +454,19 @@ impl DisplayListBuilder {
         };
 
         let item = SpecificDisplayItem::Clip(ClipDisplayItem {
-            content_size: content_size,
             id: id,
             parent_id: *self.clip_stack.last().unwrap(),
         });
 
-        self.push_item(item, clip.main, clip);
+        self.push_item(item, content_rect, clip);
         id
     }
 
     pub fn push_scroll_layer(&mut self,
                              clip: ClipRegion,
-                             content_size: LayoutSize,
+                             content_rect: LayoutRect,
                              id: Option<ScrollLayerId>) {
-        let id = self.define_clip(clip, content_size, id);
+        let id = self.define_clip(content_rect, clip, id);
         self.clip_stack.push(id);
     }
 

--- a/wrench/reftests/mask/aligned-layer-rect.yaml
+++ b/wrench/reftests/mask/aligned-layer-rect.yaml
@@ -2,16 +2,12 @@
 root:
   items:
     - type: scroll-layer
-      bounds: [0, 0, 95, 88]
-      content-size: [95, 88]
-      clip:
-        rect: [9, 9, 10, 10]
+      bounds: [9, 9, 95, 88]
+      clip: [0, 0, 10, 10]
       items:
         - type: scroll-layer
           bounds: [0, 0, 95, 88]
-          content-size: [95, 88]
-          clip:
-              rect: [0, 0, 100, 100]
+          clip: [0, 0, 100, 100]
           items:
             - type: rect
               bounds: [0, 0, 100, 100]

--- a/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
+++ b/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
@@ -18,7 +18,6 @@ root:
               image: "tiny-check-mask.png"
               rect: [0, 0, 300, 300]
               repeat: false
-          "content-size": [300, 300]
           id: 1
           items:
             - type: rect

--- a/wrench/reftests/scrolling/empty-mask.yaml
+++ b/wrench/reftests/scrolling/empty-mask.yaml
@@ -5,7 +5,6 @@ root:
       color: green
     - type: scroll-layer
       bounds: [0, 0, 100, 100]
-      content-size: [100, 100]
       clip:
         rect: [0, 0, 0, 0]
         complex:

--- a/wrench/reftests/scrolling/scroll-layer-with-mask-ref.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask-ref.yaml
@@ -6,3 +6,6 @@ root:
     - type: rect
       bounds: [120, 20, 80, 80]
       color: green
+    - type: rect
+      bounds: [220, 20, 80, 80]
+      color: green

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -10,7 +10,6 @@ root:
       items:
       - type: scroll-layer
         bounds: [0, 0, 100, 100]
-        content-size: [100, 100]
         clip:
           rect: [0, 0, 100, 100]
           image-mask:
@@ -29,10 +28,10 @@ root:
       scroll-policy: scrollable
       items:
       - type: scroll-layer
-        bounds: [10, 10, 100, 100]
-        content-size: [100, 300]
+        bounds: [10, 10, 100, 300]
         scroll-offset: [0, 100]
         clip:
+          rect: [0, 0, 100, 100]
           image-mask:
             image: "mask.png"
             rect: [0, 0, 100, 100]
@@ -41,3 +40,20 @@ root:
         - type: rect
           bounds: [0, 0, 100, 200]
           color: green
+
+    # Same as the previous case, but this time we verify that a scroll layer that is
+    # not at the origin works as well.
+    -
+      type: scroll-layer
+      bounds: [210, 10, 100, 300]
+      scroll-offset: [0, 100]
+      clip:
+        rect: [0, 0, 100, 100]
+        image-mask:
+          image: "mask.png"
+          rect: [0, 0, 100, 100]
+          repeat: false
+      items:
+      - type: rect
+        bounds: [210, 10, 100, 200]
+        color: green

--- a/wrench/reftests/scrolling/scroll-layer.yaml
+++ b/wrench/reftests/scrolling/scroll-layer.yaml
@@ -1,8 +1,8 @@
 root:
   items:
     - type: scroll-layer
-      bounds: [0, 0, 100, 100]
-      content-size: [1000, 1000]
+      bounds: [0, 0, 1000, 1000]
+      clip: [0, 0, 100, 100]
       scroll-offset: [50, 50]
       items:
         - type: rect

--- a/wrench/reftests/scrolling/simple.yaml
+++ b/wrench/reftests/scrolling/simple.yaml
@@ -1,15 +1,15 @@
 root:
   items:
     - type: scroll-layer
-      bounds: [10, 10, 50, 50]
-      content-size: [100, 100]
+      bounds: [10, 10, 100, 100]
+      clip: [0, 0, 50, 50]
       items:
         - type: rect
           bounds: [10, 10, 500, 500]
           color: green
     - type: scroll-layer
-      bounds: [70, 10, 50, 50]
-      content-size: [100, 100]
+      bounds: [70, 10, 100, 100]
+      clip: [0, 0, 50, 50]
       items:
         - type: rect
           bounds: [70, 10, 100, 100]

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -607,15 +607,15 @@ impl YamlFrameReader {
     }
 
     pub fn handle_clip_from_yaml(&mut self, wrench: &mut Wrench, yaml: &Yaml) -> ScrollLayerId {
-        let bounds = yaml["bounds"].as_rect().expect("scroll layer must have bounds");
-        let content_size = yaml["content-size"].as_size()
-                                               .expect("scroll layer must have content size");
-        let clip = self.to_clip_region(&yaml["clip"], &bounds, wrench)
-                       .unwrap_or(ClipRegion::simple(&bounds));
+        let content_rect = yaml["bounds"].as_rect().expect("scroll layer must have content rect");
+
+        let default_clip = LayoutRect::new(LayoutPoint::zero(), content_rect.size);
+        let clip = self.to_clip_region(&yaml["clip"], &default_clip, wrench)
+                       .unwrap_or(ClipRegion::simple(&default_clip));
         let id = yaml["id"].as_i64().map(|id|
             ScrollLayerId::new(id as u64, self.builder().pipeline_id));
 
-        let id = self.builder().define_clip(clip, content_size, id);
+        let id = self.builder().define_clip(content_rect, clip, id);
 
         if let Some(size) = yaml["scroll-offset"].as_point() {
             self.scroll_offsets.insert(id, LayerPoint::new(size.x, size.y));

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -737,7 +737,6 @@ impl YamlFrameWriter {
                 },
                 Clip(item) => {
                     str_node(&mut v, "type", "clip");
-                    size_node(&mut v, "content-size", &item.content_size);
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));
                 }
                 PopStackingContext => return,


### PR DESCRIPTION
Make the way that clip positions are specified a bit more predictable.
Now the display item bounds are the "content bounds," which specify the
location and size of the content that goes inside this clip. The clip
coordinates are specified relative to this location, while the content
size is only used for scrolling.

Currently we only support clips rectangles that start at the origin of
the content, which is equivalent to the capabilities we had before.
Later we can add this functionality, if it is necessary.

Also, add a test for this as well as updating all reftest files to
reflect the new arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1055)
<!-- Reviewable:end -->
