### PR TITLE
Bump bincode dependency.

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -14,7 +14,7 @@ webgl = ["offscreen_gl_context", "webrender_traits/webgl"]
 
 [dependencies]
 app_units = "0.4"
-bincode = "1.0.0-alpha2"
+bincode = "1.0.0-alpha6"
 bit-set = "0.4"
 byteorder = "1.0"
 euclid = "0.11"


### PR DESCRIPTION
Webrender doesn't actually compile with 1.0.0-alpha2 any more, so we
should update the Cargo.toml to set a new minimum bound on the bincode
version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1056)
<!-- Reviewable:end -->
