### PR TITLE
Support more cases of simple border fast path.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use frame_builder::FrameBuilder;
+use tiling::PrimitiveFlags;
+use webrender_traits::{BorderSide, BorderStyle, BorderWidths, NormalBorder};
+use webrender_traits::{ClipRegion, LayerPoint, LayerRect, LayerSize, ScrollLayerId};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum BorderCornerKind {
+    None,
+    Solid,
+    Complex,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum BorderEdgeKind {
+    None,
+    Solid,
+    Complex,
+}
+
+pub trait NormalBorderHelpers {
+    fn get_corner(&self,
+                  edge0: &BorderSide,
+                  width0: f32,
+                  edge1: &BorderSide,
+                  width1: f32,
+                  radius: &LayerSize) -> BorderCornerKind;
+
+    fn get_edge(&self,
+                edge: &BorderSide,
+                width: f32) -> (BorderEdgeKind, f32);
+}
+
+impl NormalBorderHelpers for NormalBorder {
+    fn get_corner(&self,
+                  edge0: &BorderSide,
+                  width0: f32,
+                  edge1: &BorderSide,
+                  width1: f32,
+                  radius: &LayerSize) -> BorderCornerKind {
+        // If either width is zero, a corner isn't formed.
+        if width0 == 0.0 || width1 == 0.0 {
+            return BorderCornerKind::None;
+        }
+
+        // If both edges are transparent, no corner is formed.
+        if edge0.color.a == 0.0 && edge1.color.a == 0.0 {
+            return BorderCornerKind::None;
+        }
+
+        match (edge0.style, edge1.style) {
+            // If either edge is none or hidden, no corner is needed.
+            (BorderStyle::None, _) | (_, BorderStyle::None) => BorderCornerKind::None,
+            (BorderStyle::Hidden, _) | (_, BorderStyle::Hidden) => BorderCornerKind::None,
+
+            // If both borders are solid, we can draw them with a simple rectangle if
+            // both the colors match and there is no radius.
+            (BorderStyle::Solid, BorderStyle::Solid) => {
+                if edge0.color == edge1.color && radius.width == 0.0 && radius.height == 0.0 {
+                    BorderCornerKind::Solid
+                } else {
+                    BorderCornerKind::Complex
+                }
+            }
+
+            // Assume complex for these cases.
+            // TODO(gw): There are some cases in here that can be handled with a fast path.
+            // For example, with inset/outset borders, two of the four corners are solid.
+            (BorderStyle::Dotted, _) | (_, BorderStyle::Dotted) => BorderCornerKind::Complex,
+            (BorderStyle::Dashed, _) | (_, BorderStyle::Dashed) => BorderCornerKind::Complex,
+            (BorderStyle::Double, _) | (_, BorderStyle::Double) => BorderCornerKind::Complex,
+            (BorderStyle::Groove, _) | (_, BorderStyle::Groove) => BorderCornerKind::Complex,
+            (BorderStyle::Ridge, _) | (_, BorderStyle::Ridge) => BorderCornerKind::Complex,
+            (BorderStyle::Outset, _) | (_, BorderStyle::Outset) => BorderCornerKind::Complex,
+            (BorderStyle::Inset, _) | (_, BorderStyle::Inset) => BorderCornerKind::Complex,
+        }
+    }
+
+    fn get_edge(&self,
+                edge: &BorderSide,
+                width: f32) -> (BorderEdgeKind, f32) {
+        if width == 0.0 {
+            return (BorderEdgeKind::None, 0.0);
+        }
+
+        match edge.style {
+            BorderStyle::None |
+            BorderStyle::Hidden => (BorderEdgeKind::None, 0.0),
+
+            BorderStyle::Solid |
+            BorderStyle::Inset |
+            BorderStyle::Outset => (BorderEdgeKind::Solid, width),
+
+            BorderStyle::Double |
+            BorderStyle::Dotted |
+            BorderStyle::Dashed |
+            BorderStyle::Groove |
+            BorderStyle::Ridge => (BorderEdgeKind::Complex, width),
+        }
+    }
+}
+
+impl FrameBuilder {
+    // TODO(gw): This allows us to move border types over to the
+    // simplified shader model one at a time. Once all borders
+    // are converted, this can be removed, along with the complex
+    // border code path.
+    pub fn add_simple_border(&mut self,
+                             rect: &LayerRect,
+                             border: &NormalBorder,
+                             widths: &BorderWidths,
+                             scroll_layer_id: ScrollLayerId,
+                             clip_region: &ClipRegion) -> bool {
+        // The border shader is quite expensive. For simple borders, we can just draw
+        // the border with a few rectangles. This generally gives better batching, and
+        // a GPU win in fragment shader time.
+        // More importantly, the software (OSMesa) implementation we run tests on is
+        // particularly slow at running our complex border shader, compared to the
+        // rectangle shader. This has the effect of making some of our tests time
+        // out more often on CI (the actual cause is simply too many Servo processes and
+        // threads being run on CI at once).
+
+        let radius = &border.radius;
+        let left = &border.left;
+        let right = &border.right;
+        let top = &border.top;
+        let bottom = &border.bottom;
+
+        // If any of the corners are complex, fall back to slow path for now.
+        let tl = border.get_corner(left, widths.left, top, widths.top, &radius.top_left);
+        let tr = border.get_corner(top, widths.top, right, widths.right, &radius.top_right);
+        let br = border.get_corner(right, widths.right, bottom, widths.bottom, &radius.bottom_right);
+        let bl = border.get_corner(bottom, widths.bottom, left, widths.left, &radius.bottom_left);
+
+        if tl == BorderCornerKind::Complex ||
+           tr == BorderCornerKind::Complex ||
+           br == BorderCornerKind::Complex ||
+           bl == BorderCornerKind::Complex {
+            return false;
+        }
+
+        // If any of the edges are complex, fall back to slow path for now.
+        let (left_edge, left_len) = border.get_edge(left, widths.left);
+        let (top_edge, top_len) = border.get_edge(top, widths.top);
+        let (right_edge, right_len) = border.get_edge(right, widths.right);
+        let (bottom_edge, bottom_len) = border.get_edge(bottom, widths.bottom);
+
+        if left_edge == BorderEdgeKind::Complex ||
+           top_edge == BorderEdgeKind::Complex ||
+           right_edge == BorderEdgeKind::Complex ||
+           bottom_edge == BorderEdgeKind::Complex {
+            return false;
+        }
+
+        let p0 = rect.origin;
+        let p1 = rect.bottom_right();
+        let rect_width = rect.size.width;
+        let rect_height = rect.size.height;
+
+        // Add a solid rectangle for each visible edge/corner combination.
+        if top_edge == BorderEdgeKind::Solid {
+            self.add_solid_rectangle(scroll_layer_id,
+                                     &LayerRect::new(p0,
+                                                     LayerSize::new(rect.size.width, top_len)),
+                                     clip_region,
+                                     &border.top.color,
+                                     PrimitiveFlags::None);
+        }
+        if left_edge == BorderEdgeKind::Solid {
+            self.add_solid_rectangle(scroll_layer_id,
+                                     &LayerRect::new(LayerPoint::new(p0.x, p0.y + top_len),
+                                                     LayerSize::new(left_len,
+                                                                    rect_height - top_len - bottom_len)),
+                                     clip_region,
+                                     &border.left.color,
+                                     PrimitiveFlags::None);
+        }
+        if right_edge == BorderEdgeKind::Solid {
+            self.add_solid_rectangle(scroll_layer_id,
+                                     &LayerRect::new(LayerPoint::new(p1.x - right_len,
+                                                                     p0.y + top_len),
+                                                     LayerSize::new(right_len,
+                                                                    rect_height - top_len - bottom_len)),
+                                     clip_region,
+                                     &border.right.color,
+                                     PrimitiveFlags::None);
+        }
+        if bottom_edge == BorderEdgeKind::Solid {
+            self.add_solid_rectangle(scroll_layer_id,
+                                     &LayerRect::new(LayerPoint::new(p0.x, p1.y - bottom_len),
+                                                     LayerSize::new(rect_width, bottom_len)),
+                                     clip_region,
+                                     &border.bottom.color,
+                                     PrimitiveFlags::None);
+        }
+
+        true
+    }
+}

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -28,7 +28,7 @@ use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, Ren
 use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
 use util::{self, pack_as_float, rect_from_points_f, subtract_rect};
 use util::{RectHelpers, TransformedRectKind};
-use webrender_traits::{BorderDetails, BorderDisplayItem, BorderSide, BorderStyle};
+use webrender_traits::{BorderDetails, BorderDisplayItem};
 use webrender_traits::{BoxShadowClipMode, ClipRegion, ColorF, DeviceIntPoint, DeviceIntRect};
 use webrender_traits::{DeviceIntSize, DeviceUintRect, DeviceUintSize, ExtendMode, FontKey};
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
@@ -374,26 +374,6 @@ impl FrameBuilder {
         }
     }
 
-    pub fn supported_style(&mut self, border: &BorderSide) -> bool {
-        match border.style {
-            BorderStyle::Solid |
-            BorderStyle::None |
-            BorderStyle::Dotted |
-            BorderStyle::Dashed |
-            BorderStyle::Inset |
-            BorderStyle::Ridge |
-            BorderStyle::Groove |
-            BorderStyle::Outset |
-            BorderStyle::Double => {
-                true
-            }
-            _ => {
-                println!("TODO: Other border styles {:?}", border.style);
-                false
-            }
-        }
-    }
-
     pub fn add_border(&mut self,
                       scroll_layer_id: ScrollLayerId,
                       rect: LayerRect,
@@ -543,17 +523,22 @@ impl FrameBuilder {
                 }
             }
             BorderDetails::Normal(ref border) => {
+                // Gradually move border types over to a simplified
+                // shader and code path that can handle all border
+                // cases correctly.
+                if self.add_simple_border(&rect,
+                                          border,
+                                          &border_item.widths,
+                                          scroll_layer_id,
+                                          clip_region) {
+                    return;
+                }
+
                 let radius = &border.radius;
                 let left = &border.left;
                 let right = &border.right;
                 let top = &border.top;
                 let bottom = &border.bottom;
-
-                if !self.supported_style(left) || !self.supported_style(right) ||
-                   !self.supported_style(top) || !self.supported_style(bottom) {
-                    println!("Unsupported border style, not rendering border");
-                    return;
-                }
 
                 // These colors are used during inset/outset scaling.
                 let left_color      = left.border_color(1.0, 2.0/3.0, 0.3, 0.7);
@@ -577,52 +562,6 @@ impl FrameBuilder {
                                                rect.origin.y + rect.size.height);
                 let br_inner = br_outer - LayerPoint::new(radius.bottom_right.width.max(border_item.widths.right),
                                                           radius.bottom_right.height.max(border_item.widths.bottom));
-
-                // The border shader is quite expensive. For simple borders, we can just draw
-                // the border with a few rectangles. This generally gives better batching, and
-                // a GPU win in fragment shader time.
-                // More importantly, the software (OSMesa) implementation we run tests on is
-                // particularly slow at running our complex border shader, compared to the
-                // rectangle shader. This has the effect of making some of our tests time
-                // out more often on CI (the actual cause is simply too many Servo processes and
-                // threads being run on CI at once).
-                // TODO(gw): Detect some more simple cases and handle those with simpler shaders too.
-                // TODO(gw): Consider whether it's only worth doing this for large rectangles (since
-                //           it takes a little more CPU time to handle multiple rectangles compared
-                //           to a single border primitive).
-                if left.style == BorderStyle::Solid {
-                    let same_color = left_color == top_color &&
-                                     left_color == right_color &&
-                                     left_color == bottom_color;
-                    let same_style = left.style == top.style &&
-                                     left.style == right.style &&
-                                     left.style == bottom.style;
-
-                    if same_color && same_style && radius.is_zero() {
-                        let rects = [
-                            LayerRect::new(rect.origin,
-                                           LayerSize::new(rect.size.width, border_item.widths.top)),
-                            LayerRect::new(LayerPoint::new(tl_outer.x, tl_inner.y),
-                                           LayerSize::new(border_item.widths.left,
-                                                          rect.size.height - border_item.widths.top - border_item.widths.bottom)),
-                            LayerRect::new(tr_inner,
-                                           LayerSize::new(border_item.widths.right,
-                                                          rect.size.height - border_item.widths.top - border_item.widths.bottom)),
-                            LayerRect::new(LayerPoint::new(bl_outer.x, bl_inner.y),
-                                           LayerSize::new(rect.size.width, border_item.widths.bottom))
-                        ];
-
-                        for rect in &rects {
-                            self.add_solid_rectangle(scroll_layer_id,
-                                                     rect,
-                                                     clip_region,
-                                                     &top_color,
-                                                     PrimitiveFlags::None);
-                        }
-
-                        return;
-                    }
-                }
 
                 //Note: while similar to `ComplexClipRegion::get_inner_rect()` in spirit,
                 // this code is a bit more complex and can not there for be merged.

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -46,6 +46,7 @@ extern crate bitflags;
 extern crate thread_profiler;
 
 mod batch_builder;
+mod border;
 mod clip_scroll_node;
 mod clip_scroll_tree;
 mod debug_colors;


### PR DESCRIPTION
This is the first step in refactoring how the border
shader and code path works.

Specifically, this change detects many more cases
where borders can be drawn by a series of simple
rectangles rather than the existing border shader. It now
correctly uses the fast path for any border which is a
combination of solid / none / hidden styles without
a border radius.

Follow up work will make use of the new border corner
and edge enum types to select different code paths
for specific border optimizations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1061)
<!-- Reviewable:end -->
