### PR TITLE
Introduce TransformStyle

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -23,7 +23,7 @@ use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobI
 use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
-use webrender_traits::{PipelineId, RasterizedBlobImage};
+use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle};
 
 #[derive(Debug)]
 enum Gesture {
@@ -261,6 +261,7 @@ fn main() {
                                   bounds,
                                   0,
                                   None,
+                                  TransformStyle::Flat,
                                   None,
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -439,7 +439,8 @@ impl Frame {
         context.builder.push_stacking_context(&reference_frame_relative_offset,
                                               pipeline_id,
                                               level == 0,
-                                              composition_operations);
+                                              composition_operations,
+                                              stacking_context.transform_style);
 
         // For the root pipeline, there's no need to add a full screen rectangle
         // here, as it's handled by the framebuffer clear.

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -34,6 +34,7 @@ use webrender_traits::{DeviceIntSize, DeviceUintRect, DeviceUintSize, ExtendMode
 use webrender_traits::{FontRenderMode, GlyphOptions, ImageKey, ImageRendering, ItemRange};
 use webrender_traits::{LayerPoint, LayerRect, LayerSize, LayerToScrollTransform, PipelineId};
 use webrender_traits::{RepeatMode, ScrollLayerId, TileOffset, WebGLContextId, YuvColorSpace};
+use webrender_traits::{TransformStyle};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -219,7 +220,8 @@ impl FrameBuilder {
                                  reference_frame_offset: &LayerPoint,
                                  pipeline_id: PipelineId,
                                  is_page_root: bool,
-                                 composite_ops: CompositeOps) {
+                                 composite_ops: CompositeOps,
+                                 transform_style: TransformStyle) {
         if let Some(parent_index) = self.stacking_context_stack.last() {
             let parent_is_root = self.stacking_context_store[parent_index.0].is_page_root;
 
@@ -235,6 +237,7 @@ impl FrameBuilder {
         self.stacking_context_store.push(StackingContext::new(pipeline_id,
                                                               *reference_frame_offset,
                                                               is_page_root,
+                                                              transform_style,
                                                               composite_ops));
         self.cmds.push(PrimitiveRunCmd::PushStackingContext(stacking_context_index));
         self.stacking_context_stack.push(stacking_context_index);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -27,7 +27,7 @@ use webrender_traits::{AuxiliaryLists, ColorF, DeviceIntPoint, DeviceIntRect};
 use webrender_traits::{DeviceIntSize, DeviceUintPoint};
 use webrender_traits::{DeviceUintSize, FontRenderMode, ImageRendering, LayerPoint, LayerRect};
 use webrender_traits::{LayerToWorldTransform, MixBlendMode, PipelineId, ScrollLayerId};
-use webrender_traits::{WorldPoint4D, WorldToLayerTransform};
+use webrender_traits::{TransformStyle, WorldPoint4D, WorldToLayerTransform};
 use webrender_traits::{ExternalImageType};
 
 // Special sentinel value recognized by the shader. It is considered to be
@@ -1552,6 +1552,7 @@ impl StackingContext {
     pub fn new(pipeline_id: PipelineId,
                reference_frame_offset: LayerPoint,
                is_page_root: bool,
+               transform_style: TransformStyle,
                composite_ops: CompositeOps)
                -> StackingContext {
         StackingContext {
@@ -1560,7 +1561,7 @@ impl StackingContext {
             bounding_rect: DeviceIntRect::zero(),
             composite_ops: composite_ops,
             clip_scroll_groups: Vec::new(),
-            should_isolate: false,
+            should_isolate: transform_style == TransformStyle::Preserve3D, //TODO
             is_page_root: is_page_root,
             is_visible: false,
         }

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -247,6 +247,7 @@ pub struct StackingContext {
     pub scroll_policy: ScrollPolicy,
     pub z_index: i32,
     pub transform: Option<PropertyBinding<LayoutTransform>>,
+    pub transform_style: TransformStyle,
     pub perspective: Option<LayoutTransform>,
     pub mix_blend_mode: MixBlendMode,
     pub filters: ItemRange,
@@ -260,6 +261,13 @@ pub enum ScrollPolicy {
 }
 
 known_heap_size!(0, ScrollPolicy);
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum TransformStyle {
+    Flat,
+    Preserve3D,
+}
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -358,6 +366,7 @@ impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
                z_index: i32,
                transform: Option<PropertyBinding<LayoutTransform>>,
+               transform_style: TransformStyle,
                perspective: Option<LayoutTransform>,
                mix_blend_mode: MixBlendMode,
                filters: Vec<FilterOp>,
@@ -367,6 +376,7 @@ impl StackingContext {
             scroll_policy: scroll_policy,
             z_index: z_index,
             transform: transform,
+            transform_style: transform_style,
             perspective: perspective,
             mix_blend_mode: mix_blend_mode,
             filters: auxiliary_lists_builder.add_filters(&filters),

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -9,11 +9,11 @@ use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShado
 use {ClipDisplayItem, ClipRegion, ColorF, ComplexClipRegion, DisplayItem, ExtendMode, FilterOp};
 use {FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem, GradientStop};
 use {IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering, ItemRange};
-use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, MixBlendMode, PipelineId};
+use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
+use {TransformStyle, MixBlendMode, PipelineId};
 use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
 use {RectangleDisplayItem, ScrollLayerId, ScrollPolicy, SpecificDisplayItem, StackingContext};
-use {TextDisplayItem, WebGLContextId, WebGLDisplayItem, YuvColorSpace};
-use YuvImageDisplayItem;
+use {TextDisplayItem, WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvImageDisplayItem};
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AuxiliaryLists {
@@ -329,6 +329,7 @@ impl DisplayListBuilder {
                                  bounds: LayoutRect,
                                  z_index: i32,
                                  transform: Option<PropertyBinding<LayoutTransform>>,
+                                 transform_style: TransformStyle,
                                  perspective: Option<LayoutTransform>,
                                  mix_blend_mode: MixBlendMode,
                                  filters: Vec<FilterOp>) {
@@ -337,6 +338,7 @@ impl DisplayListBuilder {
                 scroll_policy: scroll_policy,
                 z_index: z_index,
                 transform: transform,
+                transform_style: transform_style,
                 perspective: perspective,
                 mix_blend_mode: mix_blend_mode,
                 filters: self.auxiliary_lists_builder.add_filters(&filters),

--- a/wrench/src/parse_function.rs
+++ b/wrench/src/parse_function.rs
@@ -6,7 +6,7 @@ use std::str::CharIndices;
 
 // support arguments like '4', 'ab', '4.0'
 fn acceptable_arg_character(c: char) -> bool {
-    c.is_alphanumeric() || c == '.'
+    c.is_alphanumeric() || c == '.' || c == '-'
 }
 
 // A crapy parser for parsing strings like "translate(1, 3)"
@@ -50,7 +50,7 @@ pub fn parse_function(s: &str) -> (&str, Vec<&str>) {
     p.skip_whitespace();
 
     if let Some(k) = p.o {
-        if !(k.1 == '(') {
+        if k.1 != '(' {
             return (name, args);
         }
         p.start = k.0 + k.1.len_utf8();
@@ -88,8 +88,9 @@ pub fn parse_function(s: &str) -> (&str, Vec<&str>) {
 
 #[test]
 fn test() {
-    assert!(parse_function("rotate(40)").0 == "rotate");
-    assert!(parse_function("  rotate(40)").0 == "rotate");
-    assert!(parse_function("  rotate  (40)").0 == "rotate");
-    assert!(parse_function("  rotate  (  40 )").1[0] == "40");
+    assert_eq!(parse_function("rotate(40)").0, "rotate");
+    assert_eq!(parse_function("  rotate(40)").0, "rotate");
+    assert_eq!(parse_function("  rotate  (40)").0, "rotate");
+    assert_eq!(parse_function("  rotate  (  40 )").1[0], "40");
+    assert_eq!(parse_function("rotate(-40.0)").1[0], "-40.0");
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -643,6 +643,8 @@ impl YamlFrameReader {
             None => None,
         };
 
+        let transform_style = yaml["transform-style"].as_transform_style()
+                                                     .unwrap_or(TransformStyle::Flat);
         let mix_blend_mode = yaml["mix-blend-mode"].as_mix_blend_mode()
                                                    .unwrap_or(MixBlendMode::Normal);
         let scroll_policy = yaml["scroll-policy"].as_scroll_policy()
@@ -661,6 +663,7 @@ impl YamlFrameReader {
                                              bounds,
                                              z_index as i32,
                                              transform.into(),
+                                             transform_style,
                                              perspective,
                                              mix_blend_mode,
                                              filters);


### PR DESCRIPTION
This is the first PR on the way to plane splitting, it doesn't carry any actual logic but introduces the API to provide a transform style per SC (breaking change). Also happens to refactor some of the Yaml helper code to be nicer:
  - proper rotation transformation support
  - parsing of negative values
  - simpler string/enum conversion code

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1062)
<!-- Reviewable:end -->
