### PR TITLE
Fix warning on macOS.

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -148,7 +148,7 @@ impl FontContext {
     }
 
     pub fn delete_font(&mut self, font_key: &FontKey) {
-        if let Some(cg_font) = self.cg_fonts.remove(font_key) {
+        if let Some(_) = self.cg_fonts.remove(font_key) {
             // Unstable Rust has a retain() method on HashMap that will
             // let us do this in-place. https://github.com/rust-lang/rust/issues/36648
             let ct_font_keys = self.ct_fonts.keys()


### PR DESCRIPTION
The `cg_font` variable wasn't used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1063)
<!-- Reviewable:end -->
