### PR TITLE
webrender_traits: Fix or allow all clippy warnings.

### DIFF
--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -67,33 +67,33 @@ pub enum ApiMsg {
 
 impl fmt::Debug for ApiMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &ApiMsg::AddRawFont(..) => { write!(f, "ApiMsg::AddRawFont") }
-            &ApiMsg::AddNativeFont(..) => { write!(f, "ApiMsg::AddNativeFont") }
-            &ApiMsg::DeleteFont(..) => { write!(f, "ApiMsg::DeleteFont") }
-            &ApiMsg::GetGlyphDimensions(..) => { write!(f, "ApiMsg::GetGlyphDimensions") }
-            &ApiMsg::AddImage(..) => { write!(f, "ApiMsg::AddImage") }
-            &ApiMsg::UpdateImage(..) => { write!(f, "ApiMsg::UpdateImage") }
-            &ApiMsg::DeleteImage(..) => { write!(f, "ApiMsg::DeleteImage") }
-            &ApiMsg::CloneApi(..) => { write!(f, "ApiMsg::CloneApi") }
-            &ApiMsg::SetDisplayList(..) => { write!(f, "ApiMsg::SetDisplayList") }
-            &ApiMsg::SetRootPipeline(..) => { write!(f, "ApiMsg::SetRootPipeline") }
-            &ApiMsg::Scroll(..) => { write!(f, "ApiMsg::Scroll") }
-            &ApiMsg::ScrollLayerWithId(..) => { write!(f, "ApiMsg::ScrollLayerWithId") }
-            &ApiMsg::TickScrollingBounce => { write!(f, "ApiMsg::TickScrollingBounce") }
-            &ApiMsg::TranslatePointToLayerSpace(..) => { write!(f, "ApiMsg::TranslatePointToLayerSpace") }
-            &ApiMsg::GetScrollLayerState(..) => { write!(f, "ApiMsg::GetScrollLayerState") }
-            &ApiMsg::RequestWebGLContext(..) => { write!(f, "ApiMsg::RequestWebGLContext") }
-            &ApiMsg::ResizeWebGLContext(..) => { write!(f, "ApiMsg::ResizeWebGLContext") }
-            &ApiMsg::WebGLCommand(..) => { write!(f, "ApiMsg::WebGLCommand") }
-            &ApiMsg::GenerateFrame(..) => { write!(f, "ApiMsg::GenerateFrame") }
-            &ApiMsg::VRCompositorCommand(..) => { write!(f, "ApiMsg::VRCompositorCommand") }
-            &ApiMsg::ExternalEvent(..) => { write!(f, "ApiMsg::ExternalEvent") }
-            &ApiMsg::ShutDown => { write!(f, "ApiMsg::ShutDown") }
-            &ApiMsg::SetPageZoom(..) => { write!(f, "ApiMsg::SetPageZoom") }
-            &ApiMsg::SetPinchZoom(..) => { write!(f, "ApiMsg::SetPinchZoom") }
-            &ApiMsg::SetPan(..) => { write!(f, "ApiMsg::SetPan") }
-            &ApiMsg::SetWindowParameters(..) => { write!(f, "ApiMsg::SetWindowParameters") }
+        match *self {
+            ApiMsg::AddRawFont(..) => { write!(f, "ApiMsg::AddRawFont") }
+            ApiMsg::AddNativeFont(..) => { write!(f, "ApiMsg::AddNativeFont") }
+            ApiMsg::DeleteFont(..) => { write!(f, "ApiMsg::DeleteFont") }
+            ApiMsg::GetGlyphDimensions(..) => { write!(f, "ApiMsg::GetGlyphDimensions") }
+            ApiMsg::AddImage(..) => { write!(f, "ApiMsg::AddImage") }
+            ApiMsg::UpdateImage(..) => { write!(f, "ApiMsg::UpdateImage") }
+            ApiMsg::DeleteImage(..) => { write!(f, "ApiMsg::DeleteImage") }
+            ApiMsg::CloneApi(..) => { write!(f, "ApiMsg::CloneApi") }
+            ApiMsg::SetDisplayList(..) => { write!(f, "ApiMsg::SetDisplayList") }
+            ApiMsg::SetRootPipeline(..) => { write!(f, "ApiMsg::SetRootPipeline") }
+            ApiMsg::Scroll(..) => { write!(f, "ApiMsg::Scroll") }
+            ApiMsg::ScrollLayerWithId(..) => { write!(f, "ApiMsg::ScrollLayerWithId") }
+            ApiMsg::TickScrollingBounce => { write!(f, "ApiMsg::TickScrollingBounce") }
+            ApiMsg::TranslatePointToLayerSpace(..) => { write!(f, "ApiMsg::TranslatePointToLayerSpace") }
+            ApiMsg::GetScrollLayerState(..) => { write!(f, "ApiMsg::GetScrollLayerState") }
+            ApiMsg::RequestWebGLContext(..) => { write!(f, "ApiMsg::RequestWebGLContext") }
+            ApiMsg::ResizeWebGLContext(..) => { write!(f, "ApiMsg::ResizeWebGLContext") }
+            ApiMsg::WebGLCommand(..) => { write!(f, "ApiMsg::WebGLCommand") }
+            ApiMsg::GenerateFrame(..) => { write!(f, "ApiMsg::GenerateFrame") }
+            ApiMsg::VRCompositorCommand(..) => { write!(f, "ApiMsg::VRCompositorCommand") }
+            ApiMsg::ExternalEvent(..) => { write!(f, "ApiMsg::ExternalEvent") }
+            ApiMsg::ShutDown => { write!(f, "ApiMsg::ShutDown") }
+            ApiMsg::SetPageZoom(..) => { write!(f, "ApiMsg::SetPageZoom") }
+            ApiMsg::SetPinchZoom(..) => { write!(f, "ApiMsg::SetPinchZoom") }
+            ApiMsg::SetPan(..) => { write!(f, "ApiMsg::SetPan") }
+            ApiMsg::SetWindowParameters(..) => { write!(f, "ApiMsg::SetWindowParameters") }
         }
     }
 }
@@ -559,7 +559,7 @@ pub struct PropertyValue<T> {
     pub value: T,
 }
 
-/// When using generate_frame(), a list of PropertyValue structures
+/// When using `generate_frame()`, a list of `PropertyValue` structures
 /// can optionally be supplied to provide the current value of any
 /// animated properties.
 #[derive(Clone, Deserialize, Serialize, Debug)]

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -67,34 +67,34 @@ pub enum ApiMsg {
 
 impl fmt::Debug for ApiMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ApiMsg::AddRawFont(..) => { write!(f, "ApiMsg::AddRawFont") }
-            ApiMsg::AddNativeFont(..) => { write!(f, "ApiMsg::AddNativeFont") }
-            ApiMsg::DeleteFont(..) => { write!(f, "ApiMsg::DeleteFont") }
-            ApiMsg::GetGlyphDimensions(..) => { write!(f, "ApiMsg::GetGlyphDimensions") }
-            ApiMsg::AddImage(..) => { write!(f, "ApiMsg::AddImage") }
-            ApiMsg::UpdateImage(..) => { write!(f, "ApiMsg::UpdateImage") }
-            ApiMsg::DeleteImage(..) => { write!(f, "ApiMsg::DeleteImage") }
-            ApiMsg::CloneApi(..) => { write!(f, "ApiMsg::CloneApi") }
-            ApiMsg::SetDisplayList(..) => { write!(f, "ApiMsg::SetDisplayList") }
-            ApiMsg::SetRootPipeline(..) => { write!(f, "ApiMsg::SetRootPipeline") }
-            ApiMsg::Scroll(..) => { write!(f, "ApiMsg::Scroll") }
-            ApiMsg::ScrollLayerWithId(..) => { write!(f, "ApiMsg::ScrollLayerWithId") }
-            ApiMsg::TickScrollingBounce => { write!(f, "ApiMsg::TickScrollingBounce") }
-            ApiMsg::TranslatePointToLayerSpace(..) => { write!(f, "ApiMsg::TranslatePointToLayerSpace") }
-            ApiMsg::GetScrollLayerState(..) => { write!(f, "ApiMsg::GetScrollLayerState") }
-            ApiMsg::RequestWebGLContext(..) => { write!(f, "ApiMsg::RequestWebGLContext") }
-            ApiMsg::ResizeWebGLContext(..) => { write!(f, "ApiMsg::ResizeWebGLContext") }
-            ApiMsg::WebGLCommand(..) => { write!(f, "ApiMsg::WebGLCommand") }
-            ApiMsg::GenerateFrame(..) => { write!(f, "ApiMsg::GenerateFrame") }
-            ApiMsg::VRCompositorCommand(..) => { write!(f, "ApiMsg::VRCompositorCommand") }
-            ApiMsg::ExternalEvent(..) => { write!(f, "ApiMsg::ExternalEvent") }
-            ApiMsg::ShutDown => { write!(f, "ApiMsg::ShutDown") }
-            ApiMsg::SetPageZoom(..) => { write!(f, "ApiMsg::SetPageZoom") }
-            ApiMsg::SetPinchZoom(..) => { write!(f, "ApiMsg::SetPinchZoom") }
-            ApiMsg::SetPan(..) => { write!(f, "ApiMsg::SetPan") }
-            ApiMsg::SetWindowParameters(..) => { write!(f, "ApiMsg::SetWindowParameters") }
-        }
+        f.write_str(match *self {
+            ApiMsg::AddRawFont(..) => "ApiMsg::AddRawFont",
+            ApiMsg::AddNativeFont(..) => "ApiMsg::AddNativeFont",
+            ApiMsg::DeleteFont(..) => "ApiMsg::DeleteFont",
+            ApiMsg::GetGlyphDimensions(..) => "ApiMsg::GetGlyphDimensions",
+            ApiMsg::AddImage(..) => "ApiMsg::AddImage",
+            ApiMsg::UpdateImage(..) => "ApiMsg::UpdateImage",
+            ApiMsg::DeleteImage(..) => "ApiMsg::DeleteImage",
+            ApiMsg::CloneApi(..) => "ApiMsg::CloneApi",
+            ApiMsg::SetDisplayList(..) => "ApiMsg::SetDisplayList",
+            ApiMsg::SetRootPipeline(..) => "ApiMsg::SetRootPipeline",
+            ApiMsg::Scroll(..) => "ApiMsg::Scroll",
+            ApiMsg::ScrollLayerWithId(..) => "ApiMsg::ScrollLayerWithId",
+            ApiMsg::TickScrollingBounce => "ApiMsg::TickScrollingBounce",
+            ApiMsg::TranslatePointToLayerSpace(..) => "ApiMsg::TranslatePointToLayerSpace",
+            ApiMsg::GetScrollLayerState(..) => "ApiMsg::GetScrollLayerState",
+            ApiMsg::RequestWebGLContext(..) => "ApiMsg::RequestWebGLContext",
+            ApiMsg::ResizeWebGLContext(..) => "ApiMsg::ResizeWebGLContext",
+            ApiMsg::WebGLCommand(..) => "ApiMsg::WebGLCommand",
+            ApiMsg::GenerateFrame(..) => "ApiMsg::GenerateFrame",
+            ApiMsg::VRCompositorCommand(..) => "ApiMsg::VRCompositorCommand",
+            ApiMsg::ExternalEvent(..) => "ApiMsg::ExternalEvent",
+            ApiMsg::ShutDown => "ApiMsg::ShutDown",
+            ApiMsg::SetPageZoom(..) => "ApiMsg::SetPageZoom",
+            ApiMsg::SetPinchZoom(..) => "ApiMsg::SetPinchZoom",
+            ApiMsg::SetPan(..) => "ApiMsg::SetPan",
+            ApiMsg::SetWindowParameters(..) => "ApiMsg::SetWindowParameters",
+        })
     }
 }
 

--- a/webrender_traits/src/channel.rs
+++ b/webrender_traits/src/channel.rs
@@ -69,8 +69,8 @@ impl Payload {
 }
 
 
-/// A helper to handle the interface difference between IpcBytesSender and
-/// Sender<Vec<u8>>.
+/// A helper to handle the interface difference between `IpcBytesSender`
+/// and `Sender<Vec<u8>>`.
 pub trait PayloadSenderHelperMethods {
     fn send_payload(&self, data: Payload) -> Result<(), Error>;
 }

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -538,8 +538,8 @@ impl ScrollLayerId {
 
     pub fn pipeline_id(&self) -> PipelineId {
         match *self {
-            ScrollLayerId::Clip(_, pipeline_id) => pipeline_id,
-            ScrollLayerId::ClipExternalId(_, pipeline_id) => pipeline_id,
+            ScrollLayerId::Clip(_, pipeline_id) |
+            ScrollLayerId::ClipExternalId(_, pipeline_id) |
             ScrollLayerId::ReferenceFrame(_, pipeline_id) => pipeline_id,
         }
     }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -80,7 +80,7 @@ impl BuiltDisplayList {
         &self.descriptor
     }
 
-    pub fn all_display_items<'a>(&'a self) -> &'a [DisplayItem] {
+    pub fn all_display_items(&self) -> &[DisplayItem] {
         unsafe {
             convert_blob_to_pod(&self.data[0..self.descriptor.display_list_items_size])
         }
@@ -576,7 +576,7 @@ impl ItemRange {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct AuxiliaryListsBuilder {
     gradient_stops: Vec<GradientStop>,
     complex_clip_regions: Vec<ComplexClipRegion>,
@@ -586,12 +586,7 @@ pub struct AuxiliaryListsBuilder {
 
 impl AuxiliaryListsBuilder {
     pub fn new() -> AuxiliaryListsBuilder {
-        AuxiliaryListsBuilder {
-            gradient_stops: Vec::new(),
-            complex_clip_regions: Vec::new(),
-            filters: Vec::new(),
-            glyph_instances: Vec::new(),
-        }
+        AuxiliaryListsBuilder::default()
     }
 
     pub fn add_gradient_stops(&mut self, gradient_stops: &[GradientStop]) -> ItemRange {

--- a/webrender_traits/src/font.rs
+++ b/webrender_traits/src/font.rs
@@ -104,7 +104,7 @@ impl SubpixelPoint {
     }
 
     pub fn to_f64(&self) -> (f64, f64) {
-        return (self.x.into(), self.y.into());
+        (self.x.into(), self.y.into())
     }
 
     pub fn set_offset(&mut self, point: Point2D<f32>, render_mode: FontRenderMode) {

--- a/webrender_traits/src/lib.rs
+++ b/webrender_traits/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![cfg_attr(feature = "nightly", feature(nonzero))]
+#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments, float_cmp))]
 
 extern crate app_units;
 extern crate byteorder;


### PR DESCRIPTION
We now silently allow (with this commit) clippy warnings
about comparing floating point values as well as for functions
with too many arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1068)
<!-- Reviewable:end -->
