### PR TITLE
Test for subpixel_aa instead of subpixel-aa.

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -324,7 +324,7 @@ fn main() {
                                  save_type,
                                  size,
                                  args.is_present("rebuild"),
-                                 args.is_present("subpixel-aa"),
+                                 args.is_present("subpixel_aa"),
                                  args.is_present("debug"),
                                  args.is_present("verbose"));
 


### PR DESCRIPTION
clap will normalize command line arguments from subpixel-aa to
subpixel_aa but does not do the normalization in is_present. We
need to check for the proper form

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1071)
<!-- Reviewable:end -->
