### PR TITLE
Correctly set clip in for inset box shadows with border radii

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -23,7 +23,7 @@ use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobI
 use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
-use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle};
+use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle, BoxShadowClipMode};
 
 #[derive(Debug)]
 enum Gesture {
@@ -389,6 +389,29 @@ fn main() {
                           Au::from_px(32),
                           Au::from_px(0),
                           None);
+    }
+
+    if false { // draw box shadow?
+        let rect = LayoutRect::new(LayoutPoint::new(0.0, 0.0), LayoutSize::new(0.0, 0.0));
+        let simple_box_bounds = LayoutRect::new(LayoutPoint::new(20.0, 200.0),
+                                                LayoutSize::new(50.0, 50.0));
+        let offset = LayoutPoint::new(0.0, 0.0);
+        let color = ColorF::new(1.0, 1.0, 1.0, 1.0);
+        let blur_radius = 5.0;
+        let spread_radius = 0.0;
+        let simple_border_radius = 20.0;
+        let box_shadow_type = BoxShadowClipMode::Inset;
+        let full_screen_clip = builder.new_clip_region(&bounds, Vec::new(), None);
+
+        builder.push_box_shadow(rect,
+                                full_screen_clip,
+                                simple_box_bounds,
+                                offset,
+                                color,
+                                blur_radius,
+                                spread_radius,
+                                simple_border_radius,
+                                box_shadow_type);
     }
 
     builder.pop_stacking_context();

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -882,12 +882,17 @@ impl FrameBuilder {
                     BoxShadowClipMode::Inset => 1.0,
                 };
 
-                // If we have a border radius, we'll need to apply
-                // a clip-out mask.
+                // Outset box shadows with border radius
+                // need a clip out of the center box.
+                let extra_clip_mode = match clip_mode {
+                    BoxShadowClipMode::Outset | BoxShadowClipMode::None => ClipMode::ClipOut,
+                    BoxShadowClipMode::Inset => ClipMode::Clip,
+                };
+
                 let extra_clip = if border_radius > 0.0 {
                     Some(ClipSource::Complex(*box_bounds,
                                              border_radius,
-                                             ClipMode::ClipOut))
+                                             extra_clip_mode))
                 } else {
                     None
                 };

--- a/wrench/reftests/boxshadow/inset-border-radius-ref.yaml
+++ b/wrench/reftests/boxshadow/inset-border-radius-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+        - type: stacking-context
+          bounds: [0, 0, 100, 100]
+          items:
+            - type: box-shadow
+              bounds: [ 10, 10, 80, 80 ]
+              blur-radius: 25
+              clip-mode: inset
+              clip:
+                rect: [0, 0, 100, 100]
+                complex:
+                  - rect: [ 10, 10, 80, 80 ]
+                    radius: 10

--- a/wrench/reftests/boxshadow/inset-border-radius.yaml
+++ b/wrench/reftests/boxshadow/inset-border-radius.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+        - type: stacking-context
+          bounds: [0, 0, 100, 100]
+          items:
+            - type: box-shadow
+              bounds: [ 10, 10, 80, 80 ]
+              blur-radius: 25
+              clip-mode: inset
+              border-radius: 10

--- a/wrench/reftests/boxshadow/reftest.list
+++ b/wrench/reftests/boxshadow/reftest.list
@@ -1,2 +1,5 @@
 != inset-simple.yaml inset-simple-ref.yaml
 != inset-spread.yaml inset-spread-ref.yaml
+
+# fuzzy because the test is a blur. Just want to test that clip out works.
+fuzzy(7,13704) == inset-border-radius.yaml inset-border-radius-ref.yaml


### PR DESCRIPTION
Inset box shadows weren't working properly because we were performing an out clip. But inset box shadows draw inwards, so we need a clip in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1072)
<!-- Reviewable:end -->
