### PR TITLE
Interpret gradient start and end positions as relative to bounds

### DIFF
--- a/webrender/res/ps_angle_gradient.fs.glsl
+++ b/webrender/res/ps_angle_gradient.fs.glsl
@@ -5,11 +5,14 @@
 uniform sampler2D sGradients;
 
 void main(void) {
+    // Normalized offset of this vertex within the gradient, before clamp/repeat.
+    float offset = dot(vPos - vStartPoint, vScaledDir);
+
     vec2 texture_size = vec2(textureSize(sGradients, 0));
 
     // Either saturate or modulo the offset depending on repeat mode, then scale to number of
     // gradient color entries (texture width / 2).
-    float x = mix(clamp(vOffset, 0.0, 1.0), fract(vOffset), vGradientRepeat) * 0.5 * texture_size.x;
+    float x = mix(clamp(offset, 0.0, 1.0), fract(offset), vGradientRepeat) * 0.5 * texture_size.x;
 
     x = 2.0 * floor(x) + 0.5 + fract(x);
 

--- a/webrender/res/ps_angle_gradient.glsl
+++ b/webrender/res/ps_angle_gradient.glsl
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+flat varying vec2 vScaledDir;
+flat varying vec2 vStartPoint;
 flat varying float vGradientIndex;
 flat varying float vGradientRepeat;
-varying float vOffset;
+varying vec2 vPos;

--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -13,13 +13,14 @@ void main(void) {
                                  prim.layer,
                                  prim.task);
 
+    vPos = vi.local_pos - prim.local_rect.p0;
+
     vec2 start_point = gradient.start_end_point.xy;
     vec2 end_point = gradient.start_end_point.zw;
-
     vec2 dir = end_point - start_point;
 
-    // Normalized offset of this vertex within the gradient, before clamp/repeat.
-    vOffset = dot(vi.local_pos - start_point, dir) / dot(dir, dir);
+    vStartPoint = start_point;
+    vScaledDir = dir / dot(dir, dir);
 
     // V coordinate of gradient row in lookup texture.
     vGradientIndex = float(prim.sub_index);

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -7,6 +7,8 @@ void main(void) {
     Primitive prim = load_primitive();
     Gradient gradient = fetch_gradient(prim.prim_index);
 
+    vec4 abs_start_end_point = gradient.start_end_point + prim.local_rect.p0.xyxy;
+
     GradientStop g0 = fetch_gradient_stop(prim.sub_index + 0);
     GradientStop g1 = fetch_gradient_stop(prim.sub_index + 1);
 
@@ -14,9 +16,9 @@ void main(void) {
     vec2 axis;
     vec4 adjusted_color_g0 = g0.color;
     vec4 adjusted_color_g1 = g1.color;
-    if (gradient.start_end_point.y == gradient.start_end_point.w) {
+    if (abs_start_end_point.y == abs_start_end_point.w) {
         // Calculate the x coord of the gradient stops
-        vec2 g01_x = mix(gradient.start_end_point.xx, gradient.start_end_point.zz,
+        vec2 g01_x = mix(abs_start_end_point.xx, abs_start_end_point.zz,
                          vec2(g0.offset.x, g1.offset.x));
 
         // The gradient stops might exceed the geometry rect so clamp them
@@ -35,7 +37,7 @@ void main(void) {
         adjusted_color_g1 = mix(g0.color, g1.color, adjusted_offset.y);
     } else {
         // Calculate the y coord of the gradient stops
-        vec2 g01_y = mix(gradient.start_end_point.yy, gradient.start_end_point.ww,
+        vec2 g01_y = mix(abs_start_end_point.yy, abs_start_end_point.ww,
                          vec2(g0.offset.x, g1.offset.x));
 
         // The gradient stops might exceed the geometry rect so clamp them

--- a/webrender/res/ps_radial_gradient.vs.glsl
+++ b/webrender/res/ps_radial_gradient.vs.glsl
@@ -13,7 +13,7 @@ void main(void) {
                                  prim.layer,
                                  prim.task);
 
-    vPos = vi.local_pos;
+    vPos = vi.local_pos - prim.local_rect.p0;
 
     vStartCenter = gradient.start_end_center.xy;
     vEndCenter = gradient.start_end_center.zw;

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -577,23 +577,27 @@ impl FrameBuilder {
             }
             BorderDetails::Gradient(ref border) => {
                 for segment in create_segments(border.outset) {
+                    let segment_rel = segment.origin - rect.origin;
+
                     self.add_gradient(scroll_layer_id,
                                       segment,
                                       clip_region,
-                                      border.gradient.start_point,
-                                      border.gradient.end_point,
+                                      border.gradient.start_point - segment_rel,
+                                      border.gradient.end_point - segment_rel,
                                       border.gradient.stops,
                                       border.gradient.extend_mode);
                 }
             }
             BorderDetails::RadialGradient(ref border) => {
                 for segment in create_segments(border.outset) {
+                    let segment_rel = segment.origin - rect.origin;
+
                     self.add_radial_gradient(scroll_layer_id,
                                              segment,
                                              clip_region,
-                                             border.gradient.start_center,
+                                             border.gradient.start_center - segment_rel,
                                              border.gradient.start_radius,
-                                             border.gradient.end_center,
+                                             border.gradient.end_center - segment_rel,
                                              border.gradient.end_radius,
                                              border.gradient.ratio_xy,
                                              border.gradient.stops,

--- a/wrench/reftests/border/border-gradient-simple-ref.yaml
+++ b/wrench/reftests/border/border-gradient-simple-ref.yaml
@@ -12,44 +12,44 @@ root:
           repeat: false
         - type: gradient # top right
           bounds: [ 40, 0, 10, 10]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ -15, 0 ]
+          end: [ -15, 50 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # bottom left
           bounds: [ 0, 40, 10, 10]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ 25, -40 ]
+          end: [ 25, 10 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # bottom right
           bounds: [ 40, 40, 10, 10]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ -15, -40 ]
+          end: [ -15, 10 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # top
           bounds: [ 10, 0, 30, 10]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ 15, 0 ]
+          end: [ 15, 50 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # right
           bounds: [ 40, 10, 10, 30]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ -15, -10 ]
+          end: [ -15, 40 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # bottom
           bounds: [ 10, 40, 30, 10]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ 15, -40 ]
+          end: [ 15, 10 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: gradient # left
           bounds: [ 0, 10, 10, 30]
-          start: [ 25, 0 ]
-          end: [ 25, 50 ]
+          start: [ 25, -10 ]
+          end: [ 25, 40 ]
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
 

--- a/wrench/reftests/border/border-radial-gradient-simple-ref.yaml
+++ b/wrench/reftests/border/border-radial-gradient-simple-ref.yaml
@@ -14,57 +14,57 @@ root:
           repeat: false
         - type: radial-gradient # top right
           bounds: [ 40, 0, 10, 10]
-          start-center: [ 25, 25 ]
+          start-center: [ -15, 25 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ -15, 25 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # bottom left
           bounds: [ 0, 40, 10, 10]
-          start-center: [ 25, 25 ]
+          start-center: [ 25, -15 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ 25, -15 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # bottom right
           bounds: [ 40, 40, 10, 10]
-          start-center: [ 25, 25 ]
+          start-center: [ -15, -15 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ -15, -15 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # top
           bounds: [ 10, 0, 30, 10]
-          start-center: [ 25, 25 ]
+          start-center: [ 15, 25 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ 15, 25 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # right
           bounds: [ 40, 10, 10, 30]
-          start-center: [ 25, 25 ]
+          start-center: [ -15, 15 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ -15, 15 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # bottom
           bounds: [ 10, 40, 30, 10]
-          start-center: [ 25, 25 ]
+          start-center: [ 15, -15 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ 15, -15 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false
         - type: radial-gradient # left
           bounds: [ 0, 10, 10, 30]
-          start-center: [ 25, 25 ]
+          start-center: [ 25, 15 ]
           start-radius: 15
-          end-center: [ 25, 25 ]
+          end-center: [ 25, 15 ]
           end-radius: 35
           stops: [ 0.0, red, 1.0, green ]
           repeat: false

--- a/wrench/reftests/gradient/linear-aligned-clip.yaml
+++ b/wrench/reftests/gradient/linear-aligned-clip.yaml
@@ -4,6 +4,6 @@ root:
     # an aligned gradient from [0, 400] and clipped to [100, 300]
     - type: gradient
       bounds: 0 100 200 200
-      start: 100 0
-      end: 100 400
+      start: 100 -100
+      end: 100 300
       stops: [0.0, green, 1.0, blue]

--- a/wrench/reftests/gradient/linear-reverse.yaml
+++ b/wrench/reftests/gradient/linear-reverse.yaml
@@ -1,14 +1,11 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 200 100
-          end: 000 100
-          stops: [0.0, black, 0.25, black,
-                  0.25, blue, 0.5, blue,
-                  0.5, green, 0.75, green,
-                  0.75, red, 1.0, red]
+      start: 200 100
+      end: 000 100
+      stops: [0.0, black, 0.25, black,
+              0.25, blue, 0.5, blue,
+              0.5, green, 0.75, green,
+              0.75, red, 1.0, red]

--- a/wrench/reftests/gradient/linear.yaml
+++ b/wrench/reftests/gradient/linear.yaml
@@ -1,14 +1,11 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, red, 0.25, red,
-                  0.25, green, 0.5, green,
-                  0.5, blue, 0.75, blue,
-                  0.75, black, 1.0, black]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, red, 0.25, red,
+              0.25, green, 0.5, green,
+              0.5, blue, 0.75, blue,
+              0.75, black, 1.0, black]

--- a/wrench/reftests/gradient/norm-linear-1-ref.yaml
+++ b/wrench/reftests/gradient/norm-linear-1-ref.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, green, 0.5, green,
-                  0.5, blue, 1.0, blue]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, green, 0.5, green,
+              0.5, blue, 1.0, blue]

--- a/wrench/reftests/gradient/norm-linear-1.yaml
+++ b/wrench/reftests/gradient/norm-linear-1.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.25, green, 0.5, green,
-                  0.5, blue, 0.75, blue]
+      start: 0 100
+      end: 200 100
+      stops: [0.25, green, 0.5, green,
+              0.5, blue, 0.75, blue]

--- a/wrench/reftests/gradient/norm-linear-2-ref.yaml
+++ b/wrench/reftests/gradient/norm-linear-2-ref.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, green, 0.5, green,
-                  0.5, blue, 1.0, blue]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, green, 0.5, green,
+              0.5, blue, 1.0, blue]

--- a/wrench/reftests/gradient/norm-linear-2.yaml
+++ b/wrench/reftests/gradient/norm-linear-2.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.5, green,
-                  0.5, blue]
+      start: 0 100
+      end: 200 100
+      stops: [0.5, green,
+              0.5, blue]

--- a/wrench/reftests/gradient/norm-linear-3-ref.yaml
+++ b/wrench/reftests/gradient/norm-linear-3-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, blue, 1.0, blue]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, blue, 1.0, blue]

--- a/wrench/reftests/gradient/norm-linear-3.yaml
+++ b/wrench/reftests/gradient/norm-linear-3.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [-0.5, green,
-                  -0.5, blue]
+      start: 0 100
+      end: 200 100
+      stops: [-0.5, green,
+              -0.5, blue]

--- a/wrench/reftests/gradient/norm-linear-4-ref.yaml
+++ b/wrench/reftests/gradient/norm-linear-4-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, green, 1.0, green]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, green, 1.0, green]

--- a/wrench/reftests/gradient/norm-linear-4.yaml
+++ b/wrench/reftests/gradient/norm-linear-4.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [1.5, green,
-                  1.5, blue]
+      start: 0 100
+      end: 200 100
+      stops: [1.5, green,
+              1.5, blue]

--- a/wrench/reftests/gradient/norm-linear-degenerate-ref.yaml
+++ b/wrench/reftests/gradient/norm-linear-degenerate-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 300 300
-      items:
-        - type: gradient
-          bounds: 0 0 300 300
-          start: 0 150
-          end: 300 150
-          stops: [0.0, red, 1.0, red]
+      start: 0 150
+      end: 300 150
+      stops: [0.0, red, 1.0, red]

--- a/wrench/reftests/gradient/norm-linear-degenerate.yaml
+++ b/wrench/reftests/gradient/norm-linear-degenerate.yaml
@@ -6,12 +6,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 300 300
-      items:
-        - type: gradient
-          bounds: 0 0 300 300
-          start: 0 150
-          end: 300 150
-          stops: [0.5, blue, 0.5, red]
-          repeat: true
+      start: 0 150
+      end: 300 150
+      stops: [0.5, blue, 0.5, red]
+      repeat: true

--- a/wrench/reftests/gradient/norm-radial-1-ref.yaml
+++ b/wrench/reftests/gradient/norm-radial-1-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [0.0, red, 0.5, red, 0.5, blue, 1.0, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [0.0, red, 0.5, red, 0.5, blue, 1.0, blue]

--- a/wrench/reftests/gradient/norm-radial-1.yaml
+++ b/wrench/reftests/gradient/norm-radial-1.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [0.5, red, 0.5, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [0.5, red, 0.5, blue]

--- a/wrench/reftests/gradient/norm-radial-2-ref.yaml
+++ b/wrench/reftests/gradient/norm-radial-2-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [0.0, blue, 1.0, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [0.0, blue, 1.0, blue]

--- a/wrench/reftests/gradient/norm-radial-2.yaml
+++ b/wrench/reftests/gradient/norm-radial-2.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [-0.5, red, -0.5, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [-0.5, red, -0.5, blue]

--- a/wrench/reftests/gradient/norm-radial-3-ref.yaml
+++ b/wrench/reftests/gradient/norm-radial-3-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [0.0, red, 1.0, red]
+      center: 150 150
+      radius: 200 200
+      stops: [0.0, red, 1.0, red]

--- a/wrench/reftests/gradient/norm-radial-3.yaml
+++ b/wrench/reftests/gradient/norm-radial-3.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [1.5, red, 1.5, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [1.5, red, 1.5, blue]

--- a/wrench/reftests/gradient/norm-radial-degenerate-ref.yaml
+++ b/wrench/reftests/gradient/norm-radial-degenerate-ref.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 150 150
-          stops: [0.0, red, 1.0, red]
+      center: 150 150
+      radius: 150 150
+      stops: [0.0, red, 1.0, red]

--- a/wrench/reftests/gradient/norm-radial-degenerate.yaml
+++ b/wrench/reftests/gradient/norm-radial-degenerate.yaml
@@ -6,12 +6,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 150 150
-          stops: [0.5, blue, 0.5, red]
-          repeat: true
+      center: 150 150
+      radius: 150 150
+      stops: [0.5, blue, 0.5, red]
+      repeat: true

--- a/wrench/reftests/gradient/premultiplied-aligned.yaml
+++ b/wrench/reftests/gradient/premultiplied-aligned.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          start: 0 100
-          end: 200 100
-          stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]
+      start: 0 100
+      end: 200 100
+      stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]

--- a/wrench/reftests/gradient/premultiplied-angle.yaml
+++ b/wrench/reftests/gradient/premultiplied-angle.yaml
@@ -1,13 +1,10 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 200 200
-      items:
-        - type: gradient
-          bounds: 0 0 200 200
-          # offset the start and end points slightly so
-          # we force the angle gradient shader
-          start: 0 100
-          end: 200 100.001
-          stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]
+      # offset the start and end points slightly so
+      # we force the angle gradient shader
+      start: 0 100
+      end: 200 100.001
+      stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]

--- a/wrench/reftests/gradient/premultiplied-radial.yaml
+++ b/wrench/reftests/gradient/premultiplied-radial.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 200 200
-      items:
-        - type: radial-gradient
-          bounds: 0 0 200 200
-          center: 100 100
-          radius: 200 200
-          stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]
+      center: 100 100
+      radius: 200 200
+      stops: [0.0, [128, 128, 128, 0.5], 1.0, [128, 128, 128, 0.5]]

--- a/wrench/reftests/gradient/radial-circle.yaml
+++ b/wrench/reftests/gradient/radial-circle.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 200 200
-          stops: [0, red, 1, blue]
+      center: 150 150
+      radius: 200 200
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/radial-ellipse.yaml
+++ b/wrench/reftests/gradient/radial-ellipse.yaml
@@ -1,11 +1,8 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 100 200
-          stops: [0, red, 1, blue]
+      center: 150 150
+      radius: 100 200
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/repeat-linear-ref.yaml
+++ b/wrench/reftests/gradient/repeat-linear-ref.yaml
@@ -1,30 +1,27 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 300 300
-      items:
-        - type: gradient
-          bounds: 0 0 300 300
-          start: 0 150
-          end: 300 150
-          stops: [0.0, red,
-                  0.1, red,
-                  0.1, blue,
-                  0.2, blue,
-                  0.2, red,
-                  0.3, red,
-                  0.3, blue,
-                  0.4, blue,
-                  0.4, red,
-                  0.5, red,
-                  0.5, blue,
-                  0.6, blue,
-                  0.6, red,
-                  0.7, red,
-                  0.7, blue,
-                  0.8, blue,
-                  0.8, red,
-                  0.9, red,
-                  0.9, blue,
-                  1.0, blue]
+      start: 0 150
+      end: 300 150
+      stops: [0.0, red,
+              0.1, red,
+              0.1, blue,
+              0.2, blue,
+              0.2, red,
+              0.3, red,
+              0.3, blue,
+              0.4, blue,
+              0.4, red,
+              0.5, red,
+              0.5, blue,
+              0.6, blue,
+              0.6, red,
+              0.7, red,
+              0.7, blue,
+              0.8, blue,
+              0.8, red,
+              0.9, red,
+              0.9, blue,
+              1.0, blue]

--- a/wrench/reftests/gradient/repeat-linear-reverse.yaml
+++ b/wrench/reftests/gradient/repeat-linear-reverse.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 300 300
-      items:
-        - type: gradient
-          bounds: 0 0 300 300
-          start: 300 150
-          end: 0 150
-          stops: [0.1, red, 0.2, red, 0.2, blue, 0.3, blue]
-          repeat: true
+      start: 300 150
+      end: 0 150
+      stops: [0.1, red, 0.2, red, 0.2, blue, 0.3, blue]
+      repeat: true

--- a/wrench/reftests/gradient/repeat-linear.yaml
+++ b/wrench/reftests/gradient/repeat-linear.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: gradient
       bounds: 50 50 300 300
-      items:
-        - type: gradient
-          bounds: 0 0 300 300
-          start: 0 150
-          end: 300 150
-          stops: [0.1, blue, 0.2, blue, 0.2, red, 0.3, red]
-          repeat: true
+      start: 0 150
+      end: 300 150
+      stops: [0.1, blue, 0.2, blue, 0.2, red, 0.3, red]
+      repeat: true

--- a/wrench/reftests/gradient/repeat-radial-negative.yaml
+++ b/wrench/reftests/gradient/repeat-radial-negative.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 150 150
-          stops: [-0.3, blue, -0.2, blue, -0.2, red, -0.1, red]
-          repeat: true
+      center: 150 150
+      radius: 150 150
+      stops: [-0.3, blue, -0.2, blue, -0.2, red, -0.1, red]
+      repeat: true

--- a/wrench/reftests/gradient/repeat-radial-ref.yaml
+++ b/wrench/reftests/gradient/repeat-radial-ref.yaml
@@ -1,41 +1,38 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 150 150
-          # note: we need stops up to 1.4 because a repeating radial gradient
-          # will fill the whole rect beyond 1.0. So the furthest radius we have
-          # to fill in is the diagonal of the unit square
-          stops: [0.0, red,
-                  0.1, red,
-                  0.1, blue,
-                  0.2, blue,
-                  0.2, red,
-                  0.3, red,
-                  0.3, blue,
-                  0.4, blue,
-                  0.4, red,
-                  0.5, red,
-                  0.5, blue,
-                  0.6, blue,
-                  0.6, red,
-                  0.7, red,
-                  0.7, blue,
-                  0.8, blue,
-                  0.8, red,
-                  0.9, red,
-                  0.9, blue,
-                  1.0, blue,
-                  1.0, red,
-                  1.1, red,
-                  1.1, blue,
-                  1.2, blue,
-                  1.2, red,
-                  1.3, red,
-                  1.3, blue,
-                  1.4, blue]
+      center: 150 150
+      radius: 150 150
+      # note: we need stops up to 1.4 because a repeating radial gradient
+      # will fill the whole rect beyond 1.0. So the furthest radius we have
+      # to fill in is the diagonal of the unit square
+      stops: [0.0, red,
+              0.1, red,
+              0.1, blue,
+              0.2, blue,
+              0.2, red,
+              0.3, red,
+              0.3, blue,
+              0.4, blue,
+              0.4, red,
+              0.5, red,
+              0.5, blue,
+              0.6, blue,
+              0.6, red,
+              0.7, red,
+              0.7, blue,
+              0.8, blue,
+              0.8, red,
+              0.9, red,
+              0.9, blue,
+              1.0, blue,
+              1.0, red,
+              1.1, red,
+              1.1, blue,
+              1.2, blue,
+              1.2, red,
+              1.3, red,
+              1.3, blue,
+              1.4, blue]

--- a/wrench/reftests/gradient/repeat-radial.yaml
+++ b/wrench/reftests/gradient/repeat-radial.yaml
@@ -1,12 +1,9 @@
 ---
 root:
   items:
-    - type: stacking-context
+    - type: radial-gradient
       bounds: 50 50 300 300
-      items:
-        - type: radial-gradient
-          bounds: 0 0 300 300
-          center: 150 150
-          radius: 150 150
-          stops: [0.1, blue, 0.2, blue, 0.2, red, 0.3, red]
-          repeat: true
+      center: 150 150
+      radius: 150 150
+      stops: [0.1, blue, 0.2, blue, 0.2, red, 0.3, red]
+      repeat: true


### PR DESCRIPTION
Gradient start and end positions are currently relative to their
parent stacking context. This isn't necessary and slightly complicates
the representation of tiled gradients.

The angle gradient shader is modified so the offset calculation
is done in the fragment shader. This is needed for tiling gradients,
which will happen in a follow up. If this is an issue, the change can
be done later. The aligned gradient shader is relatively unchanged
as it won't be used for tiling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1074)
<!-- Reviewable:end -->
