### PR TITLE
Do not snap gradient start and end positions to device pixels

### DIFF
--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -13,16 +13,11 @@ void main(void) {
                                  prim.layer,
                                  prim.task);
 
-    // Snap the start/end points to device pixel units.
-    // I'm not sure this is entirely correct, but the
-    // old render path does this, and it is needed to
-    // make the angle gradient ref tests pass. It might
-    // be better to fix this higher up in DL construction
-    // and not snap here?
-    vec2 start_point = floor(0.5 + gradient.start_end_point.xy * uDevicePixelRatio) / uDevicePixelRatio;
-    vec2 end_point = floor(0.5 + gradient.start_end_point.zw * uDevicePixelRatio) / uDevicePixelRatio;
+    vec2 start_point = gradient.start_end_point.xy;
+    vec2 end_point = gradient.start_end_point.zw;
 
     vec2 dir = end_point - start_point;
+
     // Normalized offset of this vertex within the gradient, before clamp/repeat.
     vOffset = dot(vi.local_pos - start_point, dir) / dot(dir, dir);
 

--- a/webrender/res/ps_radial_gradient.vs.glsl
+++ b/webrender/res/ps_radial_gradient.vs.glsl
@@ -15,14 +15,9 @@ void main(void) {
 
     vPos = vi.local_pos;
 
-    // Snap the start/end points to device pixel units.
-    // I'm not sure this is entirely correct, but the
-    // old render path does this, and it is needed to
-    // make the angle gradient ref tests pass. It might
-    // be better to fix this higher up in DL construction
-    // and not snap here?
-    vStartCenter = floor(0.5 + gradient.start_end_center.xy * uDevicePixelRatio) / uDevicePixelRatio;
-    vEndCenter = floor(0.5 + gradient.start_end_center.zw * uDevicePixelRatio) / uDevicePixelRatio;
+    vStartCenter = gradient.start_end_center.xy;
+    vEndCenter = gradient.start_end_center.zw;
+
     vStartRadius = gradient.start_end_radius_ratio_xy_extend_mode.x;
     vEndRadius = gradient.start_end_radius_ratio_xy_extend_mode.y;
 


### PR DESCRIPTION
I don't believe this code is necessary anymore. I was able to run the Servo CSS and WPT test suites succesfully without them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1075)
<!-- Reviewable:end -->
