### PR TITLE
Fix subpixel position rounding to be consistent

### DIFF
--- a/webrender_traits/src/font.rs
+++ b/webrender_traits/src/font.rs
@@ -47,6 +47,14 @@ pub enum FontRenderMode {
     Subpixel,
 }
 
+const FIXED16_SHIFT: i32 = 16;
+
+// This matches the behaviour of SkScalarToFixed
+fn f32_truncate_to_fixed16(x: f32) -> i32 {
+    let fixed1 = (1 << FIXED16_SHIFT) as f32;
+    (x * fixed1) as i32
+}
+
 impl FontRenderMode {
     // Skia quantizes subpixel offets into 1/4 increments.
     // Given the absolute position, return the quantized increment
@@ -55,14 +63,18 @@ impl FontRenderMode {
             return SubpixelOffset::Zero;
         }
 
-        const SUBPIXEL_ROUNDING :f32 = 0.125; // Skia chosen value.
-        let fraction = (pos + SUBPIXEL_ROUNDING).fract();
+        const SUBPIXEL_BITS: i32 = 2;
+        const SUBPIXEL_FIXED16_MASK: i32 = ((1 << SUBPIXEL_BITS) - 1) << (FIXED16_SHIFT - SUBPIXEL_BITS);
+
+        const SUBPIXEL_ROUNDING: f32 = 0.5 / (1 << SUBPIXEL_BITS) as f32;
+        let pos = pos + SUBPIXEL_ROUNDING;
+        let fraction = (f32_truncate_to_fixed16(pos) & SUBPIXEL_FIXED16_MASK) >> (FIXED16_SHIFT - SUBPIXEL_BITS);
 
         match fraction {
-            0.0...0.25 => SubpixelOffset::Zero,
-            0.25...0.5 => SubpixelOffset::Quarter,
-            0.5...0.75 => SubpixelOffset::Half,
-            0.75...1.0 => SubpixelOffset::ThreeQuarters,
+            0 => SubpixelOffset::Zero,
+            1 => SubpixelOffset::Quarter,
+            2 => SubpixelOffset::Half,
+            3 => SubpixelOffset::ThreeQuarters,
             _ => panic!("Should only be given the fractional part"),
         }
     }

--- a/wrench/reftests/text/negative-pos.yaml
+++ b/wrench/reftests/text/negative-pos.yaml
@@ -1,0 +1,10 @@
+---
+root: 
+  items: 
+        - 
+          bounds: [14, 18, 205, 35]
+          glyphs: [55]
+          offsets: [-2, 43]
+          size: 24
+          color: black
+          font: "VeraBd.ttf"

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -1,1 +1,2 @@
 != text.yaml blank.yaml
+!= negative-pos.yaml blank.yaml


### PR DESCRIPTION
Previously we could end up with negative offsets if the input
to frac was negative. Using floor makes sure this works properly.

This change also elaborates the 0.125 constant.

Fixes #1047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1077)
<!-- Reviewable:end -->
