### PR TITLE
Add tiling for gradients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.30.0",
- "webrender_traits 0.31.0",
+ "webrender 0.31.0",
+ "webrender_traits 0.32.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -884,12 +884,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.31.0",
+ "webrender_traits 0.32.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -922,8 +922,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.30.0",
- "webrender_traits 0.31.0",
+ "webrender 0.31.0",
+ "webrender_traits 0.32.0",
 ]
 
 [[package]]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -231,16 +231,18 @@ ClipArea fetch_clip_area(int index) {
 
 struct Gradient {
     vec4 start_end_point;
+    vec4 tile_size_repeat;
     vec4 extend_mode;
 };
 
 Gradient fetch_gradient(int index) {
     Gradient gradient;
 
-    ivec2 uv = get_fetch_uv_2(index);
+    ivec2 uv = get_fetch_uv_4(index);
 
-    gradient.start_end_point = texelFetchOffset(sData32, uv, 0, ivec2(0, 0));
-    gradient.extend_mode = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
+    gradient.start_end_point = texelFetchOffset(sData64, uv, 0, ivec2(0, 0));
+    gradient.tile_size_repeat = texelFetchOffset(sData64, uv, 0, ivec2(1, 0));
+    gradient.extend_mode = texelFetchOffset(sData64, uv, 0, ivec2(2, 0));
 
     return gradient;
 }
@@ -264,15 +266,17 @@ GradientStop fetch_gradient_stop(int index) {
 struct RadialGradient {
     vec4 start_end_center;
     vec4 start_end_radius_ratio_xy_extend_mode;
+    vec4 tile_size_repeat;
 };
 
 RadialGradient fetch_radial_gradient(int index) {
     RadialGradient gradient;
 
-    ivec2 uv = get_fetch_uv_2(index);
+    ivec2 uv = get_fetch_uv_4(index);
 
-    gradient.start_end_center = texelFetchOffset(sData32, uv, 0, ivec2(0, 0));
-    gradient.start_end_radius_ratio_xy_extend_mode = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
+    gradient.start_end_center = texelFetchOffset(sData64, uv, 0, ivec2(0, 0));
+    gradient.start_end_radius_ratio_xy_extend_mode = texelFetchOffset(sData64, uv, 0, ivec2(1, 0));
+    gradient.tile_size_repeat = texelFetchOffset(sData64, uv, 0, ivec2(2, 0));
 
     return gradient;
 }

--- a/webrender/res/ps_angle_gradient.fs.glsl
+++ b/webrender/res/ps_angle_gradient.fs.glsl
@@ -5,8 +5,15 @@
 uniform sampler2D sGradients;
 
 void main(void) {
+    vec2 pos = mod(vPos, vTileRepeat);
+
+    if (pos.x >= vTileSize.x ||
+        pos.y >= vTileSize.y) {
+        discard;
+    }
+
     // Normalized offset of this vertex within the gradient, before clamp/repeat.
-    float offset = dot(vPos - vStartPoint, vScaledDir);
+    float offset = dot(pos - vStartPoint, vScaledDir);
 
     vec2 texture_size = vec2(textureSize(sGradients, 0));
 

--- a/webrender/res/ps_angle_gradient.glsl
+++ b/webrender/res/ps_angle_gradient.glsl
@@ -6,4 +6,6 @@ flat varying vec2 vScaledDir;
 flat varying vec2 vStartPoint;
 flat varying float vGradientIndex;
 flat varying float vGradientRepeat;
+flat varying vec2 vTileSize;
+flat varying vec2 vTileRepeat;
 varying vec2 vPos;

--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -22,6 +22,9 @@ void main(void) {
     vStartPoint = start_point;
     vScaledDir = dir / dot(dir, dir);
 
+    vTileSize = gradient.tile_size_repeat.xy;
+    vTileRepeat = gradient.tile_size_repeat.zw;
+
     // V coordinate of gradient row in lookup texture.
     vGradientIndex = float(prim.sub_index);
 

--- a/webrender/res/ps_radial_gradient.fs.glsl
+++ b/webrender/res/ps_radial_gradient.fs.glsl
@@ -5,8 +5,15 @@
 uniform sampler2D sGradients;
 
 void main(void) {
+    vec2 pos = mod(vPos, vTileRepeat);
+
+    if (pos.x >= vTileSize.x ||
+        pos.y >= vTileSize.y) {
+        discard;
+    }
+
     vec2 cd = vEndCenter - vStartCenter;
-    vec2 pd = vPos - vStartCenter;
+    vec2 pd = pos - vStartCenter;
     float rd = vEndRadius - vStartRadius;
 
     // Solve for t in length(t * cd - pd) = vStartRadius + t * rd

--- a/webrender/res/ps_radial_gradient.glsl
+++ b/webrender/res/ps_radial_gradient.glsl
@@ -8,4 +8,6 @@ flat varying vec2 vStartCenter;
 flat varying vec2 vEndCenter;
 flat varying float vStartRadius;
 flat varying float vEndRadius;
+flat varying vec2 vTileSize;
+flat varying vec2 vTileRepeat;
 varying vec2 vPos;

--- a/webrender/res/ps_radial_gradient.vs.glsl
+++ b/webrender/res/ps_radial_gradient.vs.glsl
@@ -21,12 +21,17 @@ void main(void) {
     vStartRadius = gradient.start_end_radius_ratio_xy_extend_mode.x;
     vEndRadius = gradient.start_end_radius_ratio_xy_extend_mode.y;
 
+    vTileSize = gradient.tile_size_repeat.xy;
+    vTileRepeat = gradient.tile_size_repeat.zw;
+
     // Transform all coordinates by the y scale so the
     // fragment shader can work with circles
     float ratio_xy = gradient.start_end_radius_ratio_xy_extend_mode.z;
     vPos.y *= ratio_xy;
     vStartCenter.y *= ratio_xy;
     vEndCenter.y *= ratio_xy;
+    vTileSize.y *= ratio_xy;
+    vTileRepeat.y *= ratio_xy;
 
     // V coordinate of gradient row in lookup texture.
     vGradientIndex = float(prim.sub_index);

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -645,7 +645,9 @@ impl Frame {
                                                  info.gradient.start_point,
                                                  info.gradient.end_point,
                                                  info.gradient.stops,
-                                                 info.gradient.extend_mode);
+                                                 info.gradient.extend_mode,
+                                                 info.tile_size,
+                                                 info.tile_spacing);
                 }
                 SpecificDisplayItem::RadialGradient(ref info) => {
                     context.builder.add_radial_gradient(scroll_layer_id,
@@ -657,7 +659,9 @@ impl Frame {
                                                         info.gradient.end_radius,
                                                         info.gradient.ratio_xy,
                                                         info.gradient.stops,
-                                                        info.gradient.extend_mode);
+                                                        info.gradient.extend_mode,
+                                                        info.tile_size,
+                                                        info.tile_spacing);
                 }
                 SpecificDisplayItem::BoxShadow(ref box_shadow_info) => {
                     context.builder.add_box_shadow(scroll_layer_id,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -235,8 +235,10 @@ pub struct GradientStopGpu {
 pub struct GradientPrimitiveGpu {
     pub start_point: LayerPoint,
     pub end_point: LayerPoint,
+    pub tile_size: LayerSize,
+    pub tile_repeat: LayerSize,
     pub extend_mode: f32,
-    pub padding: [f32; 3],
+    pub padding: [f32; 7],
 }
 
 #[derive(Debug)]
@@ -256,6 +258,9 @@ pub struct RadialGradientPrimitiveGpu {
     pub end_radius: f32,
     pub ratio_xy: f32,
     pub extend_mode: f32,
+    pub tile_size: LayerSize,
+    pub tile_repeat: LayerSize,
+    pub padding: [f32; 4],
 }
 
 #[derive(Debug)]
@@ -723,7 +728,7 @@ impl PrimitiveStore {
                 metadata
             }
             PrimitiveContainer::AlignedGradient(gradient_cpu, gradient_gpu) => {
-                let gpu_address = self.gpu_data32.push(gradient_gpu);
+                let gpu_address = self.gpu_data64.push(gradient_gpu);
                 let gpu_stops_address = self.gpu_data32.alloc(gradient_cpu.stops_range.length);
 
                 let metadata = PrimitiveMetadata {
@@ -744,7 +749,7 @@ impl PrimitiveStore {
                 metadata
             }
             PrimitiveContainer::AngleGradient(gradient_cpu, gradient_gpu) => {
-                let gpu_address = self.gpu_data32.push(gradient_gpu);
+                let gpu_address = self.gpu_data64.push(gradient_gpu);
                 let gpu_gradient_address = self.gpu_gradient_data.alloc(1);
 
                 let metadata = PrimitiveMetadata {
@@ -765,7 +770,7 @@ impl PrimitiveStore {
                 metadata
             }
             PrimitiveContainer::RadialGradient(radial_gradient_cpu, radial_gradient_gpu) => {
-                let gpu_address = self.gpu_data32.push(radial_gradient_gpu);
+                let gpu_address = self.gpu_data64.push(radial_gradient_gpu);
                 let gpu_gradient_address = self.gpu_gradient_data.alloc(1);
 
                 let metadata = PrimitiveMetadata {
@@ -1342,26 +1347,10 @@ impl Default for GpuBlock32 {
     }
 }
 
-impl From<GradientPrimitiveGpu> for GpuBlock32 {
-    fn from(data: GradientPrimitiveGpu) -> GpuBlock32 {
-        unsafe {
-            mem::transmute::<GradientPrimitiveGpu, GpuBlock32>(data)
-        }
-    }
-}
-
 impl From<GradientStopGpu> for GpuBlock32 {
     fn from(data: GradientStopGpu) -> GpuBlock32 {
         unsafe {
             mem::transmute::<GradientStopGpu, GpuBlock32>(data)
-        }
-    }
-}
-
-impl From<RadialGradientPrimitiveGpu> for GpuBlock32 {
-    fn from(data: RadialGradientPrimitiveGpu) -> GpuBlock32 {
-        unsafe {
-            mem::transmute::<RadialGradientPrimitiveGpu, GpuBlock32>(data)
         }
     }
 }
@@ -1408,6 +1397,22 @@ impl Default for GpuBlock64 {
     fn default() -> GpuBlock64 {
         GpuBlock64 {
             data: unsafe { mem::uninitialized() }
+        }
+    }
+}
+
+impl From<GradientPrimitiveGpu> for GpuBlock64 {
+    fn from(data: GradientPrimitiveGpu) -> GpuBlock64 {
+        unsafe {
+            mem::transmute::<GradientPrimitiveGpu, GpuBlock64>(data)
+        }
+    }
+}
+
+impl From<RadialGradientPrimitiveGpu> for GpuBlock64 {
+    fn from(data: RadialGradientPrimitiveGpu) -> GpuBlock64 {
+        unsafe {
+            mem::transmute::<RadialGradientPrimitiveGpu, GpuBlock64>(data)
         }
     }
 }

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -210,6 +210,8 @@ pub struct Gradient {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GradientDisplayItem {
     pub gradient: Gradient,
+    pub tile_size: LayoutSize,
+    pub tile_spacing: LayoutSize,
 }
 
 #[repr(C)]
@@ -234,6 +236,8 @@ pub struct RadialGradient {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RadialGradientDisplayItem {
     pub gradient: RadialGradient,
+    pub tile_size: LayoutSize,
+    pub tile_spacing: LayoutSize,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -395,9 +395,13 @@ impl DisplayListBuilder {
     pub fn push_gradient(&mut self,
                          rect: LayoutRect,
                          clip: ClipRegion,
-                         gradient: Gradient) {
+                         gradient: Gradient,
+                         tile_size: LayoutSize,
+                         tile_spacing: LayoutSize) {
         let item = SpecificDisplayItem::Gradient(GradientDisplayItem {
             gradient: gradient,
+            tile_size: tile_size,
+            tile_spacing: tile_spacing,
         });
 
         self.push_item(item, rect, clip);
@@ -406,9 +410,13 @@ impl DisplayListBuilder {
     pub fn push_radial_gradient(&mut self,
                                 rect: LayoutRect,
                                 clip: ClipRegion,
-                                gradient: RadialGradient) {
+                                gradient: RadialGradient,
+                                tile_size: LayoutSize,
+                                tile_spacing: LayoutSize) {
         let item = SpecificDisplayItem::RadialGradient(RadialGradientDisplayItem {
             gradient: gradient,
+            tile_size: tile_size,
+            tile_spacing: tile_spacing,
         });
 
         self.push_item(item, rect, clip);

--- a/wrench/reftests/gradient/linear-double.yaml
+++ b/wrench/reftests/gradient/linear-double.yaml
@@ -1,0 +1,13 @@
+---
+root:
+  items:
+    - type: gradient
+      bounds: 300 50 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0.0, blue, 1.0, red]
+    - type: gradient
+      bounds: 50 50 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0.0, green, 1.0, blue]

--- a/wrench/reftests/gradient/reftest.list
+++ b/wrench/reftests/gradient/reftest.list
@@ -34,3 +34,12 @@ fuzzy(255,1200) == repeat-linear.yaml repeat-linear-ref.yaml
 fuzzy(255,1200) == repeat-linear-reverse.yaml repeat-linear-ref.yaml
 fuzzy(255,2664) == repeat-radial.yaml repeat-radial-ref.yaml
 fuzzy(255,2664) == repeat-radial-negative.yaml repeat-radial-ref.yaml
+
+== tiling-linear-1.yaml tiling-linear-1-ref.yaml
+== tiling-linear-2.yaml tiling-linear-2-ref.yaml
+== tiling-linear-3.yaml tiling-linear-3-ref.yaml
+
+fuzzy(1,16) == tiling-radial-1.yaml tiling-radial-1-ref.yaml
+fuzzy(1,1) == tiling-radial-2.yaml tiling-radial-2-ref.yaml
+== tiling-radial-3.yaml tiling-radial-3-ref.yaml
+fuzzy(1,16) == tiling-radial-4.yaml tiling-radial-4-ref.yaml

--- a/wrench/reftests/gradient/tiling-linear-1-ref.yaml
+++ b/wrench/reftests/gradient/tiling-linear-1-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: gradient
+      bounds: 50 50 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: gradient
+      bounds: 350 50 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: gradient
+      bounds: 50 350 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: gradient
+      bounds: 350 350 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-linear-1.yaml
+++ b/wrench/reftests/gradient/tiling-linear-1.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # basic - 4 tiles spaced out with no clipping
+    - type: gradient
+      bounds: 50 50 500 500
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 100 100

--- a/wrench/reftests/gradient/tiling-linear-2-ref.yaml
+++ b/wrench/reftests/gradient/tiling-linear-2-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: gradient
+      bounds: 50 50 200 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: gradient
+      bounds: 350 50 100 200
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: gradient
+      bounds: 50 350 200 100
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: gradient
+      bounds: 350 350 100 100
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-linear-2.yaml
+++ b/wrench/reftests/gradient/tiling-linear-2.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # slightly clip the last tile
+    - type: gradient
+      bounds: 50 50 400 400
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 100 100

--- a/wrench/reftests/gradient/tiling-linear-3-ref.yaml
+++ b/wrench/reftests/gradient/tiling-linear-3-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+    # top left and bottom left
+    - type: gradient
+      bounds: 50 50 200 300
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+    # top right and bottom right
+    - type: gradient
+      bounds: 250 50 200 300
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-linear-3.yaml
+++ b/wrench/reftests/gradient/tiling-linear-3.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # no spacing with a clip
+    - type: gradient
+      bounds: 50 50 400 300
+      start: 0 100
+      end: 200 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 0 0

--- a/wrench/reftests/gradient/tiling-radial-1-ref.yaml
+++ b/wrench/reftests/gradient/tiling-radial-1-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: radial-gradient
+      bounds: 350 50 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: radial-gradient
+      bounds: 50 350 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: radial-gradient
+      bounds: 350 350 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-radial-1.yaml
+++ b/wrench/reftests/gradient/tiling-radial-1.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # basic - 4 tiles spaced out with no clipping
+    - type: radial-gradient
+      bounds: 50 50 500 500
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 100 100

--- a/wrench/reftests/gradient/tiling-radial-2-ref.yaml
+++ b/wrench/reftests/gradient/tiling-radial-2-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: radial-gradient
+      bounds: 350 50 100 200
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: radial-gradient
+      bounds: 50 350 200 100
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: radial-gradient
+      bounds: 350 350 100 100
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-radial-2.yaml
+++ b/wrench/reftests/gradient/tiling-radial-2.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # slightly clip the last tile
+    - type: radial-gradient
+      bounds: 50 50 400 400
+      center: 100 100
+      radius: 100 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 100 100

--- a/wrench/reftests/gradient/tiling-radial-3-ref.yaml
+++ b/wrench/reftests/gradient/tiling-radial-3-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: radial-gradient
+      bounds: 250 50 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: radial-gradient
+      bounds: 50 250 200 100
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: radial-gradient
+      bounds: 250 250 200 100
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-radial-3.yaml
+++ b/wrench/reftests/gradient/tiling-radial-3.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # no spacing with a clip
+    - type: radial-gradient
+      bounds: 50 50 400 300
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 0 0

--- a/wrench/reftests/gradient/tiling-radial-4-ref.yaml
+++ b/wrench/reftests/gradient/tiling-radial-4-ref.yaml
@@ -1,0 +1,27 @@
+---
+root:
+  items:
+    # top left
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # top right
+    - type: radial-gradient
+      bounds: 350 50 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # bottom left
+    - type: radial-gradient
+      bounds: 50 350 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+    # bottom right
+    - type: radial-gradient
+      bounds: 350 350 200 200
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]

--- a/wrench/reftests/gradient/tiling-radial-4.yaml
+++ b/wrench/reftests/gradient/tiling-radial-4.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    # make sure the ellipse transformation retains square tiles
+    - type: radial-gradient
+      bounds: 50 50 500 500
+      center: 100 100
+      radius: 200 100
+      stops: [0, red, 1, blue]
+      tile-size: 200 200
+      tile-spacing: 100 100

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -258,18 +258,22 @@ impl YamlFrameReader {
         let bounds_key = if item["type"].is_badvalue() { "gradient" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("gradient must have bounds");
         let gradient = self.to_gradient(item);
+        let tile_size = item["tile-size"].as_size().unwrap_or(bounds.size);
+        let tile_spacing = item["tile-spacing"].as_size().unwrap_or(LayoutSize::zero());
 
         let clip = self.to_clip_region(&item["clip"], &bounds, wrench).unwrap_or(*clip_region);
-        self.builder().push_gradient(bounds, clip, gradient);
+        self.builder().push_gradient(bounds, clip, gradient, tile_size, tile_spacing);
     }
 
     fn handle_radial_gradient(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {
         let bounds_key = if item["type"].is_badvalue() { "radial-gradient" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("radial gradient must have bounds");
         let gradient = self.to_radial_gradient(item);
+        let tile_size = item["tile-size"].as_size().unwrap_or(bounds.size);
+        let tile_spacing = item["tile-spacing"].as_size().unwrap_or(LayoutSize::zero());
 
         let clip = self.to_clip_region(&item["clip"], &bounds, wrench).unwrap_or(*clip_region);
-        self.builder().push_radial_gradient(bounds, clip, gradient);
+        self.builder().push_radial_gradient(bounds, clip, gradient, tile_size, tile_spacing);
     }
 
     fn handle_border(&mut self, wrench: &mut Wrench, clip_region: &ClipRegion, item: &Yaml) {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -701,6 +701,8 @@ impl YamlFrameWriter {
                     str_node(&mut v, "type", "gradient");
                     point_node(&mut v, "start", &item.gradient.start_point);
                     point_node(&mut v, "end", &item.gradient.end_point);
+                    size_node(&mut v, "tile-size", &item.tile_size);
+                    size_node(&mut v, "tile-spacing", &item.tile_spacing);
                     let mut stops = vec![];
                     for stop in aux.gradient_stops(&item.gradient.stops) {
                         stops.push(Yaml::Real(stop.offset.to_string()));
@@ -716,6 +718,8 @@ impl YamlFrameWriter {
                     point_node(&mut v, "end-center", &item.gradient.end_center);
                     f32_node(&mut v, "end-radius", item.gradient.end_radius);
                     f32_node(&mut v, "ratio-xy", item.gradient.ratio_xy);
+                    size_node(&mut v, "tile-size", &item.tile_size);
+                    size_node(&mut v, "tile-spacing", &item.tile_spacing);
                     let mut stops = vec![];
                     for stop in aux.gradient_stops(&item.gradient.stops) {
                         stops.push(Yaml::Real(stop.offset.to_string()));


### PR DESCRIPTION
This adds `tile_size` and `tile_spacing` fields to linear and radial gradient
display items to control tiling. A gradient is tiled starting at `bounds.origin`,
with tile size of `tile_size` and spacing between tiles of `tile_spacing`. Tiles
will fill and be clipped to `bounds`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1078)
<!-- Reviewable:end -->
