### PR TITLE
Sample now uses full window on Retina display on macOS.

### DIFF
--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -224,7 +224,7 @@ fn main() {
     println!("OpenGL version {}", gl.get_string(gl::VERSION));
     println!("Shader resource path: {:?}", res_path);
 
-    let (width, height) = window.get_inner_size().unwrap();
+    let (width, height) = window.get_inner_size_pixels().unwrap();
 
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,


### PR DESCRIPTION
Using the number of pixels gives us the correct device size.

Fixes issue #725.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1081)
<!-- Reviewable:end -->
