### PR TITLE
Run reftests with subpixel-aa turned on.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ script:
   - if [ $BUILD_KIND = DEBUG ]; then (cd sample && cargo test --verbose); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd sample && cargo build --verbose --features=profiler); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd wrench && cargo test --verbose); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python headless.py reftest); fi
+  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python headless.py --subpixel-aa reftest); fi


### PR DESCRIPTION
This is the configuration that Gecko is currently using and the
configuration that we'd like to end up in so it makes sense to switch
now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1083)
<!-- Reviewable:end -->
