### PR TITLE
More aggressive RectWithSize usage for local rectangles

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -34,12 +34,21 @@ CacheClipInstance fetch_clip_item(int index) {
     return cci;
 }
 
+struct ClipVertexInfo {
+    vec3 local_pos;
+    vec2 screen_pos;
+    RectWithSize clipped_local_rect;
+};
+
 // The transformed vertex function that always covers the whole clip area,
 // which is the intersection of all clip instances of a given primitive
-TransformVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
-                                           Layer layer,
-                                           ClipArea area,
-                                           int segment_index) {
+ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
+                                      Layer layer,
+                                      ClipArea area,
+                                      int segment_index) {
+
+    RectWithSize clipped_local_rect = intersect_rect(local_clip_rect,
+                                                     layer.local_clip_rect);
 
     vec2 outer_p0 = area.screen_origin_target_index.xy;
     vec2 outer_p1 = outer_p0 + area.task_bounds.zw - area.task_bounds.xy;
@@ -79,7 +88,7 @@ TransformVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
 
     gl_Position = uTransform * vec4(vertex_pos, 0.0, 1);
 
-    return TransformVertexInfo(layer_pos.xyw, actual_pos);
+    return ClipVertexInfo(layer_pos.xyw, actual_pos, clipped_local_rect);
 }
 
 #endif //WR_VERTEX_SHADER

--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -36,16 +36,10 @@ CacheClipInstance fetch_clip_item(int index) {
 
 // The transformed vertex function that always covers the whole clip area,
 // which is the intersection of all clip instances of a given primitive
-TransformVertexInfo write_clip_tile_vertex(vec4 local_clip_rect,
+TransformVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
                                            Layer layer,
                                            ClipArea area,
                                            int segment_index) {
-    vec2 lp0_base = local_clip_rect.xy;
-    vec2 lp1_base = local_clip_rect.xy + local_clip_rect.zw;
-
-    vec2 lp0 = clamp_rect(lp0_base, layer.local_clip_rect);
-    vec2 lp1 = clamp_rect(lp1_base, layer.local_clip_rect);
-    vec4 clipped_local_rect = vec4(lp0, lp1 - lp0);
 
     vec2 outer_p0 = area.screen_origin_target_index.xy;
     vec2 outer_p1 = outer_p0 + area.task_bounds.zw - area.task_bounds.xy;
@@ -85,7 +79,7 @@ TransformVertexInfo write_clip_tile_vertex(vec4 local_clip_rect,
 
     gl_Position = uTransform * vec4(vertex_pos, 0.0, 1);
 
-    return TransformVertexInfo(layer_pos.xyw, actual_pos, clipped_local_rect);
+    return TransformVertexInfo(layer_pos.xyw, actual_pos);
 }
 
 #endif //WR_VERTEX_SHADER

--- a/webrender/res/cs_clip_image.glsl
+++ b/webrender/res/cs_clip_image.glsl
@@ -5,6 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec3 vPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 flat varying vec4 vClipMaskUvRect;
 flat varying vec4 vClipMaskUvInnerRect;

--- a/webrender/res/cs_clip_image.vs.glsl
+++ b/webrender/res/cs_clip_image.vs.glsl
@@ -29,12 +29,12 @@ void main(void) {
     ImageMaskData mask = fetch_mask_data(cci.data_index);
     RectWithSize local_rect = mask.local_rect;
 
-    TransformVertexInfo vi = write_clip_tile_vertex(local_rect,
-                                                    layer,
-                                                    area,
-                                                    cci.segment_index);
+    ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
+                                               layer,
+                                               area,
+                                               cci.segment_index);
 
-    vLocalRect = local_rect;
+    vLocalRect = vi.clipped_local_rect;
     vPos = vi.local_pos;
 
     vClipMaskUv = vec3((vPos.xy / vPos.z - local_rect.p0) / local_rect.size, 0.0);

--- a/webrender/res/cs_clip_image.vs.glsl
+++ b/webrender/res/cs_clip_image.vs.glsl
@@ -4,17 +4,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 struct ImageMaskData {
-    vec4 uv_rect;
-    vec4 local_rect;
+    RectWithSize uv_rect;
+    RectWithSize local_rect;
 };
 
 ImageMaskData fetch_mask_data(int index) {
     ImageMaskData info;
+    vec4 rect;
 
     ivec2 uv = get_fetch_uv_2(index);
 
-    info.uv_rect = texelFetchOffset(sData32, uv, 0, ivec2(0, 0));
-    info.local_rect = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
+    rect = texelFetchOffset(sData32, uv, 0, ivec2(0, 0));
+    info.uv_rect = RectWithSize(rect.xy, rect.zw);
+    rect = texelFetchOffset(sData32, uv, 0, ivec2(1, 0));
+    info.local_rect = RectWithSize(rect.xy, rect.zw);
 
     return info;
 }
@@ -24,19 +27,20 @@ void main(void) {
     ClipArea area = fetch_clip_area(cci.render_task_index);
     Layer layer = fetch_layer(cci.layer_index);
     ImageMaskData mask = fetch_mask_data(cci.data_index);
-    vec4 local_rect = mask.local_rect;
+    RectWithSize local_rect = mask.local_rect;
 
     TransformVertexInfo vi = write_clip_tile_vertex(local_rect,
                                                     layer,
                                                     area,
                                                     cci.segment_index);
-    vLocalRect = vi.clipped_local_rect;
+
+    vLocalRect = local_rect;
     vPos = vi.local_pos;
 
-    vClipMaskUv = vec3((vPos.xy / vPos.z - local_rect.xy) / local_rect.zw, 0.0);
+    vClipMaskUv = vec3((vPos.xy / vPos.z - local_rect.p0) / local_rect.size, 0.0);
     vec2 texture_size = vec2(textureSize(sMask, 0));
-    vClipMaskUvRect = mask.uv_rect / texture_size.xyxy;
+    vClipMaskUvRect = vec4(mask.uv_rect.p0, mask.uv_rect.size) / texture_size.xyxy;
     // applying a half-texel offset to the UV boundaries to prevent linear samples from the outside
-    vec4 inner_rect = vec4(mask.uv_rect.xy, mask.uv_rect.xy + mask.uv_rect.zw);
+    vec4 inner_rect = vec4(mask.uv_rect.p0, mask.uv_rect.p0 + mask.uv_rect.size);
     vClipMaskUvInnerRect = (inner_rect + vec4(0.5, 0.5, -0.5, -0.5)) / texture_size.xyxy;
 }

--- a/webrender/res/cs_clip_rectangle.glsl
+++ b/webrender/res/cs_clip_rectangle.glsl
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec3 vPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 flat varying vec4 vClipRect;
 flat varying vec4 vClipRadius;
 flat varying float vClipMode;

--- a/webrender/res/cs_clip_rectangle.vs.glsl
+++ b/webrender/res/cs_clip_rectangle.vs.glsl
@@ -64,11 +64,11 @@ void main(void) {
     ClipData clip = fetch_clip(cci.data_index);
     RectWithSize local_rect = clip.rect.rect;
 
-    TransformVertexInfo vi = write_clip_tile_vertex(local_rect,
-                                                    layer,
-                                                    area,
-                                                    cci.segment_index);
-    vLocalRect = local_rect;
+    ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
+                                               layer,
+                                               area,
+                                               cci.segment_index);
+    vLocalRect = vi.clipped_local_rect;
     vPos = vi.local_pos;
 
     vClipMode = clip.rect.mode.x;

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -472,14 +472,6 @@ struct VertexInfo {
     vec2 screen_pos;
 };
 
-RectWithSize compute_clip_rect(RectWithSize local_rect,
-                               RectWithSize local_clip_rect,
-                               Layer layer) {
-    // intersect all 3 clip rectangles
-    return intersect_rect(layer.local_clip_rect,
-                          intersect_rect(local_clip_rect, local_rect));
-}
-
 VertexInfo write_vertex(RectWithSize instance_rect,
                         RectWithSize local_clip_rect,
                         float z,

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -132,15 +132,13 @@ vec4 clamp_rect(vec4 points, RectWithEndpoint rect) {
 }
 
 RectWithSize intersect_rect(RectWithSize a, RectWithSize b) {
-    vec2 p0 = max(a.p0, b.p0);
-    vec2 p1 = min(a.p0 + a.size, b.p0 + b.size);
-    return RectWithSize(p0, max(vec2(0.0), p1 - p0));
+    vec4 p = clamp_rect(vec4(a.p0, a.p0 + a.size), b);
+    return RectWithSize(p.xy, max(vec2(0.0), p.zw - p.xy));
 }
 
 RectWithEndpoint intersect_rect(RectWithEndpoint a, RectWithEndpoint b) {
-    vec2 p0 = max(a.p0, b.p0);
-    vec2 p1 = min(a.p1, b.p1);
-    return RectWithEndpoint(p0, max(p0, p1));
+    vec4 p = clamp_rect(vec4(a.p0, a.p1), b);
+    return RectWithEndpoint(p.xy, max(p.xy, p.zw));
 }
 
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -46,9 +46,52 @@ struct RectWithEndpoint {
     vec2 p1;
 };
 
+RectWithEndpoint to_rect_with_endpoint(RectWithSize rect) {
+    RectWithEndpoint result;
+    result.p0 = rect.p0;
+    result.p1 = rect.p0 + rect.size;
+
+    return result;
+}
+
+RectWithSize to_rect_with_size(RectWithEndpoint rect) {
+    RectWithSize result;
+    result.p0 = rect.p0;
+    result.size = rect.p1 - rect.p0;
+
+    return result;
+}
+
+vec2 clamp_rect(vec2 point, RectWithSize rect) {
+    return clamp(point, rect.p0, rect.p0 + rect.size);
+}
+
+vec2 clamp_rect(vec2 point, RectWithEndpoint rect) {
+    return clamp(point, rect.p0, rect.p1);
+}
+
+// Clamp 2 points at once.
+vec4 clamp_rect(vec4 points, RectWithSize rect) {
+    return clamp(points, rect.p0.xyxy, rect.p0.xyxy + rect.size.xyxy);
+}
+
+vec4 clamp_rect(vec4 points, RectWithEndpoint rect) {
+    return clamp(points, rect.p0.xyxy, rect.p1.xyxy);
+}
+
+RectWithSize intersect_rect(RectWithSize a, RectWithSize b) {
+    vec4 p = clamp_rect(vec4(a.p0, a.p0 + a.size), b);
+    return RectWithSize(p.xy, max(vec2(0.0), p.zw - p.xy));
+}
+
+RectWithEndpoint intersect_rect(RectWithEndpoint a, RectWithEndpoint b) {
+    vec4 p = clamp_rect(vec4(a.p0, a.p1), b);
+    return RectWithEndpoint(p.xy, max(p.xy, p.zw));
+}
+
+
 flat varying RectWithEndpoint vClipMaskUvBounds;
 varying vec3 vClipMaskUv;
-
 
 #ifdef WR_VERTEX_SHADER
 
@@ -97,50 +140,6 @@ ivec2 get_fetch_uv_4(int index) {
 ivec2 get_fetch_uv_8(int index) {
     return get_fetch_uv(index, 8);
 }
-
-RectWithEndpoint to_rect_with_endpoint(RectWithSize rect) {
-    RectWithEndpoint result;
-    result.p0 = rect.p0;
-    result.p1 = rect.p0 + rect.size;
-
-    return result;
-}
-
-RectWithSize to_rect_with_size(RectWithEndpoint rect) {
-    RectWithSize result;
-    result.p0 = rect.p0;
-    result.size = rect.p1 - rect.p0;
-
-    return result;
-}
-
-vec2 clamp_rect(vec2 point, RectWithSize rect) {
-    return clamp(point, rect.p0, rect.p0 + rect.size);
-}
-
-vec2 clamp_rect(vec2 point, RectWithEndpoint rect) {
-    return clamp(point, rect.p0, rect.p1);
-}
-
-// Clamp 2 points at once.
-vec4 clamp_rect(vec4 points, RectWithSize rect) {
-    return clamp(points, rect.p0.xyxy, rect.p0.xyxy + rect.size.xyxy);
-}
-
-vec4 clamp_rect(vec4 points, RectWithEndpoint rect) {
-    return clamp(points, rect.p0.xyxy, rect.p1.xyxy);
-}
-
-RectWithSize intersect_rect(RectWithSize a, RectWithSize b) {
-    vec4 p = clamp_rect(vec4(a.p0, a.p0 + a.size), b);
-    return RectWithSize(p.xy, max(vec2(0.0), p.zw - p.xy));
-}
-
-RectWithEndpoint intersect_rect(RectWithEndpoint a, RectWithEndpoint b) {
-    vec4 p = clamp_rect(vec4(a.p0, a.p1), b);
-    return RectWithEndpoint(p.xy, max(p.xy, p.zw));
-}
-
 
 struct Layer {
     mat4 transform;

--- a/webrender/res/ps_border.fs.glsl
+++ b/webrender/res/ps_border.fs.glsl
@@ -419,9 +419,9 @@ void main(void) {
     float distance_from_mix_line = (local_pos.x - vPieceRect.x) * vPieceRect.w -
                                    (local_pos.y - vPieceRect.y) * vPieceRect.z;
     distance_from_mix_line /= vPieceRectHypotenuseLength;
-    float distance_from_middle = (local_pos.x - vLocalRect.x) +
-                                 (local_pos.y - vLocalRect.y) -
-                                 0.5 * (vLocalRect.z + vLocalRect.w);
+    float distance_from_middle = (local_pos.x - vBorderRect.p0.x) +
+                                 (local_pos.y - vBorderRect.p0.y) -
+                                 0.5 * (vBorderRect.size.x + vBorderRect.size.y);
 #else
     float distance_from_mix_line = vDistanceFromMixLine;
     float distance_from_middle = vDistanceFromMiddle;

--- a/webrender/res/ps_border.glsl
+++ b/webrender/res/ps_border.glsl
@@ -8,7 +8,7 @@
 flat varying vec4 vVerticalColor;      // The vertical color, e.g. top/bottom
 flat varying vec4 vHorizontalColor;    // The horizontal color e.g. left/right
 flat varying vec4 vRadii;              // The border radius from CSS border-radius
-flat varying RectWithSize vBorderRect; // The rect of the border (x, y, w, h) in local space.
+flat varying RectWithSize vBorderRect; // The rect of the border in local space.
 
 // for corners, this is the beginning of the corner.
 // For the lines, this is the top left of the line.

--- a/webrender/res/ps_border.glsl
+++ b/webrender/res/ps_border.glsl
@@ -5,10 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // These are not changing.
-flat varying vec4 vVerticalColor;     // The vertical color, e.g. top/bottom
-flat varying vec4 vHorizontalColor;   // The horizontal color e.g. left/right
-flat varying vec4 vRadii;             // The border radius from CSS border-radius
-flat varying vec4 vLocalRect; // The rect of the border (x, y, w, h) in local space.
+flat varying vec4 vVerticalColor;      // The vertical color, e.g. top/bottom
+flat varying vec4 vHorizontalColor;    // The horizontal color e.g. left/right
+flat varying vec4 vRadii;              // The border radius from CSS border-radius
+flat varying RectWithSize vBorderRect; // The rect of the border (x, y, w, h) in local space.
 
 // for corners, this is the beginning of the corner.
 // For the lines, this is the top left of the line.
@@ -21,6 +21,7 @@ flat varying vec4 vPieceRect;
 // These are in device space
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;     // The clamped position in local space.
+flat varying RectWithSize vLocalRect;
 flat varying float vPieceRectHypotenuseLength;
 #else
 varying vec2 vLocalPos;     // The clamped position in local space.

--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -31,23 +31,24 @@ void main(void) {
     Primitive prim = load_primitive();
     Border border = fetch_border(prim.prim_index);
     int sub_part = prim.sub_index;
+    vBorderRect = prim.local_rect;
 
-    vec2 tl_outer = prim.local_rect.p0;
+    vec2 tl_outer = vBorderRect.p0;
     vec2 tl_inner = tl_outer + vec2(max(border.radii[0].x, border.widths.x),
                                     max(border.radii[0].y, border.widths.y));
 
-    vec2 tr_outer = vec2(prim.local_rect.p0.x + prim.local_rect.size.x,
-                         prim.local_rect.p0.y);
+    vec2 tr_outer = vec2(vBorderRect.p0.x + vBorderRect.size.x,
+                         vBorderRect.p0.y);
     vec2 tr_inner = tr_outer + vec2(-max(border.radii[0].z, border.widths.z),
                                     max(border.radii[0].w, border.widths.y));
 
-    vec2 br_outer = vec2(prim.local_rect.p0.x + prim.local_rect.size.x,
-                         prim.local_rect.p0.y + prim.local_rect.size.y);
+    vec2 br_outer = vec2(vBorderRect.p0.x + vBorderRect.size.x,
+                         vBorderRect.p0.y + vBorderRect.size.y);
     vec2 br_inner = br_outer - vec2(max(border.radii[1].x, border.widths.z),
                                     max(border.radii[1].y, border.widths.w));
 
-    vec2 bl_outer = vec2(prim.local_rect.p0.x,
-                         prim.local_rect.p0.y + prim.local_rect.size.y);
+    vec2 bl_outer = vec2(vBorderRect.p0.x,
+                         vBorderRect.p0.y + vBorderRect.size.y);
     vec2 bl_inner = bl_outer + vec2(max(border.radii[1].z, border.widths.x),
                                     -max(border.radii[1].w, border.widths.w));
 
@@ -132,7 +133,7 @@ void main(void) {
     vLocalPos = vi.local_pos;
 
     // Local space
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = segment_rect;
 #else
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,
@@ -140,9 +141,6 @@ void main(void) {
                                  prim.layer,
                                  prim.task);
     vLocalPos = vi.local_pos.xy;
-
-    // Local space
-    vLocalRect = vec4(prim.local_rect.p0, prim.local_rect.size);
 #endif
 
     float x0, y0, x1, y1;
@@ -209,8 +207,8 @@ void main(void) {
 #else
     vDistanceFromMixLine = (vi.local_pos.x - x0) * height -
                            (vi.local_pos.y - y0) * width;
-    vDistanceFromMiddle = (vi.local_pos.x - vLocalRect.x) +
-                          (vi.local_pos.y - vLocalRect.y) -
-                          0.5 * (vLocalRect.z + vLocalRect.w);
+    vDistanceFromMiddle = (vi.local_pos.x - vBorderRect.p0.x) +
+                          (vi.local_pos.y - vBorderRect.p0.y) -
+                          0.5 * (vBorderRect.size.x + vBorderRect.size.y);
 #endif
 }

--- a/webrender/res/ps_border.vs.glsl
+++ b/webrender/res/ps_border.vs.glsl
@@ -131,8 +131,6 @@ void main(void) {
                                                     prim.layer,
                                                     prim.task);
     vLocalPos = vi.local_pos;
-
-    // Local space
     vLocalRect = segment_rect;
 #else
     VertexInfo vi = write_vertex(segment_rect,

--- a/webrender/res/ps_gradient.glsl
+++ b/webrender/res/ps_gradient.glsl
@@ -6,7 +6,7 @@ varying vec4 vColor;
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 #else
 varying vec2 vPos;
 #endif

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -62,7 +62,7 @@ void main(void) {
                                                     prim.z,
                                                     prim.layer,
                                                     prim.task);
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = segment_rect;
     vLocalPos = vi.local_pos;
     vec2 f = (vi.local_pos.xy - prim.local_rect.p0) / prim.local_rect.size;
 #else

--- a/webrender/res/ps_image.fs.glsl
+++ b/webrender/res/ps_image.fs.glsl
@@ -12,7 +12,7 @@ void main(void) {
     // We clamp the texture coordinate calculation here to the local rectangle boundaries,
     // which makes the edge of the texture stretch instead of repeat.
     vec2 relative_pos_in_rect =
-         clamp(pos, vLocalRect.xy, vLocalRect.xy + vLocalRect.zw) - vLocalRect.xy;
+         clamp(pos, vLocalRect.p0, vLocalRect.p0 + vLocalRect.size) - vLocalRect.p0;
 #else
     float alpha = 1.0;
     vec2 relative_pos_in_rect = vLocalPos;

--- a/webrender/res/ps_image.fs.glsl
+++ b/webrender/res/ps_image.fs.glsl
@@ -11,8 +11,7 @@ void main(void) {
 
     // We clamp the texture coordinate calculation here to the local rectangle boundaries,
     // which makes the edge of the texture stretch instead of repeat.
-    vec2 relative_pos_in_rect =
-         clamp(pos, vLocalRect.p0, vLocalRect.p0 + vLocalRect.size) - vLocalRect.p0;
+    vec2 relative_pos_in_rect = clamp_rect(pos, vLocalRect) - vLocalRect.p0;
 #else
     float alpha = 1.0;
     vec2 relative_pos_in_rect = vLocalPos;

--- a/webrender/res/ps_image.glsl
+++ b/webrender/res/ps_image.glsl
@@ -12,7 +12,7 @@ flat varying vec4 vStRect;        // Rectangle of valid texture rect.
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 flat varying vec2 vStretchSize;
 #else
 varying vec2 vLocalPos;

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -14,7 +14,7 @@ void main(void) {
                                                     prim.z,
                                                     prim.layer,
                                                     prim.task);
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = prim.local_rect;
     vLocalPos = vi.local_pos;
 #else
     VertexInfo vi = write_vertex(prim.local_rect,
@@ -22,7 +22,7 @@ void main(void) {
                                  prim.z,
                                  prim.layer,
                                  prim.task);
-    vLocalPos = vi.local_pos - vi.local_rect.p0;
+    vLocalPos = vi.local_pos - prim.local_rect.p0;
 #endif
 
     write_clip(vi.screen_pos, prim.clip_area);

--- a/webrender/res/ps_rectangle.glsl
+++ b/webrender/res/ps_rectangle.glsl
@@ -6,5 +6,5 @@ varying vec4 vColor;
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 #endif

--- a/webrender/res/ps_rectangle.vs.glsl
+++ b/webrender/res/ps_rectangle.vs.glsl
@@ -13,7 +13,7 @@ void main(void) {
                                                     prim.z,
                                                     prim.layer,
                                                     prim.task);
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = prim.local_rect;
     vLocalPos = vi.local_pos;
 #else
     VertexInfo vi = write_vertex(prim.local_rect,

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -8,5 +8,5 @@ flat varying vec4 vUvBorder;
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 #endif

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -18,7 +18,7 @@ void main(void) {
                                                     prim.z,
                                                     prim.layer,
                                                     prim.task);
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = local_rect;
     vLocalPos = vi.local_pos;
     vec2 f = (vi.local_pos.xy / vi.local_pos.z - local_rect.p0) / local_rect.size;
 #else
@@ -27,7 +27,7 @@ void main(void) {
                                  prim.z,
                                  prim.layer,
                                  prim.task);
-    vec2 f = (vi.local_pos - vi.local_rect.p0) / (vi.local_rect.p1 - vi.local_rect.p0);
+    vec2 f = (vi.local_pos - local_rect.p0) / local_rect.size;
 #endif
 
     write_clip(vi.screen_pos, prim.clip_area);

--- a/webrender/res/ps_yuv_image.fs.glsl
+++ b/webrender/res/ps_yuv_image.fs.glsl
@@ -11,7 +11,7 @@ void main(void) {
     // We clamp the texture coordinate calculation here to the local rectangle boundaries,
     // which makes the edge of the texture stretch instead of repeat.
     vec2 relative_pos_in_rect =
-         clamp(pos, vLocalRect.xy, vLocalRect.xy + vLocalRect.zw) - vLocalRect.xy;
+         clamp(pos, vLocalRect.p0, vLocalRect.p0 + vLocalRect.size) - vLocalRect.p0;
 #else
     float alpha = 1.0;;
     vec2 relative_pos_in_rect = vLocalPos;

--- a/webrender/res/ps_yuv_image.fs.glsl
+++ b/webrender/res/ps_yuv_image.fs.glsl
@@ -10,8 +10,7 @@ void main(void) {
 
     // We clamp the texture coordinate calculation here to the local rectangle boundaries,
     // which makes the edge of the texture stretch instead of repeat.
-    vec2 relative_pos_in_rect =
-         clamp(pos, vLocalRect.p0, vLocalRect.p0 + vLocalRect.size) - vLocalRect.p0;
+    vec2 relative_pos_in_rect = clamp_rect(pos, vLocalRect) - vLocalRect.p0;
 #else
     float alpha = 1.0;;
     vec2 relative_pos_in_rect = vLocalPos;

--- a/webrender/res/ps_yuv_image.glsl
+++ b/webrender/res/ps_yuv_image.glsl
@@ -15,7 +15,7 @@ flat varying mat3 vYuvColorMatrix;
 
 #ifdef WR_FEATURE_TRANSFORM
 varying vec3 vLocalPos;
-flat varying vec4 vLocalRect;
+flat varying RectWithSize vLocalRect;
 #else
 varying vec2 vLocalPos;
 #endif

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -11,7 +11,7 @@ void main(void) {
                                                     prim.z,
                                                     prim.layer,
                                                     prim.task);
-    vLocalRect = vi.clipped_local_rect;
+    vLocalRect = prim.local_rect;
     vLocalPos = vi.local_pos;
 #else
     VertexInfo vi = write_vertex(prim.local_rect,
@@ -19,7 +19,7 @@ void main(void) {
                                  prim.z,
                                  prim.layer,
                                  prim.task);
-    vLocalPos = vi.local_pos - vi.local_rect.p0;
+    vLocalPos = vi.local_pos - prim.local_rect.p0;
 #endif
 
     YuvImage image = fetch_yuv_image(prim.prim_index);


### PR DESCRIPTION
Accidentally touched this during a different exploration. Figured this would be great for better readability of the shader code and compile error coverage.
r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1087)
<!-- Reviewable:end -->
