### PR TITLE
Fix a panic that can occur when the window size is zero.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -292,8 +292,7 @@ impl Frame {
         };
 
         if window_size.width == 0 || window_size.height == 0 {
-            println!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
-            return;
+            error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
         }
 
         let old_scrolling_states = self.reset();


### PR DESCRIPTION
Early exiting here can result in the aux. lists getting out of
sync with the display list.

In the future, we can revisit this and early out. However, this
is an immediate fix for a minimize crash on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1094)
<!-- Reviewable:end -->
