### PR TITLE
Use shorter synonym for Hashmap::with_hasher(Default::default())

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -42,7 +42,7 @@ impl ClipScrollTree {
     pub fn new() -> ClipScrollTree {
         let dummy_pipeline = PipelineId(0, 0);
         ClipScrollTree {
-            nodes: HashMap::with_hasher(Default::default()),
+            nodes: HashMap::default(),
             pending_scroll_offsets: HashMap::new(),
             current_scroll_layer_id: None,
             root_reference_frame_id: ScrollLayerId::root_reference_frame(dummy_pipeline),
@@ -68,7 +68,7 @@ impl ClipScrollTree {
 
     pub fn collect_nodes_bouncing_back(&self)
                                        -> HashSet<ScrollLayerId, BuildHasherDefault<FnvHasher>> {
-        let mut nodes_bouncing_back = HashSet::with_hasher(Default::default());
+        let mut nodes_bouncing_back = HashSet::default();
         for (scroll_layer_id, node) in self.nodes.iter() {
             if node.scrolling.bouncing_back {
                 nodes_bouncing_back.insert(*scroll_layer_id);
@@ -121,7 +121,7 @@ impl ClipScrollTree {
     pub fn drain(&mut self) -> ScrollStates {
         self.current_reference_frame_id = 1;
 
-        let mut scroll_states = HashMap::with_hasher(Default::default());
+        let mut scroll_states = HashMap::default();
         for (layer_id, old_node) in &mut self.nodes.drain() {
             if !self.pipelines_to_discard.contains(&layer_id.pipeline_id()) {
                 scroll_states.insert(layer_id, old_node.scrolling);

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -932,9 +932,9 @@ impl Device {
             default_read_fbo: 0,
             default_draw_fbo: 0,
 
-            textures: HashMap::with_hasher(Default::default()),
-            programs: HashMap::with_hasher(Default::default()),
-            vaos: HashMap::with_hasher(Default::default()),
+            textures: HashMap::default(),
+            programs: HashMap::default(),
+            vaos: HashMap::default(),
 
             shader_preamble: shader_preamble,
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -225,8 +225,8 @@ fn clip_intersection(original_rect: &LayerRect,
 impl Frame {
     pub fn new(config: FrameBuilderConfig) -> Frame {
         Frame {
-            pipeline_epoch_map: HashMap::with_hasher(Default::default()),
-            pipeline_auxiliary_lists: HashMap::with_hasher(Default::default()),
+            pipeline_epoch_map: HashMap::default(),
+            pipeline_auxiliary_lists: HashMap::default(),
             clip_scroll_tree: ClipScrollTree::new(),
             id: FrameId(0),
             frame_builder: None,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -952,13 +952,13 @@ impl Renderer {
             clip_vao_id: clip_vao_id,
             gdt_index: 0,
             gpu_data_textures: gpu_data_textures,
-            pipeline_epoch_map: HashMap::with_hasher(Default::default()),
+            pipeline_epoch_map: HashMap::default(),
             main_thread_dispatcher: main_thread_dispatcher,
             cache_texture_id_map: Vec::new(),
             dummy_cache_texture_id: dummy_cache_texture_id,
             dither_matrix_texture_id: dither_matrix_texture_id,
             external_image_handler: None,
-            external_images: HashMap::with_hasher(Default::default()),
+            external_images: HashMap::default(),
             vr_compositor_handler: vr_compositor,
             cpu_profiles: VecDeque::new(),
             gpu_profiles: VecDeque::new(),
@@ -1006,7 +1006,7 @@ impl Renderer {
     /// Returns a HashMap containing the pipeline ids that have been received by the renderer and
     /// their respective epochs since the last time the method was called.
     pub fn flush_rendered_epochs(&mut self) -> HashMap<PipelineId, Epoch, BuildHasherDefault<FnvHasher>> {
-        mem::replace(&mut self.pipeline_epoch_map, HashMap::with_hasher(Default::default()))
+        mem::replace(&mut self.pipeline_epoch_map, HashMap::default())
     }
 
     /// Processes the result queue.

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -129,8 +129,8 @@ pub struct ResourceClassCache<K,V> {
 impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resource {
     fn new() -> ResourceClassCache<K,V> {
         ResourceClassCache {
-            resources: HashMap::with_hasher(Default::default()),
-            last_access_times: HashMap::with_hasher(Default::default()),
+            resources: HashMap::default(),
+            last_access_times: HashMap::default(),
         }
     }
 
@@ -235,10 +235,10 @@ impl ResourceCache {
         ResourceCache {
             cached_glyphs: Some(ResourceClassCache::new()),
             cached_images: ResourceClassCache::new(),
-            webgl_textures: HashMap::with_hasher(Default::default()),
-            font_templates: HashMap::with_hasher(Default::default()),
-            image_templates: HashMap::with_hasher(Default::default()),
-            cached_glyph_dimensions: HashMap::with_hasher(Default::default()),
+            webgl_textures: HashMap::default(),
+            font_templates: HashMap::default(),
+            image_templates: HashMap::default(),
+            cached_glyph_dimensions: HashMap::default(),
             texture_cache: texture_cache,
             state: State::Idle,
             enable_aa: enable_aa,

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -21,8 +21,8 @@ pub struct SceneProperties {
 impl SceneProperties {
     pub fn new() -> SceneProperties {
         SceneProperties {
-            transform_properties: HashMap::with_hasher(Default::default()),
-            float_properties: HashMap::with_hasher(Default::default()),
+            transform_properties: HashMap::default(),
+            float_properties: HashMap::default(),
         }
     }
 
@@ -102,9 +102,9 @@ impl Scene {
     pub fn new() -> Scene {
         Scene {
             root_pipeline_id: None,
-            pipeline_map: HashMap::with_hasher(Default::default()),
-            pipeline_auxiliary_lists: HashMap::with_hasher(Default::default()),
-            display_lists: HashMap::with_hasher(Default::default()),
+            pipeline_map: HashMap::default(),
+            pipeline_auxiliary_lists: HashMap::default(),
+            display_lists: HashMap::default(),
             properties: SceneProperties::new(),
         }
     }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -546,7 +546,7 @@ impl TextureCache {
 
         TextureCache {
             cache_id_list: CacheTextureIdList::new(),
-            free_texture_levels: HashMap::with_hasher(Default::default()),
+            free_texture_levels: HashMap::default(),
             items: FreeList::new(),
             pending_updates: TextureUpdateList::new(),
             arena: TextureCacheArena::new(),

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -146,7 +146,7 @@ impl RenderTaskCollection {
     pub fn new(static_render_task_count: usize) -> RenderTaskCollection {
         RenderTaskCollection {
             render_task_data: vec![RenderTaskData::empty(); static_render_task_count],
-            dynamic_tasks: HashMap::with_hasher(Default::default()),
+            dynamic_tasks: HashMap::default(),
         }
     }
 

--- a/wrench/src/scene.rs
+++ b/wrench/src/scene.rs
@@ -26,9 +26,9 @@ impl Scene {
     pub fn new() -> Scene {
         Scene {
             root_pipeline_id: None,
-            pipeline_map: HashMap::with_hasher(Default::default()),
-            pipeline_auxiliary_lists: HashMap::with_hasher(Default::default()),
-            display_lists: HashMap::with_hasher(Default::default()),
+            pipeline_map: HashMap::default(),
+            pipeline_auxiliary_lists: HashMap::default(),
+            display_lists: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
`HashMap::new` *should* have this behaviour, but has been eternally blocked by this lang feature: https://github.com/rust-lang/rust/issues/27336. Specifically `HashMap::new` would fail to infer a hasher if it was ambiguous (most test/example code).

However we sneakily made the Default implementation generic over Hasher, so this works.