### PR TITLE
Revive "Inner rectangle compute refactor"

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -16,7 +16,7 @@ use scene::{Scene, SceneProperties};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
-use util::subtract_rect;
+use util::{ComplexClipRegionHelpers, subtract_rect};
 use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipId, ClipRegion, ColorF};
 use webrender_traits::{DeviceUintRect, DeviceUintSize, DisplayItem, Epoch, FilterOp};
 use webrender_traits::{ImageDisplayItem, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
@@ -217,7 +217,7 @@ fn clip_intersection(original_rect: &LayerRect,
     let base_rect = region.main.intersection(original_rect);
     clips.iter().fold(base_rect, |inner_combined, ccr| {
         inner_combined.and_then(|combined| {
-            ccr.get_inner_rect().and_then(|ir| ir.intersection(&combined))
+            ccr.get_inner_rect_full().and_then(|ir| ir.intersection(&combined))
         })
     })
 }

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -6,7 +6,7 @@ use gpu_store::GpuStoreAddress;
 use prim_store::{ClipData, GpuBlock32, PrimitiveStore};
 use prim_store::{CLIP_DATA_GPU_SIZE, MASK_DATA_GPU_SIZE};
 use renderer::VertexDataStore;
-use util::{MatrixHelpers, TransformedRect};
+use util::{ComplexClipRegionHelpers, MatrixHelpers, TransformedRect};
 use webrender_traits::{AuxiliaryLists, BorderRadius, ClipRegion, ComplexClipRegion, ImageMask};
 use webrender_traits::{DeviceIntRect, LayerToWorldTransform};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
@@ -207,7 +207,7 @@ impl MaskCacheInfo {
                         PrimitiveStore::populate_clip_data(slice, data);
                         local_rect = local_rect.and_then(|r| r.intersection(&rect));
                         local_inner = ComplexClipRegion::new(rect, BorderRadius::uniform(radius))
-                                                        .get_inner_rect();
+                                                        .get_inner_rect_safe();
                     }
                     ClipSource::Region(ref region, region_mode) => {
                         local_rect = local_rect.and_then(|r| r.intersection(&region.main));
@@ -240,7 +240,7 @@ impl MaskCacheInfo {
                             let data = ClipData::from_clip_region(clip);
                             PrimitiveStore::populate_clip_data(chunk, data);
                             local_rect = local_rect.and_then(|r| r.intersection(&clip.rect));
-                            local_inner = local_inner.and_then(|r| clip.get_inner_rect()
+                            local_inner = local_inner.and_then(|r| clip.get_inner_rect_safe()
                                                                        .and_then(|ref inner| r.intersection(inner)));
                         }
                     }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -301,18 +301,16 @@ fn extract_inner_rect_impl<U>(rect: &TypedRect<f32, U>,
                               radii: &BorderRadius,
                               k: f32) -> Option<TypedRect<f32, U>> {
     // `k` defines how much border is taken into account
+    // We enforce the offsets to be rounded to pixel boundaries
+    // by `ceil`-ing and `floor`-ing them
 
-    let xl = rect.origin.x +
-        k * radii.top_left.width.max(radii.bottom_left.width);
-    let xr = rect.origin.x + rect.size.width -
-        k * radii.top_right.width.max(radii.bottom_right.width);
-    let yt = rect.origin.y +
-        k * radii.top_left.height.max(radii.top_right.height);
-    let yb = rect.origin.y + rect.size.height -
-        k * radii.bottom_left.height.max(radii.bottom_right.height);
+    let xl = (k * radii.top_left.width.max(radii.bottom_left.width)).ceil();
+    let xr = (rect.size.width - k * radii.top_right.width.max(radii.bottom_right.width)).floor();
+    let yt = (k * radii.top_left.height.max(radii.top_right.height)).ceil();
+    let yb = (rect.size.height - k * radii.bottom_left.height.max(radii.bottom_right.height)).floor();
 
     if xl <= xr && yt <= yb {
-        Some(TypedRect::new(TypedPoint2D::new(xl, yt),
+        Some(TypedRect::new(TypedPoint2D::new(rect.origin.x + xl, rect.origin.y + yt),
              TypedSize2D::new(xr-xl, yb-yt)))
     } else {
         None

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::f32::consts::{FRAC_1_SQRT_2};
 use euclid::{Point2D, Rect, Size2D};
 use euclid::{TypedRect, TypedPoint2D, TypedSize2D, TypedPoint4D, TypedMatrix4D};
 use webrender_traits::{DeviceIntRect, DeviceIntPoint, DeviceIntSize};
 use webrender_traits::{LayerRect, WorldPoint4D, LayerPoint4D, LayerToWorldTransform};
+use webrender_traits::{BorderRadius, ComplexClipRegion, LayoutRect};
 use num_traits::Zero;
 
 // TODO: Implement these in euclid!
@@ -268,4 +270,51 @@ impl TransformedRect {
 #[inline(always)]
 pub fn pack_as_float(value: u32) -> f32 {
     value as f32 + 0.5
+}
+
+
+pub trait ComplexClipRegionHelpers {
+    /// Return an aligned rectangle that is inside the clip region and doesn't intersect
+    /// any of the bounding rectangles of the rounded corners.
+    fn get_inner_rect_safe(&self) -> Option<LayoutRect>;
+    /// Return the approximately largest aligned rectangle that is fully inside
+    /// the provided clip region.
+    fn get_inner_rect_full(&self) -> Option<LayoutRect>;
+}
+
+impl ComplexClipRegionHelpers for ComplexClipRegion {
+    fn get_inner_rect_safe(&self) -> Option<LayoutRect> {
+        // value of `k==1.0` is used for extraction of the corner rectangles
+        // see `SEGMENT_CORNER_*` in `clip_shared.glsl`
+        extract_inner_rect_impl(&self.rect, &self.radii, 1.0)
+    }
+
+    fn get_inner_rect_full(&self) -> Option<LayoutRect> {
+        // this `k` optimal for a simple case of all border radii being equal
+        let k = 1.0 - 0.5 * FRAC_1_SQRT_2; // could be nicely approximated to `0.3`
+        extract_inner_rect_impl(&self.rect, &self.radii, k)
+    }
+}
+
+#[inline]
+fn extract_inner_rect_impl<U>(rect: &TypedRect<f32, U>,
+                              radii: &BorderRadius,
+                              k: f32) -> Option<TypedRect<f32, U>> {
+    // `k` defines how much border is taken into account
+
+    let xl = rect.origin.x +
+        k * radii.top_left.width.max(radii.bottom_left.width);
+    let xr = rect.origin.x + rect.size.width -
+        k * radii.top_right.width.max(radii.bottom_right.width);
+    let yt = rect.origin.y +
+        k * radii.top_left.height.max(radii.top_right.height);
+    let yb = rect.origin.y + rect.size.height -
+        k * radii.bottom_left.height.max(radii.bottom_right.height);
+
+    if xl <= xr && yt <= yb {
+        Some(TypedRect::new(TypedPoint2D::new(xl, yt),
+             TypedSize2D::new(xr-xl, yb-yt)))
+    } else {
+        None
+    }
 }

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -500,24 +500,6 @@ impl ComplexClipRegion {
             radii: radii,
         }
     }
-
-    //TODO: move to `util` module?
-    /// Return an aligned rectangle that is fully inside the clip region.
-    pub fn get_inner_rect(&self) -> Option<LayoutRect> {
-        let xl = self.rect.origin.x +
-            self.radii.top_left.width.max(self.radii.bottom_left.width);
-        let xr = self.rect.origin.x + self.rect.size.width -
-            self.radii.top_right.width.max(self.radii.bottom_right.width);
-        let yt = self.rect.origin.y +
-            self.radii.top_left.height.max(self.radii.top_right.height);
-        let yb = self.rect.origin.y + self.rect.size.height -
-            self.radii.bottom_left.height.max(self.radii.bottom_right.height);
-        if xl <= xr && yt <= yb {
-            Some(LayoutRect::new(LayoutPoint::new(xl, yt), LayoutSize::new(xr-xl, yb-yt)))
-        } else {
-            None
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
Reverts #1105
Fixes the inner rectangle to always use rounded offsets
r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1107)
<!-- Reviewable:end -->
