### PR TITLE
Fix combined_local_viewport_rect for nested nodes

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -222,8 +222,8 @@ impl ClipScrollNode {
     pub fn update_transform(&mut self,
                             parent_reference_frame_transform: &LayerToWorldTransform,
                             parent_combined_viewport_rect: &ScrollLayerRect,
+                            parent_scroll_offset: LayerPoint,
                             parent_accumulated_scroll_offset: LayerPoint) {
-
         let local_transform = match self.node_type {
             NodeType::ReferenceFrame(transform) => transform,
             NodeType::Clip(_) => LayerToScrollTransform::identity(),
@@ -241,11 +241,11 @@ impl ClipScrollNode {
 
         // We are trying to move the combined viewport rectangle of our parent nodes into the
         // coordinate system of this node, so we must invert our transformation (only for
-        // reference frames) and then apply the scroll offset of all the parent layers.
+        // reference frames) and then apply the scroll offset the parent layer. The combined
+        // local viewport rect doesn't include scrolling offsets so the only one that matters
+        // is the relative offset between us and the parent.
         let parent_combined_viewport_in_local_space =
-            inv_transform.pre_translated(-parent_accumulated_scroll_offset.x,
-                                         -parent_accumulated_scroll_offset.y,
-                                         0.0)
+            inv_transform.pre_translated(-parent_scroll_offset.x, -parent_scroll_offset.y, 0.0)
                          .transform_rect(parent_combined_viewport_rect);
 
         // Now that we have the combined viewport rectangle of the parent nodes in local space,

--- a/wrench/reftests/scrolling/nested-scroll-offset-ref.yaml
+++ b/wrench/reftests/scrolling/nested-scroll-offset-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: [0, 0, 50, 50]
+      color: green

--- a/wrench/reftests/scrolling/nested-scroll-offset.yaml
+++ b/wrench/reftests/scrolling/nested-scroll-offset.yaml
@@ -1,0 +1,18 @@
+root:
+  items:
+    - type: scroll-layer
+      bounds: [0, 0, 1000, 1000]
+      clip: [0, 0, 500, 500]
+      scroll-offset: [0, 300]
+      items:
+      - type: scroll-layer
+        bounds: [0, 300, 50, 50]
+        clip: [0, 300, 50, 50]
+        items:
+        - type: scroll-layer
+          bounds: [0, 300, 50, 50]
+          clip: [0, 300, 50, 50]
+          items:
+            - type: rect
+              bounds: [0, 300, 50, 50]
+              color: green

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -4,3 +4,4 @@
 == scroll-layer.yaml scroll-layer-ref.yaml
 == scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
 == empty-mask.yaml empty-mask-ref.yaml
+== nested-scroll-offset.yaml nested-scroll-offset-ref.yaml


### PR DESCRIPTION
The calculation of the combined_local_viewport_rect was being done
using the accumulated_scroll_offset, but this was not correct, because
the parent combined_local_viewport_rect was already calculated to be
independent of those offsets. This means that the only scrolling offset
that matters is one between the parent and the child.

Add a test for this as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1114)
<!-- Reviewable:end -->
