### PR TITLE
Add a new image format RG8 in ImageFormat.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1723,6 +1723,7 @@ impl Device {
             }
             ImageFormat::RGB8 => (gl::RGB, 3, data),
             ImageFormat::RGBA8 => (get_gl_format_bgra(self.gl()), 4, data),
+            ImageFormat::RG8 => (gl::RG, 2, data),
             ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
         };
 
@@ -2088,6 +2089,7 @@ impl Drop for Device {
     }
 }
 
+/// return (gl_internal_format, gl_format)
 fn gl_texture_formats_for_image_format(gl: &gl::Gl, format: ImageFormat) -> (gl::GLint, gl::GLuint) {
     match format {
         ImageFormat::A8 => {
@@ -2109,6 +2111,7 @@ fn gl_texture_formats_for_image_format(gl: &gl::Gl, format: ImageFormat) -> (gl:
             }
         }
         ImageFormat::RGBAF32 => (gl::RGBA32F as gl::GLint, gl::RGBA),
+        ImageFormat::RG8 => (gl::RG8 as gl::GLint, gl::RG),
         ImageFormat::Invalid => unreachable!(),
     }
 }

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -271,6 +271,7 @@ pub struct TextureCacheProfileCounters {
     pub pages_a8: ResourceProfileCounter,
     pub pages_rgb8: ResourceProfileCounter,
     pub pages_rgba8: ResourceProfileCounter,
+    pub pages_rg8: ResourceProfileCounter,
 }
 
 impl TextureCacheProfileCounters {
@@ -279,6 +280,7 @@ impl TextureCacheProfileCounters {
             pages_a8: ResourceProfileCounter::new("Texture A8 cached pages"),
             pages_rgb8: ResourceProfileCounter::new("Texture RGB8 cached pages"),
             pages_rgba8: ResourceProfileCounter::new("Texture RGBA8 cached pages"),
+            pages_rg8: ResourceProfileCounter::new("Texture RG8 cached pages"),
         }
     }
 }
@@ -683,6 +685,7 @@ impl Profiler {
             &backend_profile.texture_cache.pages_a8,
             &backend_profile.texture_cache.pages_rgb8,
             &backend_profile.texture_cache.pages_rgba8,
+            &backend_profile.texture_cache.pages_rg8,
         ], debug_renderer, true);
 
         self.draw_counters(&[

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -465,6 +465,7 @@ struct TextureCacheArena {
     pages_a8: Vec<TexturePage>,
     pages_rgb8: Vec<TexturePage>,
     pages_rgba8: Vec<TexturePage>,
+    pages_rg8: Vec<TexturePage>,
 }
 
 impl TextureCacheArena {
@@ -473,12 +474,14 @@ impl TextureCacheArena {
             pages_a8: Vec::new(),
             pages_rgb8: Vec::new(),
             pages_rgba8: Vec::new(),
+            pages_rg8: Vec::new(),
         }
     }
 
     fn texture_page_for_id(&mut self, id: CacheTextureId) -> Option<&mut TexturePage> {
         for page in self.pages_a8.iter_mut().chain(self.pages_rgb8.iter_mut())
-                                            .chain(self.pages_rgba8.iter_mut()) {
+                                            .chain(self.pages_rgba8.iter_mut())
+                                            .chain(self.pages_rg8.iter_mut()) {
             if page.texture_id == id {
                 return Some(page)
             }
@@ -607,6 +610,7 @@ impl TextureCache {
             ImageFormat::A8 => (&mut self.arena.pages_a8, &mut profile.pages_a8),
             ImageFormat::RGBA8 => (&mut self.arena.pages_rgba8, &mut profile.pages_rgba8),
             ImageFormat::RGB8 => (&mut self.arena.pages_rgb8, &mut profile.pages_rgb8),
+            ImageFormat::RG8 => (&mut self.arena.pages_rg8, &mut profile.pages_rg8),
             ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
         };
 

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -30,6 +30,7 @@ pub enum ImageFormat {
     RGB8     = 2,
     RGBA8    = 3,
     RGBAF32  = 4,
+    RG8      = 5,
 }
 
 impl ImageFormat {
@@ -39,6 +40,7 @@ impl ImageFormat {
             ImageFormat::RGB8 => Some(3),
             ImageFormat::RGBA8 => Some(4),
             ImageFormat::RGBAF32 => Some(16),
+            ImageFormat::RG8 => Some(2),
             ImageFormat::Invalid => None,
         }
     }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -428,6 +428,7 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
             is_opaque
         }
         ImageFormat::RGB8 => true,
+        ImageFormat::RG8 => true,
         ImageFormat::A8 => false,
         ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
     }


### PR DESCRIPTION
@glennw @kvark @nical 
Some video decoders are decoding to NV12 format. WR already have A8 for y channel. We also need RG8 for uv interleaving channel.

https://wiki.videolan.org/YUV/#NV12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1126)
<!-- Reviewable:end -->
