### PR TITLE
Fix broken payload deserialization.

### DIFF
--- a/webrender_traits/src/channel.rs
+++ b/webrender_traits/src/channel.rs
@@ -45,8 +45,8 @@ impl Payload {
     }
 
     /// Deserializes the given payload from a raw byte vector.
-    pub fn from_data(data: Vec<u8>) -> Payload {
-        let mut payload_reader = Cursor::new(&data[..]);
+    pub fn from_data(data: &[u8]) -> Payload {
+        let mut payload_reader = Cursor::new(data);
         let epoch = Epoch(payload_reader.read_u32::<LittleEndian>().unwrap());
         let pipeline_id = PipelineId(payload_reader.read_u32::<LittleEndian>().unwrap(),
                                      payload_reader.read_u32::<LittleEndian>().unwrap());
@@ -58,6 +58,8 @@ impl Payload {
         let aux_size = payload_reader.read_u64::<LittleEndian>().unwrap() as usize;
         let mut auxiliary_lists_data = vec![0; aux_size];
         payload_reader.read_exact(&mut auxiliary_lists_data[..]).unwrap();
+
+        assert_eq!(payload_reader.position(), data.len() as u64);
 
         Payload {
             epoch: epoch,

--- a/webrender_traits/src/channel_ipc.rs
+++ b/webrender_traits/src/channel_ipc.rs
@@ -29,7 +29,7 @@ impl PayloadSenderHelperMethods for PayloadSender {
 
 impl PayloadReceiverHelperMethods for PayloadReceiver {
     fn recv_payload(&self) -> Result<Payload, Error> {
-        self.recv().map(|data| Payload::from_data(data) )
+        self.recv().map(|data| Payload::from_data(&data) )
                    .map_err(|e| io::Error::new(ErrorKind::Other, error::Error::description(&e)))
     }
 }

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -166,7 +166,7 @@ impl WrenchThing for BinaryFrameReader {
                         }
                     }
                     Item::Data(buf) => {
-                        wrench.api.payload_sender.send_payload(Payload::from_data(buf)).unwrap();
+                        wrench.api.payload_sender.send_payload(Payload::from_data(&buf)).unwrap();
                     }
                 }
             }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -19,6 +19,7 @@ use time;
 use webrender;
 use webrender_traits::*;
 use webrender_traits::SpecificDisplayItem::*;
+use webrender_traits::channel::Payload;
 use yaml_helper::StringEnum;
 use yaml_rust::{Yaml, YamlEmitter};
 
@@ -308,14 +309,10 @@ impl YamlFrameWriter {
         let dl_desc = self.dl_descriptor.take().unwrap();
         let aux_desc = self.aux_descriptor.take().unwrap();
 
-        assert_eq!(data.len(), dl_desc.size() + aux_desc.size() + 4);
+        let payload = Payload::from_data(data);
 
-        // skip 4-byte epoch header
-        let dl_data = data[4..dl_desc.size() + 4].to_vec();
-        let aux_data = data[dl_desc.size() + 4..].to_vec();
-
-        let dl = BuiltDisplayList::from_data(dl_data, dl_desc);
-        let aux = AuxiliaryLists::from_data(aux_data, aux_desc);
+        let dl = BuiltDisplayList::from_data(payload.display_list_data, dl_desc);
+        let aux = AuxiliaryLists::from_data(payload.auxiliary_lists_data, aux_desc);
 
         let mut root_dl_table = new_table();
         {


### PR DESCRIPTION
Payload deserialization was broken when we changed the format
a little while ago. Using the from_data() will help us avoid
the code from diverging in the futre.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1129)
<!-- Reviewable:end -->
