### PR TITLE
Add GL_TEXTURE_EXTERNAL_OES texture target

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -52,6 +52,7 @@ pub enum TextureTarget {
     Default,
     Array,
     Rect,
+    External,
 }
 
 impl TextureTarget {
@@ -60,6 +61,7 @@ impl TextureTarget {
             TextureTarget::Default => gl::TEXTURE_2D,
             TextureTarget::Array => gl::TEXTURE_2D_ARRAY,
             TextureTarget::Rect => gl::TEXTURE_RECTANGLE,
+            TextureTarget::External => gl::TEXTURE_EXTERNAL_OES,
         }
     }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1711,6 +1711,7 @@ impl Renderer {
                 let texture_target = match ext_image.image_type {
                     ExternalImageType::Texture2DHandle => TextureTarget::Default,
                     ExternalImageType::TextureRectHandle => TextureTarget::Rect,
+                    ExternalImageType::TextureExternalHandle => TextureTarget::External,
                     _ => {
                         panic!("{:?} is not a suitable image type in update_deferred_resolves().",
                             ext_image.image_type);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -525,7 +525,8 @@ impl ResourceCache {
             ImageData::External(ext_image) => {
                 match ext_image.image_type {
                     ExternalImageType::Texture2DHandle |
-                    ExternalImageType::TextureRectHandle => {
+                    ExternalImageType::TextureRectHandle |
+                    ExternalImageType::TextureExternalHandle => {
                         Some(ext_image)
                     },
                     // external buffer uses resource_cache.
@@ -750,7 +751,8 @@ impl ResourceCache {
             ImageData::External(ext_image) => {
                 match ext_image.image_type {
                     ExternalImageType::Texture2DHandle |
-                    ExternalImageType::TextureRectHandle => {
+                    ExternalImageType::TextureRectHandle |
+                    ExternalImageType::TextureExternalHandle => {
                         // external handle doesn't need to update the texture_cache.
                     }
                     ExternalImageType::ExternalBuffer => {

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -791,7 +791,8 @@ impl TextureCache {
                     ImageData::External(ext_image) => {
                         match ext_image.image_type {
                             ExternalImageType::Texture2DHandle |
-                            ExternalImageType::TextureRectHandle => {
+                            ExternalImageType::TextureRectHandle |
+                            ExternalImageType::TextureExternalHandle => {
                                 panic!("External texture handle should not go through texture_cache.");
                             }
                             ExternalImageType::ExternalBuffer => {
@@ -835,7 +836,8 @@ impl TextureCache {
                     ImageData::External(ext_image) => {
                         match ext_image.image_type {
                             ExternalImageType::Texture2DHandle |
-                            ExternalImageType::TextureRectHandle => {
+                            ExternalImageType::TextureRectHandle |
+                            ExternalImageType::TextureExternalHandle => {
                                 panic!("External texture handle should not go through texture_cache.");
                             }
                             ExternalImageType::ExternalBuffer => {

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -459,6 +459,9 @@ impl AlphaRenderItem {
                                 match ext_image.image_type {
                                     ExternalImageType::Texture2DHandle => AlphaBatchKind::Image,
                                     ExternalImageType::TextureRectHandle => AlphaBatchKind::ImageRect,
+                                    ExternalImageType::TextureExternalHandle => {
+                                        panic!("No implementation for single channel TextureExternalHandle image.");
+                                    }
                                     _ => {
                                         panic!("Non-texture handle type should be handled in other way.");
                                     }
@@ -514,6 +517,8 @@ impl AlphaRenderItem {
                                                                0));
                     }
                     PrimitiveKind::YuvImage => {
+                        // TODO (Jerry):
+                        // handle NV12
                         let image_yuv_cpu = &ctx.prim_store.cpu_yuv_images[prim_metadata.cpu_prim_index.0];
                         let key = AlphaBatchKey::new(AlphaBatchKind::YuvImage, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -24,8 +24,9 @@ pub struct ExternalImageId(pub u64);
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum ExternalImageType {
-    Texture2DHandle,    // gl TEXTURE_2D handle
-    TextureRectHandle,  // gl TEXTURE_RECT handle
+    Texture2DHandle,        // gl TEXTURE_2D handle
+    TextureRectHandle,      // gl TEXTURE_RECT handle
+    TextureExternalHandle,  // gl TEXTURE_EXTERNAL handle
     ExternalBuffer,
 }
 


### PR DESCRIPTION
@kvark @glennw 
#1130 
r?

Please only review the patch "Add TextureExternalHandle in ExternalImageType and External in TextureTarget". The remaining patches will be handled at #1125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1132)
<!-- Reviewable:end -->
