### PR TITLE
Support serialization to NativeFontHandle

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use webrender_traits::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
 use webrender_traits::{GlyphKey, GlyphOptions, SubpixelPoint};
+use webrender_traits::NativeFontHandle;
 use gamma_lut::{GammaLut, Color as ColorLut};
 
 pub struct FontContext {
@@ -139,12 +140,12 @@ impl FontContext {
         self.cg_fonts.insert((*font_key).clone(), cg_font);
     }
 
-    pub fn add_native_font(&mut self, font_key: &FontKey, native_font_handle: CGFont) {
+    pub fn add_native_font(&mut self, font_key: &FontKey, native_font_handle: NativeFontHandle) {
         if self.cg_fonts.contains_key(font_key) {
             return
         }
 
-        self.cg_fonts.insert((*font_key).clone(), native_font_handle);
+        self.cg_fonts.insert((*font_key).clone(), native_font_handle.0);
     }
 
     pub fn delete_font(&mut self, font_key: &FontKey) {

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -22,6 +22,7 @@ serde = "0.9"
 serde_derive = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.3"
 core-graphics = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/webrender_traits/src/font.rs
+++ b/webrender_traits/src/font.rs
@@ -6,12 +6,36 @@ use app_units::Au;
 use euclid::Point2D;
 use {ColorU, ColorF};
 
+#[cfg(target_os = "macos")] use core_foundation::string::CFString;
 #[cfg(target_os = "macos")] use core_graphics::font::CGFont;
+#[cfg(target_os = "macos")] use serde::de::{self, Deserialize, Deserializer};
+#[cfg(target_os = "macos")] use serde::ser::{Serialize, Serializer};
 #[cfg(target_os = "windows")] use dwrote::FontDescriptor;
 
 
 #[cfg(target_os = "macos")]
-pub type NativeFontHandle = CGFont;
+#[derive(Clone)]
+pub struct NativeFontHandle(pub CGFont);
+
+#[cfg(target_os = "macos")]
+impl Serialize for NativeFontHandle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let postscript_name = self.0.postscript_name().to_string();
+        postscript_name.serialize(serializer)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Deserialize for NativeFontHandle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer {
+        let postscript_name: String = try!(Deserialize::deserialize(deserializer));
+
+        match CGFont::from_name(&CFString::new(&*postscript_name)) {
+            Ok(font) => Ok(NativeFontHandle(font)),
+            _ => Err(de::Error::custom("Couldn't find a font with that PostScript name!")),
+        }
+    }
+}
 
 /// Native fonts are not used on Linux; all fonts are raw.
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]

--- a/webrender_traits/src/lib.rs
+++ b/webrender_traits/src/lib.rs
@@ -22,6 +22,9 @@ extern crate serde;
 extern crate serde_derive;
 
 #[cfg(target_os = "macos")]
+extern crate core_foundation;
+
+#[cfg(target_os = "macos")]
 extern crate core_graphics;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
NativeFontHandle needs to implement serialization due to it is removed from ```CGFont``` in ```core-graphics```.

https://github.com/servo/servo/issues/15607

This PR depends on https://github.com/servo/core-graphics-rs/pull/82.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1133)
<!-- Reviewable:end -->
