### PR TITLE
Add support for font index to add_raw_font

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "wrench"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.34.0",
- "webrender_traits 0.34.0",
+ "webrender 0.35.0",
+ "webrender_traits 0.35.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -884,12 +884,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.34.0",
+ "webrender_traits 0.35.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -923,8 +923,8 @@ dependencies = [
  "euclid 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.34.0",
- "webrender_traits 0.34.0",
+ "webrender 0.35.0",
+ "webrender_traits 0.35.0",
 ]
 
 [[package]]

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -326,7 +326,7 @@ fn main() {
     if false { // draw text?
         let font_key = api.generate_font_key();
         let font_bytes = load_file("res/FreeSans.ttf");
-        api.add_raw_font(font_key, font_bytes);
+        api.add_raw_font(font_key, font_bytes, 0);
 
         let text_bounds = LayoutRect::new(LayoutPoint::new(100.0, 200.0), LayoutSize::new(700.0, 300.0));
 

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -56,7 +56,7 @@ pub const ORTHO_FAR_PLANE: f32 = 1000000.0;
 
 #[derive(Clone)]
 pub enum FontTemplate {
-    Raw(Arc<Vec<u8>>),
+    Raw(Arc<Vec<u8>>, u32),
     Native(NativeFontHandle),
 }
 

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -126,11 +126,12 @@ impl FontContext {
         }
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8]) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8], index: u32) {
         if self.cg_fonts.contains_key(font_key) {
             return
         }
 
+        assert_eq!(index, 0);
         let data_provider = CGDataProvider::from_buffer(bytes);
         let cg_font = match CGFont::from_data_provider(data_provider) {
             Err(_) => return,

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -61,15 +61,14 @@ impl FontContext {
         }
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8]) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8], index: u32) {
         if !self.faces.contains_key(&font_key) {
             let mut face: FT_Face = ptr::null_mut();
-            let face_index = 0 as FT_Long;
             let result = unsafe {
                 FT_New_Memory_Face(self.lib,
                                    bytes.as_ptr(),
                                    bytes.len() as FT_Long,
-                                   face_index,
+                                   index as FT_Long,
                                    &mut face)
             };
             if result.succeeded() && !face.is_null() {

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -117,13 +117,13 @@ impl FontContext {
         }
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, data: &[u8]) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, data: &[u8], index: u32) {
         if self.fonts.contains_key(font_key) {
             return
         }
 
         if let Some(font_file) = dwrote::FontFile::new_from_data(data) {
-            let face = font_file.create_face(0, dwrote::DWRITE_FONT_SIMULATIONS_NONE);
+            let face = font_file.create_face(index, dwrote::DWRITE_FONT_SIMULATIONS_NONE);
             self.fonts.insert((*font_key).clone(), face);
         } else {
             // XXX add_raw_font needs to have a way to return an error

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -122,10 +122,10 @@ impl RenderBackend {
                         r.write_msg(frame_counter, &msg);
                     }
                     match msg {
-                        ApiMsg::AddRawFont(id, bytes) => {
+                        ApiMsg::AddRawFont(id, bytes, index) => {
                             profile_counters.resources.font_templates.inc(bytes.len());
                             self.resource_cache
-                                .add_font_template(id, FontTemplate::Raw(Arc::new(bytes)));
+                                .add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
                         }
                         ApiMsg::AddNativeFont(id, native_font_handle) => {
                             self.resource_cache

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -479,8 +479,8 @@ impl ResourceCache {
                 FONT_CONTEXT.with(|font_context| {
                     let mut font_context = font_context.borrow_mut();
                     match *font_template {
-                        FontTemplate::Raw(ref bytes) => {
-                            font_context.add_raw_font(&glyph_key.font_key, &**bytes);
+                        FontTemplate::Raw(ref bytes, index) => {
+                            font_context.add_raw_font(&glyph_key.font_key, &**bytes, index);
                         }
                         FontTemplate::Native(ref native_font_handle) => {
                             font_context.add_native_font(&glyph_key.font_key,
@@ -865,8 +865,8 @@ fn spawn_glyph_cache_thread(workers: Arc<Mutex<ThreadPool>>) -> (Sender<GlyphCac
                             FONT_CONTEXT.with(|font_context| {
                                 let mut font_context = font_context.borrow_mut();
                                 match font_template {
-                                    FontTemplate::Raw(ref bytes) => {
-                                        font_context.add_raw_font(&font_key, &**bytes);
+                                    FontTemplate::Raw(ref bytes, index) => {
+                                        font_context.add_raw_font(&font_key, &**bytes, index);
                                     }
                                     FontTemplate::Native(ref native_font_handle) => {
                                         font_context.add_native_font(&font_key,

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -19,7 +19,7 @@ pub type TileSize = u16;
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum ApiMsg {
-    AddRawFont(FontKey, Vec<u8>),
+    AddRawFont(FontKey, Vec<u8>, u32),
     AddNativeFont(FontKey, NativeFontHandle),
     DeleteFont(FontKey),
     /// Gets the glyph dimensions
@@ -198,8 +198,8 @@ impl RenderApi {
         FontKey::new(new_id.0, new_id.1)
     }
 
-    pub fn add_raw_font(&self, key: FontKey, bytes: Vec<u8>) {
-        let msg = ApiMsg::AddRawFont(key, bytes);
+    pub fn add_raw_font(&self, key: FontKey, bytes: Vec<u8>, index: u32) {
+        let msg = ApiMsg::AddRawFont(key, bytes, index);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrench"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 build = "build.rs"
 license = "MPL-2.0"

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -22,7 +22,7 @@ use webrender_traits::*;
 
 enum CachedFont {
     Native(NativeFontHandle),
-    Raw(Option<Vec<u8>>, Option<PathBuf>),
+    Raw(Option<Vec<u8>>, u32, Option<PathBuf>),
 }
 
 struct CachedImage {
@@ -206,8 +206,8 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
             ApiMsg::WebGLCommand(..) => {
             }
 
-            ApiMsg::AddRawFont(ref key, ref bytes) => {
-                self.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), None));
+            ApiMsg::AddRawFont(ref key, ref bytes, index) => {
+                self.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), index, None));
             }
 
             ApiMsg::AddNativeFont(ref key, ref native_font_handle) => {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -275,8 +275,8 @@ impl Wrench {
     pub fn font_key_from_yaml_table(&mut self, item: &Yaml) -> (FontKey, Option<NativeFontHandle>) {
         let family = item["family"].as_str().unwrap();
         let property = system_fonts::FontPropertyBuilder::new().family(family).build();
-        let (font, _) = system_fonts::get(&property).unwrap();
-        self.font_key_from_bytes(font)
+        let (font, index) = system_fonts::get(&property).unwrap();
+        self.font_key_from_bytes(font, index as u32)
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -284,9 +284,9 @@ impl Wrench {
         panic!("Can't font_key_from_name on this platform");
     }
 
-    pub fn font_key_from_bytes(&mut self, bytes: Vec<u8>) -> (FontKey, Option<NativeFontHandle>) {
+    pub fn font_key_from_bytes(&mut self, bytes: Vec<u8>, index: u32) -> (FontKey, Option<NativeFontHandle>) {
         let key = self.api.generate_font_key();
-        self.api.add_raw_font(key, bytes);
+        self.api.add_raw_font(key, bytes, index);
         (key, None)
     }
 

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -464,10 +464,11 @@ impl YamlFrameReader {
             wrench.font_key_from_yaml_table(item)
         } else if !item["font"].is_badvalue() {
             let font_file = self.rsrc_path(&item["font"]);
+            let font_index = item["font-index"].as_i64().unwrap_or(0) as u32;
             let mut file = File::open(&font_file).expect("Couldn't open font file");
             let mut bytes = vec![];
             file.read_to_end(&mut bytes).expect("failed to read font file");
-            wrench.font_key_from_bytes(bytes)
+            wrench.font_key_from_bytes(bytes, font_index)
         } else {
             wrench.font_key_from_name(&*PLATFORM_DEFAULT_FACE_NAME)
         };

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -206,7 +206,7 @@ fn native_font_handle_to_yaml(_: &NativeFontHandle, _: &mut yaml_rust::yaml::Has
 
 enum CachedFont {
     Native(NativeFontHandle),
-    Raw(Option<Vec<u8>>, Option<PathBuf>),
+    Raw(Option<Vec<u8>>, u32, Option<PathBuf>),
 }
 
 struct CachedImage {
@@ -517,14 +517,14 @@ impl YamlFrameWriter {
 
                     let entry = self.fonts.entry(item.font_key).or_insert_with(|| {
                         println!("Warning: font key not found in fonts table!");
-                        CachedFont::Raw(Some(vec![]), None)
+                        CachedFont::Raw(Some(vec![]), 0, None)
                     });
 
                     match entry {
                         &mut CachedFont::Native(ref handle) => {
                             native_font_handle_to_yaml(handle, &mut v);
                         }
-                        &mut CachedFont::Raw(ref mut bytes_opt, ref mut path_opt) => {
+                        &mut CachedFont::Raw(ref mut bytes_opt, index, ref mut path_opt) => {
                             if let Some(bytes) = bytes_opt.take() {
                                 let (path_file, path) =
                                     Self::next_rsrc_paths(&self.rsrc_prefix,
@@ -538,6 +538,9 @@ impl YamlFrameWriter {
                             }
 
                             path_node(&mut v, "font", path_opt.as_ref().unwrap());
+                            if index != 0 {
+                                u32_node(&mut v, "font-index", index);
+                            }
                         }
                     }
                 },
@@ -771,8 +774,8 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
             ApiMsg::WebGLCommand(..) => {
             }
 
-            ApiMsg::AddRawFont(ref key, ref bytes) => {
-                self.frame_writer.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), None));
+            ApiMsg::AddRawFont(ref key, ref bytes, index) => {
+                self.frame_writer.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), index, None));
             }
 
             ApiMsg::AddNativeFont(ref key, ref native_font_handle) => {


### PR DESCRIPTION
In Gecko, we need to be able to support font indexes in case the raw font is actually a font collection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1135)
<!-- Reviewable:end -->
