### PR TITLE
Record root_scroll_node and use ClipId::Clip in show

### DIFF
--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -576,7 +576,7 @@ impl YamlFrameReader {
 
             let yaml_clip_id = item["clip-id"].as_i64();
             if let Some(yaml_id) = yaml_clip_id {
-                let id = ClipId::new(yaml_id as u64, self.builder().pipeline_id);
+                let id = ClipId::Clip(yaml_id as u64, self.builder().pipeline_id);
                 self.builder().push_clip_id(id);
             }
 
@@ -617,7 +617,7 @@ impl YamlFrameReader {
         let default_clip = LayoutRect::new(LayoutPoint::zero(), content_rect.size);
         let clip = self.to_clip_region(&yaml["clip"], &default_clip, wrench)
                        .unwrap_or(ClipRegion::simple(&default_clip));
-        let id = yaml["id"].as_i64().map(|id| ClipId::new(id as u64, self.builder().pipeline_id));
+        let id = yaml["id"].as_i64().map(|id| ClipId::Clip(id as u64, self.builder().pipeline_id));
 
         let id = self.builder().define_clip(content_rect, clip, id);
 

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -317,7 +317,8 @@ impl YamlFrameWriter {
         let mut root_dl_table = new_table();
         {
             let mut iter = dl.all_display_items().iter();
-            self.write_display_list(&mut root_dl_table, &mut iter, &aux, &mut ClipIdMapper::new());
+            let pipeline_id = self.pipeline_id.unwrap().clone();
+            self.write_display_list(&mut root_dl_table, &mut iter, &aux, &mut ClipIdMapper::new(pipeline_id));
         }
 
 
@@ -345,7 +346,7 @@ impl YamlFrameWriter {
                 let dl = scene.display_lists.get(&pipeline_id).unwrap();
                 let aux = scene.pipeline_auxiliary_lists.get(&pipeline_id).unwrap();
                 let mut iter = dl.iter();
-                self.write_display_list(&mut pipeline, &mut iter, aux, &mut ClipIdMapper::new());
+                self.write_display_list(&mut pipeline, &mut iter, aux, &mut ClipIdMapper::new(pipeline_id));
                 pipelines.push(Yaml::Hash(pipeline));
             }
 
@@ -853,9 +854,12 @@ struct ClipIdMapper {
 }
 
 impl ClipIdMapper {
-    fn new() -> ClipIdMapper {
+    fn new(pipeline_id: PipelineId) -> ClipIdMapper {
+        let mut map = HashMap::new();
+        map.insert(ClipId::root_scroll_node(pipeline_id), 0);
+
         ClipIdMapper {
-            hash_map: HashMap::new(),
+            hash_map: map,
             current_clip_id: 1,
         }
     }


### PR DESCRIPTION
I ran into #1060 again. The problem is `replay --save yaml` followed by a `show yaml`. I put together a fix which makes sense to me, but I don't know the logic behind this code well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1144)
<!-- Reviewable:end -->
