### PR TITLE
Clear render targets with rgba(0,0,0,0) and remove isolate_clear

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1076,7 +1076,6 @@ impl FrameBuilder {
         let mut sc_stack = Vec::new();
         let mut current_task = RenderTask::new_alpha_batch(next_task_index,
                                                            DeviceIntPoint::zero(),
-                                                           false,
                                                            RenderTaskLocation::Fixed);
         next_task_index.0 += 1;
         let mut alpha_task_stack = Vec::new();
@@ -1098,7 +1097,6 @@ impl FrameBuilder {
                         let location = RenderTaskLocation::Dynamic(None, stacking_context_rect.size);
                         let new_task = RenderTask::new_alpha_batch(next_task_index,
                                                                    stacking_context_rect.origin,
-                                                                   stacking_context.should_isolate,
                                                                    location);
                         next_task_index.0 += 1;
                         let prev_task = mem::replace(&mut current_task, new_task);
@@ -1109,7 +1107,6 @@ impl FrameBuilder {
                         let location = RenderTaskLocation::Dynamic(None, stacking_context_rect.size);
                         let new_task = RenderTask::new_alpha_batch(next_task_index,
                                                                    stacking_context_rect.origin,
-                                                                   stacking_context.should_isolate,
                                                                    location);
                         next_task_index.0 += 1;
                         let prev_task = mem::replace(&mut current_task, new_task);

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -61,7 +61,6 @@ pub enum AlphaRenderItem {
 pub struct AlphaRenderTask {
     screen_origin: DeviceIntPoint,
     pub items: Vec<AlphaRenderItem>,
-    pub isolate_clear: bool,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -144,7 +143,6 @@ pub struct RenderTask {
 impl RenderTask {
     pub fn new_alpha_batch(task_index: RenderTaskIndex,
                            screen_origin: DeviceIntPoint,
-                           isolate_clear: bool,
                            location: RenderTaskLocation) -> RenderTask {
         RenderTask {
             id: RenderTaskId::Static(task_index),
@@ -153,7 +151,6 @@ impl RenderTask {
             kind: RenderTaskKind::Alpha(AlphaRenderTask {
                 screen_origin: screen_origin,
                 items: Vec::new(),
-                isolate_clear: isolate_clear,
             }),
         }
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1515,13 +1515,6 @@ impl Renderer {
                 }
             }
 
-            let isolate_clear_color = Some([0.0, 0.0, 0.0, 0.0]);
-            for isolate_clear in &target.isolate_clears {
-                self.device.clear_target_rect(isolate_clear_color,
-                                              None,
-                                              *isolate_clear);
-            }
-
             self.device.disable_depth_write();
         }
 
@@ -1848,7 +1841,7 @@ impl Renderer {
                                                  ORTHO_FAR_PLANE)
                 } else {
                     size = &frame.cache_size;
-                    clear_color = Some([1.0, 1.0, 1.0, 0.0]);
+                    clear_color = Some([0.0, 0.0, 0.0, 0.0]);
                     projection = Matrix4D::ortho(0.0,
                                                  size.width as f32,
                                                  0.0,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -805,7 +805,6 @@ pub struct ColorRenderTarget {
     pub vertical_blurs: Vec<BlurCommand>,
     pub horizontal_blurs: Vec<BlurCommand>,
     pub readbacks: Vec<DeviceIntRect>,
-    pub isolate_clears: Vec<DeviceIntRect>,
     allocator: TextureAllocator,
 }
 
@@ -823,7 +822,6 @@ impl RenderTarget for ColorRenderTarget {
             vertical_blurs: Vec::new(),
             horizontal_blurs: Vec::new(),
             readbacks: Vec::new(),
-            isolate_clears: Vec::new(),
             allocator: TextureAllocator::new(size),
         }
     }
@@ -852,16 +850,6 @@ impl RenderTarget for ColorRenderTarget {
                     task_id: task.id,
                     items: info.items,
                 });
-
-                if info.isolate_clear {
-                    let location = match task.location {
-                        RenderTaskLocation::Dynamic(origin, size) => {
-                            DeviceIntRect::new(origin.unwrap().0, size)
-                        }
-                        RenderTaskLocation::Fixed => panic!()
-                    };
-                    self.isolate_clears.push(location);
-                }
             }
             RenderTaskKind::VerticalBlur(_, prim_index) => {
                 // Find the child render task that we are applying

--- a/wrench/reftests/blend/reftest.list
+++ b/wrench/reftests/blend/reftest.list
@@ -9,3 +9,7 @@
 == isolated-2.yaml isolated-2-ref.yaml
 == isolated-with-filter.yaml isolated-ref.yaml
 == isolated-premultiplied.yaml blank.yaml
+
+# fuzzy because dithering is different for gradients
+# drawn in different render targets
+fuzzy(1,1974) == transparent-composite.yaml transparent-composite-ref.yaml

--- a/wrench/reftests/blend/transparent-composite-ref.yaml
+++ b/wrench/reftests/blend/transparent-composite-ref.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - type: gradient
+      bounds: [0, 0, 100, 100]
+      start: [0, 0]
+      end: [0, 100]
+      stops: [0.0, [0,0,0,0], 1.0, green]

--- a/wrench/reftests/blend/transparent-composite.yaml
+++ b/wrench/reftests/blend/transparent-composite.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 100]
+      mix-blend-mode: darken
+      items:
+        - type: gradient
+          bounds: [0, 0, 100, 100]
+          start: [0, 0]
+          end: [0, 100]
+          stops: [0.0, [0,0,0,0], 1.0, green]


### PR DESCRIPTION
The composite shader relies on its render target being premultiplied.
This causes issues with transparent surfaces behind a mix-blend-mode.
The clipping code no longer relies on the previous behavior, so this
can be changed.

The isolate_clear code then no longer has an effect, so that is removed
too. Notably, the code for isolating stacking context's remains as only
the code that clears the rects is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1148)
<!-- Reviewable:end -->
