### PR TITLE
Make image tiling work with external buffer images.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -285,6 +285,7 @@ pub enum TextureUpdateOp {
         id: ExternalImageId,
         channel_index: u8,
         stride: Option<u32>,
+        offset: u32,
     },
     Grow {
         width: u32,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1276,7 +1276,7 @@ impl Renderer {
                                                    width, height, stride,
                                                    &data[offset as usize..]);
                     }
-                    TextureUpdateOp::UpdateForExternalBuffer { rect, id, channel_index, stride } => {
+                    TextureUpdateOp::UpdateForExternalBuffer { rect, id, channel_index, stride, offset } => {
                         let handler = self.external_image_handler
                                           .as_mut()
                                           .expect("Found external image, but no handler set!");
@@ -1290,7 +1290,8 @@ impl Renderer {
                                                       rect.origin.y,
                                                       rect.size.width,
                                                       rect.size.height,
-                                                      stride, data);
+                                                      stride,
+                                                      &data[offset as usize..]);
                             }
                             _ => panic!("No external buffer found"),
                         };

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -803,6 +803,7 @@ impl TextureCache {
                                         id: ext_image.id,
                                         channel_index: ext_image.channel_index,
                                         stride: stride,
+                                        offset: descriptor.offset,
                                     },
                                 };
 


### PR DESCRIPTION
Tiling is already handled in the resource cache by specifying the proper size, stride and offset in order to upload the correct part of the image (the tile) to the texture atlas. Getting this to work with external buffer images is only a matter of passing the correct offset which was ignored before this commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1149)
<!-- Reviewable:end -->
