### PR TITLE
Use debug assertions to check WebGL errors

### DIFF
--- a/webrender_traits/src/webgl.rs
+++ b/webrender_traits/src/webgl.rs
@@ -612,9 +612,10 @@ impl WebGLCommand {
                 ctx.gl().generate_mipmap(target),
         }
 
-        // FIXME: Use debug_assertions once tests are run with them
-        let error = ctx.gl().get_error();
-        assert!(error == gl::NO_ERROR, "Unexpected WebGL error: 0x{:x} ({})", error, error);
+        if cfg!(debug_assertions) {
+            let error = ctx.gl().get_error();
+            assert!(error == gl::NO_ERROR, "Unexpected WebGL error: 0x{:x} ({})", error, error);
+        }
     }
 
     fn read_pixels(gl: &gl::Gl, x: i32, y: i32, width: i32, height: i32, format: u32, pixel_type: u32,


### PR DESCRIPTION
Tests already running with debug assertions enabled: https://github.com/servo/servo/blob/master/etc/ci/buildbot_steps.yml#L71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1153)
<!-- Reviewable:end -->
