### PR TITLE
Remove unused z-index parameter

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -258,7 +258,6 @@ fn main() {
     let bounds = LayoutRect::new(LayoutPoint::zero(), LayoutSize::new(width as f32, height as f32));
     builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
                                   bounds,
-                                  0,
                                   None,
                                   TransformStyle::Flat,
                                   None,

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -135,7 +135,6 @@ fn main() {
     let bounds = LayoutRect::new(LayoutPoint::zero(), LayoutSize::new(width as f32, height as f32));
     builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
                                   bounds,
-                                  0,
                                   None,
                                   TransformStyle::Flat,
                                   None,
@@ -148,7 +147,6 @@ fn main() {
         builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
                                       LayoutRect::new(LayoutPoint::new(10.0, 10.0),
                                                       LayoutSize::zero()),
-                                      0,
                                       None,
                                       TransformStyle::Flat,
                                       None,

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -248,7 +248,6 @@ pub struct PushStackingContextDisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StackingContext {
     pub scroll_policy: ScrollPolicy,
-    pub z_index: i32,
     pub transform: Option<PropertyBinding<LayoutTransform>>,
     pub transform_style: TransformStyle,
     pub perspective: Option<LayoutTransform>,
@@ -367,7 +366,6 @@ pub struct ComplexClipRegion {
 
 impl StackingContext {
     pub fn new(scroll_policy: ScrollPolicy,
-               z_index: i32,
                transform: Option<PropertyBinding<LayoutTransform>>,
                transform_style: TransformStyle,
                perspective: Option<LayoutTransform>,
@@ -377,7 +375,6 @@ impl StackingContext {
                -> StackingContext {
         StackingContext {
             scroll_policy: scroll_policy,
-            z_index: z_index,
             transform: transform,
             transform_style: transform_style,
             perspective: perspective,

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -435,7 +435,6 @@ impl DisplayListBuilder {
     pub fn push_stacking_context(&mut self,
                                  scroll_policy: ScrollPolicy,
                                  bounds: LayoutRect,
-                                 z_index: i32,
                                  transform: Option<PropertyBinding<LayoutTransform>>,
                                  transform_style: TransformStyle,
                                  perspective: Option<LayoutTransform>,
@@ -444,7 +443,6 @@ impl DisplayListBuilder {
         let item = SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
             stacking_context: StackingContext {
                 scroll_policy: scroll_policy,
-                z_index: z_index,
                 transform: transform,
                 transform_style: transform_style,
                 perspective: perspective,

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -634,7 +634,6 @@ impl YamlFrameReader {
                                           is_root: bool) {
         let default_bounds = LayoutRect::new(LayoutPoint::zero(), wrench.window_size_f32());
         let bounds = yaml["bounds"].as_rect().unwrap_or(default_bounds);
-        let z_index = yaml["z-index"].as_i64().unwrap_or(0);
 
         // TODO(gw): Add support for specifying the transform origin in yaml.
         let transform_origin = LayoutPoint::new(bounds.origin.x + bounds.size.width * 0.5,
@@ -668,7 +667,6 @@ impl YamlFrameReader {
 
         self.builder().push_stacking_context(scroll_policy,
                                              bounds,
-                                             z_index as i32,
                                              transform.into(),
                                              transform_style,
                                              perspective,

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -100,10 +100,6 @@ fn usize_node(parent: &mut Table, key: &str, value: usize) {
     yaml_node(parent, key, Yaml::Integer(value as i64));
 }
 
-fn i32_node(parent: &mut Table, key: &str, value: i32) {
-    yaml_node(parent, key, Yaml::Integer(value as i64));
-}
-
 fn f32_node(parent: &mut Table, key: &str, value: f32) {
     yaml_node(parent, key, Yaml::Real(value.to_string()));
 }
@@ -171,7 +167,6 @@ fn maybe_radius_yaml(radius: &BorderRadius) -> Option<Yaml> {
 
 fn write_sc(parent: &mut Table, sc: &StackingContext) {
     enum_node(parent, "scroll-policy", sc.scroll_policy);
-    i32_node(parent, "z-index", sc.z_index);
 
     match sc.transform {
         Some(PropertyBinding::Value(transform)) => matrix4d_node(parent, "transform", &transform),


### PR DESCRIPTION
This isn't used anywhere inside WebRender and who knows what the
semantics would be. Servo and Gecko both z-sort before creating
WebRender display lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1155)
<!-- Reviewable:end -->
