### PR TITLE
Recycle some of the vector allocations when re-building the frame.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -316,7 +316,8 @@ impl Frame {
             }
         });
 
-        let mut frame_builder = FrameBuilder::new(window_size,
+        let mut frame_builder = FrameBuilder::new(self.frame_builder.take(),
+                                                  window_size,
                                                   background_color,
                                                   self.frame_builder_config);
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -24,7 +24,7 @@ use tiling::StackingContextIndex;
 use tiling::{AuxiliaryListsMap, ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, Frame};
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
 use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
-use util::{self, pack_as_float, subtract_rect};
+use util::{self, pack_as_float, subtract_rect, recycle_vec};
 use util::RectHelpers;
 use webrender_traits::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipId, ClipRegion};
 use webrender_traits::{ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect};
@@ -124,21 +124,41 @@ pub struct FrameBuilder {
 }
 
 impl FrameBuilder {
-    pub fn new(screen_size: DeviceUintSize,
+    pub fn new(previous: Option<FrameBuilder>,
+               screen_size: DeviceUintSize,
                background_color: Option<ColorF>,
                config: FrameBuilderConfig) -> FrameBuilder {
-        FrameBuilder {
-            screen_size: screen_size,
-            background_color: background_color,
-            stacking_context_store: Vec::new(),
-            clip_scroll_group_store: Vec::new(),
-            prim_store: PrimitiveStore::new(),
-            cmds: Vec::new(),
-            packed_layers: Vec::new(),
-            scrollbar_prims: Vec::new(),
-            config: config,
-            reference_frame_stack: Vec::new(),
-            stacking_context_stack: Vec::new(),
+        match previous {
+            Some(prev) => {
+                FrameBuilder {
+                    stacking_context_store: recycle_vec(prev.stacking_context_store),
+                    clip_scroll_group_store: recycle_vec(prev.clip_scroll_group_store),
+                    cmds: recycle_vec(prev.cmds),
+                    packed_layers: recycle_vec(prev.packed_layers),
+                    scrollbar_prims: recycle_vec(prev.scrollbar_prims),
+                    reference_frame_stack: recycle_vec(prev.reference_frame_stack),
+                    stacking_context_stack: recycle_vec(prev.stacking_context_stack),
+                    prim_store: prev.prim_store.recycle(),
+                    screen_size: screen_size,
+                    background_color: background_color,
+                    config: config,
+                }
+            }
+            None => {
+                FrameBuilder {
+                    stacking_context_store: Vec::new(),
+                    clip_scroll_group_store: Vec::new(),
+                    cmds: Vec::new(),
+                    packed_layers: Vec::new(),
+                    scrollbar_prims: Vec::new(),
+                    reference_frame_stack: Vec::new(),
+                    stacking_context_stack: Vec::new(),
+                    prim_store: PrimitiveStore::new(),
+                    screen_size: screen_size,
+                    background_color: background_color,
+                    config: config,
+                }
+            }
         }
     }
 

--- a/webrender/src/gpu_store.rs
+++ b/webrender/src/gpu_store.rs
@@ -6,6 +6,7 @@ use device::TextureFilter;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Add;
+use util::recycle_vec;
 use webrender_traits::ImageFormat;
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
@@ -74,6 +75,13 @@ impl<T: Clone + Default, L: GpuStoreLayout> GpuStore<T, L> {
             data: Vec::new(),
             layout: PhantomData,
             //free_list: Vec::new(),
+        }
+    }
+
+    pub fn recycle(self) -> Self {
+        GpuStore {
+            data: recycle_vec(self.data),
+            layout: PhantomData,
         }
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -12,7 +12,7 @@ use render_task::{RenderTask, RenderTaskLocation};
 use resource_cache::{CacheItem, ImageProperties, ResourceCache};
 use std::mem;
 use std::usize;
-use util::TransformedRect;
+use util::{TransformedRect, recycle_vec};
 use webrender_traits::{AuxiliaryLists, ColorF, ImageKey, ImageRendering, YuvColorSpace};
 use webrender_traits::{ClipRegion, ComplexClipRegion, ItemRange, GlyphKey};
 use webrender_traits::{FontKey, FontRenderMode, WebGLContextId};
@@ -600,6 +600,7 @@ impl PrimitiveStore {
             cpu_gradients: Vec::new(),
             cpu_radial_gradients: Vec::new(),
             cpu_borders: Vec::new(),
+            prims_to_resolve: Vec::new(),
             gpu_geometry: VertexDataStore::new(),
             gpu_data16: VertexDataStore::new(),
             gpu_data32: VertexDataStore::new(),
@@ -607,7 +608,27 @@ impl PrimitiveStore {
             gpu_data128: VertexDataStore::new(),
             gpu_gradient_data: GradientDataStore::new(),
             gpu_resource_rects: VertexDataStore::new(),
-            prims_to_resolve: Vec::new(),
+        }
+    }
+
+    pub fn recycle(self) -> Self {
+        PrimitiveStore {
+            cpu_metadata: recycle_vec(self.cpu_metadata),
+            cpu_bounding_rects: recycle_vec(self.cpu_bounding_rects),
+            cpu_text_runs: recycle_vec(self.cpu_text_runs),
+            cpu_images: recycle_vec(self.cpu_images),
+            cpu_yuv_images: recycle_vec(self.cpu_yuv_images),
+            cpu_gradients: recycle_vec(self.cpu_gradients),
+            cpu_radial_gradients: recycle_vec(self.cpu_radial_gradients),
+            cpu_borders: recycle_vec(self.cpu_borders),
+            prims_to_resolve: recycle_vec(self.prims_to_resolve),
+            gpu_geometry: self.gpu_geometry.recycle(),
+            gpu_data16: self.gpu_data16.recycle(),
+            gpu_data32: self.gpu_data32.recycle(),
+            gpu_data64: self.gpu_data64.recycle(),
+            gpu_data128: self.gpu_data128.recycle(),
+            gpu_gradient_data: self.gpu_gradient_data.recycle(),
+            gpu_resource_rects: self.gpu_resource_rects.recycle(),
         }
     }
 

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -316,3 +316,18 @@ fn extract_inner_rect_impl<U>(rect: &TypedRect<f32, U>,
         None
     }
 }
+
+/// Consumes the old vector and returns a new one that may reuse the old vector's allocated
+/// memory.
+pub fn recycle_vec<T>(mut old_vec: Vec<T>) -> Vec<T> {
+    if old_vec.capacity() > 2 * old_vec.len() {
+        // Avoid reusing the buffer if it is a lot larger than it needs to be. This prevents
+        // a frame with exceptionally large allocations to cause subsequent frames to retain
+        // more memory than they need.
+        return Vec::with_capacity(old_vec.len());
+    }
+
+    old_vec.clear();
+
+    return old_vec;
+}


### PR DESCRIPTION
Currently, most of the data in FrameBuilder is regenerated from scratch when RenderBackend::build_scene is called. When this happens all of the FrameBuilder data from the previous frame still exists but is thrown away as we re-allocate a new FrameBuilder. In some test cases a lot of time is spent growing vectors when building frames. We can take advantage of the likelihood that the next frame will require the same amount of allocations as the previous frame and reduce the cose of reallocating by recycling vectors from the previous frame. This commit does that for some of the vectors in FrameBuilder and PrimitiveStore which show up high in some profiles.

This commit does not reuse an allocation if it is more than twice the size of the actually used data, so that if a frame allocates an outstanding amount of memory, the peak does not stay allocated forever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1158)
<!-- Reviewable:end -->
