### PR TITLE
Add texture size to VRCompositorHandler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.35.0",
- "webrender_traits 0.35.0",
+ "webrender 0.36.0",
+ "webrender_traits 0.36.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -885,12 +885,12 @@ dependencies = [
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.35.0",
+ "webrender_traits 0.36.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -533,7 +533,10 @@ impl RenderBackend {
         let texture = match cmd {
             VRCompositorCommand::SubmitFrame(..) => {
                     match self.resource_cache.get_webgl_texture(&ctx_id).texture_id {
-                        SourceTexture::WebGL(texture_id) => Some(texture_id),
+                        SourceTexture::WebGL(texture_id) => {
+                            let size = self.resource_cache.get_webgl_texture_size(&ctx_id);
+                            Some((texture_id, size))
+                        },
                         _=> None
                     }
             },

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -554,6 +554,10 @@ impl ResourceCache {
         }
     }
 
+    pub fn get_webgl_texture_size(&self, context_id: &WebGLContextId) -> DeviceIntSize {
+        self.webgl_textures[context_id].size
+    }
+
     pub fn expire_old_resources(&mut self, frame_id: FrameId) {
         self.cached_images.expire_old_resources(&mut self.texture_cache, frame_id);
 

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -580,9 +580,9 @@ pub enum VRCompositorCommand {
 }
 
 // Trait object that handles WebVR commands.
-// Receives the texture_id associated to the WebGLContext.
+// Receives the texture id and size associated to the WebGLContext.
 pub trait VRCompositorHandler: Send {
-    fn handle(&mut self, command: VRCompositorCommand, texture_id: Option<u32>);
+    fn handle(&mut self, command: VRCompositorCommand, texture: Option<(u32, DeviceIntSize)>);
 }
 
 pub trait RenderNotifier: Send {


### PR DESCRIPTION
Add texture size to VRCompositorHandler, required by some VR backends such as Daydream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1161)
<!-- Reviewable:end -->
