### PR TITLE
Split out positioning and clipping per-DisplayItem

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -6,8 +6,8 @@ use frame_builder::FrameBuilder;
 use prim_store::{BorderPrimitiveCpu, BorderPrimitiveGpu, PrimitiveContainer};
 use tiling::PrimitiveFlags;
 use util::pack_as_float;
-use webrender_traits::{BorderSide, BorderStyle, BorderWidths, ColorF, NormalBorder};
-use webrender_traits::{ClipId, ClipRegion, LayerPoint, LayerRect, LayerSize};
+use webrender_traits::{BorderSide, BorderStyle, BorderWidths, ClipAndScrollInfo, ClipRegion};
+use webrender_traits::{ColorF, LayerPoint, LayerRect, LayerSize, NormalBorder};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BorderCornerKind {
@@ -121,7 +121,7 @@ impl FrameBuilder {
                                    rect: &LayerRect,
                                    border: &NormalBorder,
                                    widths: &BorderWidths,
-                                   clip_id: ClipId,
+                                   clip_and_scroll: ClipAndScrollInfo,
                                    clip_region: &ClipRegion,
                                    use_new_border_path: bool) {
         let radius = &border.radius;
@@ -160,7 +160,7 @@ impl FrameBuilder {
             ],
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -175,7 +175,7 @@ impl FrameBuilder {
                              rect: &LayerRect,
                              border: &NormalBorder,
                              widths: &BorderWidths,
-                             clip_id: ClipId,
+                             clip_and_scroll: ClipAndScrollInfo,
                              clip_region: &ClipRegion) {
         // The border shader is quite expensive. For simple borders, we can just draw
         // the border with a few rectangles. This generally gives better batching, and
@@ -204,7 +204,7 @@ impl FrameBuilder {
             self.add_normal_border_primitive(rect,
                                              border,
                                              widths,
-                                             clip_id,
+                                             clip_and_scroll,
                                              clip_region,
                                              false);
             return;
@@ -227,7 +227,7 @@ impl FrameBuilder {
             self.add_normal_border_primitive(rect,
                                              border,
                                              widths,
-                                             clip_id,
+                                             clip_and_scroll,
                                              clip_region,
                                              false);
             return;
@@ -250,15 +250,14 @@ impl FrameBuilder {
 
             // Add a solid rectangle for each visible edge/corner combination.
             if top_edge == BorderEdgeKind::Solid {
-                self.add_solid_rectangle(clip_id,
-                                         &LayerRect::new(p0,
-                                                         LayerSize::new(rect_width, top_len)),
+                self.add_solid_rectangle(clip_and_scroll,
+                                         &LayerRect::new(p0, LayerSize::new(rect_width, top_len)),
                                          clip_region,
                                          &border.top.color,
                                          PrimitiveFlags::None);
             }
             if left_edge == BorderEdgeKind::Solid {
-                self.add_solid_rectangle(clip_id,
+                self.add_solid_rectangle(clip_and_scroll,
                                          &LayerRect::new(LayerPoint::new(p0.x, p0.y + top_len),
                                                          LayerSize::new(left_len,
                                                                         rect_height - top_len - bottom_len)),
@@ -267,7 +266,7 @@ impl FrameBuilder {
                                          PrimitiveFlags::None);
             }
             if right_edge == BorderEdgeKind::Solid {
-                self.add_solid_rectangle(clip_id,
+                self.add_solid_rectangle(clip_and_scroll,
                                          &LayerRect::new(LayerPoint::new(p1.x - right_len,
                                                                          p0.y + top_len),
                                                          LayerSize::new(right_len,
@@ -277,7 +276,7 @@ impl FrameBuilder {
                                          PrimitiveFlags::None);
             }
             if bottom_edge == BorderEdgeKind::Solid {
-                self.add_solid_rectangle(clip_id,
+                self.add_solid_rectangle(clip_and_scroll,
                                          &LayerRect::new(LayerPoint::new(p0.x, p1.y - bottom_len),
                                                          LayerSize::new(rect_width, bottom_len)),
                                          clip_region,
@@ -288,7 +287,7 @@ impl FrameBuilder {
             self.add_normal_border_primitive(rect,
                                              border,
                                              widths,
-                                             clip_id,
+                                             clip_and_scroll,
                                              clip_region,
                                              true);
         }

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -91,7 +91,7 @@ pub struct ClipScrollNode {
     pub local_clip_rect: LayerRect,
 
     /// Viewport rectangle clipped against parent layer(s) viewport rectangles.
-    /// This is in the coordinate system of the parent reference frame.
+    /// This is in the coordinate system which starts at our origin.
     pub combined_local_viewport_rect: LayerRect,
 
     /// World transform for the viewport rect itself. This is the parent
@@ -101,6 +101,11 @@ pub struct ClipScrollNode {
 
     /// World transform for content transformed by this node.
     pub world_content_transform: LayerToWorldTransform,
+
+    /// The scroll offset of all the nodes between us and our parent reference frame.
+    /// This is used to calculate intersections between us and content or nodes that
+    /// are also direct children of our reference frame.
+    pub reference_frame_relative_scroll_offset: LayerPoint,
 
     /// Pipeline that this layer belongs to
     pub pipeline_id: PipelineId,
@@ -133,6 +138,7 @@ impl ClipScrollNode {
             combined_local_viewport_rect: LayerRect::zero(),
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),
+            reference_frame_relative_scroll_offset: LayerPoint::zero(),
             parent: Some(parent_id),
             children: Vec::new(),
             pipeline_id: pipeline_id,
@@ -154,6 +160,7 @@ impl ClipScrollNode {
             combined_local_viewport_rect: LayerRect::zero(),
             world_viewport_transform: LayerToWorldTransform::identity(),
             world_content_transform: LayerToWorldTransform::identity(),
+            reference_frame_relative_scroll_offset: LayerPoint::zero(),
             parent: parent_id,
             children: Vec::new(),
             pipeline_id: pipeline_id,
@@ -224,6 +231,11 @@ impl ClipScrollNode {
                             parent_combined_viewport_rect: &ScrollLayerRect,
                             parent_scroll_offset: LayerPoint,
                             parent_accumulated_scroll_offset: LayerPoint) {
+        self.reference_frame_relative_scroll_offset = match self.node_type {
+            NodeType::ReferenceFrame(_) => LayerPoint::zero(),
+            NodeType::Clip(_) => parent_accumulated_scroll_offset,
+        };
+
         let local_transform = match self.node_type {
             NodeType::ReferenceFrame(transform) => transform,
             NodeType::Clip(_) => LayerToScrollTransform::identity(),

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use tiling::{AuxiliaryListsMap, CompositeOps, PrimitiveFlags};
 use util::{ComplexClipRegionHelpers, subtract_rect};
-use webrender_traits::{AuxiliaryLists, ClipDisplayItem, ClipId, ClipRegion, ColorF};
-use webrender_traits::{DeviceUintRect, DeviceUintSize, DisplayItem, Epoch, FilterOp};
+use webrender_traits::{AuxiliaryLists, ClipAndScrollInfo, ClipDisplayItem, ClipId, ClipRegion};
+use webrender_traits::{ColorF, DeviceUintRect, DeviceUintSize, DisplayItem, Epoch, FilterOp};
 use webrender_traits::{ImageDisplayItem, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
 use webrender_traits::{LayoutRect, LayoutTransform, MixBlendMode, PipelineId, ScrollEventPhase};
 use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, SpecificDisplayItem};
@@ -369,7 +369,7 @@ impl Frame {
                                     traversal: &mut DisplayListTraversal<'a>,
                                     pipeline_id: PipelineId,
                                     context: &mut FlattenContext,
-                                    context_clip_id: ClipId,
+                                    context_scroll_node_id: ClipId,
                                     mut reference_frame_relative_offset: LayerPoint,
                                     level: i32,
                                     bounds: &LayerRect,
@@ -394,10 +394,10 @@ impl Frame {
             return;
         }
 
-        let mut clip_id = context.clip_id_with_replacement(context_clip_id);
+        let mut clip_id = context.clip_id_with_replacement(context_scroll_node_id);
 
         if stacking_context.scroll_policy == ScrollPolicy::Fixed {
-            context.replacements.push((context_clip_id,
+            context.replacements.push((context_scroll_node_id,
                                        context.builder.current_reference_frame_id()));
         }
 
@@ -424,7 +424,7 @@ impl Frame {
                                                            &reference_frame_bounds,
                                                            &transform,
                                                            &mut self.clip_scroll_tree);
-            context.replacements.push((context_clip_id, clip_id));
+            context.replacements.push((context_scroll_node_id, clip_id));
             reference_frame_relative_offset = LayerPoint::zero();
         } else {
             reference_frame_relative_offset = LayerPoint::new(
@@ -447,7 +447,7 @@ impl Frame {
                     // Note: we don't use the original clip region here,
                     // it's already processed by the node we just pushed.
                     let background_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
-                    context.builder.add_solid_rectangle(clip_id,
+                    context.builder.add_solid_rectangle(ClipAndScrollInfo::simple(clip_id),
                                                         bounds,
                                                         &ClipRegion::simple(&background_rect),
                                                         &bg_color,
@@ -465,7 +465,7 @@ impl Frame {
         if level == 0 && self.frame_builder_config.enable_scrollbars {
             let scrollbar_rect = LayerRect::new(LayerPoint::zero(), LayerSize::new(10.0, 70.0));
             context.builder.add_solid_rectangle(
-                clip_id,
+                ClipAndScrollInfo::simple(clip_id),
                 &scrollbar_rect,
                 &ClipRegion::simple(&scrollbar_rect),
                 &DEFAULT_SCROLLBAR_COLOR,
@@ -554,10 +554,13 @@ impl Frame {
                          reference_frame_relative_offset: LayerPoint,
                          level: i32) {
         while let Some(item) = traversal.next() {
-            let clip_id = context.clip_id_with_replacement(item.clip_id);
+            let mut clip_and_scroll = item.clip_and_scroll;
+            clip_and_scroll.scroll_node_id =
+                context.clip_id_with_replacement(clip_and_scroll.scroll_node_id);
+
             match item.item {
                 SpecificDisplayItem::WebGL(ref info) => {
-                    context.builder.add_webgl_rectangle(clip_id,
+                    context.builder.add_webgl_rectangle(clip_and_scroll,
                                                         item.rect,
                                                         &item.clip,
                                                         info.context_id);
@@ -568,7 +571,7 @@ impl Frame {
                         // The image resource is tiled. We have to generate an image primitive
                         // for each tile.
                         let image_size = DeviceUintSize::new(image.descriptor.width, image.descriptor.height);
-                        self.decompose_image(clip_id,
+                        self.decompose_image(clip_and_scroll,
                                              context,
                                              &item.rect,
                                              &item.clip,
@@ -576,7 +579,7 @@ impl Frame {
                                              image_size,
                                              tile_size as u32);
                     } else {
-                        context.builder.add_image(clip_id,
+                        context.builder.add_image(clip_and_scroll,
                                                   item.rect,
                                                   &item.clip,
                                                   &info.stretch_size,
@@ -588,7 +591,7 @@ impl Frame {
                     }
                 }
                 SpecificDisplayItem::YuvImage(ref info) => {
-                    context.builder.add_yuv_image(clip_id,
+                    context.builder.add_yuv_image(clip_and_scroll,
                                                   item.rect,
                                                   &item.clip,
                                                   info.y_image_key,
@@ -597,7 +600,7 @@ impl Frame {
                                                   info.color_space);
                 }
                 SpecificDisplayItem::Text(ref text_info) => {
-                    context.builder.add_text(clip_id,
+                    context.builder.add_text(clip_and_scroll,
                                              item.rect,
                                              &item.clip,
                                              text_info.font_key,
@@ -617,20 +620,20 @@ impl Frame {
                         subtract_rect(&item.rect, &opaque_rect, &mut results);
                         // The inner rectangle is considered opaque within this layer.
                         // It may still inherit some masking from the clip stack.
-                        context.builder.add_solid_rectangle(clip_id,
+                        context.builder.add_solid_rectangle(clip_and_scroll,
                                                             &opaque_rect,
                                                             &ClipRegion::simple(&item.clip.main),
                                                             &info.color,
                                                             PrimitiveFlags::None);
                         for transparent_rect in &results {
-                            context.builder.add_solid_rectangle(clip_id,
+                            context.builder.add_solid_rectangle(clip_and_scroll,
                                                                 transparent_rect,
                                                                 &item.clip,
                                                                 &info.color,
                                                                 PrimitiveFlags::None);
                         }
                     } else {
-                        context.builder.add_solid_rectangle(clip_id,
+                        context.builder.add_solid_rectangle(clip_and_scroll,
                                                             &item.rect,
                                                             &item.clip,
                                                             &info.color,
@@ -638,7 +641,7 @@ impl Frame {
                     }
                 }
                 SpecificDisplayItem::Gradient(ref info) => {
-                    context.builder.add_gradient(clip_id,
+                    context.builder.add_gradient(clip_and_scroll,
                                                  item.rect,
                                                  &item.clip,
                                                  info.gradient.start_point,
@@ -649,7 +652,7 @@ impl Frame {
                                                  info.tile_spacing);
                 }
                 SpecificDisplayItem::RadialGradient(ref info) => {
-                    context.builder.add_radial_gradient(clip_id,
+                    context.builder.add_radial_gradient(clip_and_scroll,
                                                         item.rect,
                                                         &item.clip,
                                                         info.gradient.start_center,
@@ -663,7 +666,7 @@ impl Frame {
                                                         info.tile_spacing);
                 }
                 SpecificDisplayItem::BoxShadow(ref box_shadow_info) => {
-                    context.builder.add_box_shadow(clip_id,
+                    context.builder.add_box_shadow(clip_and_scroll,
                                                    &box_shadow_info.box_bounds,
                                                    &item.clip,
                                                    &box_shadow_info.offset,
@@ -674,7 +677,7 @@ impl Frame {
                                                    box_shadow_info.clip_mode);
                 }
                 SpecificDisplayItem::Border(ref info) => {
-                    context.builder.add_border(clip_id,
+                    context.builder.add_border(clip_and_scroll,
                                                item.rect,
                                                &item.clip,
                                                info);
@@ -683,7 +686,7 @@ impl Frame {
                     self.flatten_stacking_context(traversal,
                                                   pipeline_id,
                                                   context,
-                                                  item.clip_id,
+                                                  item.clip_and_scroll.scroll_node_id,
                                                   reference_frame_relative_offset,
                                                   level + 1,
                                                   &item.rect,
@@ -691,7 +694,7 @@ impl Frame {
                 }
                 SpecificDisplayItem::Iframe(ref info) => {
                     self.flatten_iframe(info.pipeline_id,
-                                        clip_id,
+                                        clip_and_scroll.scroll_node_id,
                                         &item.rect,
                                         context,
                                         reference_frame_relative_offset);
@@ -700,7 +703,7 @@ impl Frame {
                     let content_rect = &item.rect.translate(&reference_frame_relative_offset);
                     self.flatten_clip(context,
                                       pipeline_id,
-                                      clip_id,
+                                      clip_and_scroll.scroll_node_id,
                                       &info,
                                       &content_rect,
                                       &item.clip);
@@ -722,7 +725,7 @@ impl Frame {
     /// decompose_image and decompose_image_row handle image repetitions while decompose_tiled_image
     /// takes care of the decomposition required by the internal tiling of the image.
     fn decompose_image(&mut self,
-                       clip_id: ClipId,
+                       clip_and_scroll: ClipAndScrollInfo,
                        context: &mut FlattenContext,
                        item_rect: &LayerRect,
                        item_clip: &ClipRegion,
@@ -732,7 +735,7 @@ impl Frame {
         let no_vertical_tiling = image_size.height <= tile_size;
         let no_vertical_spacing = info.tile_spacing.height == 0.0;
         if no_vertical_tiling && no_vertical_spacing {
-            self.decompose_image_row(clip_id,
+            self.decompose_image_row(clip_and_scroll,
                                      context,
                                      item_rect,
                                      item_clip,
@@ -752,7 +755,7 @@ impl Frame {
                 item_rect.size.width,
                 info.stretch_size.height
             ).intersection(item_rect) {
-                self.decompose_image_row(clip_id,
+                self.decompose_image_row(clip_and_scroll,
                                          context,
                                          &row_rect,
                                          item_clip,
@@ -764,7 +767,7 @@ impl Frame {
     }
 
     fn decompose_image_row(&mut self,
-                           clip_id: ClipId,
+                           clip_and_scroll: ClipAndScrollInfo,
                            context: &mut FlattenContext,
                            item_rect: &LayerRect,
                            item_clip: &ClipRegion,
@@ -774,7 +777,7 @@ impl Frame {
         let no_horizontal_tiling = image_size.width <= tile_size;
         let no_horizontal_spacing = info.tile_spacing.width == 0.0;
         if no_horizontal_tiling && no_horizontal_spacing {
-            self.decompose_tiled_image(clip_id,
+            self.decompose_tiled_image(clip_and_scroll,
                                        context,
                                        item_rect,
                                        item_clip,
@@ -794,7 +797,7 @@ impl Frame {
                 info.stretch_size.width,
                 item_rect.size.height,
             ).intersection(item_rect) {
-                self.decompose_tiled_image(clip_id,
+                self.decompose_tiled_image(clip_and_scroll,
                                            context,
                                            &decomposed_rect,
                                            item_clip,
@@ -806,7 +809,7 @@ impl Frame {
     }
 
     fn decompose_tiled_image(&mut self,
-                             clip_id: ClipId,
+                             clip_and_scroll: ClipAndScrollInfo,
                              context: &mut FlattenContext,
                              item_rect: &LayerRect,
                              item_clip: &ClipRegion,
@@ -885,7 +888,7 @@ impl Frame {
 
         for ty in 0..num_tiles_y {
             for tx in 0..num_tiles_x {
-                self.add_tile_primitive(clip_id,
+                self.add_tile_primitive(clip_and_scroll,
                                         context,
                                         item_rect,
                                         item_clip,
@@ -897,7 +900,7 @@ impl Frame {
             }
             if leftover.width != 0 {
                 // Tiles on the right edge that are smaller than the tile size.
-                self.add_tile_primitive(clip_id,
+                self.add_tile_primitive(clip_and_scroll,
                                         context,
                                         item_rect,
                                         item_clip,
@@ -913,7 +916,7 @@ impl Frame {
         if leftover.height != 0 {
             for tx in 0..num_tiles_x {
                 // Tiles on the bottom edge that are smaller than the tile size.
-                self.add_tile_primitive(clip_id,
+                self.add_tile_primitive(clip_and_scroll,
                                         context,
                                         item_rect,
                                         item_clip,
@@ -928,7 +931,7 @@ impl Frame {
 
             if leftover.width != 0 {
                 // Finally, the bottom-right tile with a "leftover" size.
-                self.add_tile_primitive(clip_id,
+                self.add_tile_primitive(clip_and_scroll,
                                         context,
                                         item_rect,
                                         item_clip,
@@ -944,7 +947,7 @@ impl Frame {
     }
 
     fn add_tile_primitive(&mut self,
-                          clip_id: ClipId,
+                          clip_and_scroll: ClipAndScrollInfo,
                           context: &mut FlattenContext,
                           item_rect: &LayerRect,
                           item_clip: &ClipRegion,
@@ -989,7 +992,7 @@ impl Frame {
 
         // Fix up the primitive's rect if it overflows the original item rect.
         if let Some(prim_rect) = prim_rect.intersection(item_rect) {
-            context.builder.add_image(clip_id,
+            context.builder.add_image(clip_and_scroll,
                                       prim_rect,
                                       item_clip,
                                       &stretched_size,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -26,12 +26,12 @@ use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, Ren
 use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
 use util::{self, pack_as_float, subtract_rect, recycle_vec};
 use util::RectHelpers;
-use webrender_traits::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipId, ClipRegion};
-use webrender_traits::{ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect};
-use webrender_traits::{DeviceUintSize, ExtendMode, FontKey, FontRenderMode, GlyphOptions};
-use webrender_traits::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
-use webrender_traits::{LayerToScrollTransform, PipelineId, RepeatMode, TileOffset, TransformStyle};
-use webrender_traits::{WebGLContextId, YuvColorSpace};
+use webrender_traits::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipAndScrollInfo};
+use webrender_traits::{ClipId, ClipRegion, ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
+use webrender_traits::{DeviceUintRect, DeviceUintSize, ExtendMode, FontKey, FontRenderMode};
+use webrender_traits::{GlyphOptions, ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect};
+use webrender_traits::{LayerSize, LayerToScrollTransform, PipelineId, RepeatMode, TileOffset};
+use webrender_traits::{TransformStyle, WebGLContextId, YuvColorSpace};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -162,19 +162,28 @@ impl FrameBuilder {
         }
     }
 
+    pub fn create_clip_scroll_group_if_necessary(&mut self,
+                                                 stacking_context_index: StackingContextIndex,
+                                                 info: ClipAndScrollInfo) {
+        if self.stacking_context_store[stacking_context_index.0].has_clip_scroll_group(info) {
+            return;
+        }
+
+        let group_index = self.create_clip_scroll_group(stacking_context_index, info);
+        let stacking_context = &mut self.stacking_context_store[stacking_context_index.0];
+        stacking_context.clip_scroll_groups.push(group_index);
+    }
+
     pub fn add_primitive(&mut self,
-                         clip_id: ClipId,
+                         clip_and_scroll: ClipAndScrollInfo,
                          rect: &LayerRect,
                          clip_region: &ClipRegion,
                          extra_clips: &[ClipSource],
                          container: PrimitiveContainer)
                          -> PrimitiveIndex {
         let stacking_context_index = *self.stacking_context_stack.last().unwrap();
-        if !self.stacking_context_store[stacking_context_index.0] .has_clip_scroll_group(clip_id) {
-            let group_index = self.create_clip_scroll_group(stacking_context_index, clip_id);
-            let stacking_context = &mut self.stacking_context_store[stacking_context_index.0];
-            stacking_context.clip_scroll_groups.push(group_index);
-        }
+
+        self.create_clip_scroll_group_if_necessary(stacking_context_index, clip_and_scroll);
 
         let geometry = PrimitiveGeometry {
             local_rect: *rect,
@@ -196,8 +205,8 @@ impl FrameBuilder {
                                                        container);
 
         match self.cmds.last_mut().unwrap() {
-            &mut PrimitiveRunCmd::PrimitiveRun(_run_prim_index, ref mut count, run_layer_id)
-                if run_layer_id == clip_id => {
+            &mut PrimitiveRunCmd::PrimitiveRun(_run_prim_index, ref mut count, run_clip_and_scroll)
+                if run_clip_and_scroll == clip_and_scroll => {
                     debug_assert!(_run_prim_index.0 + *count == prim_index.0);
                     *count += 1;
                     return prim_index;
@@ -207,25 +216,26 @@ impl FrameBuilder {
             &mut PrimitiveRunCmd::PopStackingContext => {}
         }
 
-        self.cmds.push(PrimitiveRunCmd::PrimitiveRun(prim_index, 1, clip_id));
+        self.cmds.push(PrimitiveRunCmd::PrimitiveRun(prim_index, 1, clip_and_scroll));
         prim_index
     }
 
     pub fn create_clip_scroll_group(&mut self,
                                     stacking_context_index: StackingContextIndex,
-                                    clip_id: ClipId)
+                                    info: ClipAndScrollInfo)
                                     -> ClipScrollGroupIndex {
         let packed_layer_index = PackedLayerIndex(self.packed_layers.len());
         self.packed_layers.push(PackedLayer::empty());
 
         self.clip_scroll_group_store.push(ClipScrollGroup {
             stacking_context_index: stacking_context_index,
-            clip_id: clip_id,
+            scroll_node_id: info.scroll_node_id,
+            clip_node_id: info.clip_node_id(),
             packed_layer_index: packed_layer_index,
             screen_bounding_rect: None,
          });
 
-        ClipScrollGroupIndex(self.clip_scroll_group_store.len() - 1, clip_id)
+        ClipScrollGroupIndex(self.clip_scroll_group_store.len() - 1, info)
     }
 
     pub fn push_stacking_context(&mut self,
@@ -355,7 +365,7 @@ impl FrameBuilder {
     }
 
     pub fn add_solid_rectangle(&mut self,
-                               clip_id: ClipId,
+                               clip_and_scroll: ClipAndScrollInfo,
                                rect: &LayerRect,
                                clip_region: &ClipRegion,
                                color: &ColorF,
@@ -368,7 +378,7 @@ impl FrameBuilder {
             color: *color,
         };
 
-        let prim_index = self.add_primitive(clip_id,
+        let prim_index = self.add_primitive(clip_and_scroll,
                                             rect,
                                             clip_region,
                                             &[],
@@ -387,7 +397,7 @@ impl FrameBuilder {
     }
 
     pub fn add_border(&mut self,
-                      clip_id: ClipId,
+                      clip_and_scroll: ClipAndScrollInfo,
                       rect: LayerRect,
                       clip_region: &ClipRegion,
                       border_item: &BorderDisplayItem) {
@@ -523,7 +533,7 @@ impl FrameBuilder {
                 }
 
                 for segment in segments {
-                    self.add_image(clip_id,
+                    self.add_image(clip_and_scroll,
                                    segment.geom_rect,
                                    clip_region,
                                    &segment.stretch_size,
@@ -538,14 +548,14 @@ impl FrameBuilder {
                 self.add_normal_border(&rect,
                                        border,
                                        &border_item.widths,
-                                       clip_id,
+                                       clip_and_scroll,
                                        clip_region);
             }
             BorderDetails::Gradient(ref border) => {
                 for segment in create_segments(border.outset) {
                     let segment_rel = segment.origin - rect.origin;
 
-                    self.add_gradient(clip_id,
+                    self.add_gradient(clip_and_scroll,
                                       segment,
                                       clip_region,
                                       border.gradient.start_point - segment_rel,
@@ -560,7 +570,7 @@ impl FrameBuilder {
                 for segment in create_segments(border.outset) {
                     let segment_rel = segment.origin - rect.origin;
 
-                    self.add_radial_gradient(clip_id,
+                    self.add_radial_gradient(clip_and_scroll,
                                              segment,
                                              clip_region,
                                              border.gradient.start_center - segment_rel,
@@ -578,7 +588,7 @@ impl FrameBuilder {
     }
 
     pub fn add_gradient(&mut self,
-                        clip_id: ClipId,
+                        clip_and_scroll: ClipAndScrollInfo,
                         rect: LayerRect,
                         clip_region: &ClipRegion,
                         start_point: LayerPoint,
@@ -643,15 +653,11 @@ impl FrameBuilder {
             PrimitiveContainer::AngleGradient(gradient_cpu, gradient_gpu)
         };
 
-        self.add_primitive(clip_id,
-                           &rect,
-                           clip_region,
-                           &[],
-                           prim);
+        self.add_primitive(clip_and_scroll, &rect, clip_region, &[], prim);
     }
 
     pub fn add_radial_gradient(&mut self,
-                               clip_id: ClipId,
+                               clip_and_scroll: ClipAndScrollInfo,
                                rect: LayerRect,
                                clip_region: &ClipRegion,
                                start_center: LayerPoint,
@@ -681,7 +687,7 @@ impl FrameBuilder {
             padding: [0.0, 0.0, 0.0, 0.0],
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -689,7 +695,7 @@ impl FrameBuilder {
     }
 
     pub fn add_text(&mut self,
-                    clip_id: ClipId,
+                    clip_and_scroll: ClipAndScrollInfo,
                     rect: LayerRect,
                     clip_region: &ClipRegion,
                     font_key: FontKey,
@@ -734,7 +740,7 @@ impl FrameBuilder {
             color: *color,
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -742,7 +748,7 @@ impl FrameBuilder {
     }
 
     pub fn fill_box_shadow_rect(&mut self,
-                                clip_id: ClipId,
+                                clip_and_scroll: ClipAndScrollInfo,
                                 box_bounds: &LayerRect,
                                 bs_rect: LayerRect,
                                 clip_region: &ClipRegion,
@@ -771,7 +777,7 @@ impl FrameBuilder {
             color: *color,
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect_to_draw,
                            clip_region,
                            &extra_clips,
@@ -779,7 +785,7 @@ impl FrameBuilder {
     }
 
     pub fn add_box_shadow(&mut self,
-                          clip_id: ClipId,
+                          clip_and_scroll: ClipAndScrollInfo,
                           box_bounds: &LayerRect,
                           clip_region: &ClipRegion,
                           box_offset: &LayerPoint,
@@ -809,7 +815,7 @@ impl FrameBuilder {
         // Just draw a rectangle
         if (blur_radius == 0.0 && spread_radius == 0.0 && clip_mode == BoxShadowClipMode::None)
            || bs_rect_empty {
-            self.add_solid_rectangle(clip_id,
+            self.add_solid_rectangle(clip_and_scroll,
                                      box_bounds,
                                      clip_region,
                                      color,
@@ -818,7 +824,7 @@ impl FrameBuilder {
         }
 
         if blur_radius == 0.0 && spread_radius == 0.0 && border_radius != 0.0 {
-            self.fill_box_shadow_rect(clip_id,
+            self.fill_box_shadow_rect(clip_and_scroll,
                                       box_bounds,
                                       bs_rect,
                                       clip_region,
@@ -892,7 +898,7 @@ impl FrameBuilder {
         match shadow_kind {
             BoxShadowKind::Simple(rects) => {
                 for rect in &rects {
-                    self.add_solid_rectangle(clip_id,
+                    self.add_solid_rectangle(clip_and_scroll,
                                              rect,
                                              clip_region,
                                              color,
@@ -901,7 +907,7 @@ impl FrameBuilder {
             }
             BoxShadowKind::Shadow(rects) => {
                 if clip_mode == BoxShadowClipMode::Inset {
-                    self.fill_box_shadow_rect(clip_id,
+                    self.fill_box_shadow_rect(clip_and_scroll,
                                               box_bounds,
                                               bs_rect,
                                               clip_region,
@@ -939,7 +945,7 @@ impl FrameBuilder {
                     inverted: inverted,
                 };
 
-                self.add_primitive(clip_id,
+                self.add_primitive(clip_and_scroll,
                                    &outer_rect,
                                    clip_region,
                                    extra_clips.as_slice(),
@@ -949,7 +955,7 @@ impl FrameBuilder {
     }
 
     pub fn add_webgl_rectangle(&mut self,
-                               clip_id: ClipId,
+                               clip_and_scroll: ClipAndScrollInfo,
                                rect: LayerRect,
                                clip_region: &ClipRegion,
                                context_id: WebGLContextId) {
@@ -965,7 +971,7 @@ impl FrameBuilder {
             tile_spacing: LayerSize::zero(),
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -973,7 +979,7 @@ impl FrameBuilder {
     }
 
     pub fn add_image(&mut self,
-                     clip_id: ClipId,
+                     clip_and_scroll: ClipAndScrollInfo,
                      rect: LayerRect,
                      clip_region: &ClipRegion,
                      stretch_size: &LayerSize,
@@ -997,7 +1003,7 @@ impl FrameBuilder {
             tile_spacing: *tile_spacing,
         };
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -1005,7 +1011,7 @@ impl FrameBuilder {
     }
 
     pub fn add_yuv_image(&mut self,
-                         clip_id: ClipId,
+                         clip_and_scroll: ClipAndScrollInfo,
                          rect: LayerRect,
                          clip_region: &ClipRegion,
                          y_image_key: ImageKey,
@@ -1021,7 +1027,7 @@ impl FrameBuilder {
 
         let prim_gpu = YuvImagePrimitiveGpu::new(rect.size, color_space);
 
-        self.add_primitive(clip_id,
+        self.add_primitive(clip_and_scroll,
                            &rect,
                            clip_region,
                            &[],
@@ -1189,7 +1195,7 @@ impl FrameBuilder {
                         current_task = prev_task;
                     }
                 }
-                PrimitiveRunCmd::PrimitiveRun(first_prim_index, prim_count, clip_id) => {
+                PrimitiveRunCmd::PrimitiveRun(first_prim_index, prim_count, clip_and_scroll) => {
                     let stacking_context_index = *sc_stack.last().unwrap();
                     let stacking_context = &self.stacking_context_store[stacking_context_index.0];
 
@@ -1199,7 +1205,7 @@ impl FrameBuilder {
 
                     let stacking_context_index = *sc_stack.last().unwrap();
                     let group_index = self.stacking_context_store[stacking_context_index.0]
-                                          .clip_scroll_group(clip_id);
+                                          .clip_scroll_group(clip_and_scroll);
                     if self.clip_scroll_group_store[group_index.0].screen_bounding_rect.is_none() {
                         continue
                     }
@@ -1391,8 +1397,8 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             match *cmd {
                 PrimitiveRunCmd::PushStackingContext(stacking_context_index) =>
                     self.handle_push_stacking_context(stacking_context_index),
-                PrimitiveRunCmd::PrimitiveRun(prim_index, prim_count, clip_id) =>
-                    self.handle_primitive_run(prim_index, prim_count, clip_id),
+                PrimitiveRunCmd::PrimitiveRun(prim_index, prim_count, clip_and_scroll) =>
+                    self.handle_primitive_run(prim_index, prim_count, clip_and_scroll),
                 PrimitiveRunCmd::PopStackingContext => self.handle_pop_stacking_context(),
             }
         }
@@ -1458,15 +1464,16 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             let stacking_context = &mut self.frame_builder
                                             .stacking_context_store[stacking_context_index.0];
 
-            let node = &self.clip_scroll_tree.nodes[&group.clip_id];
+            let scroll_node = &self.clip_scroll_tree.nodes[&group.scroll_node_id];
+            let clip_node = &self.clip_scroll_tree.nodes[&group.clip_node_id];
             let packed_layer = &mut self.frame_builder.packed_layers[group.packed_layer_index.0];
 
             // The world content transform is relative to the containing reference frame,
             // so we translate into the origin of the stacking context itself.
-            let transform = node.world_content_transform
-                                .pre_translated(stacking_context.reference_frame_offset.x,
-                                                stacking_context.reference_frame_offset.y,
-                                                0.0);
+            let transform = scroll_node.world_content_transform
+                                       .pre_translated(stacking_context.reference_frame_offset.x,
+                                                       stacking_context.reference_frame_offset.y,
+                                                       0.0);
             packed_layer.set_transform(transform);
 
             if !stacking_context.can_contribute_to_scene() {
@@ -1476,9 +1483,11 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             // Here we move the viewport rectangle into the coordinate system
             // of the stacking context content.
             let viewport_rect =
-                &node.combined_local_viewport_rect
+                &clip_node.combined_local_viewport_rect
+                     .translate(&clip_node.reference_frame_relative_scroll_offset)
+                     .translate(&-scroll_node.reference_frame_relative_scroll_offset)
                      .translate(&-stacking_context.reference_frame_offset)
-                     .translate(&-node.scrolling.offset);
+                     .translate(&-scroll_node.scrolling.offset);
             group.screen_bounding_rect = packed_layer.set_rect(viewport_rect,
                                                                self.screen_rect,
                                                                self.device_pixel_ratio);
@@ -1574,7 +1583,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
     fn handle_primitive_run(&mut self,
                             prim_index: PrimitiveIndex,
                             prim_count: usize,
-                            clip_id: ClipId) {
+                            clip_and_scroll: ClipAndScrollInfo) {
         let stacking_context_index = *self.stacking_context_stack.last().unwrap();
         let (packed_layer_index, pipeline_id) = {
             let stacking_context =
@@ -1584,13 +1593,14 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 return;
             }
 
-            let group_index = stacking_context.clip_scroll_group(clip_id);
+            let group_index = stacking_context.clip_scroll_group(clip_and_scroll);
             let clip_scroll_group = &self.frame_builder.clip_scroll_group_store[group_index.0];
             (clip_scroll_group.packed_layer_index, stacking_context.pipeline_id)
         };
 
-        let node_clip_bounds = self.rebuild_clip_info_stack_if_necessary(clip_id);
-        if node_clip_bounds.map_or(false, |bounds| bounds.is_empty()) {
+        let clip_bounds =
+            self.rebuild_clip_info_stack_if_necessary(clip_and_scroll.clip_node_id());
+        if clip_bounds.map_or(false, |bounds| bounds.is_empty()) {
             return;
         }
 
@@ -1599,7 +1609,6 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         let packed_layer = &self.frame_builder.packed_layers[packed_layer_index.0];
         let auxiliary_lists = self.auxiliary_lists_map.get(&pipeline_id)
                                                       .expect("No auxiliary lists?");
-
         for i in 0..prim_count {
             let prim_index = PrimitiveIndex(prim_index.0 + i);
             if self.frame_builder.prim_store.build_bounding_rect(prim_index,
@@ -1644,10 +1653,11 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                     // stacking context. This means that two primitives which are only clipped
                     // by the stacking context stack can share clip masks during render task
                     // assignment to targets.
-                    let node_clip_bounds = node_clip_bounds.unwrap_or_else(DeviceIntRect::zero);
+                    let clip_bounds = clip_bounds.unwrap_or_else(DeviceIntRect::zero);
                     let (mask_key, mask_rect) = match prim_clip_info {
                         Some(..) => (MaskCacheKey::Primitive(prim_index), prim_bounding_rect),
-                        None => (MaskCacheKey::ClipNode(clip_id), node_clip_bounds)
+                        None => (MaskCacheKey::ClipNode(clip_and_scroll.clip_node_id()),
+                                                        clip_bounds)
                     };
                     let mask_opt =
                         RenderTask::new_mask(mask_rect, mask_key, &self.current_clip_stack);

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -9,12 +9,38 @@ use {ColorF, FontKey, ImageKey, PipelineId, WebGLContextId};
 use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
 use {PropertyBinding};
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ClipAndScrollInfo {
+    pub scroll_node_id: ClipId,
+    pub clip_node_id: Option<ClipId>,
+}
+
+impl ClipAndScrollInfo {
+    pub fn simple(node_id: ClipId) -> ClipAndScrollInfo {
+        ClipAndScrollInfo {
+            scroll_node_id: node_id,
+            clip_node_id: None,
+        }
+    }
+
+    pub fn new(scroll_node_id: ClipId, clip_node_id: ClipId) -> ClipAndScrollInfo {
+        ClipAndScrollInfo {
+            scroll_node_id: scroll_node_id,
+            clip_node_id: Some(clip_node_id),
+        }
+    }
+
+    pub fn clip_node_id(&self) -> ClipId {
+        self.clip_node_id.unwrap_or(self.scroll_node_id)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: LayoutRect,
     pub clip: ClipRegion,
-    pub clip_id: ClipId,
+    pub clip_and_scroll: ClipAndScrollInfo,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -7,13 +7,14 @@ use std::mem;
 use std::slice;
 use time::precise_time_ns;
 use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShadowDisplayItem};
-use {ClipDisplayItem, ClipId, ClipRegion, ColorF, ComplexClipRegion, DisplayItem, ExtendMode};
-use {FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem, GradientStop};
-use {IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering, ItemRange};
-use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, MixBlendMode, PipelineId};
-use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
-use {RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem, StackingContext, TextDisplayItem};
-use {TransformStyle, WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvImageDisplayItem};
+use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ClipRegion, ColorF, ComplexClipRegion};
+use {DisplayItem, ExtendMode, FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient};
+use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
+use {ImageRendering, ItemRange, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
+use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
+use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem};
+use {StackingContext, TextDisplayItem, TransformStyle, WebGLContextId, WebGLDisplayItem};
+use {YuvColorSpace, YuvImageDisplayItem};
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AuxiliaryLists {
@@ -106,7 +107,7 @@ pub struct DisplayListBuilder {
     pub list: Vec<DisplayItem>,
     auxiliary_lists_builder: AuxiliaryListsBuilder,
     pub pipeline_id: PipelineId,
-    clip_stack: Vec<ClipId>,
+    clip_stack: Vec<ClipAndScrollInfo>,
     next_clip_id: u64,
     builder_start_time: u64,
 }
@@ -118,7 +119,7 @@ impl DisplayListBuilder {
             list: Vec::new(),
             auxiliary_lists_builder: AuxiliaryListsBuilder::new(),
             pipeline_id: pipeline_id,
-            clip_stack: vec![ClipId::root_scroll_node(pipeline_id)],
+            clip_stack: vec![ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id))],
 
             // We start at 1 here, because the root scroll id is always 0.
             next_clip_id: 1,
@@ -137,7 +138,7 @@ impl DisplayListBuilder {
             item: item,
             rect: rect,
             clip: clip,
-            clip_id: *self.clip_stack.last().unwrap(),
+            clip_and_scroll: *self.clip_stack.last().unwrap(),
         });
     }
 
@@ -146,7 +147,7 @@ impl DisplayListBuilder {
             item: item,
             rect: LayoutRect::zero(),
             clip: ClipRegion::simple(&LayoutRect::zero()),
-            clip_id: *self.clip_stack.last().unwrap(),
+            clip_and_scroll: *self.clip_stack.last().unwrap(),
         });
     }
 
@@ -473,7 +474,7 @@ impl DisplayListBuilder {
 
         let item = SpecificDisplayItem::Clip(ClipDisplayItem {
             id: id,
-            parent_id: *self.clip_stack.last().unwrap(),
+            parent_id: self.clip_stack.last().unwrap().scroll_node_id,
         });
 
         self.push_item(item, content_rect, clip);
@@ -485,11 +486,15 @@ impl DisplayListBuilder {
                           content_rect: LayoutRect,
                           id: Option<ClipId>) {
         let id = self.define_clip(content_rect, clip, id);
-        self.clip_stack.push(id);
+        self.clip_stack.push(ClipAndScrollInfo::simple(id));
     }
 
     pub fn push_clip_id(&mut self, id: ClipId) {
-        self.clip_stack.push(id);
+        self.clip_stack.push(ClipAndScrollInfo::simple(id));
+    }
+
+    pub fn push_clip_and_scroll_info(&mut self, info: ClipAndScrollInfo) {
+        self.clip_stack.push(info);
     }
 
     pub fn pop_clip_id(&mut self) {
@@ -535,8 +540,10 @@ impl DisplayListBuilder {
                 }
                 _ => {}
             }
-            i.clip.complex = self.auxiliary_lists_builder.add_complex_clip_regions(aux.complex_clip_regions(&i.clip.complex));
-            i.clip_id = *self.clip_stack.last().unwrap();
+            i.clip.complex =
+                self.auxiliary_lists_builder
+                    .add_complex_clip_regions(aux.complex_clip_regions(&i.clip.complex));
+            i.clip_and_scroll = *self.clip_stack.last().unwrap();
             self.list.push(i);
         }
     }

--- a/wrench/reftests/scrolling/fixed-position-scrolling-clip-ref.yaml
+++ b/wrench/reftests/scrolling/fixed-position-scrolling-clip-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 50, 50]
+      color: green

--- a/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
+++ b/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
@@ -1,0 +1,29 @@
+root:
+  items:
+    - type: scroll-layer
+      bounds: [10, 10, 100, 700]
+      clip: [0, 0, 100, 300]
+      id: 41
+      scroll-offset: [0, 50]
+      items:
+      # The rectangles below should stay in place even when the parent scroll area scrolls,
+      # because they are in a fixed position stacking context. On the other hand, the clip
+      # item here will scroll with its parent scroll area. Normally fixed position items
+      # would only be clipped by their reference frame (in this case the root), but since
+      # these items specify an auxiliary clip, they will be clipped by their sibling clip (42).
+      - type: clip
+        bounds: [10, 60, 50, 50]
+        clip: [0, 0, 50, 50]
+        id: 42
+      - type: stacking-context
+        bounds: [10, 10, 100, 100]
+        scroll-policy: fixed
+        items:
+          - type: rect
+            bounds: [0, 0, 100, 50]
+            color: green
+            clip-and-scroll: [41, 42]
+          - type: rect
+            bounds: [0, 50, 100, 50]
+            color: red
+            clip-and-scroll: [41, 42]

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -1,7 +1,8 @@
-== simple.yaml simple-ref.yaml
-== root-scroll.yaml root-scroll-ref.yaml
-== fixed-position.yaml fixed-position-ref.yaml
-== scroll-layer.yaml scroll-layer-ref.yaml
-== scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
 == empty-mask.yaml empty-mask-ref.yaml
+== fixed-position.yaml fixed-position-ref.yaml
+== fixed-position-scrolling-clip.yaml fixed-position-scrolling-clip-ref.yaml
 == nested-scroll-offset.yaml nested-scroll-offset-ref.yaml
+== root-scroll.yaml root-scroll-ref.yaml
+== scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
+== scroll-layer.yaml scroll-layer-ref.yaml
+== simple.yaml simple-ref.yaml

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -574,10 +574,10 @@ impl YamlFrameReader {
                 continue;
             }
 
-            let yaml_clip_id = item["clip-id"].as_i64();
-            if let Some(yaml_id) = yaml_clip_id {
-                let id = ClipId::new(yaml_id as u64, self.builder().pipeline_id);
-                self.builder().push_clip_id(id);
+            let clip_scroll_info =
+                item["clip-and-scroll"].as_clip_and_scroll_info(self.builder().pipeline_id);
+            if let Some(clip_scroll_info) = clip_scroll_info {
+                self.builder().push_clip_and_scroll_info(clip_scroll_info);
             }
 
             match item_type {
@@ -595,7 +595,7 @@ impl YamlFrameReader {
                 _ => println!("Skipping unknown item type: {:?}", item),
             }
 
-            if yaml_clip_id.is_some() {
+            if clip_scroll_info.is_some() {
                 self.builder().pop_clip_id();
             }
         }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -486,7 +486,18 @@ impl YamlFrameWriter {
             let mut v = new_table();
             rect_node(&mut v, "bounds", &base.rect);
             yaml_node(&mut v, "clip", self.make_clip_node(&base.clip, aux));
-            usize_node(&mut v, "clip-id", clip_id_mapper.map(&base.clip_id));
+
+            let scroll_id =
+                Yaml::Integer(clip_id_mapper.map(&base.clip_and_scroll.scroll_node_id) as i64);
+            let clip_and_scroll = match base.clip_and_scroll.clip_node_id {
+                Some(clip_id) => {
+                    let clip_id = Yaml::Integer(clip_id_mapper.map(&clip_id) as i64);
+                    Yaml::Array(vec![scroll_id, clip_id])
+                }
+                None => scroll_id,
+            };
+
+            yaml_node(&mut v, "clip-and-scroll", clip_and_scroll);
 
             match base.item {
                 Rectangle(item) => {

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -25,6 +25,7 @@ pub trait YamlHelper {
     fn as_pt_to_au(&self) -> Option<Au>;
     fn as_vec_string(&self) -> Option<Vec<String>>;
     fn as_border_radius_component(&self) -> LayoutSize;
+    fn as_clip_and_scroll_info(&self, pipeline_id: PipelineId) -> Option<ClipAndScrollInfo>;
     fn as_border_radius(&self) -> Option<BorderRadius>;
     fn as_transform_style(&self) -> Option<TransformStyle>;
     fn as_mix_blend_mode(&self) -> Option<MixBlendMode>;
@@ -324,6 +325,24 @@ impl YamlHelper for Yaml {
             return LayoutSize::new(integer as f32, integer as f32);
         }
         self.as_size().unwrap_or(TypedSize2D::zero())
+    }
+
+    fn as_clip_and_scroll_info(&self, pipeline_id: PipelineId) -> Option<ClipAndScrollInfo> {
+        match *self {
+            Yaml::Integer(value) =>
+                Some(ClipAndScrollInfo::simple(ClipId::new(value as u64, pipeline_id))),
+            Yaml::Array(ref array) if array.len() == 2 => {
+                let id_ints = (array[0].as_i64(), array[1].as_i64());
+                if let (Some(scroll_node_id), Some(clip_node_id)) = id_ints {
+                    Some(ClipAndScrollInfo::new(ClipId::new(scroll_node_id as u64, pipeline_id),
+                                                ClipId::new(clip_node_id as u64, pipeline_id)))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+
     }
 
     fn as_border_radius(&self) -> Option<BorderRadius> {


### PR DESCRIPTION
This allows items to be positioned by one scrolling clipped, but
clipped by another. This is necessary to add support for CSS clip,
which allows clip to move with a scroll, but also clip a fixed position
element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1165)
<!-- Reviewable:end -->
