### PR TITLE
Update clipping documentation

### DIFF
--- a/webrender/doc/CLIPPING.md
+++ b/webrender/doc/CLIPPING.md
@@ -82,6 +82,10 @@ let generated_id = define_clip(content_rect, clip, id);
 assert!(id == generated_id);
 ```
 
+Note that calling `define_clip` multiple times with the same `clip_id` value
+results in undefined behaviour, and should be avoided. There is a debug mode
+assertion to catch this.
+
 ## Pending changes
 1. Normalize the way that clipping coordinates are defined. Having them
    specified in two different ways makes for a confusing API. This should be


### PR DESCRIPTION
When I updated the commit in #1151 I forgot to include the CLIPPING.md changes. I still think they're worth keeping though, so here they are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1166)
<!-- Reviewable:end -->
