### PR TITLE
Revert "Use debug assertions to check WebGL errors"

### DIFF
--- a/webrender_traits/src/webgl.rs
+++ b/webrender_traits/src/webgl.rs
@@ -612,10 +612,9 @@ impl WebGLCommand {
                 ctx.gl().generate_mipmap(target),
         }
 
-        if cfg!(debug_assertions) {
-            let error = ctx.gl().get_error();
-            assert!(error == gl::NO_ERROR, "Unexpected WebGL error: 0x{:x} ({})", error, error);
-        }
+        // FIXME: Use debug_assertions once tests are run with them
+        let error = ctx.gl().get_error();
+        assert!(error == gl::NO_ERROR, "Unexpected WebGL error: 0x{:x} ({})", error, error);
     }
 
     fn read_pixels(gl: &gl::Gl, x: i32, y: i32, width: i32, height: i32, format: u32, pixel_type: u32,


### PR DESCRIPTION
This reverts commit 57c5cd430e2360ef4e3fc4473be25bc313979d35.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1167)
<!-- Reviewable:end -->
