### PR TITLE
Only send scroll state for clips that actually scroll

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -399,6 +399,14 @@ impl ClipScrollNode {
         }
         ray_intersects_rect(p0, p1, self.local_viewport_rect.to_untyped())
     }
+
+    pub fn scroll_offset(&self) -> Option<LayerPoint> {
+        match self.node_type {
+            NodeType::Clip(_) if self.scrollable_width() > 0. || self.scrollable_height() > 0. =>
+                Some(self.scrolling.offset),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -109,10 +109,9 @@ impl ClipScrollTree {
     pub fn get_scroll_node_state(&self) -> Vec<ScrollLayerState> {
         let mut result = vec![];
         for (id, node) in self.nodes.iter() {
-            match node.node_type {
-                NodeType::Clip(_) => result.push(
-                    ScrollLayerState { id: *id, scroll_offset: node.scrolling.offset }),
-                _ => {},
+            match node.scroll_offset() {
+                Some(offset) => result.push(ScrollLayerState { id: *id, scroll_offset: offset }),
+                None => {}
             }
         }
         result


### PR DESCRIPTION
This should reduce the amount of traffic across the API boundary as
well as prevent clients from having to track which nodes actually scroll
and which don't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1168)
<!-- Reviewable:end -->
