### PR TITLE
Handle RadialGradients with zero sized radius

### DIFF
--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -334,6 +334,33 @@ impl DisplayListBuilder {
                                   radius: LayoutSize,
                                   mut stops: Vec<GradientStop>,
                                   extend_mode: ExtendMode) -> RadialGradient {
+        if radius.width <= 0.0 || radius.height <= 0.0 {
+            // The shader cannot handle a non positive radius. So
+            // reuse the stops vector and construct an equivalent
+            // gradient.
+            let last_color = stops.last().unwrap().color;
+
+            stops.clear();
+            stops.push(GradientStop {
+                offset: 0.0,
+                color: last_color,
+            });
+            stops.push(GradientStop {
+                offset: 1.0,
+                color: last_color,
+            });
+
+            return RadialGradient {
+                start_center: center,
+                start_radius: 0.0,
+                end_center: center,
+                end_radius: 1.0,
+                ratio_xy: 1.0,
+                stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
+                extend_mode: extend_mode,
+            };
+        }
+
         let (start_offset,
              end_offset) = DisplayListBuilder::normalize_stops(&mut stops, extend_mode);
 

--- a/wrench/reftests/gradient/radial-zero-size-1.yaml
+++ b/wrench/reftests/gradient/radial-zero-size-1.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 100 0
+      stops: [0.0, blue, 1.0, red]

--- a/wrench/reftests/gradient/radial-zero-size-2.yaml
+++ b/wrench/reftests/gradient/radial-zero-size-2.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 0 100
+      stops: [0.0, blue, 1.0, red]

--- a/wrench/reftests/gradient/radial-zero-size-3.yaml
+++ b/wrench/reftests/gradient/radial-zero-size-3.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: 50 50 200 200
+      color: red

--- a/wrench/reftests/gradient/radial-zero-size-ref.yaml
+++ b/wrench/reftests/gradient/radial-zero-size-ref.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - type: radial-gradient
+      bounds: 50 50 200 200
+      center: 100 100
+      radius: 100 100
+      stops: [0.0, red, 1.0, red]

--- a/wrench/reftests/gradient/reftest.list
+++ b/wrench/reftests/gradient/reftest.list
@@ -43,3 +43,7 @@ fuzzy(1,16) == tiling-radial-1.yaml tiling-radial-1-ref.yaml
 fuzzy(1,1) == tiling-radial-2.yaml tiling-radial-2-ref.yaml
 == tiling-radial-3.yaml tiling-radial-3-ref.yaml
 fuzzy(1,16) == tiling-radial-4.yaml tiling-radial-4-ref.yaml
+
+== radial-zero-size-1.yaml radial-zero-size-ref.yaml
+== radial-zero-size-2.yaml radial-zero-size-ref.yaml
+== radial-zero-size-3.yaml radial-zero-size-ref.yaml


### PR DESCRIPTION
A RadialGradient with radius of zero should only display the final color
stop value.

Currently, a radius of zero will cause ratio_xy to be NaN, Inf, or -Inf and
the output will be blank. Forcing the radius to zero and ratio_xy to one
won't work because ps_radial_gradient can't handle a zero sized radius. So
instead we can construct an equivalent gradient with only the last color stop.

Alternatively this could be caught on the backend and the RadialGradient
could be converted to a color rect, but that would disable dithering.
This is a simple enough fix and makes reftests consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1171)
<!-- Reviewable:end -->
