### PR TITLE
Add a feature for dithering

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -820,6 +820,7 @@ float do_clip() {
         all(inside) ? textureLod(sCacheA8, vClipMaskUv, 0.0).r : 0.0;
 }
 
+#ifdef WR_FEATURE_DITHERING
 vec4 dither(vec4 color) {
     const int matrix_mask = 7;
 
@@ -829,4 +830,10 @@ vec4 dither(vec4 color) {
 
     return color + vec4(noise, noise, noise, 0);
 }
+#else
+vec4 dither(vec4 color) {
+    return color;
+}
+#endif
+
 #endif //WR_FRAGMENT_SHADER

--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -66,7 +66,9 @@ uniform sampler2D sColor1;
 uniform sampler2D sColor2;
 #endif
 
+#ifdef WR_FEATURE_DITHERING
 uniform sampler2D sDither;
+#endif
 
 //======================================================================================
 // Interpolator definitions

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -568,7 +568,7 @@ pub struct Renderer {
     /// when no target is yet provided as a cache texture input.
     dummy_cache_texture_id: TextureId,
 
-    dither_matrix_texture_id: TextureId,
+    dither_matrix_texture_id: Option<TextureId>,
 
     /// Optional trait object that allows the client
     /// application to provide external buffers for image data.
@@ -806,24 +806,38 @@ impl Renderer {
                                  options.precache_shaders)
         };
 
+        let dithering_feature = ["DITHERING"];
+
         let ps_gradient = try!{
             PrimitiveShader::new("ps_gradient",
                                  &mut device,
-                                 &[],
+                                 if options.enable_dithering {
+                                    &dithering_feature
+                                 } else {
+                                    &[]
+                                 },
                                  options.precache_shaders)
         };
 
         let ps_angle_gradient = try!{
             PrimitiveShader::new("ps_angle_gradient",
                                  &mut device,
-                                 &[],
+                                 if options.enable_dithering {
+                                    &dithering_feature
+                                 } else {
+                                    &[]
+                                 },
                                  options.precache_shaders)
         };
 
         let ps_radial_gradient = try!{
             PrimitiveShader::new("ps_radial_gradient",
                                  &mut device,
-                                 &[],
+                                 if options.enable_dithering {
+                                    &dithering_feature
+                                 } else {
+                                    &[]
+                                 },
                                  options.precache_shaders)
         };
 
@@ -875,17 +889,6 @@ impl Renderer {
             0xff, 0xff,
         ];
 
-        let dither_matrix: [u8; 64] = [
-            00, 48, 12, 60, 03, 51, 15, 63,
-            32, 16, 44, 28, 35, 19, 47, 31,
-            08, 56, 04, 52, 11, 59, 07, 55,
-            40, 24, 36, 20, 43, 27, 39, 23,
-            02, 50, 14, 62, 01, 49, 13, 61,
-            34, 18, 46, 30, 33, 17, 45, 29,
-            10, 58, 06, 54, 09, 57, 05, 53,
-            42, 26, 38, 22, 41, 25, 37, 21
-        ];
-
         // TODO: Ensure that the white texture can never get evicted when the cache supports LRU eviction!
         let white_image_id = texture_cache.new_item_id();
         texture_cache.insert(white_image_id,
@@ -910,14 +913,31 @@ impl Renderer {
                             RenderTargetMode::LayerRenderTarget(1),
                             None);
 
-        let dither_matrix_texture_id = device.create_texture_ids(1, TextureTarget::Default)[0];
-        device.init_texture(dither_matrix_texture_id,
-                            8,
-                            8,
-                            ImageFormat::A8,
-                            TextureFilter::Nearest,
-                            RenderTargetMode::None,
-                            Some(&dither_matrix));
+        let dither_matrix_texture_id = if options.enable_dithering {
+            let dither_matrix: [u8; 64] = [
+                00, 48, 12, 60, 03, 51, 15, 63,
+                32, 16, 44, 28, 35, 19, 47, 31,
+                08, 56, 04, 52, 11, 59, 07, 55,
+                40, 24, 36, 20, 43, 27, 39, 23,
+                02, 50, 14, 62, 01, 49, 13, 61,
+                34, 18, 46, 30, 33, 17, 45, 29,
+                10, 58, 06, 54, 09, 57, 05, 53,
+                42, 26, 38, 22, 41, 25, 37, 21
+            ];
+
+            let id = device.create_texture_ids(1, TextureTarget::Default)[0];
+            device.init_texture(id,
+                                8,
+                                8,
+                                ImageFormat::A8,
+                                TextureFilter::Nearest,
+                                RenderTargetMode::None,
+                                Some(&dither_matrix));
+
+            Some(id)
+        } else {
+            None
+        };
 
         let debug_renderer = DebugRenderer::new(&mut device);
 
@@ -1413,7 +1433,9 @@ impl Renderer {
         }
 
         // TODO: this probably isn't the best place for this.
-        self.device.bind_texture(TextureSampler::Dither, self.dither_matrix_texture_id);
+        if let Some(id) = self.dither_matrix_texture_id {
+            self.device.bind_texture(TextureSampler::Dither, id);
+        }
 
         self.device.update_vao_instances(vao, data, VertexUsageHint::Stream);
         self.device.draw_indexed_triangles_instanced_u16(6, data.len() as i32);
@@ -2088,6 +2110,7 @@ pub struct RendererOptions {
     pub device_pixel_ratio: f32,
     pub resource_override_path: Option<PathBuf>,
     pub enable_aa: bool,
+    pub enable_dithering: bool,
     pub enable_profiler: bool,
     pub max_recorded_profiles: usize,
     pub debug: bool,
@@ -2110,6 +2133,7 @@ impl Default for RendererOptions {
             device_pixel_ratio: 1.0,
             resource_override_path: None,
             enable_aa: true,
+            enable_dithering: true,
             enable_profiler: false,
             max_recorded_profiles: 0,
             debug: false,


### PR DESCRIPTION
In order to help pass all the reftests for enabling gradients by default in
Gecko, it would be nice to be able to disable dithering. Canvas2D gradients
and border gradients in Gecko don't use dithering, and that causes some
issues. Enabling dithering can be investigated as a follow up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1172)
<!-- Reviewable:end -->
