### PR TITLE
Blob image renderer tiling and partial updates

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -49,4 +49,7 @@ core-text = "4.0"
 name = "basic"
 
 [[example]]
+name = "blob"
+
+[[example]]
 name = "scrolling"

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -17,11 +17,10 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use std::sync::Arc;
 use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer, BlobImageRequest};
 use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
-use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageStore, ImageRendering};
+use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageStore, ImageRendering, ImageKey, TileSize};
 use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle, BoxShadowClipMode};
 
 #[derive(Debug)]
@@ -478,12 +477,17 @@ impl FakeBlobImageRenderer {
 }
 
 impl BlobImageRenderer for FakeBlobImageRenderer {
-    fn request_blob_image(&mut self,
-                          key: BlobImageRequest,
-                          _: Arc<BlobImageData>,
-                          descriptor: &BlobImageDescriptor,
-                          _dirty_rect: Option<DeviceUintRect>,
-                          _images: &ImageStore) {
+    fn add(&mut self, _: ImageKey, _: BlobImageData, _: Option<TileSize>) {}
+
+    fn update(&mut self, _: ImageKey, _: BlobImageData) {}
+
+    fn delete(&mut self, _: ImageKey) {}
+
+    fn request(&mut self,
+               key: BlobImageRequest,
+               descriptor: &BlobImageDescriptor,
+               _dirty_rect: Option<DeviceUintRect>,
+               _images: &ImageStore) {
         let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
         for y in 0..descriptor.height {
             for x in 0..descriptor.width {
@@ -519,7 +523,7 @@ impl BlobImageRenderer for FakeBlobImageRenderer {
         }));
     }
 
-    fn resolve_blob_image(&mut self, key: BlobImageRequest) -> BlobImageResult {
+    fn resolve(&mut self, key: BlobImageRequest) -> BlobImageResult {
         self.images.remove(&key).unwrap_or(Err(BlobImageError::InvalidKey))
     }
 }

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -18,11 +18,11 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
-use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer};
+use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer, BlobImageRequest};
 use webrender_traits::{BlobImageResult, ClipRegion, ColorF, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
-use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageKey, ImageRendering};
-use webrender_traits::{PipelineId, RasterizedBlobImage, ImageStore, TransformStyle, BoxShadowClipMode};
+use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageStore, ImageRendering};
+use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle, BoxShadowClipMode};
 
 #[derive(Debug)]
 enum Gesture {
@@ -468,7 +468,7 @@ fn main() {
 }
 
 struct FakeBlobImageRenderer {
-    images: HashMap<ImageKey, BlobImageResult>,
+    images: HashMap<BlobImageRequest, BlobImageResult>,
 }
 
 impl FakeBlobImageRenderer {
@@ -479,7 +479,7 @@ impl FakeBlobImageRenderer {
 
 impl BlobImageRenderer for FakeBlobImageRenderer {
     fn request_blob_image(&mut self,
-                          key: ImageKey,
+                          key: BlobImageRequest,
                           _: Arc<BlobImageData>,
                           descriptor: &BlobImageDescriptor,
                           _dirty_rect: Option<DeviceUintRect>,
@@ -519,7 +519,7 @@ impl BlobImageRenderer for FakeBlobImageRenderer {
         }));
     }
 
-    fn resolve_blob_image(&mut self, key: ImageKey) -> BlobImageResult {
+    fn resolve_blob_image(&mut self, key: BlobImageRequest) -> BlobImageResult {
         self.images.remove(&key).unwrap_or(Err(BlobImageError::InvalidKey))
     }
 }

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -1,0 +1,287 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate app_units;
+extern crate euclid;
+extern crate gleam;
+extern crate glutin;
+extern crate webrender;
+extern crate webrender_traits;
+
+use gleam::gl;
+use std::collections::HashMap;
+use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer, BlobImageRequest};
+use webrender_traits::{BlobImageResult, ImageStore, ClipRegion, ColorF, ColorU, Epoch};
+use webrender_traits::{DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
+use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageRendering, ImageKey, TileSize};
+use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle};
+
+// This example shows how to implement a very basic BlobImageRenderer that can only render
+// a checkerboard pattern.
+
+// The deserialized command list internally used by this example is just a color.
+type ImageRenderingCommands = ColorU;
+
+// Serialize/deserialze the blob.
+// Ror real usecases you should probably use serde rather than doing it by hand.
+
+fn serialize_blob(color: ColorU) -> Vec<u8> {
+    vec![color.r, color.g, color.b, color.a]
+}
+
+fn deserialize_blob(blob: &[u8]) -> Result<ImageRenderingCommands, ()> {
+    let mut iter = blob.iter();
+    return match (iter.next(), iter.next(), iter.next(), iter.next()) {
+        (Some(&r), Some(&g), Some(&b), Some(&a)) => Ok(ColorU::new(r, g, b, a)),
+        (Some(&a), None, None, None) => Ok(ColorU::new(a, a, a, a)),
+        _ => Err(()),
+    }
+}
+
+struct CheckerboardRenderer {
+    // The deserialized drawing commands.
+    image_cmds: HashMap<ImageKey, ImageRenderingCommands>,
+
+    // The images rendered in the current frame (not kept here between frames)
+    rendered_images: HashMap<BlobImageRequest, BlobImageResult>,
+}
+
+impl CheckerboardRenderer {
+    fn new() -> Self {
+        CheckerboardRenderer {
+            image_cmds: HashMap::new(),
+            rendered_images: HashMap::new(),
+        }
+    }
+}
+
+impl BlobImageRenderer for CheckerboardRenderer {
+    fn add(&mut self, key: ImageKey, cmds: BlobImageData, _: Option<TileSize>) {
+        self.image_cmds.insert(key, deserialize_blob(&cmds[..]).unwrap());
+    }
+
+    fn update(&mut self, key: ImageKey, cmds: BlobImageData) {
+        // Here, updating is just replacing the current version of the commands with
+        // the new one (no incremental updates)
+        self.image_cmds.insert(key, deserialize_blob(&cmds[..]).unwrap());
+    }
+
+    fn delete(&mut self, key: ImageKey) {
+        self.image_cmds.remove(&key);
+    }
+
+    fn request(&mut self,
+               request: BlobImageRequest,
+               descriptor: &BlobImageDescriptor,
+               _dirty_rect: Option<DeviceUintRect>,
+               _images: &ImageStore) {
+        let color = self.image_cmds.get(&request.key).unwrap().clone();
+
+        // Allocate storage for the result. Right now the resource cache expects the
+        // tiles to have have no stride or offset.
+        let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
+
+        // Generate a per-tile pattern to see it in the demo. For a real use case it would not
+        // make sense for the rendered content to depend on its tile.
+        let tile_checker = match request.tile {
+            Some(tile) => (tile.x % 2 == 0) != (tile.y % 2 == 0),
+            None => true,
+        };
+
+        for y in 0..descriptor.height {
+            for x in 0..descriptor.width {
+                // Apply the tile's offset. This is important: all drawing commands should be
+                // translated by this offset to give correct results with tiled blob images.
+                let x2 = x + descriptor.offset.x as u32;
+                let y2 = y + descriptor.offset.y as u32;
+
+                // Render a simple checkerboard pattern
+                let checker = if (x2 % 20 >= 10) != (y2 % 20 >= 10) { 1 } else { 0 };
+                // ..nested in the per-tile cherkerboard pattern
+                let tc = if tile_checker { 0 } else { (1 - checker) * 40 };
+
+                match descriptor.format {
+                    ImageFormat::RGBA8 => {
+                        texels.push(color.b * checker + tc);
+                        texels.push(color.g * checker + tc);
+                        texels.push(color.r * checker + tc);
+                        texels.push(color.a * checker + tc);
+                    }
+                    ImageFormat::A8 => {
+                        texels.push(color.a * checker + tc);
+                    }
+                    _ => {
+                        self.rendered_images.insert(request,
+                            Err(BlobImageError::Other(format!(
+                                "Usupported image format {:?}",
+                                descriptor.format
+                            )))
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+
+        self.rendered_images.insert(request, Ok(RasterizedBlobImage {
+            data: texels,
+            width: descriptor.width,
+            height: descriptor.height,
+        }));
+    }
+
+    fn resolve(&mut self, request: BlobImageRequest) -> BlobImageResult {
+        self.rendered_images.remove(&request).unwrap_or(Err(BlobImageError::InvalidKey))
+    }
+}
+
+fn main() {
+    let window = glutin::WindowBuilder::new()
+                .with_title("WebRender Sample (BlobImageRenderer)")
+                .with_multitouch()
+                .with_gl(glutin::GlRequest::GlThenGles {
+                    opengl_version: (3, 2),
+                    opengles_version: (3, 0)
+                })
+                .build()
+                .unwrap();
+
+    unsafe {
+        window.make_current().ok();
+    }
+
+    let gl = match gl::GlType::default() {
+        gl::GlType::Gl => unsafe { gl::GlFns::load_with(|symbol| window.get_proc_address(symbol) as *const _) },
+        gl::GlType::Gles => unsafe { gl::GlesFns::load_with(|symbol| window.get_proc_address(symbol) as *const _) },
+    };
+
+    println!("OpenGL version {}", gl.get_string(gl::VERSION));
+
+    let (width, height) = window.get_inner_size_pixels().unwrap();
+
+    let opts = webrender::RendererOptions {
+        debug: true,
+        blob_image_renderer: Some(Box::new(CheckerboardRenderer::new())),
+        device_pixel_ratio: window.hidpi_factor(),
+        .. Default::default()
+    };
+
+    let size = DeviceUintSize::new(width, height);
+    let (mut renderer, sender) = webrender::renderer::Renderer::new(gl, opts, size).unwrap();
+    let api = sender.create_api();
+
+    let notifier = Box::new(Notifier::new(window.create_window_proxy()));
+    renderer.set_render_notifier(notifier);
+
+    let epoch = Epoch(0);
+    let root_background_color = ColorF::new(0.2, 0.2, 0.2, 1.0);
+
+    let blob_img1 = api.generate_image_key();
+    api.add_image(
+        blob_img1,
+        ImageDescriptor::new(500, 500, ImageFormat::RGBA8, true),
+        ImageData::new_blob_image(serialize_blob(ColorU::new(50, 50, 150, 255))),
+        Some(128),
+    );
+
+    let blob_img2 = api.generate_image_key();
+    api.add_image(
+        blob_img2,
+        ImageDescriptor::new(200, 200, ImageFormat::RGBA8, true),
+        ImageData::new_blob_image(serialize_blob(ColorU::new(50, 150, 50, 255))),
+        None,
+    );
+
+    let pipeline_id = PipelineId(0, 0);
+    let mut builder = webrender_traits::DisplayListBuilder::new(pipeline_id);
+
+    let bounds = LayoutRect::new(LayoutPoint::zero(), LayoutSize::new(width as f32, height as f32));
+    builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
+                                  bounds,
+                                  None,
+                                  TransformStyle::Flat,
+                                  None,
+                                  webrender_traits::MixBlendMode::Normal,
+                                  Vec::new());
+    builder.push_image(
+        LayoutRect::new(LayoutPoint::new(30.0, 30.0), LayoutSize::new(500.0, 500.0)),
+        ClipRegion::simple(&bounds),
+        LayoutSize::new(500.0, 500.0),
+        LayoutSize::new(0.0, 0.0),
+        ImageRendering::Auto,
+        blob_img1,
+    );
+
+    builder.push_image(
+        LayoutRect::new(LayoutPoint::new(600.0, 60.0), LayoutSize::new(200.0, 200.0)),
+        ClipRegion::simple(&bounds),
+        LayoutSize::new(200.0, 200.0),
+        LayoutSize::new(0.0, 0.0),
+        ImageRendering::Auto,
+        blob_img2,
+    );
+
+    builder.pop_stacking_context();
+
+    api.set_display_list(
+        Some(root_background_color),
+        epoch,
+        LayoutSize::new(width as f32, height as f32),
+        builder.finalize(),
+        true);
+    api.set_root_pipeline(pipeline_id);
+    api.generate_frame(None);
+
+    'outer: for event in window.wait_events() {
+        let mut events = Vec::new();
+        events.push(event);
+
+        for event in window.poll_events() {
+            events.push(event);
+        }
+
+        for event in events {
+            match event {
+                glutin::Event::Closed |
+                glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) |
+                glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Q)) => break 'outer,
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
+                                             _, Some(glutin::VirtualKeyCode::P)) => {
+                    let enable_profiler = !renderer.get_profiler_enabled();
+                    renderer.set_profiler_enabled(enable_profiler);
+                    api.generate_frame(None);
+                }
+                _ => ()
+            }
+        }
+
+        renderer.update();
+        renderer.render(DeviceUintSize::new(width, height));
+        window.swap_buffers().ok();
+    }
+}
+
+struct Notifier {
+    window_proxy: glutin::WindowProxy,
+}
+
+impl Notifier {
+    fn new(window_proxy: glutin::WindowProxy) -> Notifier {
+        Notifier {
+            window_proxy: window_proxy,
+        }
+    }
+}
+
+impl webrender_traits::RenderNotifier for Notifier {
+    fn new_frame_ready(&mut self) {
+        #[cfg(not(target_os = "android"))]
+        self.window_proxy.wakeup_event_loop();
+    }
+
+    fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {
+        #[cfg(not(target_os = "android"))]
+        self.window_proxy.wakeup_event_loop();
+    }
+}

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -404,7 +404,7 @@ impl ResourceCache {
 
         match value {
             Some(image) => {
-                if let ImageData::Blob(_) = image.data {
+                if image.data.is_blob() {
                     self.blob_image_renderer.as_mut().unwrap().delete(image_key);
                 }
             }
@@ -442,7 +442,7 @@ impl ResourceCache {
         };
 
         let template = self.image_templates.get(key).unwrap();
-        if let ImageData::Blob(_) = template.data {
+        if template.data.is_blob() {
             if let Some(ref mut renderer) = self.blob_image_renderer {
                 let same_epoch = match self.cached_images.resources.get(&request) {
                     Some(entry) => entry.epoch == template.epoch,
@@ -450,21 +450,27 @@ impl ResourceCache {
                 };
 
                 if !same_epoch && self.blob_image_requests.insert(request) {
-                    let offset = match request.tile {
-                        Some(tile_offset) => {
-                            let tile_size = template.tiling.unwrap() as f32;
-                            DevicePoint::new(
-                                tile_offset.x as f32 * tile_size,
-                                tile_offset.y as f32 * tile_size,
-                            )
+                    let (offset, w, h) = match template.tiling {
+                        Some(tile_size) => {
+                            let tile_offset = request.tile.unwrap();
+                            let (w, h) = compute_tile_size(&template.descriptor, tile_size, tile_offset);
+                            let offset = DevicePoint::new(
+                                tile_offset.x as f32 * tile_size as f32,
+                                tile_offset.y as f32 * tile_size as f32,
+                            );
+
+                            (offset, w, h)
                         }
-                        None => { DevicePoint::zero() }
+                        None => {
+                            (DevicePoint::zero(), template.descriptor.width, template.descriptor.height)
+                        }
                     };
+
                     renderer.request(
                         request.into(),
                         &BlobImageDescriptor {
-                            width: template.descriptor.width,
-                            height: template.descriptor.height,
+                            width: w,
+                            height: h,
                             offset: offset,
                             format: template.descriptor.format,
                         },
@@ -747,32 +753,30 @@ impl ResourceCache {
         });
 
         let descriptor = if let Some(tile) = request.tile {
-            let tile_size = image_template.tiling.unwrap() as u32;
+            let tile_size = image_template.tiling.unwrap();
             let image_descriptor = &image_template.descriptor;
-            let stride = image_descriptor.compute_stride();
-            let bpp = image_descriptor.format.bytes_per_pixel().unwrap();
 
-            // Storage for the tiles on the right and bottom edges is shrunk to
-            // fit the image data (See decompose_tiled_image in frame.rs).
-            let actual_width = if (tile.x as u32) < image_descriptor.width / tile_size {
-                tile_size
+            let (actual_width, actual_height) = compute_tile_size(image_descriptor, tile_size, tile);
+
+            // The tiled image could be stored on the CPU as one large image or be
+            // already broken up into tiles. This affects the way we compute the stride
+            // and offset.
+            let tiled_on_cpu = image_template.data.is_blob();
+
+            let (stride, offset) = if tiled_on_cpu {
+                (image_descriptor.stride, 0)
             } else {
-                image_descriptor.width % tile_size
+                let bpp = image_descriptor.format.bytes_per_pixel().unwrap();
+                let stride = image_descriptor.compute_stride();
+                let offset = image_descriptor.offset + tile.y as u32 * tile_size as u32 * stride
+                                                     + tile.x as u32 * tile_size as u32 * bpp;
+                (Some(stride), offset)
             };
-
-            let actual_height = if (tile.y as u32) < image_descriptor.height / tile_size {
-                tile_size
-            } else {
-                image_descriptor.height % tile_size
-            };
-
-            let offset = image_descriptor.offset + tile.y as u32 * tile_size * stride
-                                                 + tile.x as u32 * tile_size * bpp;
 
             ImageDescriptor {
                 width: actual_width,
                 height: actual_height,
-                stride: Some(stride),
+                stride: stride,
                 offset: offset,
                 format: image_descriptor.format,
                 is_opaque: image_descriptor.is_opaque,
@@ -1044,4 +1048,27 @@ fn spawn_glyph_cache_thread(workers: Arc<Mutex<ThreadPool>>) -> (Sender<GlyphCac
     }).unwrap();
 
     (msg_tx, result_rx)
+}
+
+// Compute the width and height of a tile depending on its position in the image.
+pub fn compute_tile_size(descriptor: &ImageDescriptor,
+                         base_size: TileSize,
+                         tile: TileOffset) -> (u32, u32) {
+    let base_size = base_size as u32;
+    // Most tiles are going to have base_size as width and height,
+    // except for tiles around the edges that are shrunk to fit the mage data
+    // (See decompose_tiled_image in frame.rs).
+    let actual_width = if (tile.x as u32) < descriptor.width / base_size {
+        base_size
+    } else {
+        descriptor.width % base_size
+    };
+
+    let actual_height = if (tile.y as u32) < descriptor.height / base_size {
+        base_size
+    } else {
+        descriptor.height % base_size
+    };
+
+    (actual_width, actual_height)
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -25,7 +25,7 @@ use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRen
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, DeviceUintRect, ImageDescriptor, ColorF};
 use webrender_traits::{GlyphOptions, GlyphInstance, TileOffset, TileSize};
-use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, ImageStore};
+use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest, ImageStore};
 use webrender_traits::{ExternalImageData, ExternalImageType, LayoutPoint};
 use threadpool::ThreadPool;
 
@@ -215,11 +215,21 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 struct ImageRequest {
     key: ImageKey,
     rendering: ImageRendering,
     tile: Option<TileOffset>,
+}
+
+impl Into<BlobImageRequest> for ImageRequest {
+    fn into(self) -> BlobImageRequest {
+        BlobImageRequest {
+            key: self.key,
+            tile: self.tile,
+        }
+    }
 }
 
 struct GlyphRasterJob {
@@ -418,15 +428,24 @@ impl ResourceCache {
                 };
 
                 if !same_epoch && self.blob_image_requests.insert(request) {
+                    let offset = match request.tile {
+                        Some(tile_offset) => {
+                            let tile_size = template.tiling.unwrap() as f32;
+                            DevicePoint::new(
+                                tile_offset.x as f32 * tile_size,
+                                tile_offset.y as f32 * tile_size,
+                            )
+                        }
+                        None => { DevicePoint::zero() }
+                    };
                     renderer.request_blob_image(
-                        key,
+                        request.into(),
                         Arc::clone(data),
                         &BlobImageDescriptor {
                             width: template.descriptor.width,
                             height: template.descriptor.height,
+                            offset: offset,
                             format: template.descriptor.format,
-                            // TODO(nical): figure out the scale factor (should change with zoom).
-                            scale_factor: 1.0,
                         },
                         template.dirty_rect,
                         &self.image_templates,
@@ -671,7 +690,7 @@ impl ResourceCache {
         if self.blob_image_renderer.is_some() {
             for request in blob_image_requests.drain() {
                 match self.blob_image_renderer.as_mut().unwrap()
-                                                .resolve_blob_image(request.key) {
+                                              .resolve_blob_image(request.into()) {
                     Ok(image) => {
                         self.finalize_image_request(request,
                                                     Some(ImageData::new(image.data)),
@@ -742,7 +761,7 @@ impl ResourceCache {
             image_template.descriptor.clone()
         };
 
-        match self.cached_images.entry(request.clone(), self.current_frame_id) {
+        match self.cached_images.entry(*request, self.current_frame_id) {
             Occupied(entry) => {
                 let image_id = entry.get().texture_cache_id;
 

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::sync::Arc;
-use DeviceUintRect;
-use TileOffset;
-use DevicePoint;
+use {DeviceUintRect, DevicePoint};
+use {TileOffset, TileSize};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -93,7 +92,7 @@ impl ImageDescriptor {
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ImageData {
     Raw(Arc<Vec<u8>>),
-    Blob(Arc<BlobImageData>),
+    Blob(BlobImageData),
     External(ExternalImageData),
 }
 
@@ -107,22 +106,24 @@ impl ImageData {
     }
 
     pub fn new_blob_image(commands: Vec<u8>) -> ImageData {
-        ImageData::Blob(Arc::new(commands))
-    }
-
-    pub fn new_shared_blob_image(commands: Arc<Vec<u8>>) -> ImageData {
         ImageData::Blob(commands)
     }
 }
 
 pub trait BlobImageRenderer: Send {
-    fn request_blob_image(&mut self,
-                          key: BlobImageRequest,
-                          data: Arc<BlobImageData>,
-                          descriptor: &BlobImageDescriptor,
-                          dirty_rect: Option<DeviceUintRect>,
-                          images: &ImageStore);
-    fn resolve_blob_image(&mut self, key: BlobImageRequest) -> BlobImageResult;
+    fn add(&mut self, key: ImageKey, data: BlobImageData, tiling: Option<TileSize>);
+
+    fn update(&mut self, key: ImageKey, data: BlobImageData);
+
+    fn delete(&mut self, key: ImageKey);
+
+    fn request(&mut self,
+               key: BlobImageRequest,
+               descriptor: &BlobImageDescriptor,
+               dirty_rect: Option<DeviceUintRect>,
+               images: &ImageStore);
+
+    fn resolve(&mut self, key: BlobImageRequest) -> BlobImageResult;
 }
 
 pub type BlobImageData = Vec<u8>;

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -4,6 +4,8 @@
 
 use std::sync::Arc;
 use DeviceUintRect;
+use TileOffset;
+use DevicePoint;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -115,12 +117,12 @@ impl ImageData {
 
 pub trait BlobImageRenderer: Send {
     fn request_blob_image(&mut self,
-                          key: ImageKey,
+                          key: BlobImageRequest,
                           data: Arc<BlobImageData>,
                           descriptor: &BlobImageDescriptor,
                           dirty_rect: Option<DeviceUintRect>,
                           images: &ImageStore);
-    fn resolve_blob_image(&mut self, key: ImageKey) -> BlobImageResult;
+    fn resolve_blob_image(&mut self, key: BlobImageRequest) -> BlobImageResult;
 }
 
 pub type BlobImageData = Vec<u8>;
@@ -132,8 +134,8 @@ pub type BlobImageResult = Result<RasterizedBlobImage, BlobImageError>;
 pub struct BlobImageDescriptor {
     pub width: u32,
     pub height: u32,
+    pub offset: DevicePoint,
     pub format: ImageFormat,
-    pub scale_factor: f32,
 }
 
 pub struct RasterizedBlobImage {
@@ -148,6 +150,12 @@ pub enum BlobImageError {
     InvalidKey,
     InvalidData,
     Other(String),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BlobImageRequest {
+    pub key: ImageKey,
+    pub tile: Option<TileOffset>,
 }
 
 pub trait ImageStore {

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -108,6 +108,14 @@ impl ImageData {
     pub fn new_blob_image(commands: Vec<u8>) -> ImageData {
         ImageData::Blob(commands)
     }
+
+    #[inline]
+    pub fn is_blob(&self) -> bool {
+        match self {
+            &ImageData::Blob(_) => true,
+            _ => false,
+        }
+    }
 }
 
 pub trait BlobImageRenderer: Send {


### PR DESCRIPTION
I changed the BlobImageRenderer API so that it can handle tiled images: the request key now take the tile offset into account in addition to the image key, and an offset in image space is passed in the BlobImageDescriptor.

In the gecko integration we want to be able to send partial updates of the blob, which means that the BlobImageRenderer has to be responsible for managing and storing the blobs since the resource_cache does not know how to apply the updates.

The blob renderer example was moved to its own file and improved a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1173)
<!-- Reviewable:end -->
