### PR TITLE
make JSON frame writer use proper payload API

### DIFF
--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -19,6 +19,7 @@ use super::CURRENT_FRAME_NUMBER;
 use time;
 use webrender;
 use webrender_traits::*;
+use webrender_traits::channel::Payload;
 
 enum CachedFont {
     Native(NativeFontHandle),
@@ -94,17 +95,12 @@ impl JsonFrameWriter {
                                      frame: u32,
                                      data: &[u8])
     {
+        let payload = Payload::from_data(data);
         let dl_desc = self.dl_descriptor.take().unwrap();
         let aux_desc = self.aux_descriptor.take().unwrap();
 
-        assert_eq!(data.len(), dl_desc.size() + aux_desc.size() + 4);
-
-        // there's a 4 byte epoch header that we skip
-        let dl_data = data[4..dl_desc.size() + 4].to_vec();
-        let aux_data = data[dl_desc.size() + 4..].to_vec();
-
-        let dl = BuiltDisplayList::from_data(dl_data, dl_desc);
-        let aux = AuxiliaryLists::from_data(aux_data, aux_desc);
+        let dl = BuiltDisplayList::from_data(payload.display_list_data, dl_desc);
+        let aux = AuxiliaryLists::from_data(payload.auxiliary_lists_data, aux_desc);
 
         let mut frame_file_name = self.frame_base.clone();
         let current_shown_frame = unsafe { CURRENT_FRAME_NUMBER };


### PR DESCRIPTION
It's been broken for a while because the format changed; this should prevent that from ever happening again (without causing compiler errors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1174)
<!-- Reviewable:end -->
