### PR TITLE
Add #[repr(u32)] for YuvColorSpace enum.

### DIFF
--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -336,7 +336,6 @@ pub struct IframeDisplayItem {
     pub pipeline_id: PipelineId,
 }
 
-
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageDisplayItem {
     pub image_key: ImageKey,
@@ -359,6 +358,7 @@ pub struct YuvImageDisplayItem {
     pub color_space: YuvColorSpace,
 }
 
+#[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum YuvColorSpace {
     Rec601 = 0,


### PR DESCRIPTION
r? @glennw @kvark 
The cbindgen needs this to generate the proper c binding enum code.
If I don't have the u32 type, I only see the forward declaration in the generated header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1176)
<!-- Reviewable:end -->
