### PR TITLE
Combined clip rect workaround

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -259,6 +259,11 @@ impl ClipScrollNode {
             NodeType::ReferenceFrame(_) => parent_combined_viewport_in_local_space,
         };
 
+        // HACK: prevent the code above for non-AA transforms, it's incorrect.
+        if (local_transform.m13, local_transform.m23) != (0.0, 0.0) {
+            self.combined_local_viewport_rect = self.local_clip_rect;
+        }
+
         // The transformation for this viewport in world coordinates is the transformation for
         // our parent reference frame, plus any accumulated scrolling offsets from nodes
         // between our reference frame and this node. For reference frames, we also include


### PR DESCRIPTION
There is a problem with `combined_local_viewport_rect` that makes it too tight for transformed layers. This PR attempts to work around this, not a proper fix. Having it would make the new reftest of #1169 to pass.

r? @mrobinson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1177)
<!-- Reviewable:end -->
