### PR TITLE
New bincode-based IPC model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ name = "webrender_traits"
 version = "0.36.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/doc/CLIPPING.md
+++ b/webrender/doc/CLIPPING.md
@@ -12,7 +12,7 @@ Clips are defined using the ClipRegion in both cases.
 ```rust
 pub struct ClipRegion {
     pub main: LayoutRect,
-    pub complex: ItemRange,
+    pub complex: ItemRange<ComplexClip>,
     pub image_mask: Option<ImageMask>,
 }
 ```

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -17,10 +17,10 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use webrender_traits::{ColorF, Epoch, GlyphInstance};
+use webrender_traits::{ClipRegionToken, ColorF, DisplayListBuilder, Epoch, GlyphInstance};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat};
-use webrender_traits::{PipelineId, TransformStyle, BoxShadowClipMode};
+use webrender_traits::{PipelineId, RenderApi, TransformStyle, BoxShadowClipMode};
 
 #[derive(Debug)]
 enum Gesture {
@@ -191,6 +191,26 @@ impl webrender_traits::RenderNotifier for Notifier {
     }
 }
 
+fn push_sub_clip(api: &RenderApi, builder: &mut DisplayListBuilder, bounds: &LayoutRect)
+                 -> ClipRegionToken {
+    let mask_image = api.generate_image_key();
+    api.add_image(mask_image,
+                  ImageDescriptor::new(2, 2, ImageFormat::A8, true),
+                  ImageData::new(vec![0, 80, 180, 255]),
+                  None);
+    let mask = webrender_traits::ImageMask {
+        image: mask_image,
+        rect: LayoutRect::new(LayoutPoint::new(75.0, 75.0), LayoutSize::new(100.0, 100.0)),
+        repeat: false,
+    };
+    let complex = webrender_traits::ComplexClipRegion::new(
+        LayoutRect::new(LayoutPoint::new(50.0, 50.0), LayoutSize::new(100.0, 100.0)),
+        webrender_traits::BorderRadius::uniform(20.0));
+
+    builder.push_clip_region(bounds, vec![complex], Some(mask))
+}
+
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let res_path = if args.len() > 1 {
@@ -252,31 +272,15 @@ fn main() {
                                   None,
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
-    let sub_clip = {
-        let mask_image = api.generate_image_key();
-        api.add_image(
-            mask_image,
-            ImageDescriptor::new(2, 2, ImageFormat::A8, true),
-            ImageData::new(vec![0, 80, 180, 255]),
-            None,
-        );
-        let mask = webrender_traits::ImageMask {
-            image: mask_image,
-            rect: LayoutRect::new(LayoutPoint::new(75.0, 75.0), LayoutSize::new(100.0, 100.0)),
-            repeat: false,
-        };
-        let complex = webrender_traits::ComplexClipRegion::new(
-            LayoutRect::new(LayoutPoint::new(50.0, 50.0), LayoutSize::new(100.0, 100.0)),
-            webrender_traits::BorderRadius::uniform(20.0));
 
-        builder.new_clip_region(&bounds, vec![complex], Some(mask))
-    };
-
+    let clip = push_sub_clip(&api, &mut builder, &bounds);
     builder.push_rect(LayoutRect::new(LayoutPoint::new(100.0, 100.0), LayoutSize::new(100.0, 100.0)),
-                      sub_clip,
+                      clip,
                       ColorF::new(0.0, 1.0, 0.0, 1.0));
+
+    let clip = push_sub_clip(&api, &mut builder, &bounds);
     builder.push_rect(LayoutRect::new(LayoutPoint::new(250.0, 100.0), LayoutSize::new(100.0, 100.0)),
-                      sub_clip,
+                      clip,
                       ColorF::new(0.0, 1.0, 0.0, 1.0));
     let border_side = webrender_traits::BorderSide {
         color: ColorF::new(0.0, 0.0, 1.0, 1.0),
@@ -295,8 +299,10 @@ fn main() {
         left: border_side,
         radius: webrender_traits::BorderRadius::uniform(20.0),
     });
+
+    let clip = push_sub_clip(&api, &mut builder, &bounds);
     builder.push_border(LayoutRect::new(LayoutPoint::new(100.0, 100.0), LayoutSize::new(100.0, 100.0)),
-                        sub_clip,
+                        clip,
                         border_widths,
                         border_details);
 
@@ -359,8 +365,9 @@ fn main() {
             },
         ];
 
+        let clip = builder.push_clip_region(&bounds, Vec::new(), None);
         builder.push_text(text_bounds,
-                          webrender_traits::ClipRegion::simple(&bounds),
+                          clip,
                           &glyphs,
                           font_key,
                           ColorF::new(1.0, 1.0, 0.0, 1.0),
@@ -379,7 +386,7 @@ fn main() {
         let spread_radius = 0.0;
         let simple_border_radius = 8.0;
         let box_shadow_type = BoxShadowClipMode::Inset;
-        let full_screen_clip = builder.new_clip_region(&bounds, Vec::new(), None);
+        let full_screen_clip = builder.push_clip_region(&bounds, Vec::new(), None);
 
         builder.push_box_shadow(rect,
                                 full_screen_clip,

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -12,7 +12,7 @@ extern crate webrender_traits;
 use gleam::gl;
 use std::collections::HashMap;
 use webrender_traits::{BlobImageData, BlobImageDescriptor, BlobImageError, BlobImageRenderer, BlobImageRequest};
-use webrender_traits::{BlobImageResult, ImageStore, ClipRegion, ColorF, ColorU, Epoch};
+use webrender_traits::{BlobImageResult, ImageStore, ColorF, ColorU, Epoch};
 use webrender_traits::{DeviceUintSize, DeviceUintRect, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageRendering, ImageKey, TileSize};
 use webrender_traits::{PipelineId, RasterizedBlobImage, TransformStyle};
@@ -204,18 +204,21 @@ fn main() {
                                   None,
                                   webrender_traits::MixBlendMode::Normal,
                                   Vec::new());
+
+    let clip = builder.push_clip_region(&bounds, vec![], None);
     builder.push_image(
         LayoutRect::new(LayoutPoint::new(30.0, 30.0), LayoutSize::new(500.0, 500.0)),
-        ClipRegion::simple(&bounds),
+        clip,
         LayoutSize::new(500.0, 500.0),
         LayoutSize::new(0.0, 0.0),
         ImageRendering::Auto,
         blob_img1,
     );
 
+    let clip = builder.push_clip_region(&bounds, vec![], None);
     builder.push_image(
         LayoutRect::new(LayoutPoint::new(600.0, 60.0), LayoutSize::new(200.0, 200.0)),
-        ClipRegion::simple(&bounds),
+        clip,
         LayoutSize::new(200.0, 200.0),
         LayoutSize::new(0.0, 0.0),
         ImageRendering::Auto,

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -10,7 +10,7 @@ extern crate webrender_traits;
 use gleam::gl;
 use std::env;
 use std::path::PathBuf;
-use webrender_traits::{ClipId, ClipRegion, ColorF, DeviceUintSize, Epoch, LayoutPoint, LayoutRect};
+use webrender_traits::{ClipId, ColorF, DeviceUintSize, Epoch, LayoutPoint, LayoutRect};
 use webrender_traits::{LayoutSize, PipelineId, ScrollEventPhase, ScrollLocation, TransformStyle};
 use webrender_traits::WorldPoint;
 
@@ -123,47 +123,55 @@ fn main() {
                                       webrender_traits::MixBlendMode::Normal,
                                       Vec::new());
         // set the scrolling clip
+        let clip = builder.push_clip_region(&scrollbox, vec![], None);
         let clip_id = builder.define_clip((0, 0).to(1000, 1000),
-                                          ClipRegion::simple(&scrollbox),
+                                          clip,
                                           Some(ClipId::new(42, pipeline_id)));
         builder.push_clip_id(clip_id);
         // now put some content into it.
         // start with a white background
+        let clip = builder.push_clip_region(&(0, 0).to(1000, 1000), vec![], None);
         builder.push_rect((0, 0).to(500, 500),
-                          ClipRegion::simple(&(0, 0).to(1000, 1000)),
+                          clip,
                           ColorF::new(1.0, 1.0, 1.0, 1.0));
         // let's make a 50x50 blue square as a visual reference
+        let clip = builder.push_clip_region(&(0, 0).to(50, 50), vec![], None);
         builder.push_rect((0, 0).to(50, 50),
-                          ClipRegion::simple(&(0, 0).to(50, 50)),
+                          clip,
                           ColorF::new(0.0, 0.0, 1.0, 1.0));
         // and a 50x50 green square next to it with an offset clip
         // to see what that looks like
+        let clip = builder.push_clip_region(&(60, 10).to(110, 60), vec![], None);
         builder.push_rect((50, 0).to(100, 50),
-                          ClipRegion::simple(&(60, 10).to(110, 60)),
+                          clip,
                           ColorF::new(0.0, 1.0, 0.0, 1.0));
 
         // Below the above rectangles, set up a nested scrollbox. It's still in
         // the same stacking context, so note that the rects passed in need to
         // be relative to the stacking context.
+        let clip = builder.push_clip_region(&(0, 100).to(200, 300), vec![], None);
         let nested_clip_id = builder.define_clip((0, 100).to(300, 400),
-                                                 ClipRegion::simple(&(0, 100).to(200, 300)),
+                                                 clip,
                                                  Some(ClipId::new(43, pipeline_id)));
         builder.push_clip_id(nested_clip_id);
         // give it a giant gray background just to distinguish it and to easily
         // visually identify the nested scrollbox
+        let clip = builder.push_clip_region(&(-1000, -1000).to(5000, 5000), vec![], None);
         builder.push_rect((-1000, -1000).to(5000, 5000),
-                          ClipRegion::simple(&(-1000, -1000).to(5000, 5000)),
+                          clip,
                           ColorF::new(0.5, 0.5, 0.5, 1.0));
         // add a teal square to visualize the scrolling/clipping behaviour
         // as you scroll the nested scrollbox with WASD keys
+        let clip = builder.push_clip_region(&(0, 100).to(50, 150), vec![], None);
         builder.push_rect((0, 100).to(50, 150),
-                          ClipRegion::simple(&(0, 100).to(50, 150)),
+                          clip,
                           ColorF::new(0.0, 1.0, 1.0, 1.0));
         // just for good measure add another teal square in the bottom-right
         // corner of the nested scrollframe content, which can be scrolled into
         // view by the user
+        let clip = builder.push_clip_region(&(250, 350).to(300, 400), vec![], None);
         builder.push_rect((250, 350).to(300, 400),
-                          ClipRegion::simple(&(250, 350).to(300, 400)),
+                          clip,
                           ColorF::new(0.0, 1.0, 1.0, 1.0));
         builder.pop_clip_id(); // nested_clip_id
 

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -14,7 +14,7 @@ use glutin::TouchPhase;
 use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
-use webrender_traits::{ClipRegion, ColorF, Epoch};
+use webrender_traits::{ColorF, Epoch};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, LayoutPoint, LayoutRect, LayoutSize};
 use webrender_traits::{ImageData, ImageDescriptor, ImageFormat};
 use webrender_traits::{PipelineId, TransformStyle};
@@ -275,16 +275,18 @@ fn main() {
         None,
     );
 
+    let clip = builder.push_clip_region(&bounds, vec![], None);
     builder.push_yuv_image(
         LayoutRect::new(LayoutPoint::new(100.0, 0.0), LayoutSize::new(100.0, 100.0)),
-        ClipRegion::simple(&bounds),
+        clip,
         YuvData::NV12(yuv_chanel1, yuv_chanel2),
         YuvColorSpace::Rec601,
     );
 
+    let clip = builder.push_clip_region(&bounds, vec![], None);
     builder.push_yuv_image(
         LayoutRect::new(LayoutPoint::new(300.0, 0.0), LayoutSize::new(100.0, 100.0)),
-        ClipRegion::simple(&bounds),
+        clip,
         YuvData::PlanarYCbCr(yuv_chanel1, yuv_chanel2_1, yuv_chanel3),
         YuvColorSpace::Rec601,
     );

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -22,7 +22,7 @@ use clip_scroll_tree::ClipScrollTree;
 use std::{cmp, f32, i32, mem, usize};
 use euclid::{SideOffsets2D, TypedPoint3D};
 use tiling::{ContextIsolation, StackingContextIndex};
-use tiling::{AuxiliaryListsMap, ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, Frame};
+use tiling::{ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, DisplayListMap, Frame};
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
 use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
 use util::{self, pack_as_float, subtract_rect, recycle_vec};
@@ -30,9 +30,10 @@ use util::RectHelpers;
 use webrender_traits::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipAndScrollInfo};
 use webrender_traits::{ClipId, ClipRegion, ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use webrender_traits::{DeviceUintRect, DeviceUintSize, ExtendMode, FontKey, FontRenderMode};
-use webrender_traits::{GlyphOptions, ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect};
-use webrender_traits::{LayerSize, LayerToScrollTransform, PipelineId, RepeatMode, TileOffset};
-use webrender_traits::{TransformStyle, WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
+use webrender_traits::{GlyphInstance, GlyphOptions, GradientStop, ImageKey, ImageRendering};
+use webrender_traits::{ItemRange, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
+use webrender_traits::{PipelineId, RepeatMode, TileOffset, TransformStyle, WebGLContextId};
+use webrender_traits::{WorldPixel, YuvColorSpace, YuvData};
 
 #[derive(Debug, Clone)]
 struct ImageBorderSegment {
@@ -419,7 +420,9 @@ impl FrameBuilder {
                       clip_and_scroll: ClipAndScrollInfo,
                       rect: LayerRect,
                       clip_region: &ClipRegion,
-                      border_item: &BorderDisplayItem) {
+                      border_item: &BorderDisplayItem,
+                      gradient_stops: ItemRange<GradientStop>,
+                      gradient_stops_count: usize) {
         let create_segments = |outset: SideOffsets2D<f32>| {
             // Calculate the modified rect as specific by border-image-outset
             let origin = LayerPoint::new(rect.origin.x - outset.left,
@@ -579,7 +582,8 @@ impl FrameBuilder {
                                       clip_region,
                                       border.gradient.start_point - segment_rel,
                                       border.gradient.end_point - segment_rel,
-                                      border.gradient.stops,
+                                      gradient_stops,
+                                      gradient_stops_count,
                                       border.gradient.extend_mode,
                                       segment.size,
                                       LayerSize::zero());
@@ -597,7 +601,7 @@ impl FrameBuilder {
                                              border.gradient.end_center - segment_rel,
                                              border.gradient.end_radius,
                                              border.gradient.ratio_xy,
-                                             border.gradient.stops,
+                                             gradient_stops,
                                              border.gradient.extend_mode,
                                              segment.size,
                                              LayerSize::zero());
@@ -612,7 +616,8 @@ impl FrameBuilder {
                         clip_region: &ClipRegion,
                         start_point: LayerPoint,
                         end_point: LayerPoint,
-                        stops: ItemRange,
+                        stops: ItemRange<GradientStop>,
+                        stops_count: usize,
                         extend_mode: ExtendMode,
                         tile_size: LayerSize,
                         tile_spacing: LayerSize) {
@@ -643,6 +648,7 @@ impl FrameBuilder {
 
         let gradient_cpu = GradientPrimitiveCpu {
             stops_range: stops,
+            stops_count: stops_count,
             extend_mode: extend_mode,
             reverse_stops: reverse_stops,
             cache_dirty: true,
@@ -684,7 +690,7 @@ impl FrameBuilder {
                                end_center: LayerPoint,
                                end_radius: f32,
                                ratio_xy: f32,
-                               stops: ItemRange,
+                               stops: ItemRange<GradientStop>,
                                extend_mode: ExtendMode,
                                tile_size: LayerSize,
                                tile_spacing: LayerSize) {
@@ -721,7 +727,8 @@ impl FrameBuilder {
                     size: Au,
                     blur_radius: Au,
                     color: &ColorF,
-                    glyph_range: ItemRange,
+                    glyph_range: ItemRange<GlyphInstance>,
+                    glyph_count: usize,
                     glyph_options: Option<GlyphOptions>) {
         if color.a == 0.0 {
             return
@@ -746,6 +753,7 @@ impl FrameBuilder {
             logical_font_size: size,
             blur_radius: blur_radius,
             glyph_range: glyph_range,
+            glyph_count: glyph_count,
             cache_dirty: true,
             glyph_instances: Vec::new(),
             color_texture_id: SourceTexture::Invalid,
@@ -1064,7 +1072,7 @@ impl FrameBuilder {
     fn build_layer_screen_rects_and_cull_layers(&mut self,
                                                 screen_rect: &DeviceIntRect,
                                                 clip_scroll_tree: &mut ClipScrollTree,
-                                                auxiliary_lists_map: &AuxiliaryListsMap,
+                                                display_lists: &DisplayListMap,
                                                 resource_cache: &mut ResourceCache,
                                                 profile_counters: &mut FrameProfileCounters,
                                                 device_pixel_ratio: f32) {
@@ -1072,7 +1080,7 @@ impl FrameBuilder {
         LayerRectCalculationAndCullingPass::create_and_run(self,
                                                            screen_rect,
                                                            clip_scroll_tree,
-                                                           auxiliary_lists_map,
+                                                           display_lists,
                                                            resource_cache,
                                                            profile_counters,
                                                            device_pixel_ratio);
@@ -1326,7 +1334,7 @@ impl FrameBuilder {
                  resource_cache: &mut ResourceCache,
                  frame_id: FrameId,
                  clip_scroll_tree: &mut ClipScrollTree,
-                 auxiliary_lists_map: &AuxiliaryListsMap,
+                 display_lists: &DisplayListMap,
                  device_pixel_ratio: f32,
                  texture_cache_profile: &mut TextureCacheProfileCounters)
                  -> Frame {
@@ -1353,7 +1361,7 @@ impl FrameBuilder {
 
         self.build_layer_screen_rects_and_cull_layers(&screen_rect,
                                                       clip_scroll_tree,
-                                                      auxiliary_lists_map,
+                                                      display_lists,
                                                       resource_cache,
                                                       &mut profile_counters,
                                                       device_pixel_ratio);
@@ -1433,7 +1441,7 @@ struct LayerRectCalculationAndCullingPass<'a> {
     frame_builder: &'a mut FrameBuilder,
     screen_rect: &'a DeviceIntRect,
     clip_scroll_tree: &'a mut ClipScrollTree,
-    auxiliary_lists_map: &'a AuxiliaryListsMap,
+    display_lists: &'a DisplayListMap,
     resource_cache: &'a mut ResourceCache,
     profile_counters: &'a mut FrameProfileCounters,
     device_pixel_ratio: f32,
@@ -1453,7 +1461,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
     fn create_and_run(frame_builder: &'a mut FrameBuilder,
                       screen_rect: &'a DeviceIntRect,
                       clip_scroll_tree: &'a mut ClipScrollTree,
-                      auxiliary_lists_map: &'a AuxiliaryListsMap,
+                      display_lists: &'a DisplayListMap,
                       resource_cache: &'a mut ResourceCache,
                       profile_counters: &'a mut FrameProfileCounters,
                       device_pixel_ratio: f32) {
@@ -1462,7 +1470,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             frame_builder: frame_builder,
             screen_rect: screen_rect,
             clip_scroll_tree: clip_scroll_tree,
-            auxiliary_lists_map: auxiliary_lists_map,
+            display_lists: display_lists,
             resource_cache: resource_cache,
             profile_counters: profile_counters,
             device_pixel_ratio: device_pixel_ratio,
@@ -1525,14 +1533,14 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 _ => continue,
             };
 
-            let auxiliary_lists = self.auxiliary_lists_map.get(&node.pipeline_id)
-                                                          .expect("No auxiliary lists?");
+            let display_list = self.display_lists.get(&node.pipeline_id)
+                                                 .expect("No display list?");
 
             mask_info.update(&node_clip_info.clip_sources,
                              &packed_layer.transform,
                              &mut self.frame_builder.prim_store.gpu_data32,
                              self.device_pixel_ratio,
-                             auxiliary_lists);
+                             display_list);
 
             for clip_source in &node_clip_info.clip_sources {
                 if let Some(mask) = clip_source.image_mask() {
@@ -1693,8 +1701,8 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         let stacking_context =
             &mut self.frame_builder.stacking_context_store[stacking_context_index.0];
         let packed_layer = &self.frame_builder.packed_layers[packed_layer_index.0];
-        let auxiliary_lists = self.auxiliary_lists_map.get(&pipeline_id)
-                                                      .expect("No auxiliary lists?");
+        let display_list = self.display_lists.get(&pipeline_id)
+                                             .expect("No display list?");
         for i in 0..prim_count {
             let prim_index = PrimitiveIndex(prim_index.0 + i);
             if self.frame_builder.prim_store.build_bounding_rect(prim_index,
@@ -1706,7 +1714,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                                                                          self.resource_cache,
                                                                          &packed_layer.transform,
                                                                          self.device_pixel_ratio,
-                                                                         auxiliary_lists) {
+                                                                         display_list) {
                     self.frame_builder.prim_store.build_bounding_rect(prim_index,
                                                                       self.screen_rect,
                                                                       &packed_layer.transform,

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -8,7 +8,7 @@ use prim_store::{ClipData, GpuBlock32, PrimitiveStore};
 use prim_store::{CLIP_DATA_GPU_SIZE, MASK_DATA_GPU_SIZE};
 use renderer::VertexDataStore;
 use util::{ComplexClipRegionHelpers, MatrixHelpers, TransformedRect};
-use webrender_traits::{AuxiliaryLists, BorderRadius, ClipRegion, ComplexClipRegion, ImageMask};
+use webrender_traits::{BorderRadius, BuiltDisplayList, ClipRegion, ComplexClipRegion, ImageMask};
 use webrender_traits::{DeviceIntRect, LayerToWorldTransform};
 use webrender_traits::{LayerRect, LayerPoint, LayerSize};
 use std::ops::Not;
@@ -154,8 +154,7 @@ impl MaskCacheInfo {
                         debug_assert!(image.is_none());     // TODO(gw): Support >1 image mask!
                         image = Some((info, clip_store.alloc(MASK_DATA_GPU_SIZE)));
                     }
-
-                    complex_clip_count += region.complex.length;
+                    complex_clip_count += region.complex_clip_count;
                     if region_mode == RegionMode::IncludeRect {
                         complex_clip_count += 1;
                     }
@@ -193,7 +192,7 @@ impl MaskCacheInfo {
                   transform: &LayerToWorldTransform,
                   clip_store: &mut VertexDataStore<GpuBlock32>,
                   device_pixel_ratio: f32,
-                  aux_lists: &AuxiliaryLists) {
+                  display_list: &BuiltDisplayList) {
         let is_aligned = transform.can_losslessly_transform_and_perspective_project_a_2d_rect();
 
         // If we haven't cached this info, or if the transform type has changed
@@ -238,7 +237,7 @@ impl MaskCacheInfo {
                             None => local_rect,
                         };
 
-                        let clips = aux_lists.complex_clip_regions(&region.complex);
+                        let clips = display_list.get(region.complex_clips);
                         if !self.is_aligned && region_mode == RegionMode::IncludeRect {
                             // we have an extra clip rect coming from the transformed layer
                             debug_assert!(self.effective_complex_clip_count < self.complex_clip_range.item_count);
@@ -254,8 +253,8 @@ impl MaskCacheInfo {
                         self.effective_complex_clip_count += clips.len();
 
                         let slice = clip_store.get_slice_mut(address, CLIP_DATA_GPU_SIZE * clips.len());
-                        for (clip, chunk) in clips.iter().zip(slice.chunks_mut(CLIP_DATA_GPU_SIZE)) {
-                            let data = ClipData::from_clip_region(clip);
+                        for (clip, chunk) in clips.zip(slice.chunks_mut(CLIP_DATA_GPU_SIZE)) {
+                            let data = ClipData::from_clip_region(&clip);
                             PrimitiveStore::populate_clip_data(chunk, data);
                             local_rect = local_rect.and_then(|r| r.intersection(&clip.rect));
                             local_inner = local_inner.and_then(|r| clip.get_inner_rect_safe()

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -14,14 +14,14 @@ use resource_cache::{CacheItem, ImageProperties, ResourceCache};
 use std::mem;
 use std::usize;
 use util::{TransformedRect, recycle_vec};
-use webrender_traits::{AuxiliaryLists, ColorF, ImageKey, ImageRendering, YuvColorSpace, YuvFormat};
-use webrender_traits::{ClipRegion, ComplexClipRegion, ItemRange, GlyphKey};
+use webrender_traits::{BuiltDisplayList, ColorF, ImageKey, ImageRendering, YuvColorSpace};
+use webrender_traits::{YuvFormat, ClipRegion, ComplexClipRegion, ItemRange, GlyphKey};
 use webrender_traits::{FontKey, FontRenderMode, WebGLContextId};
 use webrender_traits::{device_length, DeviceIntRect, DeviceIntSize};
 use webrender_traits::{DeviceRect, DevicePoint, DeviceSize};
 use webrender_traits::{LayerRect, LayerSize, LayerPoint, LayoutPoint};
 use webrender_traits::{LayerToWorldTransform, GlyphInstance, GlyphOptions};
-use webrender_traits::{ExtendMode, GradientStop, TileOffset};
+use webrender_traits::{ExtendMode, GradientStop, AuxIter, TileOffset};
 
 pub const CLIP_DATA_GPU_SIZE: usize = 5;
 pub const MASK_DATA_GPU_SIZE: usize = 1;
@@ -271,7 +271,8 @@ pub struct GradientPrimitiveGpu {
 
 #[derive(Debug)]
 pub struct GradientPrimitiveCpu {
-    pub stops_range: ItemRange,
+    pub stops_range: ItemRange<GradientStop>,
+    pub stops_count: usize,
     pub extend_mode: ExtendMode,
     pub reverse_stops: bool,
     pub cache_dirty: bool,
@@ -293,7 +294,7 @@ pub struct RadialGradientPrimitiveGpu {
 
 #[derive(Debug)]
 pub struct RadialGradientPrimitiveCpu {
-    pub stops_range: ItemRange,
+    pub stops_range: ItemRange<GradientStop>,
     pub extend_mode: ExtendMode,
     pub cache_dirty: bool,
 }
@@ -379,7 +380,7 @@ impl GradientData {
     }
 
     // Build the gradient data from the supplied stops, reversing them if necessary.
-    fn build(&mut self, src_stops: &[GradientStop], reverse_stops: bool) {
+    fn build(&mut self, src_stops: AuxIter<GradientStop>, reverse_stops: bool) {
 
         const MAX_IDX: usize = GRADIENT_DATA_RESOLUTION;
         const MIN_IDX: usize = 0;
@@ -440,7 +441,8 @@ pub struct TextRunPrimitiveCpu {
     pub font_key: FontKey,
     pub logical_font_size: Au,
     pub blur_radius: Au,
-    pub glyph_range: ItemRange,
+    pub glyph_range: ItemRange<GlyphInstance>,
+    pub glyph_count: usize,
     pub cache_dirty: bool,
     // TODO(gw): Maybe make this an Arc for sharing with resource cache
     pub glyph_instances: Vec<GlyphInstance>,
@@ -710,8 +712,8 @@ impl PrimitiveStore {
             }
             PrimitiveContainer::TextRun(mut text_cpu, text_gpu) => {
                 let gpu_address = self.gpu_data16.push(text_gpu);
-                let gpu_glyphs_address = self.gpu_data16.alloc(text_cpu.glyph_range.length);
-                text_cpu.resource_address = self.gpu_resource_rects.alloc(text_cpu.glyph_range.length);
+                let gpu_glyphs_address = self.gpu_data16.alloc(text_cpu.glyph_count);
+                text_cpu.resource_address = self.gpu_resource_rects.alloc(text_cpu.glyph_count);
 
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
@@ -721,7 +723,7 @@ impl PrimitiveStore {
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_text_runs.len()),
                     gpu_prim_index: gpu_address,
                     gpu_data_address: gpu_glyphs_address,
-                    gpu_data_count: text_cpu.glyph_range.length as i32,
+                    gpu_data_count: text_cpu.glyph_count as i32,
                     render_task: None,
                     clip_task: None,
                 };
@@ -792,7 +794,7 @@ impl PrimitiveStore {
             }
             PrimitiveContainer::AlignedGradient(gradient_cpu, gradient_gpu) => {
                 let gpu_address = self.gpu_data64.push(gradient_gpu);
-                let gpu_stops_address = self.gpu_data32.alloc(gradient_cpu.stops_range.length);
+                let gpu_stops_address = self.gpu_data32.alloc(gradient_cpu.stops_count);
 
                 let metadata = PrimitiveMetadata {
                     // TODO: calculate if the gradient is actually opaque
@@ -803,7 +805,7 @@ impl PrimitiveStore {
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_gradients.len()),
                     gpu_prim_index: gpu_address,
                     gpu_data_address: gpu_stops_address,
-                    gpu_data_count: gradient_cpu.stops_range.length as i32,
+                    gpu_data_count: gradient_cpu.stops_count as i32,
                     render_task: None,
                     clip_task: None,
                 };
@@ -985,7 +987,7 @@ impl PrimitiveStore {
                     let font_size_dp = text.logical_font_size.scale_by(device_pixel_ratio);
 
                     let dest_rects = self.gpu_resource_rects.get_slice_mut(text.resource_address,
-                                                                           text.glyph_range.length);
+                                                                           text.glyph_count);
 
                     let texture_id = resource_cache.get_glyphs(text.font_key,
                                                                font_size_dp,
@@ -1131,7 +1133,7 @@ impl PrimitiveStore {
                                    resource_cache: &mut ResourceCache,
                                    layer_transform: &LayerToWorldTransform,
                                    device_pixel_ratio: f32,
-                                   auxiliary_lists: &AuxiliaryLists) -> bool {
+                                   display_list: &BuiltDisplayList) -> bool {
 
         let metadata = &mut self.cpu_metadata[prim_index.0];
         let mut prim_needs_resolve = false;
@@ -1142,9 +1144,9 @@ impl PrimitiveStore {
                              layer_transform,
                              &mut self.gpu_data32,
                              device_pixel_ratio,
-                             auxiliary_lists);
+                             display_list);
             for clip in &metadata.clips {
-                if let ClipSource::Region(ClipRegion{ image_mask: Some(ref mask), .. }, _) = *clip {
+                if let ClipSource::Region(ClipRegion{ image_mask: Some(ref mask), .. }, ..) = *clip {
                     resource_cache.request_image(mask.image, ImageRendering::Auto, None);
                     prim_needs_resolve = true;
                 }
@@ -1175,23 +1177,24 @@ impl PrimitiveStore {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
 
                 let font_size_dp = text.logical_font_size.scale_by(device_pixel_ratio);
-                let src_glyphs = auxiliary_lists.glyph_instances(&text.glyph_range);
+                let src_glyphs = display_list.get(text.glyph_range);
                 prim_needs_resolve = true;
 
                 if text.cache_dirty {
                     rebuild_bounding_rect = true;
                     text.cache_dirty = false;
 
-                    debug_assert!(metadata.gpu_data_count == text.glyph_range.length as i32);
+                    debug_assert!(metadata.gpu_data_count == src_glyphs.len() as i32);
                     debug_assert!(text.glyph_instances.is_empty());
 
                     let dest_glyphs = self.gpu_data16.get_slice_mut(metadata.gpu_data_address,
-                                                                    text.glyph_range.length);
+                                                                    src_glyphs.len());
+
                     let mut glyph_key = GlyphKey::new(text.font_key,
                                                       font_size_dp,
                                                       text.color,
-                                                      src_glyphs[0].index,
-                                                      src_glyphs[0].point,
+                                                      0,
+                                                      LayoutPoint::new(0.0, 0.0),
                                                       text.render_mode);
                     let mut local_rect = LayerRect::zero();
                     let mut actual_glyph_count = 0;
@@ -1302,13 +1305,13 @@ impl PrimitiveStore {
             PrimitiveKind::AlignedGradient => {
                 let gradient = &mut self.cpu_gradients[metadata.cpu_prim_index.0];
                 if gradient.cache_dirty {
-                    let src_stops = auxiliary_lists.gradient_stops(&gradient.stops_range);
+                    let src_stops = display_list.get(gradient.stops_range);
 
-                    debug_assert!(metadata.gpu_data_count == gradient.stops_range.length as i32);
+                    debug_assert!(metadata.gpu_data_count == src_stops.len() as i32);
                     let dest_stops = self.gpu_data32.get_slice_mut(metadata.gpu_data_address,
-                                                                   gradient.stops_range.length);
+                                                                   src_stops.len());
 
-                    for (src, dest) in src_stops.iter().zip(dest_stops.iter_mut()) {
+                    for (src, dest) in src_stops.zip(dest_stops.iter_mut()) {
                         *dest = GpuBlock32::from(GradientStopGpu {
                             offset: src.offset,
                             color: src.color,
@@ -1322,7 +1325,8 @@ impl PrimitiveStore {
             PrimitiveKind::AngleGradient => {
                 let gradient = &mut self.cpu_gradients[metadata.cpu_prim_index.0];
                 if gradient.cache_dirty {
-                    let src_stops = auxiliary_lists.gradient_stops(&gradient.stops_range);
+                    let src_stops = display_list.get(gradient.stops_range);
+
                     let dest_gradient = self.gpu_gradient_data.get_mut(metadata.gpu_data_address);
                     dest_gradient.build(src_stops, gradient.reverse_stops);
                     gradient.cache_dirty = false;
@@ -1331,7 +1335,8 @@ impl PrimitiveStore {
             PrimitiveKind::RadialGradient => {
                 let gradient = &mut self.cpu_radial_gradients[metadata.cpu_prim_index.0];
                 if gradient.cache_dirty {
-                    let src_stops = auxiliary_lists.gradient_stops(&gradient.stops_range);
+                    let src_stops = display_list.get(gradient.stops_range);
+
                     let dest_gradient = self.gpu_gradient_data.get_mut(metadata.gpu_data_address);
                     dest_gradient.build(src_stops, false);
                     gradient.cache_dirty = false;

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -18,7 +18,7 @@ use thread_profiler::register_thread_with_profiler;
 use threadpool::ThreadPool;
 use webgl_types::{GLContextHandleWrapper, GLContextWrapper};
 use webrender_traits::{DeviceIntPoint, DeviceUintPoint, DeviceUintRect, DeviceUintSize, LayerPoint};
-use webrender_traits::{ApiMsg, AuxiliaryLists, BuiltDisplayList, IdNamespace, ImageData};
+use webrender_traits::{ApiMsg, BuiltDisplayList, IdNamespace, ImageData};
 use webrender_traits::{PipelineId, RenderNotifier, RenderDispatcher, WebGLCommand, WebGLContextId};
 use webrender_traits::channel::{PayloadSenderHelperMethods, PayloadReceiverHelperMethods, PayloadReceiver, PayloadSender, MsgReceiver};
 use webrender_traits::{BlobImageRenderer, VRCompositorCommand, VRCompositorHandler};
@@ -181,63 +181,57 @@ impl RenderBackend {
                                                pipeline_id,
                                                viewport_size,
                                                display_list_descriptor,
-                                               auxiliary_lists_descriptor,
                                                preserve_frame_state) => {
                             profile_scope!("SetDisplayList");
-                            let mut leftover_auxiliary_data = vec![];
-                            let mut auxiliary_data;
+                            let mut leftover_data = vec![];
+                            let mut data;
                             loop {
-                                auxiliary_data = self.payload_rx.recv_payload().unwrap();
+                                data = self.payload_rx.recv_payload().unwrap();
                                 {
-                                    if auxiliary_data.epoch == epoch &&
-                                       auxiliary_data.pipeline_id == pipeline_id {
+                                    if data.epoch == epoch &&
+                                       data.pipeline_id == pipeline_id {
                                         break
                                     }
                                 }
-                                leftover_auxiliary_data.push(auxiliary_data)
+                                leftover_data.push(data)
                             }
-                            for leftover_auxiliary_data in leftover_auxiliary_data {
-                                self.payload_tx.send_payload(leftover_auxiliary_data).unwrap()
+                            for leftover_data in leftover_data {
+                                self.payload_tx.send_payload(leftover_data).unwrap()
                             }
                             if let Some(ref mut r) = self.recorder {
-                                r.write_payload(frame_counter, &auxiliary_data.to_data());
+                                r.write_payload(frame_counter, &data.to_data());
                             }
 
                             let built_display_list =
-                                BuiltDisplayList::from_data(auxiliary_data.display_list_data,
+                                BuiltDisplayList::from_data(data.display_list_data,
                                                             display_list_descriptor);
-                            let auxiliary_lists =
-                                AuxiliaryLists::from_data(auxiliary_data.auxiliary_lists_data,
-                                                          auxiliary_lists_descriptor);
 
                             if !preserve_frame_state {
                                 self.discard_frame_state_for_pipeline(pipeline_id);
                             }
-                            
+
                             let display_list_len = built_display_list.data().len();
-                            let aux_list_len = auxiliary_lists.data().len();
                             let (builder_start_time, builder_finish_time) = built_display_list.times();
 
                             let display_list_received_time = precise_time_ns();
-                            
+
                             profile_counters.total_time.profile(|| {
                                 self.scene.set_display_list(pipeline_id,
                                                             epoch,
                                                             built_display_list,
                                                             background_color,
-                                                            viewport_size,
-                                                            auxiliary_lists);
+                                                            viewport_size);
                                 self.build_scene();
                             });
 
-                            // Note: this isn't quite right as auxiliary values will be 
+                            // Note: this isn't quite right as auxiliary values will be
                             // pulled out somewhere in the prim_store, but aux values are
                             // really simple and cheap to access, so it's not a big deal.
                             let display_list_consumed_time = precise_time_ns();
 
-                            profile_counters.ipc.set(builder_start_time, builder_finish_time, 
+                            profile_counters.ipc.set(builder_start_time, builder_finish_time,
                                                      display_list_received_time, display_list_consumed_time,
-                                                     display_list_len + aux_list_len);
+                                                     display_list_len);
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {
                             profile_scope!("SetRootPipeline");
@@ -491,7 +485,7 @@ impl RenderBackend {
         let pan = LayerPoint::new(self.pan.x as f32 / accumulated_scale_factor,
                                   self.pan.y as f32 / accumulated_scale_factor);
         let frame = self.frame.build(&mut self.resource_cache,
-                                     &self.scene.pipeline_auxiliary_lists,
+                                     &self.scene.display_lists,
                                      accumulated_scale_factor,
                                      pan,
                                      texture_cache_profile);

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -5,9 +5,8 @@
 use fnv::FnvHasher;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use tiling::AuxiliaryListsMap;
-use webrender_traits::{AuxiliaryLists, BuiltDisplayList, PipelineId, Epoch, ColorF};
-use webrender_traits::{DisplayItem, DynamicProperties, LayerSize, LayoutTransform};
+use webrender_traits::{BuiltDisplayList, PipelineId, Epoch, ColorF};
+use webrender_traits::{DynamicProperties, LayerSize, LayoutTransform};
 use webrender_traits::{PropertyBinding, PropertyBindingId};
 
 /// Stores a map of the animated property bindings for the current display list. These
@@ -93,8 +92,7 @@ pub struct ScenePipeline {
 pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipeline_map: HashMap<PipelineId, ScenePipeline, BuildHasherDefault<FnvHasher>>,
-    pub pipeline_auxiliary_lists: AuxiliaryListsMap,
-    pub display_lists: HashMap<PipelineId, Vec<DisplayItem>, BuildHasherDefault<FnvHasher>>,
+    pub display_lists: HashMap<PipelineId, BuiltDisplayList, BuildHasherDefault<FnvHasher>>,
     pub properties: SceneProperties,
 }
 
@@ -103,7 +101,6 @@ impl Scene {
         Scene {
             root_pipeline_id: None,
             pipeline_map: HashMap::default(),
-            pipeline_auxiliary_lists: HashMap::default(),
             display_lists: HashMap::default(),
             properties: SceneProperties::new(),
         }
@@ -118,11 +115,9 @@ impl Scene {
                             epoch: Epoch,
                             built_display_list: BuiltDisplayList,
                             background_color: Option<ColorF>,
-                            viewport_size: LayerSize,
-                            auxiliary_lists: AuxiliaryLists) {
+                            viewport_size: LayerSize) {
 
-        self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
-        self.display_lists.insert(pipeline_id, built_display_list.into_display_items());
+        self.display_lists.insert(pipeline_id, built_display_list);
         
         let new_pipeline = ScenePipeline {
             pipeline_id: pipeline_id,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use texture_cache::TexturePage;
 use util::{TransformedRect, TransformedRectKind};
-use webrender_traits::{AuxiliaryLists, ClipAndScrollInfo, ClipId, ColorF, DeviceIntPoint};
+use webrender_traits::{BuiltDisplayList, ClipAndScrollInfo, ClipId, ColorF, DeviceIntPoint};
 use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize};
 use webrender_traits::{ExternalImageType, FontRenderMode, ImageRendering, LayerPoint, LayerRect};
 use webrender_traits::{LayerToWorldTransform, MixBlendMode, PipelineId, TransformStyle};
@@ -36,9 +36,9 @@ use webrender_traits::{YuvColorSpace, YuvFormat};
 const OPAQUE_TASK_INDEX: RenderTaskIndex = RenderTaskIndex(i32::MAX as usize);
 
 
-pub type AuxiliaryListsMap = HashMap<PipelineId,
-                                     AuxiliaryLists,
-                                     BuildHasherDefault<FnvHasher>>;
+pub type DisplayListMap = HashMap<PipelineId,
+                                  BuiltDisplayList,
+                                  BuildHasherDefault<FnvHasher>>;
 
 trait AlphaBatchHelpers {
     fn get_color_textures(&self, metadata: &PrimitiveMetadata) -> [SourceTexture; 3];

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -12,6 +12,7 @@ webgl = ["offscreen_gl_context"]
 
 [dependencies]
 app_units = "0.4"
+bincode = "1.0.0-alpha2"
 byteorder = "1.0"
 euclid = "0.11"
 gleam = "0.4"

--- a/webrender_traits/src/channel.rs
+++ b/webrender_traits/src/channel.rs
@@ -18,7 +18,6 @@ pub struct Payload {
     /// A pipeline id to key the payload with, along with the epoch.
     pub pipeline_id: PipelineId,
     pub display_list_data: Vec<u8>,
-    pub auxiliary_lists_data: Vec<u8>
 }
 
 impl Payload {
@@ -31,16 +30,12 @@ impl Payload {
         let mut data = Vec::with_capacity(mem::size_of::<u32>() +
                                           2 * mem::size_of::<u32>() +
                                           mem::size_of::<u64>() +
-                                          self.display_list_data.len() +
-                                          mem::size_of::<u64>() +
-                                          self.auxiliary_lists_data.len());
+                                          self.display_list_data.len());
         data.write_u32::<LittleEndian>(self.epoch.0).unwrap();
         data.write_u32::<LittleEndian>(self.pipeline_id.0).unwrap();
         data.write_u32::<LittleEndian>(self.pipeline_id.1).unwrap();
         data.write_u64::<LittleEndian>(self.display_list_data.len() as u64).unwrap();
         data.extend_from_slice(&self.display_list_data);
-        data.write_u64::<LittleEndian>(self.auxiliary_lists_data.len() as u64).unwrap();
-        data.extend_from_slice(&self.auxiliary_lists_data);
         data
     }
 
@@ -55,17 +50,13 @@ impl Payload {
         let mut built_display_list_data = vec![0; dl_size];
         payload_reader.read_exact(&mut built_display_list_data[..]).unwrap();
 
-        let aux_size = payload_reader.read_u64::<LittleEndian>().unwrap() as usize;
-        let mut auxiliary_lists_data = vec![0; aux_size];
-        payload_reader.read_exact(&mut auxiliary_lists_data[..]).unwrap();
+        // TODO(new-ipc): assert_eq!(payload_reader.position(), data.len() as u64);
 
-        assert_eq!(payload_reader.position(), data.len() as u64);
 
         Payload {
             epoch: epoch,
             pipeline_id: pipeline_id,
             display_list_data: built_display_list_data,
-            auxiliary_lists_data: auxiliary_lists_data,
         }
     }
 }

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -4,10 +4,14 @@
 
 use app_units::Au;
 use euclid::SideOffsets2D;
-use display_list::AuxiliaryListsBuilder;
-use {ColorF, FontKey, ImageKey, PipelineId, WebGLContextId};
+use {ColorF, FontKey, ImageKey, ItemRange, PipelineId, WebGLContextId};
 use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
 use {PropertyBinding};
+
+// NOTE: some of these structs have an "IMPLICIT" comment.
+// This indicates that the BuiltDisplayList will have serialized
+// a list of values nearby that this item consumes. The traversal
+// iterator should handle finding these.
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ClipAndScrollInfo {
@@ -39,7 +43,6 @@ impl ClipAndScrollInfo {
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: LayoutRect,
-    pub clip: ClipRegion,
     pub clip_and_scroll: ClipAndScrollInfo,
 }
 
@@ -58,13 +61,8 @@ pub enum SpecificDisplayItem {
     Iframe(IframeDisplayItem),
     PushStackingContext(PushStackingContextDisplayItem),
     PopStackingContext,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ItemRange {
-    pub start: usize,
-    pub length: usize,
+    SetGradientStops,
+    SetClipRegion(ClipRegion),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -80,13 +78,12 @@ pub struct RectangleDisplayItem {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct TextDisplayItem {
-    pub glyphs: ItemRange,
     pub font_key: FontKey,
     pub size: Au,
     pub color: ColorF,
     pub blur_radius: Au,
     pub glyph_options: Option<GlyphOptions>,
-}
+} // IMPLICIT: glyphs: Vec<GlyphInstance>
 
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {
@@ -229,9 +226,8 @@ pub enum ExtendMode {
 pub struct Gradient {
     pub start_point: LayoutPoint,
     pub end_point: LayoutPoint,
-    pub stops: ItemRange,
     pub extend_mode: ExtendMode,
-}
+} // IMPLICIT: stops: Vec<GradientStop>
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GradientDisplayItem {
@@ -255,9 +251,8 @@ pub struct RadialGradient {
     pub end_center: LayoutPoint,
     pub end_radius: f32,
     pub ratio_xy: f32,
-    pub stops: ItemRange,
     pub extend_mode: ExtendMode,
-}
+} // IMPLICIT stops: Vec<GradientStop>
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RadialGradientDisplayItem {
@@ -278,8 +273,7 @@ pub struct StackingContext {
     pub transform_style: TransformStyle,
     pub perspective: Option<LayoutTransform>,
     pub mix_blend_mode: MixBlendMode,
-    pub filters: ItemRange,
-}
+} // IMPLICIT: filters: Vec<FilterOp>
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -423,9 +417,12 @@ pub struct ImageMask {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ClipRegion {
     pub main: LayoutRect,
-    pub complex: ItemRange,
     pub image_mask: Option<ImageMask>,
-}
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub complex_clips: ItemRange<ComplexClipRegion>,
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub complex_clip_count: usize,
+} 
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
@@ -433,26 +430,6 @@ pub struct ComplexClipRegion {
     pub rect: LayoutRect,
     /// Border radii of this rectangle.
     pub radii: BorderRadius,
-}
-
-impl StackingContext {
-    pub fn new(scroll_policy: ScrollPolicy,
-               transform: Option<PropertyBinding<LayoutTransform>>,
-               transform_style: TransformStyle,
-               perspective: Option<LayoutTransform>,
-               mix_blend_mode: MixBlendMode,
-               filters: Vec<FilterOp>,
-               auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
-               -> StackingContext {
-        StackingContext {
-            scroll_policy: scroll_policy,
-            transform: transform,
-            transform_style: transform_style,
-            perspective: perspective,
-            mix_blend_mode: mix_blend_mode,
-            filters: auxiliary_lists_builder.add_filters(&filters),
-        }
-    }
 }
 
 impl BorderRadius {
@@ -512,27 +489,36 @@ impl BorderRadius {
 
 impl ClipRegion {
     pub fn new(rect: &LayoutRect,
-               complex: Vec<ComplexClipRegion>,
-               image_mask: Option<ImageMask>,
-               auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+               image_mask: Option<ImageMask>)
                -> ClipRegion {
         ClipRegion {
             main: *rect,
-            complex: auxiliary_lists_builder.add_complex_clip_regions(&complex),
             image_mask: image_mask,
+            complex_clips: ItemRange::default(),
+            complex_clip_count: 0,
         }
     }
 
     pub fn simple(rect: &LayoutRect) -> ClipRegion {
         ClipRegion {
             main: *rect,
-            complex: ItemRange::empty(),
             image_mask: None,
+            complex_clips: ItemRange::default(),
+            complex_clip_count: 0,
+        }
+    }
+
+    pub fn empty() -> ClipRegion {
+        ClipRegion {
+            main: LayoutRect::zero(),
+            image_mask: None,
+            complex_clips: ItemRange::default(),
+            complex_clip_count: 0,
         }
     }
 
     pub fn is_complex(&self) -> bool {
-        self.complex.length !=0 || self.image_mask.is_some()
+        self.complex_clip_count != 0 || self.image_mask.is_some()
     }
 }
 

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -3,43 +3,45 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use std::mem;
-use std::slice;
+use bincode;
+use serde::{Deserialize, Serialize, Serializer};
+use serde::ser::{SerializeSeq, SerializeMap};
 use time::precise_time_ns;
 use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShadowDisplayItem};
-use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ClipRegion, ColorF, ComplexClipRegion};
-use {DisplayItem, ExtendMode, FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient};
-use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
-use {ImageRendering, ItemRange, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
-use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
-use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem};
-use {StackingContext, TextDisplayItem, TransformStyle, WebGLContextId, WebGLDisplayItem};
-use {YuvColorSpace, YuvData, YuvImageDisplayItem};
+use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ClipRegion, ColorF, ComplexClipRegion, DisplayItem};
+use {ExtendMode, FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem};
+use {GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering};
+use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, MixBlendMode, PipelineId};
+use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
+use {RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem, StackingContext, TextDisplayItem};
+use {TransformStyle, WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
+use std::marker::PhantomData;
 
-#[derive(Clone, Deserialize, Serialize)]
-pub struct AuxiliaryLists {
-    /// The concatenation of: gradient stops, complex clip regions, filters, and glyph instances,
-    /// in that order.
-    data: Vec<u8>,
-    descriptor: AuxiliaryListsDescriptor,
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ItemRange<T> {
+    start: usize,
+    length: usize,
+    _boo: PhantomData<T>,
 }
 
-/// Describes the memory layout of the auxiliary lists.
-///
-/// Auxiliary lists consist of some number of gradient stops, complex clip regions, filters, and
-/// glyph instances, in that order.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct AuxiliaryListsDescriptor {
-    gradient_stops_size: usize,
-    complex_clip_regions_size: usize,
-    filters_size: usize,
-    glyph_instances_size: usize,
+impl<T> Default for ItemRange<T> {
+    fn default() -> Self {
+        ItemRange { start: 0, length: 0, _boo: PhantomData }
+    }
+}
+
+impl<T> ItemRange<T> {
+    pub fn is_empty(&self) -> bool {
+        // Nothing more than space for a length (0).
+        self.length <= ::std::mem::size_of::<u64>()
+    }
 }
 
 /// A display list.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Default)]
 pub struct BuiltDisplayList {
+    /// Serde encoded bytes. Mostly DisplayItems, but some mixed in slices.
     data: Vec<u8>,
     descriptor: BuiltDisplayListDescriptor,
 }
@@ -49,7 +51,7 @@ pub struct BuiltDisplayList {
 /// A display list consists of some number of display list items, followed by a number of display
 /// items.
 #[repr(C)]
-#[derive(Copy, Clone, Deserialize, Serialize)]
+#[derive(Copy, Clone, Default, Deserialize, Serialize)]
 pub struct BuiltDisplayListDescriptor {
     /// The size in bytes of the display list items in this display list.
     display_list_items_size: usize,
@@ -57,6 +59,35 @@ pub struct BuiltDisplayListDescriptor {
     builder_start_time: u64,
     /// The second IPC time stamp: after serialization
     builder_finish_time: u64,
+}
+
+pub struct BuiltDisplayListIter<'a> {
+    list: &'a BuiltDisplayList,
+    data: &'a [u8],
+    cur_item: DisplayItem,
+    cur_stops: ItemRange<GradientStop>,
+    cur_glyphs: ItemRange<GlyphInstance>,
+    cur_filters: ItemRange<FilterOp>,
+    cur_clip: ClipRegion,
+    peeking: Peek,
+}
+
+pub struct DisplayItemRef<'a: 'b, 'b> {
+    iter: &'b BuiltDisplayListIter<'a>,
+}
+
+#[derive(PartialEq)]
+enum Peek {
+    StartPeeking,
+    IsPeeking,
+    NotPeeking,
+}
+
+#[derive(Clone)]
+pub struct AuxIter<'a, T> {
+    data: &'a [u8],
+    size: usize,
+    _boo: PhantomData<T>,
 }
 
 impl BuiltDisplayListDescriptor {
@@ -85,27 +116,312 @@ impl BuiltDisplayList {
         &self.descriptor
     }
 
-    pub fn all_display_items(&self) -> &[DisplayItem] {
-        unsafe {
-            convert_blob_to_pod(&self.data)
-        }
-    }
-
-    pub fn into_display_items(self) -> Vec<DisplayItem> {
-        unsafe {
-            convert_vec_blob_to_pod(self.data)
-        }
-    }
-
     pub fn times(&self) -> (u64, u64) {
       (self.descriptor.builder_start_time, self.descriptor.builder_finish_time)
+    }
+
+    pub fn iter(&self) -> BuiltDisplayListIter {
+        BuiltDisplayListIter::new(self)
+    }
+
+    pub fn get<T: Deserialize>(&self, range: ItemRange<T>) -> AuxIter<T> {
+        AuxIter::new(&self.data[range.start .. range.start + range.length])
+    }
+}
+
+impl<'a> BuiltDisplayListIter<'a> {
+    pub fn new(list: &'a BuiltDisplayList) -> Self {
+        BuiltDisplayListIter {
+            list: list,
+            data: &list.data,
+            // Dummy data, will be overwritten by `next`
+            cur_item: DisplayItem {
+                item: SpecificDisplayItem::PopStackingContext,
+                rect: LayoutRect::zero(),
+                clip_and_scroll: ClipAndScrollInfo::simple(ClipId::new(0, PipelineId(0, 0))),
+            },
+            cur_stops: ItemRange::default(),
+            cur_glyphs: ItemRange::default(),
+            cur_filters: ItemRange::default(),
+            cur_clip: ClipRegion::empty(),
+            peeking: Peek::NotPeeking,
+        }
+    }
+
+    pub fn display_list(&self) -> &'a BuiltDisplayList {
+        self.list
+    }
+
+    pub fn next<'b>(&'b mut self) -> Option<DisplayItemRef<'a, 'b>> {
+        use SpecificDisplayItem::*;
+
+        match self.peeking {
+            Peek::IsPeeking => {
+                self.peeking = Peek::NotPeeking;
+                return Some(self.as_ref())
+            }
+            Peek::StartPeeking => {
+                self.peeking = Peek::IsPeeking;
+            }
+            Peek::NotPeeking => { /* do nothing */ }
+        }
+
+        // Don't let these bleed into another item
+        self.cur_stops = ItemRange::default();
+        self.cur_clip = ClipRegion::empty();
+
+        loop {
+            if self.data.len() == 0 {
+                return None
+            }
+
+            self.cur_item = bincode::deserialize_from(&mut self.data, bincode::Infinite)
+                                    .expect("MEH: malicious process?");
+
+            match self.cur_item.item {
+                SetClipRegion(clip) => {
+                    self.cur_clip = clip;
+                    let (clip_range, clip_count) = self.skip_slice::<ComplexClipRegion>();
+                    self.cur_clip.complex_clip_count = clip_count;
+                    self.cur_clip.complex_clips = clip_range;
+
+                    // This is a dummy item, skip over it
+                    continue;
+                }
+                SetGradientStops => {
+                    self.cur_stops = self.skip_slice::<GradientStop>().0;
+
+                    // This is a dummy item, skip over it
+                    continue;
+                }
+                Text(_) => {
+                    self.cur_glyphs = self.skip_slice::<GlyphInstance>().0;
+                }
+                PushStackingContext(_) => {
+                    self.cur_filters = self.skip_slice::<FilterOp>().0;
+                }
+                _ => { /* do nothing */ }
+            }
+
+            break;
+        }
+
+        Some(self.as_ref())
+    }
+
+    /// Returns the byte-range the slice occupied, and the number of elements
+    /// in the slice.
+    fn skip_slice<T: Deserialize>(&mut self) -> (ItemRange<T>, usize) {
+        let base = self.list.data.as_ptr() as usize;
+        let start = self.data.as_ptr() as usize;
+
+        // Read through the values (this is a bit of a hack to reuse logic)
+        let mut iter = AuxIter::<T>::new(self.data);
+        let count = iter.len();
+        for _ in &mut iter {}
+        let end = iter.data.as_ptr() as usize;
+
+        let range = ItemRange { start: start - base, length: end - start, _boo: PhantomData };
+
+        // Adjust data pointer to skip read values
+        self.data = &self.data[range.length..];
+        (range, count)
+    }
+
+    pub fn as_ref<'b>(&'b self) -> DisplayItemRef<'a, 'b> {
+        DisplayItemRef { iter: self }
+    }
+
+    pub fn starting_stacking_context(&mut self)
+        -> Option<(StackingContext, LayoutRect, ItemRange<FilterOp>)> {
+
+        self.next().and_then(|item| match *item.item() {
+            SpecificDisplayItem::PushStackingContext(ref specific_item) => {
+                Some((specific_item.stacking_context, item.rect(), item.filters()))
+            },
+            _ => None,
+        })
+    }
+
+    pub fn skip_current_stacking_context(&mut self) {
+        let mut depth = 0;
+        while let Some(item) = self.next() {
+            match *item.item() {
+                SpecificDisplayItem::PushStackingContext(..) => depth += 1,
+                SpecificDisplayItem::PopStackingContext if depth == 0 => return,
+                SpecificDisplayItem::PopStackingContext => depth -= 1,
+                _ => {}
+            }
+            debug_assert!(depth >= 0);
+        }
+    }
+
+    pub fn current_stacking_context_empty(&mut self) -> bool {
+        match self.peek() {
+            Some(item) => *item.item() == SpecificDisplayItem::PopStackingContext,
+            None => true,
+        }
+    }
+
+    pub fn peek<'b>(&'b mut self) -> Option<DisplayItemRef<'a, 'b>> {
+        if self.peeking == Peek::NotPeeking {
+            self.peeking = Peek::StartPeeking;
+            self.next()
+        } else {
+            Some(self.as_ref())
+        }
+    }
+}
+
+// Some of these might just become ItemRanges
+impl<'a, 'b> DisplayItemRef<'a, 'b> {
+    pub fn display_item(&self) -> &DisplayItem {
+        &self.iter.cur_item
+    }
+
+    pub fn rect(&self) -> LayoutRect {
+        self.iter.cur_item.rect
+    }
+
+    pub fn clip_and_scroll(&self) -> ClipAndScrollInfo {
+        self.iter.cur_item.clip_and_scroll
+    }
+
+    pub fn item(&self) -> &SpecificDisplayItem {
+        &self.iter.cur_item.item
+    }
+
+    pub fn clip_region(&self) -> &ClipRegion {
+        &self.iter.cur_clip
+    }
+
+    pub fn gradient_stops(&self) -> ItemRange<GradientStop> {
+        self.iter.cur_stops
+    }
+
+    pub fn glyphs(&self) -> ItemRange<GlyphInstance> {
+        self.iter.cur_glyphs
+    }
+
+    pub fn filters(&self) -> ItemRange<FilterOp> {
+        self.iter.cur_filters
+    }
+
+    pub fn display_list(&self) -> &BuiltDisplayList {
+        self.iter.display_list()
+    }
+
+    // Creates a new iterator where this element's iterator
+    // is, to hack around borrowck.
+    pub fn sub_iter(&self) -> BuiltDisplayListIter<'a> {
+        BuiltDisplayListIter {
+            list: self.iter.list,
+            data: self.iter.data,
+            // Dummy data, will be overwritten by `next`
+            cur_item: DisplayItem {
+                item: SpecificDisplayItem::PopStackingContext,
+                rect: LayoutRect::zero(),
+                clip_and_scroll: ClipAndScrollInfo::simple(ClipId::new(0, PipelineId(0, 0))),
+            },
+            cur_stops: ItemRange::default(),
+            cur_glyphs: ItemRange::default(),
+            cur_filters: ItemRange::default(),
+            cur_clip: ClipRegion::empty(),
+            peeking: Peek::NotPeeking,
+        }
+    }
+}
+
+impl<'a, T: Deserialize> AuxIter<'a, T> {
+    pub fn new(mut data: &'a [u8]) -> Self {
+
+        let size: usize = if data.len() == 0 {
+            0   // Accept empty ItemRanges pointing anywhere
+        } else {
+            bincode::deserialize_from(&mut data, bincode::Infinite)
+                                  .expect("MEH: malicious input?")
+        };
+
+        AuxIter {
+            data: data,
+            size: size,
+            _boo: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: Deserialize> Iterator for AuxIter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.size == 0 {
+            None
+        } else {
+            self.size -= 1;
+            Some(bincode::deserialize_from(&mut self.data, bincode::Infinite)
+                         .expect("MEH: malicious input?"))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.size, Some(self.size))
+    }
+}
+
+impl<'a, T: Deserialize> ::std::iter::ExactSizeIterator for AuxIter<'a, T> { }
+
+
+// This is purely for the JSON writer in wrench
+impl Serialize for BuiltDisplayList {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(None)?;
+        let mut traversal = self.iter();
+        while let Some(item) = traversal.next() {
+            seq.serialize_element(&item)?
+        }
+        seq.end()
+    }
+}
+
+impl<'a, 'b> Serialize for DisplayItemRef<'a, 'b> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+
+        map.serialize_entry("item", self.display_item())?;
+
+        match *self.item() {
+            SpecificDisplayItem::Text(_) => {
+                map.serialize_entry("glyphs",
+                    &self.iter.list.get(self.glyphs()).collect::<Vec<_>>())?;
+            }
+            SpecificDisplayItem::PushStackingContext(_) => {
+                map.serialize_entry("filters",
+                    &self.iter.list.get(self.filters()).collect::<Vec<_>>())?;
+            }
+            _ => { }
+        }
+
+        let clip_region = self.clip_region();
+        let gradient_stops = self.gradient_stops();
+
+        map.serialize_entry("clip_region", &clip_region)?;
+        if !clip_region.complex_clips.is_empty() {
+            map.serialize_entry("complex_clips",
+                &self.iter.list.get(clip_region.complex_clips).collect::<Vec<_>>())?;
+        }
+
+        if !gradient_stops.is_empty() {
+            map.serialize_entry("gradient_stops",
+                &self.iter.list.get(gradient_stops).collect::<Vec<_>>())?;
+        }
+
+        map.end()
     }
 }
 
 #[derive(Clone)]
 pub struct DisplayListBuilder {
-    pub list: Vec<DisplayItem>,
-    auxiliary_lists_builder: AuxiliaryListsBuilder,
+    pub data: Vec<u8>,
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ClipAndScrollInfo>,
     next_clip_id: u64,
@@ -116,8 +432,7 @@ impl DisplayListBuilder {
     pub fn new(pipeline_id: PipelineId) -> DisplayListBuilder {
         let start_time = precise_time_ns();
         DisplayListBuilder {
-            list: Vec::new(),
-            auxiliary_lists_builder: AuxiliaryListsBuilder::new(),
+            data: Vec::with_capacity(1024 * 1024),
             pipeline_id: pipeline_id,
             clip_stack: vec![ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id))],
 
@@ -128,43 +443,71 @@ impl DisplayListBuilder {
     }
 
     pub fn print_display_list(&mut self) {
-        for item in &self.list {
-            println!("{:?}", item);
+        let mut temp = BuiltDisplayList::default();
+        ::std::mem::swap(&mut temp.data, &mut self.data);
+
+        {
+            let mut iter = BuiltDisplayListIter::new(&temp);
+            while let Some(item) = iter.next() {
+                println!("{:?}", item.display_item());
+            }
         }
+
+        self.data = temp.data;
     }
 
-    fn push_item(&mut self, item: SpecificDisplayItem, rect: LayoutRect, clip: ClipRegion) {
-        self.list.push(DisplayItem {
+    fn push_item(&mut self, item: SpecificDisplayItem, rect: LayoutRect) {
+        bincode::serialize_into(&mut self.data, &DisplayItem {
             item: item,
             rect: rect,
-            clip: clip,
             clip_and_scroll: *self.clip_stack.last().unwrap(),
-        });
+        }, bincode::Infinite).unwrap();
     }
 
     fn push_new_empty_item(&mut self, item: SpecificDisplayItem) {
-        self.list.push(DisplayItem {
+        bincode::serialize_into(&mut self.data, &DisplayItem {
             item: item,
             rect: LayoutRect::zero(),
-            clip: ClipRegion::simple(&LayoutRect::zero()),
             clip_and_scroll: *self.clip_stack.last().unwrap(),
-        });
+        }, bincode::Infinite).unwrap();
+    }
+
+    fn push_iter<I>(&mut self, iter: I)
+    where I: IntoIterator,
+          I::IntoIter: ExactSizeIterator,
+          I::Item: Serialize,
+    {
+        let iter = iter.into_iter();
+        let len = iter.len();
+        let mut count = 0;
+
+        bincode::serialize_into(&mut self.data, &len, bincode::Infinite).unwrap();
+        for elem in iter {
+            count += 1;
+            bincode::serialize_into(&mut self.data, &elem, bincode::Infinite).unwrap();
+        }
+
+        debug_assert_eq!(len, count);
+    }
+
+    fn push_range<T>(&mut self, range: ItemRange<T>, src: &BuiltDisplayList) {
+        self.data.extend_from_slice(&src.data[range.start..range.start+range.length]);
     }
 
     pub fn push_rect(&mut self,
                      rect: LayoutRect,
-                     clip: ClipRegion,
+                     _token: ClipRegionToken,
                      color: ColorF) {
         let item = SpecificDisplayItem::Rectangle(RectangleDisplayItem {
             color: color,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_image(&mut self,
                       rect: LayoutRect,
-                      clip: ClipRegion,
+                      _token: ClipRegionToken,
                       stretch_size: LayoutSize,
                       tile_spacing: LayoutSize,
                       image_rendering: ImageRendering,
@@ -176,35 +519,35 @@ impl DisplayListBuilder {
             image_rendering: image_rendering,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     /// Push a yuv image. All planar data in yuv image should use the same buffer type.
     pub fn push_yuv_image(&mut self,
                           rect: LayoutRect,
-                          clip: ClipRegion,
+                          _token: ClipRegionToken,
                           yuv_data: YuvData,
                           color_space: YuvColorSpace) {
         let item = SpecificDisplayItem::YuvImage(YuvImageDisplayItem {
             yuv_data: yuv_data,
             color_space: color_space,
         });
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_webgl_canvas(&mut self,
                              rect: LayoutRect,
-                             clip: ClipRegion,
+                             _token: ClipRegionToken,
                              context_id: WebGLContextId) {
         let item = SpecificDisplayItem::WebGL(WebGLDisplayItem {
             context_id: context_id,
         });
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_text(&mut self,
                      rect: LayoutRect,
-                     clip: ClipRegion,
+                     _token: ClipRegionToken,
                      glyphs: &[GlyphInstance],
                      font_key: FontKey,
                      color: ColorF,
@@ -220,14 +563,14 @@ impl DisplayListBuilder {
         if size < Au::from_px(4096) {
             let item = SpecificDisplayItem::Text(TextDisplayItem {
                 color: color,
-                glyphs: self.auxiliary_lists_builder.add_glyph_instances(&glyphs),
                 font_key: font_key,
                 size: size,
                 blur_radius: blur_radius,
                 glyph_options: glyph_options,
             });
 
-            self.push_item(item, rect, clip);
+            self.push_item(item, rect);
+            self.push_iter(glyphs);
         }
     }
 
@@ -308,6 +651,8 @@ impl DisplayListBuilder {
         }
     }
 
+    // NOTE: gradients must be pushed in the order they're created
+    // because create_gradient stores the stops in anticipation
     pub fn create_gradient(&mut self,
                            start_point: LayoutPoint,
                            end_point: LayoutPoint,
@@ -318,14 +663,17 @@ impl DisplayListBuilder {
 
         let start_to_end = end_point - start_point;
 
+        self.push_stops(&stops);
+
         Gradient {
             start_point: start_point + start_to_end * start_offset,
             end_point: start_point + start_to_end * end_offset,
-            stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
             extend_mode: extend_mode,
         }
     }
 
+    // NOTE: gradients must be pushed in the order they're created
+    // because create_gradient stores the stops in anticipation
     pub fn create_radial_gradient(&mut self,
                                   center: LayoutPoint,
                                   radius: LayoutSize,
@@ -337,15 +685,18 @@ impl DisplayListBuilder {
             // gradient.
             let last_color = stops.last().unwrap().color;
 
-            stops.clear();
-            stops.push(GradientStop {
-                offset: 0.0,
-                color: last_color,
-            });
-            stops.push(GradientStop {
-                offset: 1.0,
-                color: last_color,
-            });
+            let stops = [
+                GradientStop {
+                    offset: 0.0,
+                    color: last_color,
+                },
+                GradientStop {
+                    offset: 1.0,
+                    color: last_color,
+                },
+            ];
+
+            self.push_stops(&stops);
 
             return RadialGradient {
                 start_center: center,
@@ -353,7 +704,6 @@ impl DisplayListBuilder {
                 end_center: center,
                 end_radius: 1.0,
                 ratio_xy: 1.0,
-                stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
                 extend_mode: extend_mode,
             };
         }
@@ -361,17 +711,20 @@ impl DisplayListBuilder {
         let (start_offset,
              end_offset) = DisplayListBuilder::normalize_stops(&mut stops, extend_mode);
 
+        self.push_stops(&stops);
+
         RadialGradient {
             start_center: center,
             start_radius: radius.width * start_offset,
             end_center: center,
             end_radius: radius.width * end_offset,
             ratio_xy: radius.width / radius.height,
-            stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
             extend_mode: extend_mode,
         }
     }
 
+    // NOTE: gradients must be pushed in the order they're created
+    // because create_gradient stores the stops in anticipation
     pub fn create_complex_radial_gradient(&mut self,
                                           start_center: LayoutPoint,
                                           start_radius: f32,
@@ -380,20 +733,22 @@ impl DisplayListBuilder {
                                           ratio_xy: f32,
                                           stops: Vec<GradientStop>,
                                           extend_mode: ExtendMode) -> RadialGradient {
+
+        self.push_stops(&stops);
+
         RadialGradient {
             start_center: start_center,
             start_radius: start_radius,
             end_center: end_center,
             end_radius: end_radius,
             ratio_xy: ratio_xy,
-            stops: self.auxiliary_lists_builder.add_gradient_stops(&stops),
             extend_mode: extend_mode,
         }
     }
 
     pub fn push_border(&mut self,
                        rect: LayoutRect,
-                       clip: ClipRegion,
+                       _token: ClipRegionToken,
                        widths: BorderWidths,
                        details: BorderDetails) {
         let item = SpecificDisplayItem::Border(BorderDisplayItem {
@@ -401,12 +756,12 @@ impl DisplayListBuilder {
             widths: widths,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_box_shadow(&mut self,
                            rect: LayoutRect,
-                           clip: ClipRegion,
+                           _token: ClipRegionToken,
                            box_bounds: LayoutRect,
                            offset: LayoutPoint,
                            color: ColorF,
@@ -424,12 +779,12 @@ impl DisplayListBuilder {
             clip_mode: clip_mode,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_gradient(&mut self,
                          rect: LayoutRect,
-                         clip: ClipRegion,
+                         _token: ClipRegionToken,
                          gradient: Gradient,
                          tile_size: LayoutSize,
                          tile_spacing: LayoutSize) {
@@ -439,12 +794,12 @@ impl DisplayListBuilder {
             tile_spacing: tile_spacing,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_radial_gradient(&mut self,
                                 rect: LayoutRect,
-                                clip: ClipRegion,
+                                _token: ClipRegionToken,
                                 gradient: RadialGradient,
                                 tile_size: LayoutSize,
                                 tile_spacing: LayoutSize) {
@@ -454,7 +809,7 @@ impl DisplayListBuilder {
             tile_spacing: tile_spacing,
         });
 
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     pub fn push_stacking_context(&mut self,
@@ -472,20 +827,28 @@ impl DisplayListBuilder {
                 transform_style: transform_style,
                 perspective: perspective,
                 mix_blend_mode: mix_blend_mode,
-                filters: self.auxiliary_lists_builder.add_filters(&filters),
             }
         });
 
-        self.push_item(item, bounds, ClipRegion::simple(&LayoutRect::zero()));
+        self.push_item(item, bounds);
+        self.push_iter(&filters);
     }
 
     pub fn pop_stacking_context(&mut self) {
         self.push_new_empty_item(SpecificDisplayItem::PopStackingContext);
     }
 
+    pub fn push_stops(&mut self, stops: &[GradientStop]) {
+        if stops.is_empty() {
+            return
+        }
+        self.push_new_empty_item(SpecificDisplayItem::SetGradientStops);
+        self.push_iter(stops);
+    }
+
     pub fn define_clip(&mut self,
                        content_rect: LayoutRect,
-                       clip: ClipRegion,
+                       _token: ClipRegionToken,
                        id: Option<ClipId>)
                        -> ClipId {
         let id = match id {
@@ -501,15 +864,15 @@ impl DisplayListBuilder {
             parent_id: self.clip_stack.last().unwrap().scroll_node_id,
         });
 
-        self.push_item(item, content_rect, clip);
+        self.push_item(item, content_rect);
         id
     }
 
     pub fn push_clip_node(&mut self,
-                          clip: ClipRegion,
                           content_rect: LayoutRect,
-                          id: Option<ClipId>) {
-        let id = self.define_clip(content_rect, clip, id);
+                          token: ClipRegionToken,
+                          id: Option<ClipId>){
+        let id = self.define_clip(content_rect, token, id);
         self.clip_stack.push(ClipAndScrollInfo::simple(id));
     }
 
@@ -530,259 +893,81 @@ impl DisplayListBuilder {
         self.pop_clip_id();
     }
 
-    pub fn push_iframe(&mut self, rect: LayoutRect, clip: ClipRegion, pipeline_id: PipelineId) {
+    pub fn push_iframe(&mut self, rect: LayoutRect, _token: ClipRegionToken, pipeline_id: PipelineId) {
         let item = SpecificDisplayItem::Iframe(IframeDisplayItem { pipeline_id: pipeline_id });
-        self.push_item(item, rect, clip);
+        self.push_item(item, rect);
     }
 
     // Don't use this function. It will go away.
     // We're using it as a hack in Gecko to retain parts sub-parts of display lists so that
-    // we can regenerate them without building Gecko display items. 
-    pub fn push_built_display_list(&mut self, dl: BuiltDisplayList, aux: AuxiliaryLists) {
-        use SpecificDisplayItem::*;
-        // It's important for us to make sure that all of ItemRange structures are relocated
-        // when copying from one list to another. To avoid this problem we could use a custom
-        // derive implementation that would let ItemRanges relocate themselves.
-        for i in dl.all_display_items() {
-            let mut i = *i;
-            match i.item {
-                Text(ref mut item) => {
-                    item.glyphs = self.auxiliary_lists_builder.add_glyph_instances(aux.glyph_instances(&item.glyphs));
-                }
-                Gradient(ref mut item) => {
-                    item.gradient.stops = self.auxiliary_lists_builder.add_gradient_stops(aux.gradient_stops(&item.gradient.stops));
-                }
-                RadialGradient(ref mut item) => {
-                    item.gradient.stops = self.auxiliary_lists_builder.add_gradient_stops(aux.gradient_stops(&item.gradient.stops));
-                }
-                PushStackingContext(ref mut item) => {
-                    item.stacking_context.filters = self.auxiliary_lists_builder.add_filters(aux.filters(&item.stacking_context.filters));
-                }
-                Iframe(_) | Clip(_) => {
-                    // We don't support relocating these
-                    panic!();
-                }
-                _ => {}
+    // we can regenerate them without building Gecko display items.
+    pub fn push_built_display_list(&mut self, dl: BuiltDisplayList) {
+        // NOTE: Iframe and Clips aren't supported.
+
+        // FIXME: what `iter` here is doing an expensive deserialization
+        // because we need to update clip_and_scroll info! If we didn't need to
+        // update that, this function could just be memcopy!
+
+        // This implementation is basically BuiltDisplayListIter::next in reverse.
+
+        let mut iter = dl.iter();
+        while let Some(item) = iter.next() {
+            // First handle explicit prefix dummy items
+            let clip_region = item.clip_region();
+            if *clip_region != ClipRegion::empty() {
+                self.push_new_empty_item(SpecificDisplayItem::SetClipRegion(*clip_region));
+                self.push_range(clip_region.complex_clips, &dl);
             }
-            i.clip.complex =
-                self.auxiliary_lists_builder
-                    .add_complex_clip_regions(aux.complex_clip_regions(&i.clip.complex));
-            i.clip_and_scroll = *self.clip_stack.last().unwrap();
-            self.list.push(i);
-        }
-    }
 
-    pub fn new_clip_region(&mut self,
-                           rect: &LayoutRect,
-                           complex: Vec<ComplexClipRegion>,
-                           image_mask: Option<ImageMask>)
-                           -> ClipRegion {
-        ClipRegion::new(rect, complex, image_mask, &mut self.auxiliary_lists_builder)
-    }
+            let stops = item.gradient_stops();
+            if stops != ItemRange::default() {
+                self.push_new_empty_item(SpecificDisplayItem::SetGradientStops);
+                self.push_range(stops, &dl);
+            }
 
-    pub fn finalize(self) -> (PipelineId, BuiltDisplayList, AuxiliaryLists) {
-        unsafe {
-            let blob = convert_vec_pod_to_blob(self.list);
-            let aux_list = self.auxiliary_lists_builder.finalize();
+            // Then reinsert the actual item, updating its clip_and_scroll
+            self.push_item(*item.item(), item.rect());
 
-            let end_time = precise_time_ns();
-
-            (self.pipeline_id,
-             BuiltDisplayList {
-                 descriptor: BuiltDisplayListDescriptor {
-                    display_list_items_size: blob.len(),
-                    builder_start_time: self.builder_start_time,
-                    builder_finish_time: end_time,
-                 },
-                 data: blob,
-             },
-             aux_list)
-        }
-    }
-}
-
-impl ItemRange {
-    pub fn new<T>(backing_list: &mut Vec<T>, items: &[T]) -> ItemRange where T: Copy + Clone {
-        let start = backing_list.len();
-        backing_list.extend_from_slice(items);
-        ItemRange {
-            start: start,
-            length: items.len(),
-        }
-    }
-
-    pub fn empty() -> ItemRange {
-        ItemRange {
-            start: 0,
-            length: 0,
-        }
-    }
-
-    pub fn get<'a, T>(&self, backing_list: &'a [T]) -> &'a [T] {
-        &backing_list[self.start..(self.start + self.length)]
-    }
-
-    pub fn get_mut<'a, T>(&self, backing_list: &'a mut [T]) -> &'a mut [T] {
-        &mut backing_list[self.start..(self.start + self.length)]
-    }
-}
-
-#[derive(Clone, Default)]
-pub struct AuxiliaryListsBuilder {
-    gradient_stops: Vec<GradientStop>,
-    complex_clip_regions: Vec<ComplexClipRegion>,
-    filters: Vec<FilterOp>,
-    glyph_instances: Vec<GlyphInstance>,
-}
-
-impl AuxiliaryListsBuilder {
-    pub fn new() -> AuxiliaryListsBuilder {
-        AuxiliaryListsBuilder::default()
-    }
-
-    pub fn add_gradient_stops(&mut self, gradient_stops: &[GradientStop]) -> ItemRange {
-        ItemRange::new(&mut self.gradient_stops, gradient_stops)
-    }
-
-    pub fn gradient_stops(&self, gradient_stops_range: &ItemRange) -> &[GradientStop] {
-        gradient_stops_range.get(&self.gradient_stops[..])
-    }
-
-    pub fn add_complex_clip_regions(&mut self, complex_clip_regions: &[ComplexClipRegion])
-                                    -> ItemRange {
-        ItemRange::new(&mut self.complex_clip_regions, complex_clip_regions)
-    }
-
-    pub fn complex_clip_regions(&self, complex_clip_regions_range: &ItemRange)
-                                -> &[ComplexClipRegion] {
-        complex_clip_regions_range.get(&self.complex_clip_regions[..])
-    }
-
-    pub fn add_filters(&mut self, filters: &[FilterOp]) -> ItemRange {
-        ItemRange::new(&mut self.filters, filters)
-    }
-
-    pub fn filters(&self, filters_range: &ItemRange) -> &[FilterOp] {
-        filters_range.get(&self.filters[..])
-    }
-
-    pub fn add_glyph_instances(&mut self, glyph_instances: &[GlyphInstance]) -> ItemRange {
-        ItemRange::new(&mut self.glyph_instances, glyph_instances)
-    }
-
-    pub fn glyph_instances(&self, glyph_instances_range: &ItemRange) -> &[GlyphInstance] {
-        glyph_instances_range.get(&self.glyph_instances[..])
-    }
-
-    pub fn finalize(self) -> AuxiliaryLists {
-        unsafe {
-            let mut blob = convert_vec_pod_to_blob(self.gradient_stops);
-            let gradient_stops_size = blob.len();
-            blob.extend_from_slice(convert_pod_to_blob(&self.complex_clip_regions));
-            let complex_clip_regions_size = blob.len() - gradient_stops_size;
-            blob.extend_from_slice(convert_pod_to_blob(&self.filters));
-            let filters_size = blob.len() - (complex_clip_regions_size + gradient_stops_size);
-            blob.extend_from_slice(convert_pod_to_blob(&self.glyph_instances));
-            let glyph_instances_size = blob.len() -
-                (complex_clip_regions_size + gradient_stops_size + filters_size);
-
-            AuxiliaryLists {
-                data: blob,
-                descriptor: AuxiliaryListsDescriptor {
-                    gradient_stops_size: gradient_stops_size,
-                    complex_clip_regions_size: complex_clip_regions_size,
-                    filters_size: filters_size,
-                    glyph_instances_size: glyph_instances_size,
-                },
+            // Then handle implicit suffix items
+            match *item.item() {
+                SpecificDisplayItem::Text(_)                => self.push_range(item.glyphs(), &dl),
+                SpecificDisplayItem::PushStackingContext(_) => self.push_range(item.filters(), &dl),
+                _ => { /* do nothing */ }
             }
         }
     }
-}
 
-impl AuxiliaryListsDescriptor {
-    pub fn size(&self) -> usize {
-        self.gradient_stops_size + self.complex_clip_regions_size + self.filters_size +
-            self.glyph_instances_size
+    pub fn push_clip_region<I>(&mut self,
+                            rect: &LayoutRect,
+                            complex: I,
+                            image_mask: Option<ImageMask>)
+                            -> ClipRegionToken
+    where I: IntoIterator<Item = ComplexClipRegion>,
+          I::IntoIter: ExactSizeIterator,
+    {
+        self.push_new_empty_item(SpecificDisplayItem::SetClipRegion(
+            ClipRegion::new(rect, image_mask),
+        ));
+        self.push_iter(complex);
+
+        ClipRegionToken { _unforgeable: () }
+    }
+
+    pub fn finalize(self) -> (PipelineId, BuiltDisplayList) {
+        let end_time = precise_time_ns();
+
+        (self.pipeline_id,
+         BuiltDisplayList {
+            descriptor: BuiltDisplayListDescriptor {
+            display_list_items_size: self.data.len(),
+            builder_start_time: self.builder_start_time,
+            builder_finish_time: end_time,
+            },
+            data: self.data,
+         })
     }
 }
 
-impl AuxiliaryLists {
-    /// Creates a new `AuxiliaryLists` instance from a descriptor and data received over a channel.
-    pub fn from_data(data: Vec<u8>, descriptor: AuxiliaryListsDescriptor) -> AuxiliaryLists {
-        AuxiliaryLists {
-            data: data,
-            descriptor: descriptor,
-        }
-    }
-
-    pub fn into_data(self) -> (Vec<u8>, AuxiliaryListsDescriptor) {
-        (self.data, self.descriptor)
-    }
-
-    pub fn data(&self) -> &[u8] {
-        &self.data[..]
-    }
-
-    pub fn descriptor(&self) -> &AuxiliaryListsDescriptor {
-        &self.descriptor
-    }
-
-    /// Returns the gradient stops described by `gradient_stops_range`.
-    pub fn gradient_stops(&self, gradient_stops_range: &ItemRange) -> &[GradientStop] {
-        unsafe {
-            let end = self.descriptor.gradient_stops_size;
-            gradient_stops_range.get(convert_blob_to_pod(&self.data[0..end]))
-        }
-    }
-
-    /// Returns the complex clipping regions described by `complex_clip_regions_range`.
-    pub fn complex_clip_regions(&self, complex_clip_regions_range: &ItemRange)
-                                -> &[ComplexClipRegion] {
-        let start = self.descriptor.gradient_stops_size;
-        let end = start + self.descriptor.complex_clip_regions_size;
-        unsafe {
-            complex_clip_regions_range.get(convert_blob_to_pod(&self.data[start..end]))
-        }
-    }
-
-    /// Returns the filters described by `filters_range`.
-    pub fn filters(&self, filters_range: &ItemRange) -> &[FilterOp] {
-        let start = self.descriptor.gradient_stops_size +
-            self.descriptor.complex_clip_regions_size;
-        let end = start + self.descriptor.filters_size;
-        unsafe {
-            filters_range.get(convert_blob_to_pod(&self.data[start..end]))
-        }
-    }
-
-    /// Returns the glyph instances described by `glyph_instances_range`.
-    pub fn glyph_instances(&self, glyph_instances_range: &ItemRange) -> &[GlyphInstance] {
-        let start = self.descriptor.gradient_stops_size +
-            self.descriptor.complex_clip_regions_size + self.descriptor.filters_size;
-        unsafe {
-            glyph_instances_range.get(convert_blob_to_pod(&self.data[start..]))
-        }
-    }
-}
-
-unsafe fn convert_pod_to_blob<T>(data: &[T]) -> &[u8] where T: Copy + 'static {
-    slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * mem::size_of::<T>())
-}
-
-// this variant of the above lets us convert without needing to make a copy
-unsafe fn convert_vec_pod_to_blob<T>(mut data: Vec<T>) -> Vec<u8> where T: Copy + 'static {
-    let v = Vec::from_raw_parts(data.as_mut_ptr() as *mut u8, data.len() * mem::size_of::<T>(), data.capacity() * mem::size_of::<T>());
-    mem::forget(data);
-    v
-}
-
-unsafe fn convert_blob_to_pod<T>(blob: &[u8]) -> &[T] where T: Copy + 'static {
-    slice::from_raw_parts(blob.as_ptr() as *const T, blob.len() / mem::size_of::<T>())
-}
-
-// this variant of the above lets us convert without needing to make a copy
-unsafe fn convert_vec_blob_to_pod<T>(mut data: Vec<u8>) -> Vec<T> where T: Copy + 'static {
-    let v = Vec::from_raw_parts(data.as_mut_ptr() as *mut T, data.len() / mem::size_of::<T>(), data.capacity() / mem::size_of::<T>());
-    mem::forget(data);
-    v
-}
+/// Verification that push_clip_region was called before
+/// pushing an item that requires it.
+pub struct ClipRegionToken { _unforgeable: () }

--- a/webrender_traits/src/lib.rs
+++ b/webrender_traits/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments, float_cmp))]
 
 extern crate app_units;
+extern crate bincode;
 extern crate byteorder;
 #[cfg(feature = "nightly")]
 extern crate core;

--- a/wrench/src/scene.rs
+++ b/wrench/src/scene.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-use webrender_traits::{AuxiliaryLists, BuiltDisplayList, ColorF, DisplayItem, Epoch};
+use webrender_traits::{BuiltDisplayList, ColorF, Epoch};
 use webrender_traits::{LayerSize, PipelineId};
 
 /// A representation of the layout within the display port for a given document or iframe.
@@ -18,8 +18,7 @@ pub struct ScenePipeline {
 pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipeline_map: HashMap<PipelineId, ScenePipeline>,
-    pub pipeline_auxiliary_lists: HashMap<PipelineId, AuxiliaryLists>,
-    pub display_lists: HashMap<PipelineId, Vec<DisplayItem>>,
+    pub display_lists: HashMap<PipelineId, BuiltDisplayList>,
 }
 
 impl Scene {
@@ -27,7 +26,6 @@ impl Scene {
         Scene {
             root_pipeline_id: None,
             pipeline_map: HashMap::default(),
-            pipeline_auxiliary_lists: HashMap::default(),
             display_lists: HashMap::default(),
         }
     }
@@ -52,9 +50,7 @@ impl Scene {
 
     pub fn finish_display_list(&mut self,
                                pipeline_id: PipelineId,
-                               built_display_list: BuiltDisplayList,
-                               auxiliary_lists: AuxiliaryLists) {
-        self.pipeline_auxiliary_lists.insert(pipeline_id, auxiliary_lists);
-        self.display_lists.insert(pipeline_id, built_display_list.all_display_items().to_vec());
+                               built_display_list: BuiltDisplayList) {
+        self.display_lists.insert(pipeline_id, built_display_list);
     }
 }


### PR DESCRIPTION
This replaces the existing unsound IPC with new sound and validated bincode-based IPC. On my laptop this regresses mean display list IPC time from 1.5ms to 1.8ms, which is reasonable enough to land and optimize later.

Major differences:

* We never construct a `Vec<DisplayItem>` any more. DisplayListBuilder directly serializes the data into a Vec<u8>. The backend similarly deserializes data on-the-fly. This reduces the memory footprint of BuiltDisplayLists, and eliminates several copies/allocations.

* AuxiliaryLists are no more. Auxiliary data is stored in the DisplayList next to the relevant item. When streaming the data out, we skip over these lists and just produce ItemRanges, similar to the old API. To do this while minimally impacting the rest of webrender and its consumers, there are two new "dummy" DisplayItems: SetGradientStops and SetClipRegion. These affect the subsequent DisplayItem, and will never be yielded by the BuiltDisplayListIter.

* DisplayItem no longer stores any ItemRanges or a ClipRegion. Instead these values are stored "on the side" and can be requested from the item yielded by BuiltDisplayListIter. This necessitates threading some additional state for certain methods. Notably number-of-items and size-of-item-range are no longer equivalent, and the former must therefore be threaded separately. ItemRange's fields have been made private to prevent anyone from relying on this.

* ItemRanges are now typed. This makes type declarations clearer, prevents theoretical bugs, and gives DisplayList a nicer API for getting auxiliary data.

* I needed to rewrite some of the gradient code, as it was relying on reverse iteration of auxiliary data, which is no longer supported. @rlhunt has approved my new implementation.

NOTE: this changes some public APIs and will need some changes in Servo and Gecko. I'll work on those follow ups next week.

# wr-stats in Servo:

With Transmute (Before This PR):
<img width="539" alt="ipc-with-transmute" src="https://cloud.githubusercontent.com/assets/1136864/25545859/924c1848-2c2e-11e7-9833-efb2c8612ca0.png">

With Bincode (After This PR):
<img width="535" alt="ipc-with-bincode" src="https://cloud.githubusercontent.com/assets/1136864/25545858/924bc9a6-2c2e-11e7-9288-80a6ad8e671b.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1181)
<!-- Reviewable:end -->
