### PR TITLE
Don't allow creating an external ClipId 0 that isn't root

### DIFF
--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -587,6 +587,12 @@ impl ClipId {
     }
 
     pub fn new(id: u64, pipeline_id: PipelineId) -> ClipId {
+        // We do this because it is very easy to create accidentally create something that
+        // seems like a root scroll node, but isn't one.
+        if id == 0 {
+            return ClipId::root_scroll_node(pipeline_id);
+        }
+
         ClipId::ClipExternalId(id, pipeline_id)
     }
 

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -873,6 +873,10 @@ impl ClipIdMapper {
     }
 
     fn map(&self, id: &ClipId) -> usize {
+        if id.is_root_scroll_node() {
+            return 0;
+        }
+
         *self.hash_map.get(id).unwrap()
     }
 }


### PR DESCRIPTION
Also, specifically handle the root ClipId in the wrench yaml writer.

Fixes #1060.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1184)
<!-- Reviewable:end -->
