### PR TITLE
An option to force no batching

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -86,19 +86,7 @@ pub struct FrameBuilderConfig {
     pub enable_scrollbars: bool,
     pub enable_subpixel_aa: bool,
     pub debug: bool,
-}
-
-impl FrameBuilderConfig {
-    pub fn new(enable_scrollbars: bool,
-               enable_subpixel_aa: bool,
-               debug: bool)
-               -> FrameBuilderConfig {
-        FrameBuilderConfig {
-            enable_scrollbars: enable_scrollbars,
-            enable_subpixel_aa: enable_subpixel_aa,
-            debug: debug,
-        }
-    }
+    pub force_cut_batches: bool,
 }
 
 pub struct FrameBuilder {
@@ -1305,7 +1293,8 @@ impl FrameBuilder {
         for index in 0..required_pass_count {
             passes.push(RenderPass::new(index as isize,
                                         index == required_pass_count-1,
-                                        cache_size));
+                                        cache_size,
+                                        self.config.force_cut_batches));
         }
 
         main_render_task.assign_to_passes(passes.len() - 1, &mut passes);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -994,9 +994,12 @@ impl Renderer {
             RendererKind::OSMesa => GLContextHandleWrapper::current_osmesa_handle(),
         };
 
-        let config = FrameBuilderConfig::new(options.enable_scrollbars,
-                                             options.enable_subpixel_aa,
-                                             options.debug);
+        let config = FrameBuilderConfig {
+            enable_scrollbars: options.enable_scrollbars,
+            enable_subpixel_aa: options.enable_subpixel_aa,
+            debug: options.debug,
+            force_cut_batches: options.force_cut_batches,
+        };
 
         let (device_pixel_ratio, enable_aa) = (options.device_pixel_ratio, options.enable_aa);
         let render_target_debug = options.render_target_debug;
@@ -2122,6 +2125,7 @@ pub struct RendererOptions {
     pub clear_color: ColorF,
     pub render_target_debug: bool,
     pub max_texture_size: Option<u32>,
+    pub force_cut_batches: bool,
     pub workers: Option<Arc<Mutex<ThreadPool>>>,
     pub blob_image_renderer: Option<Box<BlobImageRenderer>>,
     pub recorder: Option<Box<ApiRecordingReceiver>>,
@@ -2145,6 +2149,7 @@ impl Default for RendererOptions {
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
             render_target_debug: false,
             max_texture_size: None,
+            force_cut_batches: false,
             workers: None,
             blob_image_renderer: None,
             recorder: None,

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -50,6 +50,10 @@ args:
   - vsync:
       long: vsync
       help: Enable vsync for OpenGL window
+  - no_batch:
+      short: b
+      long: no-batch
+      help: Disable instanced batching
 
 subcommands:
     - png:

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -324,7 +324,8 @@ fn main() {
                                  args.is_present("rebuild"),
                                  args.is_present("subpixel_aa"),
                                  args.is_present("debug"),
-                                 args.is_present("verbose"));
+                                 args.is_present("verbose"),
+                                 args.is_present("no_batch"));
 
     let mut thing =
         if let Some(subargs) = args.subcommand_matches("show") {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -146,7 +146,8 @@ impl Wrench {
                do_rebuild: bool,
                subpixel_aa: bool,
                debug: bool,
-               verbose: bool)
+               verbose: bool,
+               force_batch_cut: bool)
            -> Wrench
     {
         println!("Shader override path: {:?}", shader_override_path);
@@ -172,6 +173,7 @@ impl Wrench {
             enable_subpixel_aa: subpixel_aa,
             debug: debug,
             max_recorded_profiles: 16,
+            force_cut_batches: force_batch_cut,
             .. Default::default()
         };
 


### PR DESCRIPTION
The new option allows inspecting intermediate rendering results easier with `apitrace` and other GPU debugging tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1185)
<!-- Reviewable:end -->
