### PR TITLE
Yuv interleaved format

### DIFF
--- a/webrender/res/ps_yuv_image.fs.glsl
+++ b/webrender/res/ps_yuv_image.fs.glsl
@@ -54,6 +54,7 @@ void main(void) {
     vec2 st_y = vTextureOffsetY + clamp(
         relative_pos_in_rect / vStretchSize * vTextureSizeY,
         vHalfTexelY, vTextureSizeY - vHalfTexelY);
+#ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR
     vec2 uv_offset = clamp(
         relative_pos_in_rect / vStretchSize * vTextureSizeUv,
         vHalfTexelUv, vTextureSizeUv - vHalfTexelUv);
@@ -61,9 +62,12 @@ void main(void) {
     // The texture coordinates of u and v are the same. So, we could skip the
     // st_v if the format is NV12.
     vec2 st_u = vTextureOffsetU + uv_offset;
+#endif
 
     vec3 yuv_value;
-#ifdef WR_FEATURE_NV12
+#ifdef WR_FEATURE_INTERLEAVED_Y_CB_CR
+    yuv_value = TEX_SAMPLE(sColor0, st_y).rgb;
+#elif defined(WR_FEATURE_NV12)
     yuv_value.x = TEX_SAMPLE(sColor0, st_y).r;
     yuv_value.yz = TEX_SAMPLE(sColor1, st_u).rg;
 #else

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -26,9 +26,11 @@ void main(void) {
     write_clip(vi.screen_pos, prim.clip_area);
 
     ResourceRect y_rect = fetch_resource_rect(prim.user_data.x);
+#ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR  // only 1 channel
     ResourceRect u_rect = fetch_resource_rect(prim.user_data.x + 1);
-#ifndef WR_FEATURE_NV12
+#ifndef WR_FEATURE_NV12 // 2 channel
     ResourceRect v_rect = fetch_resource_rect(prim.user_data.x + 2);
+#endif
 #endif
 
     // If this is in WR_FEATURE_TEXTURE_RECT mode, the rect and size use
@@ -44,6 +46,7 @@ void main(void) {
     vTextureSizeY = y_st1 - y_st0;
     vTextureOffsetY = y_st0;
 
+#ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR
     // This assumes the U and V surfaces have the same size.
 #ifdef WR_FEATURE_TEXTURE_RECT
     vec2 uv_texture_size_normalization_factor = vec2(1, 1);
@@ -62,10 +65,13 @@ void main(void) {
 #ifndef WR_FEATURE_NV12
     vTextureOffsetV = v_st0;
 #endif
+#endif
 
     YuvImage image = fetch_yuv_image(prim.prim_index);
     vStretchSize = image.size;
 
     vHalfTexelY = vec2(0.5) / y_texture_size_normalization_factor;
+#ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR
     vHalfTexelUv = vec2(0.5) / uv_texture_size_normalization_factor;
+#endif
 }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1040,6 +1040,8 @@ impl FrameBuilder {
             YuvData::NV12(plane_0, plane_1) => [plane_0, plane_1, ImageKey::new(0, 0)],
             YuvData::PlanarYCbCr(plane_0, plane_1, plane_2) =>
                 [plane_0, plane_1, plane_2],
+            YuvData::InterleavedYCbCr(plane_0) =>
+                [plane_0, ImageKey::new(0, 0), ImageKey::new(0, 0)],
         };
 
         let prim_cpu = YuvImagePrimitiveCpu {

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -377,8 +377,9 @@ impl YuvColorSpace {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum YuvData {
-    NV12(ImageKey, ImageKey),
-    PlanarYCbCr(ImageKey, ImageKey, ImageKey),
+    NV12(ImageKey, ImageKey),   // (Y channel, CbCr interleaved channel)
+    PlanarYCbCr(ImageKey, ImageKey, ImageKey),  // (Y channel, Cb channel, Cr Channel)
+    InterleavedYCbCr(ImageKey), // (YCbCr interleaved channel)
 }
 
 impl YuvData {
@@ -386,6 +387,7 @@ impl YuvData {
         match *self {
             YuvData::NV12(..) => YuvFormat::NV12,
             YuvData::PlanarYCbCr(..) => YuvFormat::PlanarYCbCr,
+            YuvData::InterleavedYCbCr(..) => YuvFormat::InterleavedYCbCr,
         }
     }
 }
@@ -394,14 +396,16 @@ impl YuvData {
 pub enum YuvFormat {
     NV12 = 0,
     PlanarYCbCr = 1,
+    InterleavedYCbCr = 2,
 }
-pub const YUV_FORMATS: [YuvFormat; 2] = [YuvFormat::NV12, YuvFormat::PlanarYCbCr];
+pub const YUV_FORMATS: [YuvFormat; 3] = [YuvFormat::NV12, YuvFormat::PlanarYCbCr, YuvFormat::InterleavedYCbCr];
 
 impl YuvFormat {
     pub fn get_plane_num(&self) -> usize {
         match *self {
             YuvFormat::NV12 => 2,
             YuvFormat::PlanarYCbCr => 3,
+            YuvFormat::InterleavedYCbCr => 1,
         }
     }
 
@@ -409,6 +413,7 @@ impl YuvFormat {
         match *self {
             YuvFormat::NV12 => "NV12",
             YuvFormat::PlanarYCbCr => "",
+            YuvFormat::InterleavedYCbCr => "INTERLEAVED_Y_CB_CR"
         }
     }
 }

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -23,6 +23,7 @@ impl ImageKey {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ExternalImageId(pub u64);
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum ExternalImageType {
     Texture2DHandle,        // gl TEXTURE_2D handle


### PR DESCRIPTION
If we use OpenGL 3.1 context at mac, there is no GL_APPLE_ycbcr_422 ext[1]. We should turn to use GL_APPLE_rgb_422 ext[2]. We could just get the rgb data from the APPLE_ycbcr_422 format because it will apply the Rec601 color space conversion automatically. The GL_APPLE_rgb_422 doesn't contain this color space conversion. We should do the conversion manually in shader.

So, this bug try to support the GL_APPLE_rgb_422 format for hardware decoded video.

[1]
https://www.khronos.org/registry/OpenGL/extensions/APPLE/APPLE_ycbcr_422.txt
[2]
https://www.khronos.org/registry/OpenGL/extensions/APPLE/APPLE_rgb_422.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1193)
<!-- Reviewable:end -->
