### PR TITLE
Read the correct render task for composite backdrops

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -262,6 +262,23 @@ AlphaBatchTask fetch_alpha_batch_task(int index) {
     return task;
 }
 
+struct ReadbackTask {
+    vec2 render_target_origin;
+    vec2 size;
+    float render_target_layer_index;
+};
+
+ReadbackTask fetch_readback_task(int index) {
+    RenderTaskData data = fetch_render_task(index);
+
+    ReadbackTask task;
+    task.render_target_origin = data.data0.xy;
+    task.size = data.data0.zw;
+    task.render_target_layer_index = data.data1.x;
+
+    return task;
+}
+
 struct ClipArea {
     vec4 task_bounds;
     vec4 screen_origin_target_index;

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -6,7 +6,7 @@
 void main(void) {
     PrimitiveInstance pi = fetch_prim_instance();
     AlphaBatchTask dest_task = fetch_alpha_batch_task(pi.render_task_index);
-    AlphaBatchTask backdrop_task = fetch_alpha_batch_task(pi.user_data.x);
+    ReadbackTask backdrop_task = fetch_readback_task(pi.user_data.x);
     AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.y);
 
     vec2 dest_origin = dest_task.render_target_origin -

--- a/wrench/reftests/blend/large-ref.yaml
+++ b/wrench/reftests/blend/large-ref.yaml
@@ -1,0 +1,9 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: 0 0 2000 2000
+      items:
+        - type: rect
+          bounds: 0 0 2000 2000
+          color: [0, 128, 0, 1]

--- a/wrench/reftests/blend/large.yaml
+++ b/wrench/reftests/blend/large.yaml
@@ -1,0 +1,13 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: 0 0 2000 2000
+      items:
+        - type: stacking-context
+          bounds: 0 0 2000 2000
+          mix-blend-mode: screen
+          items:
+            - type: rect
+              bounds: 0 0 2000 2000
+              color: [0, 128, 0, 1]

--- a/wrench/reftests/blend/reftest.list
+++ b/wrench/reftests/blend/reftest.list
@@ -3,12 +3,16 @@
 == difference.yaml difference-ref.yaml
 == darken.yaml darken-ref.yaml
 == lighten.yaml lighten-ref.yaml
+
 == repeated-difference.yaml repeated-difference-ref.yaml
 == canvas.yaml canvas-ref.yaml
+
 == isolated.yaml isolated-ref.yaml
 == isolated-2.yaml isolated-2-ref.yaml
 == isolated-with-filter.yaml isolated-ref.yaml
 == isolated-premultiplied.yaml blank.yaml
+
+== large.yaml large-ref.yaml
 
 # fuzzy because dithering is different for gradients
 # drawn in different render targets


### PR DESCRIPTION
The backdrop for a composite is a readback task not an alpha batch task.
And they have different locations for `render_target_layer_index`, which
causes problems when the source and backdrop are in different render
targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1201)
<!-- Reviewable:end -->
