### PR TITLE
Add --fuzzy=<tolerance> option to wrench reftest.

### DIFF
--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -102,6 +102,11 @@ subcommands:
     - reftest:
         about: run reftests
         args:
+          - fuzz_tolerance:
+              long: fuzzy
+              takes_value: true
+              help: Add a minimum fuzziness tolerance to all tests.
+              required: false
           - REFTEST:
               help: a specific reftest or directory to run
               required: false


### PR DESCRIPTION
This option sets the minimum allowed fuzziness for all reftests. For example, running ```wrench reftest --fuzzy=3``` allows all tests to pass with a maximum difference of at least 3 for all pixels (unless the test already specifies a greater tolerance).

This is useful to filter out rounding differences between GL implementations when running reftests without osmesa.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1203)
<!-- Reviewable:end -->
