### PR TITLE
Make the check for a matrix preserving a 2d axis aligned rect more robust.

### DIFF
--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -193,7 +193,7 @@ impl MaskCacheInfo {
                   clip_store: &mut VertexDataStore<GpuBlock32>,
                   device_pixel_ratio: f32,
                   display_list: &BuiltDisplayList) {
-        let is_aligned = transform.can_losslessly_transform_and_perspective_project_a_2d_rect();
+        let is_aligned = transform.preserves_2d_axis_alignment();
 
         // If we haven't cached this info, or if the transform type has changed
         // we need to re-calculate the number of clips.


### PR DESCRIPTION
Port the Skia implementation for this functionality. Previously, several
reftests were running through the transform shader path when they didn't
need to.

Also remove several unused methods from the matrix helper trait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1204)
<!-- Reviewable:end -->
