### PR TITLE
Fix interaction between selecting subpixel AA and disabling text AA.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -70,7 +70,6 @@ impl RenderBackend {
                result_tx: Sender<ResultMsg>,
                hidpi_factor: f32,
                texture_cache: TextureCache,
-               enable_aa: bool,
                workers: Arc<Mutex<ThreadPool>>,
                notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
                webrender_context_handle: Option<GLContextHandleWrapper>,
@@ -81,7 +80,7 @@ impl RenderBackend {
                vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
                initial_window_size: DeviceUintSize) -> RenderBackend {
 
-        let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer, enable_aa);
+        let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer);
 
         register_thread_with_profiler("Backend".to_string());
 


### PR DESCRIPTION
Previously, if the render options selected subpixel AA *on*, but
text AA *off* the text rendering would be incorrect. This was due
to the glyphs being rasterized without AA, but the batching code
incorrectly selecting the subpixel blend mode.

This unifies where the selection is made of the type of glyphs
to render, meaning the resource cache just rasterizes what it
is requested to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1205)
<!-- Reviewable:end -->
