### PR TITLE
Better Preserve3D support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-loader 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,6 +31,14 @@ dependencies = [
 name = "adler32"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "android_glue"
@@ -71,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "binary-space-partition"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -260,6 +269,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -479,6 +497,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "metadeps"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,10 +640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plane-split"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "binary-space-partition 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -661,6 +687,23 @@ dependencies = [
 [[package]]
 name = "redox_syscall"
 version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -808,6 +851,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_profiler"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +915,14 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "user32-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +930,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
@@ -873,6 +947,11 @@ dependencies = [
 [[package]]
 name = "vec_map"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -897,7 +976,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plane-split 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plane-split 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -986,12 +1065,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum adler32 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57be033eb4100070a93a9400a725839cda9c415244f808b0357e72b9e003d5ba"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e2b80445d331077679dfc6f3014f3e9ab7083e588423d35041d3fc017198189"
 "checksum angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0c3b5be4ed53affe3e1a162b2e7ef9979bcaac80daa9026e9d7988c41e0e83"
 "checksum base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d156a04ec694d726e92ea3c13e4a62949b4f0488a9344f04341d679ec6b127b"
-"checksum binary-space-partition 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df65281d9b2b5c332f5bfbd9bb5e5f2e62f627c259cf9dc9cd10fecb758be33d"
+"checksum binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"
 "checksum bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)" = "fb0cdeac1c5d567fdb487ae5853c024e4acf1ea85ba6a6552fe084e0805fea5d"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
@@ -1015,6 +1095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c4c7cc7b396419bc0a4d90371d0cee16cb5053b53647d287c0b728000c41fe"
 "checksum dwrote 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74114b6b49d6731835da7a28a3642651451e315f7f9b9d04e907e65a45681796"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
+"checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum euclid 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4c0e975062331b56e4c94367ae74a79cd38884641e2ad11ac205065faa66af"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
@@ -1043,6 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
 "checksum mio 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eecdbdd49a849336e77b453f021c89972a2cfb5b51931a0026ae0ac4602de681"
 "checksum miow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a78d2605eb97302c10cf944b8d96b0a2a890c52957caf92fcd1f24f69049579"
@@ -1057,12 +1139,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum plane-split 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a05e1e40e37630095627acfd2c7c6cf259e8b4f4ef4f01b2adf2a35331e45975"
+"checksum plane-split 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b3624c9e5e728dcc6347bde5762406b0f0707bea527d585e8f7b6ac44fdd33a"
 "checksum png 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cb773e9a557edb568ce9935cf783e3cdcabe06a9449d41b3e5506d88e582c82"
 "checksum quote 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "08de3f12e670f83f61e450443cbae34496a35b665691fd8e99b24ec662f75865"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50c575b58c2b109e2fbc181820cbe177474f35610ff9e357dc75f6bac854ffbf"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum serde 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "204db0f2a5335be7313fd4453132fd56d2085aed081c673140a256772903e116"
@@ -1079,6 +1163,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e28da8d02d75d1e58b89258e0741128f0b0d8a8309fb5c627be0fbd37a76c67"
 "checksum synom 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8fece1853fb872b0acdc3ff88f37c474018e125ef81cd4cb8c0ca515746b62ed"
 "checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf947d192a9be60ef5131cc7a4648886ba89d712f16700ebbf80c8a69d05d48f"
 "checksum threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59f6d3eff89920113dac9db44dde461d71d01e88a5b57b258a0466c32b5d7fe1"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
@@ -1086,9 +1172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -30,7 +30,7 @@ webrender_traits = {path = "../webrender_traits"}
 bitflags = "0.7"
 gamma-lut = "0.1"
 thread_profiler = "0.1.1"
-plane-split = "0.2.1"
+plane-split = "0.3"
 
 [dev-dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}

--- a/webrender/res/ps_blend.vs.glsl
+++ b/webrender/res/ps_blend.vs.glsl
@@ -17,10 +17,12 @@ void main(void) {
                          aPosition.xy);
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
-    vec2 st0 = src_task.render_target_origin / texture_size;
-    vec2 st1 = (src_task.render_target_origin + src_task.size) / texture_size;
-    vUv = vec3(mix(st0, st1, aPosition.xy), src_task.render_target_layer_index);
-    vUvBounds = vec4(st0 + 0.5 / texture_size, st1 - 0.5 / texture_size);
+    vec2 st0 = src_task.render_target_origin;
+    vec2 st1 = src_task.render_target_origin + src_task.size;
+
+    vec2 uv = src_task.render_target_origin + aPosition.xy * src_task.size;
+    vUv = vec3(uv / texture_size, src_task.render_target_layer_index);
+    vUvBounds = vec4(st0 + 0.5, st1 - 0.5) / texture_size.xyxy;
 
     vOp = pi.sub_index;
     vAmount = float(pi.user_data.y) / 65535.0;

--- a/webrender/res/ps_split_composite.fs.glsl
+++ b/webrender/res/ps_split_composite.fs.glsl
@@ -4,6 +4,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    vec2 uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
-    oFragColor = textureLod(sCacheRGBA8, vec3(uv, vUv.z), 0.0);
+    bvec4 inside = lessThanEqual(vec4(vUvTaskBounds.xy, vUv.xy),
+                                 vec4(vUv.xy, vUvTaskBounds.zw));
+    if (all(inside)) {
+        vec2 uv = clamp(vUv.xy, vUvSampleBounds.xy, vUvSampleBounds.zw);
+        oFragColor = textureLod(sCacheRGBA8, vec3(uv, vUv.z), 0.0);
+    } else {
+        oFragColor = vec4(0.0);
+    }
 }

--- a/webrender/res/ps_split_composite.glsl
+++ b/webrender/res/ps_split_composite.glsl
@@ -4,4 +4,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec3 vUv;
-flat varying vec4 vUvBounds;
+flat varying vec4 vUvTaskBounds;
+flat varying vec4 vUvSampleBounds;

--- a/webrender/res/ps_split_composite.vs.glsl
+++ b/webrender/res/ps_split_composite.vs.glsl
@@ -40,9 +40,10 @@ void main(void) {
 
     gl_Position = uTransform * final_pos;
 
-    vec2 uv_origin = src_task.render_target_origin - src_task.screen_space_origin;
-    vec2 uv_pos = uv_origin + world_pos.xy;
+    vec2 uv_origin = src_task.render_target_origin;
+    vec2 uv_pos = uv_origin + world_pos.xy - src_task.screen_space_origin;
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
     vUv = vec3(uv_pos / texture_size, src_task.render_target_layer_index);
-    vUvBounds = vec4((uv_origin + 0.5) / texture_size, (uv_origin + src_task.size - 0.5) / texture_size);
+    vUvTaskBounds = vec4(uv_origin, uv_origin + src_task.size) / texture_size.xyxy;
+    vUvSampleBounds = vec4(uv_origin + 0.5, uv_origin + src_task.size - 0.5) / texture_size.xyxy;
 }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -45,6 +45,7 @@ static SHADER_PREAMBLE: &'static str = "shared";
 #[repr(u32)]
 pub enum DepthFunction {
     Less = gl::LESS,
+    LessEqual = gl::LEQUAL,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -37,7 +37,7 @@ pub enum MaskCacheKey {
     ClipNode(ClipId),
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum RenderTaskId {
     Static(RenderTaskIndex),
     Dynamic(RenderTaskKey),

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1746,7 +1746,8 @@ impl Renderer {
         self.device.set_blend(false);
         let mut prev_blend_mode = BlendMode::None;
 
-        self.device.set_depth_func(DepthFunction::Less);
+        //Note: depth equality is needed for split planes
+        self.device.set_depth_func(DepthFunction::LessEqual);
         self.device.enable_depth();
         self.device.enable_depth_write();
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -931,10 +931,10 @@ impl RenderTarget for ColorRenderTarget {
                 render_tasks: &RenderTaskCollection,
                 pass_index: RenderPassIndex) {
         match task.kind {
-            RenderTaskKind::Alpha(info) => {
+            RenderTaskKind::Alpha(mut info) => {
                 self.alpha_batcher.add_task(AlphaBatchTask {
                     task_id: task.id,
-                    items: info.items,
+                    items: mem::replace(&mut info.items, Vec::new()),
                 });
             }
             RenderTaskKind::VerticalBlur(_, prim_index) => {
@@ -1554,4 +1554,3 @@ pub struct Frame {
     // patch the data structures.
     pub deferred_resolves: Vec<DeferredResolve>,
 }
-

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -287,8 +287,8 @@ known_heap_size!(0, ScrollPolicy);
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum TransformStyle {
-    Flat,
-    Preserve3D,
+    Flat        = 0,
+    Preserve3D  = 1,
 }
 
 #[repr(u32)]
@@ -628,3 +628,5 @@ macro_rules! define_empty_heap_size_of {
 define_empty_heap_size_of!(ClipId);
 define_empty_heap_size_of!(RepeatMode);
 define_empty_heap_size_of!(ImageKey);
+define_empty_heap_size_of!(MixBlendMode);
+define_empty_heap_size_of!(TransformStyle);

--- a/wrench/reftests/split/cross-ref.yaml
+++ b/wrench/reftests/split/cross-ref.yaml
@@ -1,0 +1,34 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 200]
+      items:
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [0, 0, 50, 100]
+              color: red
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(-45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [0, 0, 50, 100]
+              color: green
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [50, 0, 50, 100]
+              color: red
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(-45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [50, 0, 50, 100]
+              color: green

--- a/wrench/reftests/split/cross-ref.yaml
+++ b/wrench/reftests/split/cross-ref.yaml
@@ -6,18 +6,18 @@ root:
       items:
         - type: stacking-context
           bounds: [0, 0, 100, 200]
-          transform: rotate-y(45) rotate-x(45)
-          items:
-            - type: rect
-              bounds: [0, 0, 50, 100]
-              color: red
-        - type: stacking-context
-          bounds: [0, 0, 100, 200]
           transform: rotate-y(-45) rotate-x(45)
           items:
             - type: rect
               bounds: [0, 0, 50, 100]
               color: green
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [0, 0, 50, 100]
+              color: red
         - type: stacking-context
           bounds: [0, 0, 100, 200]
           transform: rotate-y(45) rotate-x(45)
@@ -32,3 +32,5 @@ root:
             - type: rect
               bounds: [50, 0, 50, 100]
               color: green
+
+

--- a/wrench/reftests/split/cross.yaml
+++ b/wrench/reftests/split/cross.yaml
@@ -1,0 +1,24 @@
+# Crossed planes test. Similar to "simple" but has more complex transformations,
+# which puts higher requirements on the precision of arithmetics,
+# and all 4 pieces are visible on screen.
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 200]
+      transform-style: preserve-3d
+      items:
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: red
+        - type: stacking-context
+          bounds: [0, 0, 100, 200]
+          transform: rotate-y(-45) rotate-x(45)
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: green

--- a/wrench/reftests/split/nested-ref.yaml
+++ b/wrench/reftests/split/nested-ref.yaml
@@ -5,9 +5,8 @@ root:
       bounds: [0, 0, 1024, 1024]
       items:
         - type: rect
-          bounds: [150, 0, 300, 200]
-          color: [128, 192, 64]
+          bounds: [150, 0, 300, 600]
+          color: red
         - type: rect
-          bounds: [150, 200, 300, 400]
-          color: [255, 127, 127]
-
+          bounds: [150, 0, 50, 100]
+          color: green

--- a/wrench/reftests/split/nested.yaml
+++ b/wrench/reftests/split/nested.yaml
@@ -5,7 +5,6 @@ root:
   items:
     - type: stacking-context
       bounds: [0, 0, 1024, 1024]
-      transform-style: preserve-3d
       items:
         - type: stacking-context
           bounds: [0, 0, 600, 600]

--- a/wrench/reftests/split/nested.yaml
+++ b/wrench/reftests/split/nested.yaml
@@ -1,5 +1,8 @@
 # This tests have a non-preserve3d stacking context nested within
-# preserve-3d sub-tree.
+# preserve-3d sub-tree. This nested context is still getting baked in
+# and participates (as a whole) in plane splitting.
+# It is layed out in the same plane as the parent, so should be ordered
+# last, given that it's coming later than the parent.
 ---
 root:
   items:
@@ -13,11 +16,10 @@ root:
           items:
             - type: rect
               bounds: [0, 0, 600, 600]
-              color: [255, 0, 0, 0.5]
+              color: red
             - type: stacking-context
               bounds: [0, 0, 100, 100]
-              filters: opacity(0.5)
               items:
                 - type: rect
                   bounds: [0, 0, 600, 200]
-                  color: [0, 255, 0]
+                  color: green

--- a/wrench/reftests/split/order-ref.yaml
+++ b/wrench/reftests/split/order-ref.yaml
@@ -1,0 +1,8 @@
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 100]
+      items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: green

--- a/wrench/reftests/split/order.yaml
+++ b/wrench/reftests/split/order.yaml
@@ -1,0 +1,20 @@
+# The "preserve-3d" context has a "flat" child. Rotation by 180 degrees and positive Z offset
+# should compensate each other, resulting in a gree rectangle.
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 100]
+      transform-style: preserve-3d
+      transform: rotate-x(180)
+      items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: green
+        - type: stacking-context
+          bounds: [0, 0, 100, 100]
+          transform: translate(0, 0, 10)
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: red

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -1,3 +1,4 @@
 == simple.yaml simple-ref.yaml
 == order.yaml order-ref.yaml
-#TODO: == nested.yaml nested-ref.yaml
+== nested.yaml nested-ref.yaml
+#== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -1,2 +1,3 @@
 == simple.yaml simple-ref.yaml
-== nested.yaml nested-ref.yaml
+== order.yaml order-ref.yaml
+#TODO: == nested.yaml nested-ref.yaml

--- a/wrench/reftests/split/simple-ref.yaml
+++ b/wrench/reftests/split/simple-ref.yaml
@@ -6,7 +6,7 @@ root:
       items:
         - type: rect
           bounds: [150, 0, 150, 600]
-          color: [127, 191, 63]
+          color: [191, 127,  63]
         - type: rect
           bounds: [300, 0, 150, 600]
-          color: [191, 127, 63]
+          color: [127, 191, 63]

--- a/wrench/reftests/split/simple.yaml
+++ b/wrench/reftests/split/simple.yaml
@@ -10,7 +10,6 @@ root:
       items:
         - type: stacking-context
           bounds: [0, 0, 600, 600]
-          transform-style: preserve-3d
           transform: rotate-y(60.0)
           items:
             - type: rect
@@ -18,7 +17,6 @@ root:
               color: [255, 0, 0, 0.5]
         - type: stacking-context
           bounds: [0, 0, 600, 600]
-          transform-style: preserve-3d
           transform: rotate-y(-60.0)
           items:
             - type: rect


### PR DESCRIPTION
Follow up to #1169
Includes #1207

r? @glennw @mrobinson 

## Fixes
  - "preserve-3d" only affects children stacking contexts and contained items
  - generated polygon coordinates of non-zero local bounds
  - sorting order

## Servo 

The Servo PR is being [worked on](https://github.com/servo/servo/compare/master...kvark:preserve3d), but it's not required here, since it may safely continue using `TransformStyle::Flat`.

## Future work

There is at least one feature on the horizon to be implemented before  #739 can be truly closed.
The `TransformStyle` should be moved out of the stacking context and deserve it's own pushable item (similar to clip-scroll groups). This is required because an item without "preserve-3d" automatically becomes "flat" but does not establish a stacking context, which is [tested by Servo](https://raw.githubusercontent.com/servo/servo/master/tests/wpt/css-tests/css-transforms-1_dev/html/transform3d-sorting-004.htm).

Edit: apparently, Chrome disagrees here, so the current approach of WR might stay.
Create Bugstar [issue-1362543](https://bugzilla.mozilla.org/show_bug.cgi?id=1362543).


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1208)
<!-- Reviewable:end -->
