### PR TITLE
Allow setting the scroll position of nodes without clamping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,8 +22,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.37.0",
- "webrender_traits 0.37.0",
+ "webrender 0.38.0",
+ "webrender_traits 0.38.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -966,7 +966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,12 +991,12 @@ dependencies = [
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.37.0",
+ "webrender_traits 0.38.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -7,14 +7,15 @@ use fnv::FnvHasher;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use webrender_traits::{ClipId, LayerPoint, LayerRect, LayerToScrollTransform};
-use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollEventPhase, ScrollLayerRect};
-use webrender_traits::{ScrollLayerState, ScrollLocation, WorldPoint, as_scroll_parent_rect};
+use webrender_traits::{LayerToWorldTransform, PipelineId, ScrollClamping, ScrollEventPhase};
+use webrender_traits::{ScrollLayerRect, ScrollLayerState, ScrollLocation, WorldPoint};
+use webrender_traits::as_scroll_parent_rect;
 
 pub type ScrollStates = HashMap<ClipId, ScrollingState, BuildHasherDefault<FnvHasher>>;
 
 pub struct ClipScrollTree {
     pub nodes: HashMap<ClipId, ClipScrollNode, BuildHasherDefault<FnvHasher>>,
-    pub pending_scroll_offsets: HashMap<ClipId, LayerPoint>,
+    pub pending_scroll_offsets: HashMap<ClipId, (LayerPoint, ScrollClamping)>,
 
     /// The ClipId of the currently scrolling node. Used to allow the same
     /// node to scroll even if a touch operation leaves the boundaries of that node.
@@ -131,23 +132,22 @@ impl ClipScrollTree {
         scroll_states
     }
 
-    pub fn scroll_nodes(&mut self, origin: LayerPoint, id: ClipId) -> bool {
+    pub fn scroll_node(&mut self, origin: LayerPoint, id: ClipId, clamp: ScrollClamping) -> bool {
         if id.is_reference_frame() {
             warn!("Tried to scroll a reference frame.");
             return false;
         }
 
         if self.nodes.is_empty() {
-            self.pending_scroll_offsets.insert(id, origin);
+            self.pending_scroll_offsets.insert(id, (origin, clamp));
             return false;
         }
 
-        let origin = LayerPoint::new(origin.x.max(0.0), origin.y.max(0.0));
         if let Some(node) = self.nodes.get_mut(&id) {
-            return node.set_scroll_origin(&origin);
+            return node.set_scroll_origin(&origin, clamp);
         }
 
-        self.pending_scroll_offsets.insert(id, origin);
+        self.pending_scroll_offsets.insert(id, (origin, clamp));
         false
     }
 
@@ -309,7 +309,7 @@ impl ClipScrollTree {
             node.finalize(&scrolling_state);
 
             if let Some(pending_offset) = self.pending_scroll_offsets.remove(clip_id) {
-                node.set_scroll_origin(&pending_offset);
+                node.set_scroll_origin(&pending_offset.0, pending_offset.1);
             }
         }
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -21,9 +21,9 @@ use webrender_traits::{BuiltDisplayList, BuiltDisplayListIter, ClipAndScrollInfo
 use webrender_traits::{ClipId, ClipRegion, ColorF, DeviceUintRect, DeviceUintSize, DisplayItemRef};
 use webrender_traits::{Epoch, FilterOp, ImageDisplayItem, ItemRange, LayerPoint, LayerRect};
 use webrender_traits::{LayerSize, LayerToScrollTransform, LayoutSize, LayoutTransform};
-use webrender_traits::{MixBlendMode, PipelineId, ScrollEventPhase, ScrollLayerState};
-use webrender_traits::{ScrollLocation, ScrollPolicy, SpecificDisplayItem, StackingContext};
-use webrender_traits::{TileOffset, TransformStyle, WorldPoint};
+use webrender_traits::{MixBlendMode, PipelineId, ScrollClamping, ScrollEventPhase};
+use webrender_traits::{ScrollLayerState, ScrollLocation, ScrollPolicy, SpecificDisplayItem};
+use webrender_traits::{StackingContext, TileOffset, TransformStyle, WorldPoint};
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct FrameId(pub u32);
@@ -178,9 +178,9 @@ impl Frame {
         self.clip_scroll_tree.get_scroll_node_state()
     }
 
-    /// Returns true if any nodes actually changed position or false otherwise.
-    pub fn scroll_nodes(&mut self, origin: LayerPoint, id: ClipId) -> bool {
-        self.clip_scroll_tree.scroll_nodes(origin, id)
+    /// Returns true if the node actually changed position or false otherwise.
+    pub fn scroll_node(&mut self, origin: LayerPoint, id: ClipId, clamp: ScrollClamping) -> bool {
+        self.clip_scroll_tree.scroll_node(origin, id, clamp)
     }
 
     /// Returns true if any nodes actually changed position or false otherwise.

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -270,12 +270,12 @@ impl RenderBackend {
                                 None => self.notify_compositor_of_new_scroll_frame(false),
                             }
                         }
-                        ApiMsg::ScrollNodeWithId(origin, id) => {
+                        ApiMsg::ScrollNodeWithId(origin, id, clamp) => {
                             profile_scope!("ScrollNodeWithScrollId");
                             let frame = {
                                 let counters = &mut profile_counters.resources.texture_cache;
                                 profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll_nodes(origin, id) {
+                                    if self.frame.scroll_node(origin, id, clamp) {
                                         Some(self.render(counters))
                                     } else {
                                         None

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -18,6 +18,12 @@ use {WebGLCommand, WebGLContextId};
 pub type TileSize = u16;
 
 #[derive(Clone, Deserialize, Serialize)]
+pub enum ScrollClamping {
+    ToContentBounds,
+    NoClamping,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 pub enum ApiMsg {
     AddRawFont(FontKey, Vec<u8>, u32),
     AddNativeFont(FontKey, NativeFontHandle),
@@ -48,7 +54,7 @@ pub enum ApiMsg {
     SetRootPipeline(PipelineId),
     SetWindowParameters(DeviceUintSize, DeviceUintRect),
     Scroll(ScrollLocation, WorldPoint, ScrollEventPhase),
-    ScrollNodeWithId(LayoutPoint, ClipId),
+    ScrollNodeWithId(LayoutPoint, ClipId, ScrollClamping),
     TickScrollingBounce,
     TranslatePointToLayerSpace(WorldPoint, MsgSender<(LayoutPoint, PipelineId)>),
     GetScrollNodeState(MsgSender<Vec<ScrollLayerState>>),
@@ -332,8 +338,8 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
-    pub fn scroll_node_with_id(&self, new_scroll_origin: LayoutPoint, id: ClipId) {
-        let msg = ApiMsg::ScrollNodeWithId(new_scroll_origin, id);
+    pub fn scroll_node_with_id(&self, origin: LayoutPoint, id: ClipId, clamp: ScrollClamping) {
+        let msg = ApiMsg::ScrollNodeWithId(origin, id, clamp);
         self.api_sender.send(msg).unwrap();
     }
 

--- a/wrench/reftests/scrolling/out-of-bounds-scroll-ref.yaml
+++ b/wrench/reftests/scrolling/out-of-bounds-scroll-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 50, 50]
+      color: green

--- a/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
+++ b/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
@@ -1,0 +1,10 @@
+root:
+  items:
+    - type: scroll-layer
+      bounds: [10, 10, 50, 100]
+      content-size: [50, 100]
+      scroll-offset: [0, 50]
+      items:
+        - type: rect
+          bounds: [10, 60, 50, 50]
+          color: green

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -1,7 +1,8 @@
 == empty-mask.yaml empty-mask-ref.yaml
-== fixed-position.yaml fixed-position-ref.yaml
 == fixed-position-scrolling-clip.yaml fixed-position-scrolling-clip-ref.yaml
+== fixed-position.yaml fixed-position-ref.yaml
 == nested-scroll-offset.yaml nested-scroll-offset-ref.yaml
+== out-of-bounds-scroll.yaml out-of-bounds-scroll-ref.yaml
 == root-scroll.yaml root-scroll-ref.yaml
 == scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
 == scroll-layer.yaml scroll-layer-ref.yaml

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -375,7 +375,7 @@ impl Wrench {
                                   false);
 
         for (id, offset) in scroll_offsets {
-            self.api.scroll_node_with_id(*offset, *id);
+            self.api.scroll_node_with_id(*offset, *id, ScrollClamping::NoClamping);
         }
 
         self.api.generate_frame(None);


### PR DESCRIPTION
This change allows optionally setting arbitrary scroll positions on
scroll nodes in order to support more types of Gecko behavior. Content
will still be clipped normally, but can be moved arbitrarily. In order
to support full Gecko behavior we will need to prevent content from
being clipped as well, but that will come in a later change.

Fixes #1213.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1223)
<!-- Reviewable:end -->
