### PR TITLE
Requesting an image should mark it as needed for this frame.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -438,6 +438,7 @@ impl ResourceCache {
             tile: tile,
         };
 
+        self.cached_images.mark_as_needed(&request, self.current_frame_id);
         let template = self.image_templates.get(key).unwrap();
         if template.data.is_blob() {
             if let Some(ref mut renderer) = self.blob_image_renderer {


### PR DESCRIPTION
Currently there is no code that explicitly marks images as needed in the resource cache, so the last access time is updated (by chance) as a side effect of creating the image or using the entry method on the cached images in various places. It is pretty easy when using the gecko integration to hit the assertion that checks the image's ```last_access_time``` in ResourceClassCache::get.

I believe that it makes sense to mark the image as needed from request_image which is called during the culling phase on visible primitives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1225)
<!-- Reviewable:end -->
