### PR TITLE
Mark as needed when blob image is same epoch.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -447,7 +447,9 @@ impl ResourceCache {
                     None => false,
                 };
 
-                if !same_epoch && self.blob_image_requests.insert(request) {
+                if same_epoch {
+                    self.cached_images.mark_as_needed(&request, self.current_frame_id);
+                } else if self.blob_image_requests.insert(request) {
                     let (offset, w, h) = match template.tiling {
                         Some(tile_size) => {
                             let tile_offset = request.tile.unwrap();


### PR DESCRIPTION
Otherwise, we'll hit assertion in https://github.com/servo/webrender/blob/master/webrender/src/resource_cache.rs#L177-L180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1230)
<!-- Reviewable:end -->
