### PR TITLE
Revamp the multi-threaded font renderer.

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -340,3 +340,56 @@ struct GlyphRasterJob {
     request: GlyphRequest,
     result: Option<RasterizedGlyph>,
 }
+
+#[test]
+fn raterize_200_glyphs() {
+    // This test loads a font from disc, the renders 4 requests containing
+    // 50 glyphs each, deletes the font and waits for the result.
+
+    use rayon::Configuration;
+    use std::fs::File;
+    use std::io::Read;
+
+    let workers = Arc::new(ThreadPool::new(Configuration::new()).unwrap());
+    let mut glyph_rasterizer = GlyphRasterizer::new(workers);
+    let mut glyph_cache = GlyphCache::new();
+
+    let mut font_file = File::open("../wrench/reftests/text/VeraBd.ttf").expect("Couldn't open font file");
+    let mut font_data = vec![];
+    font_file.read_to_end(&mut font_data).expect("failed to read font file");
+
+    let font_key = FontKey::new(0, 0);
+    glyph_rasterizer.add_font(font_key, FontTemplate::Raw(Arc::new(font_data), 0));
+
+    let frame_id = FrameId(1);
+
+    let mut glyph_instances = Vec::with_capacity(200);
+    for i in 0..200 {
+        glyph_instances.push(GlyphInstance {
+            index: i, // It doesn't matter which glyphs we are actually rendering.
+            point: LayoutPoint::new(0.0, 0.0),
+        });
+    }
+
+    for i in 0..4 {
+        glyph_rasterizer.request_glyphs(
+            &mut glyph_cache,
+            frame_id,
+            font_key,
+            Au::from_px(32),
+            ColorF::new(0.0, 0.0, 0.0, 1.0),
+            &glyph_instances[(50 * i)..(50 * (i + 1))],
+            FontRenderMode::Subpixel,
+            None,
+        );
+    }
+
+    glyph_rasterizer.delete_font(font_key);
+
+    glyph_rasterizer.resolve_glyphs(
+        frame_id,
+        &mut glyph_cache,
+        &mut TextureCache::new(4096),
+        &mut TextureCacheProfileCounters::new(),
+    );
+}

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -1,0 +1,342 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use app_units::Au;
+use device::TextureFilter;
+use frame::FrameId;
+use platform::font::{FontContext, RasterizedGlyph};
+use profiler::TextureCacheProfileCounters;
+use rayon::ThreadPool;
+use rayon::prelude::*;
+use resource_cache::ResourceClassCache;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::collections::HashSet;
+use std::mem;
+use texture_cache::{TextureCacheItemId, TextureCache};
+use internal_types::FontTemplate;
+use webrender_traits::{FontKey, FontRenderMode, ImageData, ImageFormat};
+use webrender_traits::{ImageDescriptor, ColorF, LayoutPoint};
+use webrender_traits::{GlyphKey, GlyphOptions, GlyphInstance, GlyphDimensions};
+
+pub type GlyphCache = ResourceClassCache<GlyphRequest, Option<TextureCacheItemId>>;
+
+pub struct FontContexts {
+    // These worker are mostly accessed from their corresponding worker threads.
+    // The goal is that there should be no noticeable contention on the muteces.
+    worker_contexts: Vec<Mutex<FontContext>>,
+
+    // This worker should be accessed by threads that don't belong to thre thread pool
+    // (in theory that's only the render backend thread so no contention expected either).
+    shared_context: Mutex<FontContext>,
+
+    // Stored here as a convenience to get the current thread index.
+    workers: Arc<ThreadPool>,
+}
+
+impl FontContexts {
+    /// Get access to the font context associated to the current thread.
+    pub fn lock_current_context(&self) -> MutexGuard<FontContext> {
+        let id = self.current_worker_id();
+        self.lock_context(id)
+    }
+
+    /// Get access to any particular font context.
+    ///
+    /// The id is ```Some(i)``` where i is an index between 0 and num_worker_contexts
+    /// for font contexts associated to the thread pool, and None for the shared
+    /// global font context for use outside of the thread pool.
+    pub fn lock_context(&self, id: Option<usize>) -> MutexGuard<FontContext> {
+        match id {
+            Some(index) => self.worker_contexts[index].lock().unwrap(),
+            None => self.shared_context.lock().unwrap(),
+        }
+    }
+
+    /// Get access to the font context usable outside of the thread pool.
+    pub fn lock_shared_context(&self) -> MutexGuard<FontContext> {
+        self.shared_context.lock().unwrap()
+    }
+
+    // number of contexts associated to workers
+    pub fn num_worker_contexts(&self) -> usize {
+        self.worker_contexts.len()
+    }
+
+    fn current_worker_id(&self) -> Option<usize> {
+        self.workers.current_thread_index()
+    }
+}
+
+pub struct GlyphRasterizer {
+    workers: Arc<ThreadPool>,
+    font_contexts: Arc<FontContexts>,
+
+    // Receives the rendered glyphs.
+    glyph_rx: Receiver<Vec<GlyphRasterJob>>,
+    glyph_tx: Sender<Vec<GlyphRasterJob>>,
+
+    // Maintain a set of glyphs that have been requested this
+    // frame. This ensures the glyph thread won't rasterize
+    // the same glyph more than once in a frame. This is required
+    // because the glyph cache hash table is not updated
+    // until the end of the frame when we wait for glyph requests
+    // to be resolved.
+    pending_glyphs: HashSet<GlyphRequest>,
+
+    // We defer removing fonts to the end of the frame so that:
+    // - this work is done outside of the critical path,
+    // - we don't have to worry about the ordering of events if a font is used on
+    //   a frame where it is used (although it seems unlikely).
+    fonts_to_remove: Vec<FontKey>,
+}
+
+impl GlyphRasterizer {
+    pub fn new(workers: Arc<ThreadPool>) -> Self {
+        let (glyph_tx, glyph_rx) = channel();
+
+        let num_workers = workers.current_num_threads();
+        let mut contexts = Vec::with_capacity(num_workers);
+
+        for _ in 0..num_workers {
+            contexts.push(Mutex::new(FontContext::new()));
+        }
+
+        GlyphRasterizer {
+            font_contexts: Arc::new(
+                FontContexts {
+                    worker_contexts: contexts,
+                    shared_context: Mutex::new(FontContext::new()),
+                    workers: Arc::clone(&workers),
+                }
+            ),
+            glyph_rx: glyph_rx,
+            glyph_tx: glyph_tx,
+            pending_glyphs: HashSet::new(),
+            workers: workers,
+            fonts_to_remove: Vec::new(),
+        }
+    }
+
+    pub fn add_font(&mut self, font_key: FontKey, template: FontTemplate) {
+        let font_contexts = Arc::clone(&self.font_contexts);
+        // It's important to synchronously add the font for the shared context because
+        // we use it to check that fonts have been properly added when requesting glyphs.
+        font_contexts.lock_shared_context().add_font(&font_key, &template);
+
+        // TODO: this locks each font context while adding the font data, probably not a big deal,
+        // but if there is contention on this lock we could easily have a queue of per-context
+        // operations to add and delete fonts, and have these queues lazily processed by each worker
+        // before rendering a glyph.
+        // We can also move this into a worker to free up some cycles in the calling (render backend)
+        // thread.
+        for i in 0..font_contexts.num_worker_contexts() {
+            font_contexts.lock_context(Some(i)).add_font(&font_key, &template);
+        }
+    }
+
+    pub fn delete_font(&mut self, font_key: FontKey) {
+        self.fonts_to_remove.push(font_key);
+    }
+
+    pub fn request_glyphs(
+        &mut self,
+        glyph_cache: &mut GlyphCache,
+        current_frame_id: FrameId,
+        font_key: FontKey,
+        size: Au,
+        color: ColorF,
+        glyph_instances: &[GlyphInstance],
+        render_mode: FontRenderMode,
+        glyph_options: Option<GlyphOptions>,
+    ) {
+        assert!(self.font_contexts.lock_shared_context().has_font(&font_key));
+
+        let mut glyphs = Vec::with_capacity(glyph_instances.len());
+
+        {
+            // TODO: If this takes too long we can resurect a dedicated glyph
+            // dispatch thread, hopefully not.
+            profile_scope!("glyph-requests");
+
+            // select glyphs that have not been requested yet.
+            for glyph in glyph_instances {
+                let glyph_request = GlyphRequest::new(
+                    font_key,
+                    size,
+                    color,
+                    glyph.index,
+                    glyph.point,
+                    render_mode,
+                    glyph_options,
+                );
+
+                glyph_cache.mark_as_needed(&glyph_request, current_frame_id);
+                if !glyph_cache.contains_key(&glyph_request) && !self.pending_glyphs.contains(&glyph_request) {
+                    self.pending_glyphs.insert(glyph_request.clone());
+                    glyphs.push(glyph_request);
+                }
+            }
+        }
+
+        if glyphs.is_empty() {
+            return;
+        }
+
+        let font_contexts = Arc::clone(&self.font_contexts);
+        let glyph_tx = self.glyph_tx.clone();
+        // spawn an async task to get off of the render backend thread as early as
+        // possible and in that task use rayon's fork join dispatch to rasterize the
+        // glyphs in the thread pool.
+        self.workers.spawn_async(move || {
+            let jobs = glyphs.par_iter().map(|request: &GlyphRequest| {
+                profile_scope!("glyph-raster");
+                let mut context = font_contexts.lock_current_context();
+                let job = GlyphRasterJob {
+                    request: request.clone(),
+                    result: context.rasterize_glyph(
+                        &request.key,
+                        request.render_mode,
+                        request.glyph_options
+                    ),
+                };
+
+                // Sanity check.
+                if let Some(ref glyph) = job.result {
+                    let bpp = 4; // We always render glyphs in 32 bits RGBA format.
+                    assert_eq!(glyph.bytes.len(), bpp * (glyph.width * glyph.height) as usize);
+                }
+
+                job
+            }).collect();
+
+            glyph_tx.send(jobs).unwrap();
+        });
+    }
+
+    pub fn get_glyph_dimensions(&mut self, glyph_key: &GlyphKey) -> Option<GlyphDimensions> {
+        self.font_contexts.lock_shared_context().get_glyph_dimensions(glyph_key)
+    }
+
+    pub fn resolve_glyphs(
+        &mut self,
+        current_frame_id: FrameId,
+        glyph_cache: &mut GlyphCache,
+        texture_cache: &mut TextureCache,
+        texture_cache_profile: &mut TextureCacheProfileCounters,
+    ) {
+        let mut rasterized_glyphs = Vec::with_capacity(self.pending_glyphs.len());
+
+        // Pull rasterized glyphs from the queue.
+        while !self.pending_glyphs.is_empty() {
+            // TODO: rather than blocking until all pending glyphs are available
+            // we could try_recv and steal work from the thread pool to take advantage
+            // of the fact that this thread is alive and we avoid the added latency
+            // of blocking it.
+            let raster_jobs = self.glyph_rx.recv().expect("BUG: Should be glyphs pending!");
+            for job in raster_jobs {
+                debug_assert!(self.pending_glyphs.contains(&job.request));
+                self.pending_glyphs.remove(&job.request);
+
+                rasterized_glyphs.push(job);
+            }
+        }
+
+        // Ensure that the glyphs are always processed in the same
+        // order for a given text run (since iterating a hash set doesn't
+        // guarantee order). This can show up as very small float inaccuacry
+        // differences in rasterizers due to the different coordinates
+        // that text runs get associated with by the texture cache allocator.
+        rasterized_glyphs.sort_by(|a, b| a.request.cmp(&b.request));
+
+        // Update the caches.
+        for job in rasterized_glyphs {
+            let image_id = job.result.and_then(
+                |glyph| if glyph.width > 0 && glyph.height > 0 {
+                    let image_id = texture_cache.new_item_id();
+                    texture_cache.insert(
+                        image_id,
+                        ImageDescriptor {
+                            width: glyph.width,
+                            height: glyph.height,
+                            stride: None,
+                            format: ImageFormat::RGBA8,
+                            is_opaque: false,
+                            offset: 0,
+                        },
+                        TextureFilter::Linear,
+                        ImageData::Raw(Arc::new(glyph.bytes)),
+                        texture_cache_profile,
+                    );
+                    Some(image_id)
+                } else {
+                    None
+                }
+            );
+
+            glyph_cache.insert(job.request, image_id, current_frame_id);
+        }
+
+        // Now that we are done with the critical path (rendering the glyphs),
+        // we can schedule removing the fonts if needed.
+        if !self.fonts_to_remove.is_empty() {
+            let font_contexts = Arc::clone(&self.font_contexts);
+            let fonts_to_remove = mem::replace(&mut self.fonts_to_remove, Vec::new());
+            self.workers.spawn_async(move || {
+                for font_key in &fonts_to_remove {
+                    font_contexts.lock_shared_context().delete_font(font_key);
+                }
+                for i in 0..font_contexts.num_worker_contexts() {
+                    let mut context = font_contexts.lock_context(Some(i));
+                    for font_key in &fonts_to_remove {
+                        context.delete_font(font_key);
+                    }
+                }
+            });
+        }
+    }
+}
+
+impl FontContext {
+    fn add_font(&mut self, font_key: &FontKey, template: &FontTemplate) {
+        match template {
+            &FontTemplate::Raw(ref bytes, index) => {
+                self.add_raw_font(&font_key, &**bytes, index);
+            }
+            &FontTemplate::Native(ref native_font_handle) => {
+                self.add_native_font(&font_key, (*native_font_handle).clone());
+            }
+        }
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
+pub struct GlyphRequest {
+    pub key: GlyphKey,
+    pub render_mode: FontRenderMode,
+    pub glyph_options: Option<GlyphOptions>,
+}
+
+impl GlyphRequest {
+    pub fn new(
+        font_key: FontKey,
+        size: Au,
+        color: ColorF,
+        index: u32,
+        point: LayoutPoint,
+        render_mode: FontRenderMode,
+        glyph_options: Option<GlyphOptions>,
+    ) -> GlyphRequest {
+        GlyphRequest {
+            key: GlyphKey::new(font_key, size, color, index, point, render_mode),
+            render_mode: render_mode,
+            glyph_options: glyph_options,
+        }
+    }
+}
+
+struct GlyphRasterJob {
+    request: GlyphRequest,
+    result: Option<RasterizedGlyph>,
+}

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -57,6 +57,7 @@ mod frame;
 mod frame_builder;
 mod freelist;
 mod geometry;
+mod glyph_rasterizer;
 mod gpu_store;
 mod internal_types;
 mod mask_cache;

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -80,6 +80,22 @@ fn get_glyph_metrics(ct_font: &CTFont,
                      subpixel_point: &SubpixelPoint) -> GlyphMetrics {
     let bounds = ct_font.get_bounding_rects_for_glyphs(kCTFontDefaultOrientation, &[glyph]);
 
+    if bounds.origin.x.is_nan() || bounds.origin.y.is_nan() ||
+       bounds.size.width.is_nan() || bounds.size.height.is_nan() {
+        // If an unexpected glyph index is requested, core text will return NaN values
+        // which causes us to do bad thing as the value is cast into an integer and
+        // overflow when expanding the bounds a few lines below.
+        // Instead we are better off returning zero-sized metrics because this special
+        // case is handled by the callers of this method.
+        return GlyphMetrics {
+            rasterized_left: 0,
+            rasterized_width: 0,
+            rasterized_height: 0,
+            rasterized_ascent: 0,
+            rasterized_descent: 0,
+        };
+    }
+
     let (x_offset, y_offset) = subpixel_point.to_f64();
 
     // First round out to pixel boundaries

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -26,6 +26,10 @@ pub struct FontContext {
     gamma_lut: GammaLut,
 }
 
+// core text is safe to use on multiple threads and non-shareable resources are
+// all hidden inside their font context.
+unsafe impl Send for FontContext {}
+
 pub struct RasterizedGlyph {
     pub width: u32,
     pub height: u32,
@@ -125,6 +129,10 @@ impl FontContext {
             ct_fonts: HashMap::new(),
             gamma_lut: GammaLut::new(contrast, gamma, gamma),
         }
+    }
+
+    pub fn has_font(&self, font_key: &FontKey) -> bool {
+        self.cg_fonts.contains_key(font_key)
     }
 
     pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8], index: u32) {

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -27,6 +27,11 @@ pub struct FontContext {
     faces: HashMap<FontKey, Face>,
 }
 
+// FreeType resources are safe to move between threads as long as they
+// are not concurrently accessed. In our case, everything is hidden inside
+// a given FontContext so it is safe to move the latter between threads.
+unsafe impl Send for FontContext {}
+
 pub struct RasterizedGlyph {
     pub width: u32,
     pub height: u32,
@@ -61,6 +66,10 @@ impl FontContext {
             lib: lib,
             faces: HashMap::new(),
         }
+    }
+
+    pub fn has_font(&self, font_key: &FontKey) -> bool {
+        self.faces.contains_key(font_key)
     }
 
     pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: &[u8], index: u32) {

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -180,7 +180,11 @@ impl FontContext {
             return None;
         }
 
-        let dimensions = Self::get_glyph_dimensions_impl(slot).unwrap();
+        let dimensions = match Self::get_glyph_dimensions_impl(slot) {
+            Some(val) => val,
+            None => return None,
+        };
+
         let bitmap = unsafe { &(*slot).bitmap };
         let pixel_mode = unsafe { mem::transmute(bitmap.pixel_mode as u32) };
         info!("Rasterizing {:?} as {:?} with dimensions {:?}", key, render_mode, dimensions);

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -24,6 +24,10 @@ pub struct FontContext {
     gdi_gamma_lut: GammaLut,
 }
 
+// DirectWrite is safe to use on multiple threads and non-shareable resources are
+// all hidden inside their font context.
+unsafe impl Send for FontContext {}
+
 pub struct RasterizedGlyph {
     pub width: u32,
     pub height: u32,
@@ -115,6 +119,10 @@ impl FontContext {
             gamma_lut: GammaLut::new(contrast, gamma, gamma),
             gdi_gamma_lut: GammaLut::new(contrast, gdi_gamma, gdi_gamma),
         }
+    }
+
+    pub fn has_font(&self, font_key: &FontKey) -> bool {
+        self.fonts.contains_key(font_key)
     }
 
     pub fn add_raw_font(&mut self, font_key: &FontKey, data: &[u8], index: u32) {

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -279,9 +279,11 @@ impl FontContext {
         let width = (bounds.right - bounds.left) as usize;
         let height = (bounds.bottom - bounds.top) as usize;
 
-        // We should not get here since glyph_dimensions would return
-        // None for empty glyphs.
-        assert!(width > 0 && height > 0);
+        // Alpha texture bounds can sometimes return an empty rect
+        // Such as for spaces
+        if width == 0 || height == 0 {
+            return None;
+        }
 
         let mut pixels = analysis.create_alpha_texture(texture_type, bounds);
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -7,53 +7,25 @@ use device::TextureFilter;
 use fnv::FnvHasher;
 use frame::FrameId;
 use internal_types::{FontTemplate, SourceTexture, TextureUpdateList};
-use platform::font::{FontContext, RasterizedGlyph};
 use profiler::TextureCacheProfileCounters;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::fmt::Debug;
 use std::hash::BuildHasherDefault;
 use std::hash::Hash;
 use std::mem;
-use std::sync::{Arc, Barrier};
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::thread;
+use std::sync::Arc;
 use texture_cache::{TextureCache, TextureCacheItemId};
-use thread_profiler::register_thread_with_profiler;
-use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageFormat, ImageRendering};
+use webrender_traits::{Epoch, FontKey, GlyphKey, ImageKey, ImageRendering};
 use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use webrender_traits::{DevicePoint, DeviceIntSize, DeviceUintRect, ImageDescriptor, ColorF};
 use webrender_traits::{GlyphOptions, GlyphInstance, TileOffset, TileSize};
 use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest, BlobImageData, ImageStore};
 use webrender_traits::{ExternalImageData, ExternalImageType, LayoutPoint};
 use rayon::ThreadPool;
+use glyph_rasterizer::{GlyphRasterizer, GlyphCache, GlyphRequest};
 
 const DEFAULT_TILE_SIZE: TileSize = 512;
-
-thread_local!(pub static FONT_CONTEXT: RefCell<FontContext> = RefCell::new(FontContext::new()));
-
-type GlyphCache = ResourceClassCache<RenderedGlyphKey, Option<TextureCacheItemId>>;
-
-/// Message sent from the resource cache to the glyph cache thread.
-enum GlyphCacheMsg {
-    /// Begin the frame - pass ownership of the glyph cache to the thread.
-    BeginFrame(FrameId, GlyphCache),
-    /// Add a new font.
-    AddFont(FontKey, FontTemplate),
-    /// Request glyphs for a text run.
-    RequestGlyphs(FontKey, Au, ColorF, Vec<GlyphInstance>, FontRenderMode, Option<GlyphOptions>),
-    // Remove an existing font.
-    DeleteFont(FontKey),
-    /// Finished requesting glyphs. Reply with new glyphs.
-    EndFrame,
-}
-
-/// Results send from glyph cache thread back to main resource cache.
-enum GlyphCacheResultMsg {
-    /// Return the glyph cache, and a list of newly rasterized glyphs.
-    EndFrame(GlyphCache, Vec<GlyphRasterJob>),
-}
 
 // These coordinates are always in texels.
 // They are converted to normalized ST
@@ -68,30 +40,6 @@ pub struct CacheItem {
     pub texture_id: SourceTexture,
     pub uv0: DevicePoint,
     pub uv1: DevicePoint,
-}
-
-#[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
-pub struct RenderedGlyphKey {
-    pub key: GlyphKey,
-    pub render_mode: FontRenderMode,
-    pub glyph_options: Option<GlyphOptions>,
-}
-
-impl RenderedGlyphKey {
-    pub fn new(font_key: FontKey,
-               size: Au,
-               color: ColorF,
-               index: u32,
-               point: LayoutPoint,
-               render_mode: FontRenderMode,
-               glyph_options: Option<GlyphOptions>) -> RenderedGlyphKey {
-        RenderedGlyphKey {
-            key: GlyphKey::new(font_key, size, color, index,
-                               point, render_mode),
-            render_mode: render_mode,
-            glyph_options: glyph_options,
-        }
-    }
 }
 
 pub struct ImageProperties {
@@ -167,7 +115,7 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
         }
     }
 
-    fn contains_key(&self, key: &K) -> bool {
+    pub fn contains_key(&self, key: &K) -> bool {
         self.resources.contains_key(key)
     }
 
@@ -181,7 +129,7 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
         self.resources.get(key).expect("Didn't find a cached resource with that ID!")
     }
 
-    fn insert(&mut self, key: K, value: V, frame: FrameId) {
+    pub fn insert(&mut self, key: K, value: V, frame: FrameId) {
         self.last_access_times.insert(key.clone(), frame);
         self.resources.insert(key, value);
     }
@@ -191,7 +139,7 @@ impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resourc
         self.resources.entry(key)
     }
 
-    fn mark_as_needed(&mut self, key: &K, frame: FrameId) {
+    pub fn mark_as_needed(&mut self, key: &K, frame: FrameId) {
         self.last_access_times.insert((*key).clone(), frame);
     }
 
@@ -232,18 +180,13 @@ impl Into<BlobImageRequest> for ImageRequest {
     }
 }
 
-struct GlyphRasterJob {
-    key: RenderedGlyphKey,
-    result: Option<RasterizedGlyph>,
-}
-
 struct WebGLTexture {
     id: SourceTexture,
     size: DeviceIntSize,
 }
 
 pub struct ResourceCache {
-    cached_glyphs: Option<GlyphCache>,
+    cached_glyphs: GlyphCache,
     cached_images: ResourceClassCache<ImageRequest, CachedImageInfo>,
 
     // TODO(pcwalton): Figure out the lifecycle of these.
@@ -259,8 +202,7 @@ pub struct ResourceCache {
     // TODO(gw): We should expire (parts of) this cache semi-regularly!
     cached_glyph_dimensions: HashMap<GlyphKey, Option<GlyphDimensions>, BuildHasherDefault<FnvHasher>>,
     pending_image_requests: Vec<ImageRequest>,
-    glyph_cache_tx: Sender<GlyphCacheMsg>,
-    glyph_cache_result_queue: Receiver<GlyphCacheResultMsg>,
+    glyph_rasterizer: GlyphRasterizer,
 
     blob_image_renderer: Option<Box<BlobImageRenderer>>,
     blob_image_requests: HashSet<ImageRequest>,
@@ -270,10 +212,8 @@ impl ResourceCache {
     pub fn new(texture_cache: TextureCache,
                workers: Arc<ThreadPool>,
                blob_image_renderer: Option<Box<BlobImageRenderer>>) -> ResourceCache {
-        let (glyph_cache_tx, glyph_cache_result_queue) = spawn_glyph_cache_thread(workers);
-
         ResourceCache {
-            cached_glyphs: Some(ResourceClassCache::new()),
+            cached_glyphs: ResourceClassCache::new(),
             cached_images: ResourceClassCache::new(),
             webgl_textures: HashMap::default(),
             font_templates: HashMap::default(),
@@ -283,8 +223,7 @@ impl ResourceCache {
             state: State::Idle,
             current_frame_id: FrameId(0),
             pending_image_requests: Vec::new(),
-            glyph_cache_tx: glyph_cache_tx,
-            glyph_cache_result_queue: glyph_cache_result_queue,
+            glyph_rasterizer: GlyphRasterizer::new(workers),
 
             blob_image_renderer: blob_image_renderer,
             blob_image_requests: HashSet::new(),
@@ -309,18 +248,14 @@ impl ResourceCache {
     }
 
     pub fn add_font_template(&mut self, font_key: FontKey, template: FontTemplate) {
-        // Push the new font to the glyph cache thread, and also store
+        // Push the new font to the font renderer, and also store
         // it locally for glyph metric requests.
-        self.glyph_cache_tx
-            .send(GlyphCacheMsg::AddFont(font_key, template.clone()))
-            .unwrap();
+        self.glyph_rasterizer.add_font(font_key, template.clone());
         self.font_templates.insert(font_key, template);
     }
 
     pub fn delete_font_template(&mut self, font_key: FontKey) {
-        self.glyph_cache_tx
-            .send(GlyphCacheMsg::DeleteFont(font_key))
-            .unwrap();
+        self.glyph_rasterizer.delete_font(font_key);
         self.font_templates.remove(&font_key);
     }
 
@@ -492,16 +427,17 @@ impl ResourceCache {
                           render_mode: FontRenderMode,
                           glyph_options: Option<GlyphOptions>) {
         debug_assert_eq!(self.state, State::AddResources);
-        // Immediately request that the glyph cache thread start
-        // rasterizing glyphs from this request if they aren't
-        // already cached.
-        let msg = GlyphCacheMsg::RequestGlyphs(key,
-                                               size,
-                                               color,
-                                               glyph_instances.to_vec(),
-                                               render_mode,
-                                               glyph_options);
-        self.glyph_cache_tx.send(msg).unwrap();
+
+        self.glyph_rasterizer.request_glyphs(
+            &mut self.cached_glyphs,
+            self.current_frame_id,
+            key,
+            size,
+            color,
+            glyph_instances,
+            render_mode,
+            glyph_options,
+        );
     }
 
     pub fn pending_updates(&mut self) -> TextureUpdateList {
@@ -517,20 +453,21 @@ impl ResourceCache {
                          glyph_options: Option<GlyphOptions>,
                          mut f: F) -> SourceTexture where F: FnMut(usize, DevicePoint, DevicePoint) {
         debug_assert_eq!(self.state, State::QueryResources);
-        let cache = self.cached_glyphs.as_ref().unwrap();
-        let mut glyph_key = RenderedGlyphKey::new(font_key,
-                                                  size,
-                                                  color,
-                                                  0,
-                                                  LayoutPoint::new(0.0, 0.0),
-                                                  render_mode,
-                                                  glyph_options);
+        let mut glyph_key = GlyphRequest::new(
+            font_key,
+            size,
+            color,
+            0,
+            LayoutPoint::new(0.0, 0.0),
+            render_mode,
+            glyph_options
+        );
         let mut texture_id = None;
         for (loop_index, glyph_instance) in glyph_instances.iter().enumerate() {
             glyph_key.key.index = glyph_instance.index;
             glyph_key.key.subpixel_point.set_offset(glyph_instance.point, render_mode);
 
-            let image_id = cache.get(&glyph_key, self.current_frame_id);
+            let image_id = self.cached_glyphs.get(&glyph_key, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
                 let uv0 = DevicePoint::new(cache_item.pixel_rect.top_left.x as f32,
@@ -551,25 +488,7 @@ impl ResourceCache {
         match self.cached_glyph_dimensions.entry(glyph_key.clone()) {
             Occupied(entry) => *entry.get(),
             Vacant(entry) => {
-                let mut dimensions = None;
-                let font_template = &self.font_templates[&glyph_key.font_key];
-
-                FONT_CONTEXT.with(|font_context| {
-                    let mut font_context = font_context.borrow_mut();
-                    match *font_template {
-                        FontTemplate::Raw(ref bytes, index) => {
-                            font_context.add_raw_font(&glyph_key.font_key, &**bytes, index);
-                        }
-                        FontTemplate::Native(ref native_font_handle) => {
-                            font_context.add_native_font(&glyph_key.font_key,
-                                                         (*native_font_handle).clone());
-                        }
-                    }
-
-                    dimensions = font_context.get_glyph_dimensions(glyph_key);
-                });
-
-                *entry.insert(dimensions)
+                *entry.insert(self.glyph_rasterizer.get_glyph_dimensions(glyph_key))
             }
         }
     }
@@ -638,17 +557,13 @@ impl ResourceCache {
 
     pub fn expire_old_resources(&mut self, frame_id: FrameId) {
         self.cached_images.expire_old_resources(&mut self.texture_cache, frame_id);
-
-        let cached_glyphs = self.cached_glyphs.as_mut().unwrap();
-        cached_glyphs.expire_old_resources(&mut self.texture_cache, frame_id);
+        self.cached_glyphs.expire_old_resources(&mut self.texture_cache, frame_id);
     }
 
     pub fn begin_frame(&mut self, frame_id: FrameId) {
         debug_assert_eq!(self.state, State::Idle);
         self.state = State::AddResources;
         self.current_frame_id = frame_id;
-        let glyph_cache = self.cached_glyphs.take().unwrap();
-        self.glyph_cache_tx.send(GlyphCacheMsg::BeginFrame(frame_id, glyph_cache)).ok();
     }
 
     pub fn block_until_all_resources_added(&mut self,
@@ -658,53 +573,12 @@ impl ResourceCache {
         debug_assert_eq!(self.state, State::AddResources);
         self.state = State::QueryResources;
 
-        // Tell the glyph cache thread that all glyphs have been requested
-        // and block, waiting for any pending glyphs to be rasterized. In the
-        // future, we will expand this to have a timeout. If the glyph rasterizing
-        // takes longer than the timeout, then we will select the best glyphs
-        // available in the cache, render with those, and then re-render at
-        // a later point when the correct resolution glyphs finally become
-        // available.
-        self.glyph_cache_tx.send(GlyphCacheMsg::EndFrame).unwrap();
-
-        // Loop until the end frame message is retrieved here. This loop
-        // doesn't serve any real purpose right now, but in the future
-        // it will be receiving small amounts of glyphs at a time, up until
-        // it decides that it should just render the frame.
-        while let Ok(result) = self.glyph_cache_result_queue.recv() {
-            match result {
-                GlyphCacheResultMsg::EndFrame(mut cache, glyph_jobs) => {
-                    // Add any newly rasterized glyphs to the texture cache.
-                    for job in glyph_jobs {
-                        let image_id = job.result.and_then(|glyph| {
-                            if glyph.width > 0 && glyph.height > 0 {
-                                let image_id = self.texture_cache.new_item_id();
-                                self.texture_cache.insert(image_id,
-                                                          ImageDescriptor {
-                                                              width: glyph.width,
-                                                              height: glyph.height,
-                                                              stride: None,
-                                                              format: ImageFormat::RGBA8,
-                                                              is_opaque: false,
-                                                              offset: 0,
-                                                          },
-                                                          TextureFilter::Linear,
-                                                          ImageData::Raw(Arc::new(glyph.bytes)),
-                                                          texture_cache_profile);
-                                Some(image_id)
-                            } else {
-                                None
-                            }
-                        });
-
-                        cache.insert(job.key, image_id, self.current_frame_id);
-                    }
-
-                    self.cached_glyphs = Some(cache);
-                    break;
-                }
-            }
-        }
+        self.glyph_rasterizer.resolve_glyphs(
+            self.current_frame_id,
+            &mut self.cached_glyphs,
+            &mut self.texture_cache,
+            texture_cache_profile,
+        );
 
         let mut image_requests = mem::replace(&mut self.pending_image_requests, Vec::new());
         for request in image_requests.drain(..) {
@@ -877,174 +751,6 @@ impl Resource for CachedImageInfo {
     }
 }
 
-fn spawn_glyph_cache_thread(workers: Arc<ThreadPool>) -> (Sender<GlyphCacheMsg>, Receiver<GlyphCacheResultMsg>) {
-    let worker_count = {
-        workers.current_num_threads()
-    };
-    // Used for messages from resource cache -> glyph cache thread.
-    let (msg_tx, msg_rx) = channel();
-    // Used for returning results from glyph cache thread -> resource cache.
-    let (result_tx, result_rx) = channel();
-    // Used for rasterizer worker threads to send glyphs -> glyph cache thread.
-    let (glyph_tx, glyph_rx) = channel();
-
-    thread::Builder::new().name("GlyphCache".to_string()).spawn(move|| {
-        let mut glyph_cache = None;
-        let mut current_frame_id = FrameId(0);
-
-        register_thread_with_profiler("GlyphCache".to_string());
-
-        let barrier = Arc::new(Barrier::new(worker_count));
-        for i in 0..worker_count {
-            let barrier = Arc::clone(&barrier);
-            workers.spawn_async(move || {
-                register_thread_with_profiler(format!("Glyph Worker {}", i));
-                barrier.wait();
-            });
-        }
-
-        // Maintain a set of glyphs that have been requested this
-        // frame. This ensures the glyph thread won't rasterize
-        // the same glyph more than once in a frame. This is required
-        // because the glyph cache hash table is not updated
-        // until the glyph cache is passed back to the resource
-        // cache which is able to add the items to the texture cache.
-        let mut pending_glyphs = HashSet::new();
-
-        while let Ok(msg) = msg_rx.recv() {
-            profile_scope!("handle_msg");
-            match msg {
-                GlyphCacheMsg::BeginFrame(frame_id, cache) => {
-                    profile_scope!("BeginFrame");
-
-                    // We are beginning a new frame. Take ownership of the glyph
-                    // cache hash map, so we can easily see which glyph requests
-                    // actually need to be rasterized.
-                    current_frame_id = frame_id;
-                    glyph_cache = Some(cache);
-                }
-                GlyphCacheMsg::AddFont(font_key, font_template) => {
-                    profile_scope!("AddFont");
-
-                    // Add a new font to the font context in each worker thread.
-                    // Use a barrier to ensure that each worker in the pool handles
-                    // one of these messages, to ensure that the new font gets
-                    // added to each worker thread.
-                    let barrier = Arc::new(Barrier::new(worker_count));
-                    for _ in 0..worker_count {
-                        let barrier = Arc::clone(&barrier);
-                        let font_template = font_template.clone();
-                        workers.spawn_async(move || {
-                            FONT_CONTEXT.with(|font_context| {
-                                let mut font_context = font_context.borrow_mut();
-                                match font_template {
-                                    FontTemplate::Raw(ref bytes, index) => {
-                                        font_context.add_raw_font(&font_key, &**bytes, index);
-                                    }
-                                    FontTemplate::Native(ref native_font_handle) => {
-                                        font_context.add_native_font(&font_key,
-                                                                     (*native_font_handle).clone());
-                                    }
-                                }
-                            });
-
-                            barrier.wait();
-                        });
-                    }
-                }
-                GlyphCacheMsg::DeleteFont(font_key) => {
-                    profile_scope!("DeleteFont");
-
-                    // Delete a font from the font context in each worker thread.
-                    let barrier = Arc::new(Barrier::new(worker_count));
-                    for _ in 0..worker_count {
-                        let barrier = Arc::clone(&barrier);
-                        workers.spawn_async(move || {
-                            FONT_CONTEXT.with(|font_context| {
-                                let mut font_context = font_context.borrow_mut();
-                                font_context.delete_font(&font_key);
-                            });
-                            barrier.wait();
-                        });
-                    }
-
-                }
-                GlyphCacheMsg::RequestGlyphs(key, size, color, glyph_instances, render_mode, glyph_options) => {
-                    profile_scope!("RequestGlyphs");
-
-                    // Request some glyphs for a text run.
-                    // For any glyph that isn't currently in the cache,
-                    // immeediately push a job to the worker thread pool
-                    // to start rasterizing this glyph now!
-                    let glyph_cache = glyph_cache.as_mut().unwrap();
-
-                    for glyph_instance in glyph_instances {
-                        let glyph_key = RenderedGlyphKey::new(key,
-                                                              size,
-                                                              color,
-                                                              glyph_instance.index,
-                                                              glyph_instance.point,
-                                                              render_mode,
-                                                              glyph_options);
-
-                        glyph_cache.mark_as_needed(&glyph_key, current_frame_id);
-                        if !glyph_cache.contains_key(&glyph_key) &&
-                           !pending_glyphs.contains(&glyph_key) {
-                            let glyph_tx = glyph_tx.clone();
-                            pending_glyphs.insert(glyph_key.clone());
-                            workers.spawn_async(move || {
-                                profile_scope!("glyph");
-                                FONT_CONTEXT.with(move |font_context| {
-                                    let mut font_context = font_context.borrow_mut();
-                                    let result = font_context.rasterize_glyph(&glyph_key.key,
-                                                                              render_mode,
-                                                                              glyph_options);
-                                    if let Some(ref glyph) = result {
-                                        assert_eq!(glyph.bytes.len(), 4 * (glyph.width * glyph.height) as usize);
-                                    }
-                                    glyph_tx.send((glyph_key, result)).unwrap();
-                                });
-                            });
-                        }
-                    }
-                }
-                GlyphCacheMsg::EndFrame => {
-                    profile_scope!("EndFrame");
-
-                    // The resource cache has finished requesting glyphs. Block
-                    // on completion of any pending glyph rasterizing jobs, and then
-                    // return the list of new glyphs to the resource cache.
-                    let cache = glyph_cache.take().unwrap();
-                    let mut rasterized_glyphs = Vec::new();
-                    while !pending_glyphs.is_empty() {
-                        let (key, glyph) = glyph_rx.recv()
-                                                   .expect("BUG: Should be glyphs pending!");
-                        debug_assert!(pending_glyphs.contains(&key));
-                        pending_glyphs.remove(&key);
-                        if let Some(ref v) = glyph {
-                            debug!("received {}x{} data len {}", v.width, v.height, v.bytes.len());
-                        }
-                        rasterized_glyphs.push(GlyphRasterJob {
-                            key: key,
-                            result: glyph,
-                        });
-                    }
-                    // Ensure that the glyphs are always processed in the same
-                    // order for a given text run (since iterating a hash set doesn't
-                    // guarantee order). This can show up as very small float inaccuacry
-                    // differences in rasterizers due to the different coordinates
-                    // that text runs get associated with by the texture cache allocator.
-                    rasterized_glyphs.sort_by(|a, b| {
-                        a.key.cmp(&b.key)
-                    });
-                    result_tx.send(GlyphCacheResultMsg::EndFrame(cache, rasterized_glyphs)).unwrap();
-                }
-            }
-        }
-    }).unwrap();
-
-    (msg_tx, result_rx)
-}
 
 // Compute the width and height of a tile depending on its position in the image.
 pub fn compute_tile_size(descriptor: &ImageDescriptor,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -108,7 +108,7 @@ pub struct ResourceClassCache<K,V> {
 }
 
 impl<K,V> ResourceClassCache<K,V> where K: Clone + Hash + Eq + Debug, V: Resource {
-    fn new() -> ResourceClassCache<K,V> {
+    pub fn new() -> ResourceClassCache<K,V> {
         ResourceClassCache {
             resources: HashMap::default(),
             last_access_times: HashMap::default(),


### PR DESCRIPTION
This is a work in progress. I am trying to address a few things here:

 - The way the glyph cache adds and removes font templates is terribly inefficient: it basically schedules N jobs (N being the number of workers) and each job waits for all of the other jobs to complete in order to insure that each worker gets exactly one of these jobs to do some thread-local storage manipulation. Bad. If the thread pool is busy, we wait for all jobs in progress to complete, then wait for all add/remove jobs to be processed on each worker, and then we can start doing useful things again. Right now it is not very noticeable because we use a thread pool dedicated to glyph rendering for each WebRender instance, but we want to share this thread pool between instances and use it for blob image rendeing as well.
 - The way things currently work is more complicated than it needs to be, It has an extra thread that does nothing other than posting jobs to the thread pool, and requires the glyph cache to move between threads. The latter means we can't easily expose the glyph cache to the blob image renderer. The extra thread isn't necessary. At best it adds a bit latency, and it is written in a way that makes it hard to share it between several webrender instances.
 - the way jobs are dispatch does not let us take advantage of the most efficient way to schedule work on the thread pool (rayon's fork-join API).
 - resource_cache.rs is quite big. It would be nice to move the font rendering bits to a separate file.


How the new font renderer works:

Font contexts are not in thread-local storage anymore, they are in a vector accessible to the workers, accessed with a worker id (provided by rayon), and protected by a mutex. each font context is almost only accessed from its dedicated worker so there should not be contention on the muteces (nothing like the current system that stops all threads anyway). It would be easy to make them really only accessed by their worker if need be.

There is no glyph cache thread anymore. if something needs to be done off the render backend thread, just schedule a job on the thread pool to do it (for example look at add_font). The glyph cache does not need to move around anymore. glyphs are just added to it in resolve_glyphs which corresponds to what we have in end_frame currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1238)
<!-- Reviewable:end -->
