### PR TITLE
Fix resource_cache mark_as_needed() usage.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -438,8 +438,10 @@ impl ResourceCache {
             tile: tile,
         };
 
-        self.cached_images.mark_as_needed(&request, self.current_frame_id);
         let template = self.image_templates.get(key).unwrap();
+        if template.data.uses_texture_cache() {
+            self.cached_images.mark_as_needed(&request, self.current_frame_id);
+        }
         if template.data.is_blob() {
             if let Some(ref mut renderer) = self.blob_image_renderer {
                 let same_epoch = match self.cached_images.resources.get(&request) {

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -117,6 +117,22 @@ impl ImageData {
             _ => false,
         }
     }
+
+    #[inline]
+    pub fn uses_texture_cache(&self) -> bool {
+        match self {
+            &ImageData::External(ext_data) => {
+                match ext_data.image_type {
+                    ExternalImageType::Texture2DHandle => false,
+                    ExternalImageType::TextureRectHandle => false,
+                    ExternalImageType::TextureExternalHandle => false,
+                    ExternalImageType::ExternalBuffer => true,
+                }
+            }
+            &ImageData::Blob(_) => true,
+            &ImageData::Raw(_) => true,
+        }
+    }
 }
 
 pub trait BlobImageRenderer: Send {


### PR DESCRIPTION
r? @glennw @kvark 
cc @nical 
 
After #1225, every image will call mark_as_needed(). Then we will hit the assert for external image in expire_old_resources().

Only the image which uses resource_cache should call mark_as_needed(). The external image doesn't need that call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1261)
<!-- Reviewable:end -->
