### PR TITLE
Show backtraces in case of unit test failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
       - llvm-3.8-dev
       - libedit-dev
 env:
-  - BUILD_KIND=DEBUG
-  - BUILD_KIND=RELEASE
+  - BUILD_KIND=DEBUG RUST_BACKTRACE=1
+  - BUILD_KIND=RELEASE RUST_BACKTRACE=1
 before_install:
   - pip install mako servo-tidy
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Rust\bin'
+  RUST_BACKTRACE: 1
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.msi"


### PR DESCRIPTION
There is probably a more elegant way to do this, I just prefixed with 'RUST_BACKTRACE=1' the ```cargo test``` commands I came across.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1268)
<!-- Reviewable:end -->
