### PR TITLE
Coalescing optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 dist: trusty
 language: rust
-rust: stable
+rust:
+  - stable
+  - nightly
 os:
   - linux
   - osx
-rust:
-  - nightly-2017-01-26
 notifications:
   webhooks: http://build.servo.org:54856/travis
 addons:
@@ -25,8 +25,7 @@ before_install:
 script:
   - servo-tidy
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_traits && cargo test --verbose --features "ipc"); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_traits && cargo test --verbose); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo test --verbose); fi
-  - if [ $BUILD_KIND = DEBUG ]; then (cd wrench && cargo test --verbose); fi
+  - if [ $BUILD_KIND = DEBUG ]; then (cargo test --all --verbose); fi
   - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python headless.py --subpixel-aa reftest); fi
+  - if [ $TRAVIS_RUST_VERSION == "nightly" ]; then (cd webrender && cargo bench --verbose); fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plane-split 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -34,6 +34,7 @@ plane-split = "0.3"
 
 [dev-dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}
+rand = "0.3"                # for the benchmarks
 servo-glutin = "0.10.1"     # for the example apps
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]

--- a/webrender/benches/coalesce.rs
+++ b/webrender/benches/coalesce.rs
@@ -1,0 +1,23 @@
+#![feature(test)]
+
+extern crate rand;
+extern crate test;
+extern crate webrender;
+extern crate webrender_traits;
+
+use rand::Rng;
+use test::Bencher;
+use webrender::TexturePage;
+use webrender_traits::{DeviceUintSize as Size};
+
+#[bench]
+fn bench_coalesce(b: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let mut page = TexturePage::new_dummy(Size::new(10000, 10000));
+    let mut test_page = TexturePage::new_dummy(Size::new(10000, 10000));
+    while page.allocate(&Size::new(rng.gen_range(1, 100), rng.gen_range(1, 100))).is_some() {}
+    b.iter(|| {
+        test_page.fill_from(&page);
+        test_page.coalesce();
+    });
+}

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -73,6 +73,9 @@ mod texture_cache;
 mod tiling;
 mod util;
 
+#[doc(hidden)] // for benchmarks
+pub use texture_cache::TexturePage;
+
 #[cfg(feature = "webgl")]
 mod webgl_types;
 

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -296,6 +296,25 @@ impl TexturePage {
     }
 }
 
+// testing functionality
+impl TexturePage {
+    #[doc(hidden)]
+    pub fn new_dummy(size: DeviceUintSize) -> TexturePage {
+        Self::new(CacheTextureId(0), size)
+    }
+
+    #[doc(hidden)]
+    pub fn fill_from(&mut self, other: &TexturePage) {
+        self.dirty = true;
+        self.free_list.small.clear();
+        self.free_list.small.extend_from_slice(&other.free_list.small);
+        self.free_list.medium.clear();
+        self.free_list.medium.extend_from_slice(&other.free_list.medium);
+        self.free_list.large.clear();
+        self.free_list.large.extend_from_slice(&other.free_list.large);
+    }
+}
+
 /// A binning free list. Binning is important to avoid sifting through lots of small strips when
 /// allocating many texture items.
 struct FreeRectList {


### PR DESCRIPTION
Fixes #1266
(if it doesn't fix it yet, the PR would be a step in the right direction anyway)

This PR removes indexing and dynamic allocations from `TexturePage::coalesce`, cleans up the code, adds a basic benchmark for it. Results on my machine - time dropped by about 25%. It's not super great, but I believe that real-world parameters have improved more, given that we are able to capture intermediate coalescing results now even when timed out.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1271)
<!-- Reviewable:end -->
