### PR TITLE
Mostly decoupled wrench from GL

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -140,4 +140,4 @@ extern crate plane_split;
 extern crate gamma_lut;
 
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
-pub use renderer::{Renderer, RendererOptions};
+pub use renderer::{GraphicsApi, GraphicsApiInfo, Renderer, RendererOptions};

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -51,7 +51,7 @@ use util::TransformedRectKind;
 use webgl_types::GLContextHandleWrapper;
 use webrender_traits::{ColorF, Epoch, PipelineId, RenderNotifier, RenderDispatcher};
 use webrender_traits::{ExternalImageId, ExternalImageType, ImageData, ImageFormat, RenderApiSender};
-use webrender_traits::{DeviceIntRect, DevicePoint, DeviceIntPoint, DeviceIntSize, DeviceUintSize};
+use webrender_traits::{DeviceIntRect, DeviceUintRect, DevicePoint, DeviceIntPoint, DeviceIntSize, DeviceUintSize};
 use webrender_traits::{ImageDescriptor, BlobImageRenderer};
 use webrender_traits::{channel, FontRenderMode};
 use webrender_traits::VRCompositorHandler;
@@ -82,6 +82,18 @@ const GPU_TAG_PRIM_BORDER_CORNER: GpuProfileTag = GpuProfileTag { label: "Border
 const GPU_TAG_PRIM_BORDER_EDGE: GpuProfileTag = GpuProfileTag { label: "BorderEdge", color: debug_colors::LAVENDER };
 const GPU_TAG_PRIM_CACHE_IMAGE: GpuProfileTag = GpuProfileTag { label: "CacheImage", color: debug_colors::SILVER };
 const GPU_TAG_BLUR: GpuProfileTag = GpuProfileTag { label: "Blur", color: debug_colors::VIOLET };
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GraphicsApi {
+    OpenGL,
+}
+
+#[derive(Clone, Debug)]
+pub struct GraphicsApiInfo {
+    pub kind: GraphicsApi,
+    pub renderer: String,
+    pub version: String,
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ImageBufferKind {
@@ -1136,12 +1148,16 @@ impl Renderer {
         Ok((renderer, sender))
     }
 
-    fn get_yuv_shader_index(buffer_kind: ImageBufferKind, format: YuvFormat, color_space: YuvColorSpace) -> usize {
-        ((buffer_kind as usize) * YUV_FORMATS.len() + (format as usize)) * YUV_COLOR_SPACES.len() + (color_space as usize)
+    pub fn get_graphics_api_info(&self) -> GraphicsApiInfo {
+        GraphicsApiInfo {
+            kind: GraphicsApi::OpenGL,
+            version: self.device.gl().get_string(gl::VERSION),
+            renderer: self.device.gl().get_string(gl::RENDERER),
+        }
     }
 
-    pub fn gl(&self) -> &gl::Gl {
-        self.device.gl()
+    fn get_yuv_shader_index(buffer_kind: ImageBufferKind, format: YuvFormat, color_space: YuvColorSpace) -> usize {
+        ((buffer_kind as usize) * YUV_FORMATS.len() + (format as usize)) * YUV_COLOR_SPACES.len() + (color_space as usize)
     }
 
     /// Sets the new RenderNotifier.
@@ -2142,6 +2158,15 @@ impl Renderer {
                 }
             }
         }
+    }
+
+    pub fn read_pixels_rgba8(&self, rect: DeviceUintRect) -> Vec<u8> {
+            self.device.gl().read_pixels(rect.origin.x as gl::GLint,
+                                         rect.origin.y as gl::GLint,
+                                         rect.size.width as gl::GLsizei,
+                                         rect.size.height as gl::GLsizei,
+                                         gl::RGBA,
+                                         gl::UNSIGNED_BYTE)
     }
 
     // De-initialize the Renderer safely, assuming the GL is still alive and active.

--- a/wrench/src/png.rs
+++ b/wrench/src/png.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use WindowWrapper;
-use gleam::gl;
 use image::ColorType;
 use image::png::PNGEncoder;
 use std::fs::File;
@@ -55,12 +54,8 @@ pub fn png(wrench: &mut Wrench,
     wrench.render();
 
     let size = window.get_inner_size_pixels();
-    let data = wrench.renderer.gl().read_pixels(0,
-                                                0,
-                                                size.0 as gl::GLsizei,
-                                                size.1 as gl::GLsizei,
-                                                gl::RGBA,
-                                                gl::UNSIGNED_BYTE);
+    let data = wrench.renderer.read_pixels_rgba8(DeviceUintRect::new(DeviceUintPoint::zero(),
+                                                                     DeviceUintSize::new(size.0, size.1)));
 
     let mut out_path = reader.yaml_path().clone();
     out_path.set_extension("png");

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -4,7 +4,6 @@
 
 use WindowWrapper;
 use base64;
-use gleam::gl;
 use image::load as load_piston_image;
 use image::png::PNGEncoder;
 use image::{ColorType, ImageFormat};
@@ -306,12 +305,9 @@ impl<'a> ReftestHarness<'a> {
         assert!(size.width <= window_size.0 && size.height <= window_size.1);
 
         // taking the bottom left sub-rectangle
-        let pixels = self.window.gl().read_pixels(0,
-                                                  (window_size.1 - size.height) as gl::GLsizei,
-                                                  size.width as gl::GLsizei,
-                                                  size.height as gl::GLsizei,
-                                                  gl::RGBA,
-                                                  gl::UNSIGNED_BYTE);
+        let rect = DeviceUintRect::new(DeviceUintPoint::new(0, window_size.1 - size.height),
+                                       size);
+        let pixels = self.wrench.renderer.read_pixels_rgba8(rect);
         self.window.swap_buffers();
 
         let write_debug_images = false;

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -10,7 +10,6 @@ use crossbeam::sync::chase_lev;
 use dwrote;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use font_loader::system_fonts;
-use gleam::gl;
 use glutin::WindowProxy;
 use image;
 use image::GenericImage;
@@ -21,7 +20,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use time;
 use webrender;
-use webrender::renderer::{CpuProfile, GpuProfile};
+use webrender::renderer::{CpuProfile, GpuProfile, GraphicsApiInfo};
 use webrender_traits::*;
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use yaml_rust::Yaml;
@@ -128,8 +127,7 @@ pub struct Wrench {
 
     image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
-    gl_renderer: String,
-    gl_version: String,
+    graphics_api: GraphicsApiInfo,
 
     pub rebuild_display_lists: bool,
     pub verbose: bool,
@@ -191,8 +189,7 @@ impl Wrench {
         let notifier = Box::new(Notifier::new(proxy, timing_receiver, verbose));
         renderer.set_render_notifier(notifier);
 
-        let gl_version = renderer.gl().get_string(gl::VERSION);
-        let gl_renderer = renderer.gl().get_string(gl::RENDERER);
+        let graphics_api = renderer.get_graphics_api_info();
 
         let mut wrench = Wrench {
             window_size: size,
@@ -209,8 +206,7 @@ impl Wrench {
 
             root_pipeline_id: PipelineId(0, 0),
 
-            gl_renderer: gl_renderer,
-            gl_version: gl_version,
+            graphics_api: graphics_api,
             frame_start_sender: timing_sender,
         };
 
@@ -222,7 +218,7 @@ impl Wrench {
 
     pub fn set_title(&mut self, extra: &str) {
         self.window_title_to_set = Some(format!("Wrench: {} ({}x) - {} - {}", extra,
-            self.device_pixel_ratio, self.gl_renderer, self.gl_version));
+            self.device_pixel_ratio, self.graphics_api.renderer, self.graphics_api.version));
     }
 
     pub fn take_title(&mut self) -> Option<String> {
@@ -354,7 +350,6 @@ impl Wrench {
 
     pub fn update(&mut self, dim: DeviceUintSize) {
         if dim != self.window_size {
-            self.renderer.gl().viewport(0, 0, dim.width as i32, dim.height as i32);
             self.window_size = dim;
         }
     }


### PR DESCRIPTION
Fixes #1269
Note: even though `main.rs` of Wrench still depends on GL, it's only used for context initialization, so the original issue is largely addressed by the PR.
Note: this is technically a breaking API change.
r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1274)
<!-- Reviewable:end -->
