### PR TITLE
Some optimizations and cleanups of primitive instances.

### DIFF
--- a/webrender/res/cs_box_shadow.vs.glsl
+++ b/webrender/res/cs_box_shadow.vs.glsl
@@ -6,7 +6,7 @@
 void main(void) {
     PrimitiveInstance pi = fetch_prim_instance();
     RenderTaskData task = fetch_render_task(pi.render_task_index);
-    BoxShadow bs = fetch_boxshadow(pi.specific_prim_index);
+    BoxShadow bs = fetch_boxshadow(pi.specific_prim_address);
 
     vec2 p0 = task.data0.xy;
     vec2 p1 = p0 + task.data0.zw;

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -10,10 +10,10 @@
 void main(void) {
     PrimitiveInstance pi = fetch_prim_instance();
     RenderTaskData task = fetch_render_task(pi.render_task_index);
-    TextRun text = fetch_text_run(pi.specific_prim_index);
-    Glyph glyph = fetch_glyph(pi.sub_index);
+    TextRun text = fetch_text_run(pi.specific_prim_address);
+    Glyph glyph = fetch_glyph(pi.user_data0);
     PrimitiveGeometry pg = fetch_prim_geometry(pi.global_prim_index);
-    ResourceRect res = fetch_resource_rect(pi.user_data.x);
+    ResourceRect res = fetch_resource_rect(pi.user_data1);
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -133,14 +133,8 @@ uniform sampler2D sData128;
 uniform sampler2D sResourceRects;
 
 // Instanced attributes
-in int aGlobalPrimId;
-in int aPrimitiveAddress;
-in int aTaskIndex;
-in int aClipTaskIndex;
-in int aLayerIndex;
-in int aElementIndex;
-in ivec2 aUserData;
-in int aZIndex;
+in ivec4 aData0;
+in ivec4 aData1;
 
 // get_fetch_uv is a macro to work around a macOS Intel driver parsing bug.
 // TODO: convert back to a function once the driver issues are resolved, if ever.
@@ -441,28 +435,51 @@ PrimitiveGeometry fetch_prim_geometry(int index) {
 
 struct PrimitiveInstance {
     int global_prim_index;
-    int specific_prim_index;
+    int specific_prim_address;
     int render_task_index;
     int clip_task_index;
     int layer_index;
-    int sub_index;
     int z;
-    ivec2 user_data;
+    int user_data0;
+    int user_data1;
 };
 
 PrimitiveInstance fetch_prim_instance() {
     PrimitiveInstance pi;
 
-    pi.global_prim_index = aGlobalPrimId;
-    pi.specific_prim_index = aPrimitiveAddress;
-    pi.render_task_index = aTaskIndex;
-    pi.clip_task_index = aClipTaskIndex;
-    pi.layer_index = aLayerIndex;
-    pi.sub_index = aElementIndex;
-    pi.user_data = aUserData;
-    pi.z = aZIndex;
+    pi.global_prim_index = aData0.x;
+    pi.specific_prim_address = aData0.y;
+    pi.render_task_index = aData0.z;
+    pi.clip_task_index = aData0.w;
+    pi.layer_index = aData1.x;
+    pi.z = aData1.y;
+    pi.user_data0 = aData1.z;
+    pi.user_data1 = aData1.w;
 
     return pi;
+}
+
+struct CompositeInstance {
+    int render_task_index;
+    int src_task_index;
+    int backdrop_task_index;
+    int user_data0;
+    int user_data1;
+    float z;
+};
+
+CompositeInstance fetch_composite_instance() {
+    CompositeInstance ci;
+
+    ci.render_task_index = aData0.x;
+    ci.src_task_index = aData0.y;
+    ci.backdrop_task_index = aData0.z;
+    ci.z = float(aData0.w);
+
+    ci.user_data0 = aData1.x;
+    ci.user_data1 = aData1.y;
+
+    return ci;
 }
 
 struct Primitive {
@@ -472,10 +489,8 @@ struct Primitive {
     RectWithSize local_rect;
     RectWithSize local_clip_rect;
     int prim_index;
-    // when sending multiple primitives of the same type (e.g. border segments)
-    // this index allows the vertex shader to recognize the difference
-    int sub_index;
-    ivec2 user_data;
+    int user_data0;
+    int user_data1;
     float z;
 };
 
@@ -490,9 +505,9 @@ Primitive load_primitive_custom(PrimitiveInstance pi) {
     prim.local_rect = pg.local_rect;
     prim.local_clip_rect = pg.local_clip_rect;
 
-    prim.prim_index = pi.specific_prim_index;
-    prim.sub_index = pi.sub_index;
-    prim.user_data = pi.user_data;
+    prim.prim_index = pi.specific_prim_address;
+    prim.user_data0 = pi.user_data0;
+    prim.user_data1 = pi.user_data1;
     prim.z = float(pi.z);
 
     return prim;

--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -27,7 +27,7 @@ void main(void) {
     vTileRepeat = gradient.tile_size_repeat.zw;
 
     // V coordinate of gradient row in lookup texture.
-    vGradientIndex = float(prim.sub_index);
+    vGradientIndex = float(prim.user_data0);
 
     // The texture size of the lookup texture
     vGradientTextureSize = vec2(textureSize(sGradients, 0));

--- a/webrender/res/ps_blend.vs.glsl
+++ b/webrender/res/ps_blend.vs.glsl
@@ -4,9 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    PrimitiveInstance pi = fetch_prim_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(pi.render_task_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.x);
+    CompositeInstance ci = fetch_composite_instance();
+    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.render_target_origin -
                        dest_task.screen_space_origin +
@@ -24,8 +24,8 @@ void main(void) {
     vUv = vec3(uv / texture_size, src_task.render_target_layer_index);
     vUvBounds = vec4(st0 + 0.5, st1 - 0.5) / texture_size.xyxy;
 
-    vOp = pi.sub_index;
-    vAmount = float(pi.user_data.y) / 65535.0;
+    vOp = ci.user_data0;
+    vAmount = float(ci.user_data1) / 65535.0;
 
-    gl_Position = uTransform * vec4(local_pos, pi.z, 1.0);
+    gl_Position = uTransform * vec4(local_pos, ci.z, 1.0);
 }

--- a/webrender/res/ps_border_corner.vs.glsl
+++ b/webrender/res/ps_border_corner.vs.glsl
@@ -114,7 +114,7 @@ int select_style(int color_select, vec2 fstyle) {
 void main(void) {
     Primitive prim = load_primitive();
     Border border = fetch_border(prim.prim_index);
-    int sub_part = prim.sub_index;
+    int sub_part = prim.user_data0;
     BorderCorners corners = get_border_corners(border, prim.local_rect);
 
     vec2 p0, p1;
@@ -137,7 +137,7 @@ void main(void) {
             color1 = border.colors[1];
             vClipCenter = corners.tl_outer + border.radii[0].xy;
             vClipSign = vec2(1.0);
-            style = select_style(prim.user_data.x, border.style.yx);
+            style = select_style(prim.user_data1, border.style.yx);
             vec4 adjusted_widths = get_effective_border_widths(border, style);
             vec4 inv_adjusted_widths = border.widths - adjusted_widths;
             set_radii(style,
@@ -159,7 +159,7 @@ void main(void) {
             color1 = border.colors[2];
             vClipCenter = corners.tr_outer + vec2(-border.radii[0].z, border.radii[0].w);
             vClipSign = vec2(-1.0, 1.0);
-            style = select_style(prim.user_data.x, border.style.zy);
+            style = select_style(prim.user_data1, border.style.zy);
             vec4 adjusted_widths = get_effective_border_widths(border, style);
             vec4 inv_adjusted_widths = border.widths - adjusted_widths;
             set_radii(style,
@@ -183,7 +183,7 @@ void main(void) {
             color1 = border.colors[3];
             vClipCenter = corners.br_outer - border.radii[1].xy;
             vClipSign = vec2(-1.0, -1.0);
-            style = select_style(prim.user_data.x, border.style.wz);
+            style = select_style(prim.user_data1, border.style.wz);
             vec4 adjusted_widths = get_effective_border_widths(border, style);
             vec4 inv_adjusted_widths = border.widths - adjusted_widths;
             set_radii(style,
@@ -207,7 +207,7 @@ void main(void) {
             color1 = border.colors[0];
             vClipCenter = corners.bl_outer + vec2(border.radii[1].z, -border.radii[1].w);
             vClipSign = vec2(1.0, -1.0);
-            style = select_style(prim.user_data.x, border.style.xw);
+            style = select_style(prim.user_data1, border.style.xw);
             vec4 adjusted_widths = get_effective_border_widths(border, style);
             vec4 inv_adjusted_widths = border.widths - adjusted_widths;
             set_radii(style,
@@ -255,7 +255,7 @@ void main(void) {
         }
     }
 
-    write_color(color0, color1, style, color_delta, prim.user_data.x);
+    write_color(color0, color1, style, color_delta, prim.user_data1);
 
     RectWithSize segment_rect;
     segment_rect.p0 = p0;

--- a/webrender/res/ps_border_edge.vs.glsl
+++ b/webrender/res/ps_border_edge.vs.glsl
@@ -105,7 +105,7 @@ void write_clip_params(float style,
 void main(void) {
     Primitive prim = load_primitive();
     Border border = fetch_border(prim.prim_index);
-    int sub_part = prim.sub_index;
+    int sub_part = prim.user_data0;
     BorderCorners corners = get_border_corners(border, prim.local_rect);
     vec4 color = border.colors[sub_part];
 

--- a/webrender/res/ps_box_shadow.vs.glsl
+++ b/webrender/res/ps_box_shadow.vs.glsl
@@ -6,7 +6,7 @@
 void main(void) {
     Primitive prim = load_primitive();
     BoxShadow bs = fetch_boxshadow(prim.prim_index);
-    RectWithSize segment_rect = fetch_instance_geometry(prim.sub_index);
+    RectWithSize segment_rect = fetch_instance_geometry(prim.user_data0);
 
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,
@@ -15,7 +15,7 @@ void main(void) {
                                  prim.task,
                                  prim.local_rect.p0);
 
-    RenderTaskData child_task = fetch_render_task(prim.user_data.x);
+    RenderTaskData child_task = fetch_render_task(prim.user_data1);
     vUv.z = child_task.data1.x;
 
     // Constant offsets to inset from bilinear filtering border.

--- a/webrender/res/ps_cache_image.vs.glsl
+++ b/webrender/res/ps_cache_image.vs.glsl
@@ -16,7 +16,7 @@ void main(void) {
                                  prim.task,
                                  prim.local_rect.p0);
 
-    RenderTaskData child_task = fetch_render_task(prim.user_data.x);
+    RenderTaskData child_task = fetch_render_task(prim.user_data1);
     vUv.z = child_task.data1.x;
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));

--- a/webrender/res/ps_composite.vs.glsl
+++ b/webrender/res/ps_composite.vs.glsl
@@ -4,10 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    PrimitiveInstance pi = fetch_prim_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(pi.render_task_index);
-    ReadbackTask backdrop_task = fetch_readback_task(pi.user_data.x);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.y);
+    CompositeInstance ci = fetch_composite_instance();
+    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+    ReadbackTask backdrop_task = fetch_readback_task(ci.backdrop_task_index);
+    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.render_target_origin -
                        dest_task.screen_space_origin +
@@ -27,8 +27,7 @@ void main(void) {
     st1 = (src_task.render_target_origin + src_task.size) / texture_size;
     vUv1 = vec3(mix(st0, st1, aPosition.xy), src_task.render_target_layer_index);
 
-    vOp = pi.sub_index;
+    vOp = ci.user_data0;
 
-    gl_Position = uTransform * vec4(local_pos, pi.z, 1.0);
-
+    gl_Position = uTransform * vec4(local_pos, ci.z, 1.0);
 }

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -9,8 +9,8 @@ void main(void) {
 
     vec4 abs_start_end_point = gradient.start_end_point + prim.local_rect.p0.xyxy;
 
-    GradientStop g0 = fetch_gradient_stop(prim.sub_index + 0);
-    GradientStop g1 = fetch_gradient_stop(prim.sub_index + 1);
+    GradientStop g0 = fetch_gradient_stop(prim.user_data0 + 0);
+    GradientStop g1 = fetch_gradient_stop(prim.user_data0 + 1);
 
     RectWithSize segment_rect;
     vec2 axis;

--- a/webrender/res/ps_hardware_composite.vs.glsl
+++ b/webrender/res/ps_hardware_composite.vs.glsl
@@ -4,9 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    PrimitiveInstance pi = fetch_prim_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(pi.render_task_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.x);
+    CompositeInstance ci = fetch_composite_instance();
+    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.render_target_origin -
                        dest_task.screen_space_origin +
@@ -21,5 +21,5 @@ void main(void) {
     vec2 st1 = (src_task.render_target_origin + src_task.size) / texture_size;
     vUv = vec3(mix(st0, st1, aPosition.xy), src_task.render_target_layer_index);
 
-    gl_Position = uTransform * vec4(local_pos, pi.z, 1.0);
+    gl_Position = uTransform * vec4(local_pos, ci.z, 1.0);
 }

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -6,7 +6,7 @@
 void main(void) {
     Primitive prim = load_primitive();
     Image image = fetch_image(prim.prim_index);
-    ResourceRect res = fetch_resource_rect(prim.user_data.x);
+    ResourceRect res = fetch_resource_rect(prim.user_data0);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(prim.local_rect,

--- a/webrender/res/ps_radial_gradient.vs.glsl
+++ b/webrender/res/ps_radial_gradient.vs.glsl
@@ -35,7 +35,7 @@ void main(void) {
     vTileRepeat.y *= ratio_xy;
 
     // V coordinate of gradient row in lookup texture.
-    vGradientIndex = float(prim.sub_index);
+    vGradientIndex = float(prim.user_data0);
 
     // The texture size of the lookup texture
     vGradientTextureSize = vec2(textureSize(sGradients, 0));

--- a/webrender/res/ps_split_composite.vs.glsl
+++ b/webrender/res/ps_split_composite.vs.glsl
@@ -31,14 +31,14 @@ vec3 bilerp(vec3 a, vec3 b, vec3 c, vec3 d, float s, float t) {
 }
 
 void main(void) {
-    PrimitiveInstance pi = fetch_prim_instance();
-    SplitGeometry geometry = fetch_split_geometry(pi.specific_prim_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(pi.user_data.x);
+    CompositeInstance ci = fetch_composite_instance();
+    SplitGeometry geometry = fetch_split_geometry(ci.user_data0);
+    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
     vec3 world_pos = bilerp(geometry.points[0], geometry.points[1],
                             geometry.points[3], geometry.points[2],
                             aPosition.y, aPosition.x);
-    vec4 final_pos = vec4(world_pos.xy * uDevicePixelRatio, pi.z, 1.0);
+    vec4 final_pos = vec4(world_pos.xy * uDevicePixelRatio, ci.z, 1.0);
 
     gl_Position = uTransform * final_pos;
 

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -6,8 +6,8 @@
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.prim_index);
-    Glyph glyph = fetch_glyph(prim.sub_index);
-    ResourceRect res = fetch_resource_rect(prim.user_data.x);
+    Glyph glyph = fetch_glyph(prim.user_data0);
+    ResourceRect res = fetch_resource_rect(prim.user_data1);
 
     RectWithSize local_rect = RectWithSize(glyph.offset.xy,
                                            (res.uv_rect.zw - res.uv_rect.xy) / uDevicePixelRatio);

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -25,11 +25,11 @@ void main(void) {
 
     write_clip(vi.screen_pos, prim.clip_area);
 
-    ResourceRect y_rect = fetch_resource_rect(prim.user_data.x);
+    ResourceRect y_rect = fetch_resource_rect(prim.user_data0);
 #ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR  // only 1 channel
-    ResourceRect u_rect = fetch_resource_rect(prim.user_data.x + 1);
+    ResourceRect u_rect = fetch_resource_rect(prim.user_data0 + 1);
 #ifndef WR_FEATURE_NV12 // 2 channel
-    ResourceRect v_rect = fetch_resource_rect(prim.user_data.x + 2);
+    ResourceRect v_rect = fetch_resource_rect(prim.user_data0 + 2);
 #endif
 #endif
 

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -203,31 +203,18 @@ impl VertexFormat {
                 instance.bind(gl);
                 let mut offset = 0;
 
-                for &attrib in [VertexAttribute::GlobalPrimId,
-                                VertexAttribute::PrimitiveAddress,
-                                VertexAttribute::TaskIndex,
-                                VertexAttribute::ClipTaskIndex,
-                                VertexAttribute::LayerIndex,
-                                VertexAttribute::ElementIndex,
-                                VertexAttribute::ZIndex,
+                for &attrib in [VertexAttribute::Data0,
+                                VertexAttribute::Data1,
                                ].into_iter() {
                     gl.enable_vertex_attrib_array(attrib as gl::GLuint);
                     gl.vertex_attrib_divisor(attrib as gl::GLuint, 1);
                     gl.vertex_attrib_i_pointer(attrib as gl::GLuint,
-                                                1,
+                                                4,
                                                 gl::INT,
                                                 instance_stride,
                                                 offset);
-                    offset += 4;
+                    offset += 16;
                 }
-
-                gl.enable_vertex_attrib_array(VertexAttribute::UserData as gl::GLuint);
-                gl.vertex_attrib_divisor(VertexAttribute::UserData as gl::GLuint, 1);
-                gl.vertex_attrib_i_pointer(VertexAttribute::UserData as gl::GLuint,
-                                            2,
-                                            gl::INT,
-                                            instance_stride,
-                                            offset);
             }
             VertexFormat::Blur => {
                 let vertex_stride = mem::size_of::<PackedVertex>() as gl::GLuint;
@@ -394,14 +381,8 @@ impl Program {
                 self.gl.bind_attrib_location(self.id, VertexAttribute::Color as gl::GLuint, "aColor");
                 self.gl.bind_attrib_location(self.id, VertexAttribute::ColorTexCoord as gl::GLuint, "aColorTexCoord");
 
-                self.gl.bind_attrib_location(self.id, VertexAttribute::GlobalPrimId as gl::GLuint, "aGlobalPrimId");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::PrimitiveAddress as gl::GLuint, "aPrimitiveAddress");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::TaskIndex as gl::GLuint, "aTaskIndex");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::ClipTaskIndex as gl::GLuint, "aClipTaskIndex");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::LayerIndex as gl::GLuint, "aLayerIndex");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::ElementIndex as gl::GLuint, "aElementIndex");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::UserData as gl::GLuint, "aUserData");
-                self.gl.bind_attrib_location(self.id, VertexAttribute::ZIndex as gl::GLuint, "aZIndex");
+                self.gl.bind_attrib_location(self.id, VertexAttribute::Data0 as gl::GLuint, "aData0");
+                self.gl.bind_attrib_location(self.id, VertexAttribute::Data1 as gl::GLuint, "aData1");
             }
             VertexFormat::Blur => {
                 self.gl.bind_attrib_location(self.id, BlurAttribute::Position as gl::GLuint, "aPosition");

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -118,14 +118,8 @@ pub enum VertexAttribute {
     Color,
     ColorTexCoord,
     // instance-frequency primitive attributes
-    GlobalPrimId,
-    PrimitiveAddress,
-    TaskIndex,
-    ClipTaskIndex,
-    LayerIndex,
-    ElementIndex,
-    UserData,
-    ZIndex,
+    Data0,
+    Data1,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -44,7 +44,7 @@ use std::thread;
 use texture_cache::TextureCache;
 use rayon::ThreadPool;
 use rayon::Configuration as ThreadPoolConfig;
-use tiling::{AlphaBatchKind, BlurCommand, Frame, PrimitiveBatch, RenderTarget};
+use tiling::{AlphaBatchKind, BlurCommand, CompositePrimitiveInstance, Frame, PrimitiveBatch, RenderTarget};
 use tiling::{AlphaRenderTarget, CacheClipInstance, PrimitiveInstance, ColorRenderTarget, RenderTargetKind};
 use time::precise_time_ns;
 use thread_profiler::{register_thread_with_profiler, write_profile};
@@ -1613,7 +1613,7 @@ impl Renderer {
             // composites can't be grouped together because
             // they may overlap and affect each other.
             debug_assert!(batch.instances.len() == 1);
-            let instance = &batch.instances[0];
+            let instance = CompositePrimitiveInstance::from(&batch.instances[0]);
 
             // TODO(gw): This code branch is all a bit hacky. We rely
             // on pulling specific values from the render target data
@@ -1626,9 +1626,9 @@ impl Renderer {
             // composite operation in this batch.
             let cache_texture_dimensions = self.device.get_texture_dimensions(cache_texture);
 
-            let backdrop = &render_task_data[instance.task_index as usize];
-            let readback = &render_task_data[instance.user_data[0] as usize];
-            let source = &render_task_data[instance.user_data[1] as usize];
+            let backdrop = &render_task_data[instance.task_index.0 as usize];
+            let readback = &render_task_data[instance.backdrop_task_index.0 as usize];
+            let source = &render_task_data[instance.src_task_index.0 as usize];
 
             // Bind the FBO to blit the backdrop to.
             // Called per-instance in case the layer (and therefore FBO)

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -314,16 +314,14 @@ impl AlphaRenderItem {
                 let amount = (amount * 65535.0).round() as i32;
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
 
-                batch.add_instance(PrimitiveInstance {
-                    global_prim_id: -1,
-                    prim_address: GpuStoreAddress(0),
-                    task_index: task_index.0 as i32,
-                    clip_task_index: -1,
-                    layer_index: -1,
-                    sub_index: filter_mode,
-                    user_data: [src_task_index.0 as i32, amount],
-                    z_sort_index: z,
-                });
+                let instance = CompositePrimitiveInstance::new(task_index,
+                                                               src_task_index,
+                                                               RenderTaskIndex(0),
+                                                               filter_mode,
+                                                               amount,
+                                                               z);
+
+                batch.add_instance(PrimitiveInstance::from(instance));
             }
             AlphaRenderItem::HardwareComposite(stacking_context_index, src_id, composite_op, z) => {
                 let stacking_context = &ctx.stacking_context_store[stacking_context_index.0];
@@ -333,16 +331,15 @@ impl AlphaRenderItem {
                                              composite_op.to_blend_mode(),
                                              BatchTextures::no_texture());
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
-                batch.add_instance(PrimitiveInstance {
-                    global_prim_id: -1,
-                    prim_address: GpuStoreAddress(0),
-                    task_index: task_index.0 as i32,
-                    clip_task_index: -1,
-                    layer_index: -1,
-                    sub_index: -1,
-                    user_data: [src_task_index.0 as i32, 0],
-                    z_sort_index: z,
-                });
+
+                let instance = CompositePrimitiveInstance::new(task_index,
+                                                               src_task_index,
+                                                               RenderTaskIndex(0),
+                                                               0,
+                                                               0,
+                                                               z);
+
+                batch.add_instance(PrimitiveInstance::from(instance));
             }
             AlphaRenderItem::Composite(stacking_context_index,
                                        backdrop_id,
@@ -357,17 +354,15 @@ impl AlphaRenderItem {
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
                 let backdrop_task = render_tasks.get_task_index(&backdrop_id, child_pass_index);
                 let src_task_index = render_tasks.get_static_task_index(&src_id);
-                batch.add_instance(PrimitiveInstance {
-                    global_prim_id: -1,
-                    prim_address: GpuStoreAddress(0),
-                    task_index: task_index.0 as i32,
-                    clip_task_index: -1,
-                    layer_index: -1,
-                    sub_index: mode as u32 as i32,
-                    user_data: [ backdrop_task.0 as i32,
-                                 src_task_index.0 as i32 ],
-                    z_sort_index: z,
-                });
+
+                let instance = CompositePrimitiveInstance::new(task_index,
+                                                               src_task_index,
+                                                               backdrop_task,
+                                                               mode as u32 as i32,
+                                                               0,
+                                                               z);
+
+                batch.add_instance(PrimitiveInstance::from(instance));
             }
             AlphaRenderItem::Primitive(clip_scroll_group_index_opt, prim_index, z) => {
                 let prim_metadata = ctx.prim_store.get_metadata(prim_index);
@@ -375,9 +370,9 @@ impl AlphaRenderItem {
                     Some(group_index) => {
                         let group = &ctx.clip_scroll_group_store[group_index.0];
                         let bounding_rect = group.screen_bounding_rect.as_ref().unwrap();
-                        (bounding_rect.0, group.packed_layer_index.0 as i32)
+                        (bounding_rect.0, group.packed_layer_index)
                     },
-                    None => (TransformedRectKind::AxisAligned, 0),
+                    None => (TransformedRectKind::AxisAligned, PackedLayerIndex(0)),
                 };
                 let needs_clipping = prim_metadata.needs_clipping();
                 let mut flags = AlphaBatchKeyFlags::empty();
@@ -398,24 +393,18 @@ impl AlphaRenderItem {
                     None => {
                         OPAQUE_TASK_INDEX
                     }
-                }.0 as i32;
-                let global_prim_id = prim_index.0 as i32;
-                let prim_address = prim_metadata.gpu_prim_index;
-                let task_index = task_index.0 as i32;
+                };
                 let needs_blending = !prim_metadata.is_opaque ||
                                      needs_clipping ||
                                      transform_kind == TransformedRectKind::Complex;
                 let blend_mode = ctx.prim_store.get_blend_mode(needs_blending, prim_metadata);
-                let base_instance = PrimitiveInstance {
-                    task_index: task_index,
-                    clip_task_index: clip_task_index,
-                    layer_index: packed_layer_index,
-                    global_prim_id: global_prim_id,
-                    prim_address: prim_address,
-                    sub_index: 0,
-                    user_data: [0, 0],
-                    z_sort_index: z,
-                };
+
+                let base_instance = SimplePrimitiveInstance::new(prim_index,
+                                                                 prim_metadata.gpu_prim_index,
+                                                                 task_index,
+                                                                 clip_task_index,
+                                                                 packed_layer_index,
+                                                                 z);
 
                 match prim_metadata.prim_kind {
                     PrimitiveKind::Border => {
@@ -430,16 +419,13 @@ impl AlphaRenderItem {
                                 match *instance_kind {
                                     BorderCornerInstance::Single => {
                                         batch.add_instance(base_instance.build(sub_index,
-                                                                               BorderCornerSide::Both as i32,
-                                                                               0));
+                                                                               BorderCornerSide::Both as i32,));
                                     }
                                     BorderCornerInstance::Double => {
                                         batch.add_instance(base_instance.build(sub_index,
-                                                                               BorderCornerSide::First as i32,
-                                                                               0));
+                                                                               BorderCornerSide::First as i32));
                                         batch.add_instance(base_instance.build(sub_index,
-                                                                               BorderCornerSide::Second as i32,
-                                                                               0));
+                                                                               BorderCornerSide::Second as i32));
                                     }
                                 }
                             }
@@ -447,14 +433,14 @@ impl AlphaRenderItem {
 
                         batch_list.with_suitable_batch(&edge_key, item_bounding_rect, |batch| {
                             for border_segment in 0..4 {
-                                batch.add_instance(base_instance.build(border_segment, 0, 0));
+                                batch.add_instance(base_instance.build(border_segment, 0));
                             }
                         });
                     }
                     PrimitiveKind::Rectangle => {
                         let key = AlphaBatchKey::new(AlphaBatchKind::Rectangle, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        batch.add_instance(base_instance);
+                        batch.add_instance(base_instance.build(0, 0));
                     }
                     PrimitiveKind::Image => {
                         let image_cpu = &ctx.prim_store.cpu_images[prim_metadata.cpu_prim_index.0];
@@ -479,7 +465,7 @@ impl AlphaRenderItem {
 
                         let key = AlphaBatchKey::new(batch_kind, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        batch.add_instance(base_instance.build(0, image_cpu.resource_address.0, 0));
+                        batch.add_instance(base_instance.build(image_cpu.resource_address.0, 0));
                     }
                     PrimitiveKind::TextRun => {
                         let text_cpu = &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
@@ -504,36 +490,33 @@ impl AlphaRenderItem {
                         };
 
                         for glyph_index in 0..prim_metadata.gpu_data_count {
-                            let user_data0 = match batch_kind {
+                            let user_data1 = match batch_kind {
                                 AlphaBatchKind::TextRun => text_cpu.resource_address.0 + glyph_index,
                                 AlphaBatchKind::CacheImage => cache_task_index,
                                 _ => unreachable!(),
                             };
 
                             batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + glyph_index,
-                                                                   user_data0,
-                                                                   0));
+                                                                   user_data1));
                         }
                     }
                     PrimitiveKind::AlignedGradient => {
                         let key = AlphaBatchKey::new(AlphaBatchKind::AlignedGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
                         for part_index in 0..(prim_metadata.gpu_data_count - 1) {
-                            batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + part_index, 0, 0));
+                            batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + part_index, 0));
                         }
                     }
                     PrimitiveKind::AngleGradient => {
                         let key = AlphaBatchKey::new(AlphaBatchKind::AngleGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
                         batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0,
-                                                               prim_metadata.gpu_data_count,
                                                                0));
                     }
                     PrimitiveKind::RadialGradient => {
                         let key = AlphaBatchKey::new(AlphaBatchKind::RadialGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
                         batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0,
-                                                               prim_metadata.gpu_data_count,
                                                                0));
                     }
                     PrimitiveKind::YuvImage => {
@@ -571,8 +554,7 @@ impl AlphaRenderItem {
                                                      textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
 
-                        batch.add_instance(base_instance.build(0,
-                                                               image_yuv_cpu.yuv_resource_address.0,
+                        batch.add_instance(base_instance.build(image_yuv_cpu.yuv_resource_address.0,
                                                                0));
                     }
                     PrimitiveKind::BoxShadow => {
@@ -585,8 +567,7 @@ impl AlphaRenderItem {
 
                         for rect_index in 0..prim_metadata.gpu_data_count {
                             batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + rect_index,
-                                                                   cache_task_index.0 as i32,
-                                                                   0));
+                                                                   cache_task_index.0 as i32));
                         }
                     }
                 }
@@ -599,16 +580,15 @@ impl AlphaRenderItem {
                 let stacking_context = &ctx.stacking_context_store[sc_index.0];
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
                 let source_task = render_tasks.get_task_index(&task_id, child_pass_index);
-                batch.add_instance(PrimitiveInstance {
-                    global_prim_id: -1,
-                    prim_address: gpu_address,
-                    task_index: task_index.0 as i32,
-                    clip_task_index: -1,
-                    layer_index: -1, // not be used
-                    sub_index: 0,
-                    user_data: [ source_task.0 as i32, 0 ],
-                    z_sort_index: z,
-                });
+
+                let instance = CompositePrimitiveInstance::new(task_index,
+                                                               source_task,
+                                                               RenderTaskIndex(0),
+                                                               gpu_address.0,
+                                                               0,
+                                                               z);
+
+                batch.add_instance(PrimitiveInstance::from(instance));
             }
         }
     }
@@ -970,16 +950,13 @@ impl RenderTarget for ColorRenderTarget {
 
                 match prim_metadata.prim_kind {
                     PrimitiveKind::BoxShadow => {
-                        self.box_shadow_cache_prims.push(PrimitiveInstance {
-                            global_prim_id: prim_index.0 as i32,
-                            prim_address: prim_metadata.gpu_prim_index,
-                            task_index: render_tasks.get_task_index(&task.id, pass_index).0 as i32,
-                            clip_task_index: 0,
-                            layer_index: 0,
-                            sub_index: 0,
-                            user_data: [0; 2],
-                            z_sort_index: 0,        // z is disabled for rendering cache primitives
-                        });
+                        let instance = SimplePrimitiveInstance::new(prim_index,
+                                                                    prim_metadata.gpu_prim_index,
+                                                                    render_tasks.get_task_index(&task.id, pass_index),
+                                                                    RenderTaskIndex(0),
+                                                                    PackedLayerIndex(0),
+                                                                    0);     // z is disabled for rendering cache primitives
+                        self.box_shadow_cache_prims.push(instance.build(0, 0));
                     }
                     PrimitiveKind::TextRun => {
                         let text = &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
@@ -998,17 +975,16 @@ impl RenderTarget for ColorRenderTarget {
                                       self.text_run_textures.colors[0] == textures.colors[0]);
                         self.text_run_textures = textures;
 
+                        let instance = SimplePrimitiveInstance::new(prim_index,
+                                                                    prim_metadata.gpu_prim_index,
+                                                                    render_tasks.get_task_index(&task.id, pass_index),
+                                                                    RenderTaskIndex(0),
+                                                                    PackedLayerIndex(0),
+                                                                    0);     // z is disabled for rendering cache primitives
+
                         for glyph_index in 0..prim_metadata.gpu_data_count {
-                            self.text_run_cache_prims.push(PrimitiveInstance {
-                                global_prim_id: prim_index.0 as i32,
-                                prim_address: prim_metadata.gpu_prim_index,
-                                task_index: render_tasks.get_task_index(&task.id, pass_index).0 as i32,
-                                clip_task_index: 0,
-                                layer_index: 0,
-                                sub_index: prim_metadata.gpu_data_address.0 + glyph_index,
-                                user_data: [ text.resource_address.0 + glyph_index, 0],
-                                z_sort_index: 0,        // z is disabled for rendering cache primitives
-                            });
+                            self.text_run_cache_prims.push(instance.build(prim_metadata.gpu_data_address.0 + glyph_index,
+                                                                          text.resource_address.0 + glyph_index));
                         }
                     }
                     _ => {
@@ -1289,27 +1265,107 @@ pub struct CacheClipInstance {
     segment: i32,
 }
 
+// 32 bytes per instance should be enough for anyone!
 #[derive(Debug, Clone)]
 pub struct PrimitiveInstance {
-    global_prim_id: i32,
-    prim_address: GpuStoreAddress,
-    pub task_index: i32,
-    clip_task_index: i32,
-    layer_index: i32,
-    sub_index: i32,
-    z_sort_index: i32,
-    pub user_data: [i32; 2],
+    data: [i32; 8],
 }
 
-impl PrimitiveInstance {
-    pub fn build(&self,
-                 sub_index: i32,
-                 user_data0: i32,
-                 user_data1: i32) -> PrimitiveInstance {
+struct SimplePrimitiveInstance {
+    pub global_prim_index: i32,
+    pub specific_prim_address: i32,
+    pub task_index: i32,
+    pub clip_task_index: i32,
+    pub layer_index: i32,
+    pub z_sort_index: i32,
+}
+
+impl SimplePrimitiveInstance {
+    fn new(prim_index: PrimitiveIndex,
+           specific_prim_address: GpuStoreAddress,
+           task_index: RenderTaskIndex,
+           clip_task_index: RenderTaskIndex,
+           layer_index: PackedLayerIndex,
+           z_sort_index: i32) -> SimplePrimitiveInstance {
+        SimplePrimitiveInstance {
+            global_prim_index: prim_index.0 as i32,
+            specific_prim_address: specific_prim_address.0 as i32,
+            task_index: task_index.0 as i32,
+            clip_task_index: clip_task_index.0 as i32,
+            layer_index: layer_index.0 as i32,
+            z_sort_index: z_sort_index,
+        }
+    }
+
+    fn build(&self, data0: i32, data1: i32) -> PrimitiveInstance {
         PrimitiveInstance {
-            sub_index: sub_index,
-            user_data: [user_data0, user_data1],
-            ..*self
+            data: [
+                self.global_prim_index,
+                self.specific_prim_address,
+                self.task_index,
+                self.clip_task_index,
+                self.layer_index,
+                self.z_sort_index,
+                data0,
+                data1,
+            ]
+        }
+    }
+}
+
+pub struct CompositePrimitiveInstance {
+    pub task_index: RenderTaskIndex,
+    pub src_task_index: RenderTaskIndex,
+    pub backdrop_task_index: RenderTaskIndex,
+    pub data0: i32,
+    pub data1: i32,
+    pub z: i32,
+}
+
+impl CompositePrimitiveInstance {
+    fn new(task_index: RenderTaskIndex,
+           src_task_index: RenderTaskIndex,
+           backdrop_task_index: RenderTaskIndex,
+           data0: i32,
+           data1: i32,
+           z: i32) -> CompositePrimitiveInstance {
+        CompositePrimitiveInstance {
+            task_index: task_index,
+            src_task_index: src_task_index,
+            backdrop_task_index: backdrop_task_index,
+            data0: data0,
+            data1: data1,
+            z: z,
+        }
+    }
+}
+
+impl From<CompositePrimitiveInstance> for PrimitiveInstance {
+    fn from(instance: CompositePrimitiveInstance) -> PrimitiveInstance {
+        PrimitiveInstance {
+            data: [
+                instance.task_index.0 as i32,
+                instance.src_task_index.0 as i32,
+                instance.backdrop_task_index.0 as i32,
+                instance.z,
+                instance.data0,
+                instance.data1,
+                0,
+                0,
+            ]
+        }
+    }
+}
+
+impl<'a> From<&'a PrimitiveInstance> for CompositePrimitiveInstance {
+    fn from(instance: &'a PrimitiveInstance) -> CompositePrimitiveInstance {
+        CompositePrimitiveInstance {
+            task_index: RenderTaskIndex(instance.data[0] as usize),
+            src_task_index: RenderTaskIndex(instance.data[1] as usize),
+            backdrop_task_index: RenderTaskIndex(instance.data[2] as usize),
+            z: instance.data[3],
+            data0: instance.data[4],
+            data1: instance.data[5],
         }
     }
 }


### PR DESCRIPTION
* Pack the instance attributes into ivec4 - optimization on some GPUs.
* Drop the instance size from 36 to 32 bytes.
* Provide a separate instance type for composites and primitives.
* Update shaders to use the new types.

This is still a bit messy, but I think it's an improvement on
the existing code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1290)
<!-- Reviewable:end -->
