### PR TITLE
Better graphics debugging experience

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -577,6 +577,7 @@ pub struct Renderer {
     max_recorded_profiles: usize,
     clear_framebuffer: bool,
     clear_color: ColorF,
+    enable_clear_scissor: bool,
     debug: DebugRenderer,
     render_target_debug: bool,
     enable_batcher: bool,
@@ -1132,6 +1133,7 @@ impl Renderer {
             max_recorded_profiles: options.max_recorded_profiles,
             clear_framebuffer: options.clear_framebuffer,
             clear_color: options.clear_color,
+            enable_clear_scissor: options.enable_clear_scissor,
             last_time: 0,
             color_render_targets: Vec::new(),
             alpha_render_targets: Vec::new(),
@@ -1702,7 +1704,7 @@ impl Renderer {
             self.device.set_blend(false);
             self.device.set_blend_mode_alpha();
             match render_target {
-                Some(..) => {
+                Some(..) if self.enable_clear_scissor => {
                     // TODO(gw): Applying a scissor rect and minimal clear here
                     // is a very large performance win on the Intel and nVidia
                     // GPUs that I have tested with. It's possible it may be a
@@ -1712,7 +1714,7 @@ impl Renderer {
                                                   Some(1.0),
                                                   target.used_rect());
                 }
-                None => {
+                _ => {
                     self.device.clear_target(clear_color, Some(1.0));
                 }
             }
@@ -2269,6 +2271,7 @@ pub struct RendererOptions {
     pub enable_subpixel_aa: bool,
     pub clear_framebuffer: bool,
     pub clear_color: ColorF,
+    pub enable_clear_scissor: bool,
     pub enable_batcher: bool,
     pub render_target_debug: bool,
     pub max_texture_size: Option<u32>,
@@ -2293,6 +2296,7 @@ impl Default for RendererOptions {
             enable_subpixel_aa: false,
             clear_framebuffer: true,
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
+            enable_clear_scissor: true,
             enable_batcher: true,
             render_target_debug: false,
             max_texture_size: None,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -29,8 +29,7 @@ use webrender_traits::{BuiltDisplayList, ClipAndScrollInfo, ClipId, ColorF, Devi
 use webrender_traits::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize};
 use webrender_traits::{ExternalImageType, FontRenderMode, ImageRendering, LayerPoint, LayerRect};
 use webrender_traits::{LayerToWorldTransform, MixBlendMode, PipelineId, TransformStyle};
-use webrender_traits::{WorldPoint4D, WorldToLayerTransform};
-use webrender_traits::{YuvColorSpace, YuvFormat};
+use webrender_traits::{WorldToLayerTransform, YuvColorSpace, YuvFormat};
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -50,6 +50,9 @@ args:
   - vsync:
       long: vsync
       help: Enable vsync for OpenGL window
+  - no_scissor:
+      long: no-scissor
+      help: Disable scissors when clearing render targets
   - no_batch:
       long: no-batch
       help: Disable batching of instanced draw calls

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -330,6 +330,7 @@ fn main() {
                                  args.is_present("subpixel_aa"),
                                  args.is_present("debug"),
                                  args.is_present("verbose"),
+                                 args.is_present("no_scissor"),
                                  args.is_present("no_batch"));
 
     let mut thing =

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -145,6 +145,7 @@ impl Wrench {
                subpixel_aa: bool,
                debug: bool,
                verbose: bool,
+               no_scissor: bool,
                no_batch: bool)
            -> Wrench
     {
@@ -170,6 +171,7 @@ impl Wrench {
             recorder: recorder,
             enable_subpixel_aa: subpixel_aa,
             debug: debug,
+            enable_clear_scissor: !no_scissor,
             enable_batcher: !no_batch,
             max_recorded_profiles: 16,
             .. Default::default()


### PR DESCRIPTION
There were large chunks of query-related, texture parameter-related, and other GL calls that are quite inconvenient to scroll through if looking at an `apitrace` capture. This PR makes it look at bit nicer:

![wr-debug](https://cloud.githubusercontent.com/assets/107301/26509959/27136d36-4229-11e7-9ed8-8de83b072a04.png)

It also adds `no-scissor` option to `wrench` so that the texture cache doesn't show pieces of old data that are distracting. We could also use it for benchmarking, given that scissoring is a controversial optimization on clears.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1298)
<!-- Reviewable:end -->
