### PR TITLE
Introduce GPU resource cache.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -16,6 +16,7 @@ use std::hash::BuildHasherDefault;
 use std::io::Read;
 use std::iter::repeat;
 use std::mem;
+use std::ops::Add;
 use std::path::PathBuf;
 use std::rc::Rc;
 //use std::sync::mpsc::{channel, Sender};
@@ -23,8 +24,22 @@ use std::rc::Rc;
 use webrender_traits::{ColorF, ImageFormat};
 use webrender_traits::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintSize};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Ord, Eq, PartialOrd)]
 pub struct FrameId(usize);
+
+impl FrameId {
+    pub fn new(value: usize) -> FrameId {
+        FrameId(value)
+    }
+}
+
+impl Add<usize> for FrameId {
+    type Output = FrameId;
+
+    fn add(self, other: usize) -> FrameId {
+        FrameId(self.0 + other)
+    }
+}
 
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 const GL_FORMAT_A: gl::GLuint = gl::RED;
@@ -1559,9 +1574,9 @@ impl Device {
             self.gl.uniform_1i(u_data64, TextureSampler::Data64 as i32);
         }
 
-        let u_data128 = self.gl.get_uniform_location(program.id, "sData128");
-        if u_data128 != -1 {
-            self.gl.uniform_1i(u_data128, TextureSampler::Data128    as i32);
+        let u_resource_cache = self.gl.get_uniform_location(program.id, "sResourceCache");
+        if u_resource_cache != -1 {
+            self.gl.uniform_1i(u_resource_cache, TextureSampler::ResourceCache as i32);
         }
 
         let u_resource_rects = self.gl.get_uniform_location(program.id, "sResourceRects");
@@ -1641,23 +1656,6 @@ impl Device {
         self.gl.uniform_1f(program.u_device_pixel_ratio, device_pixel_ratio);
     }
 
-    fn update_image_for_2d_texture(&mut self,
-                                   target: gl::GLuint,
-                                   x0: gl::GLint,
-                                   y0: gl::GLint,
-                                   width: gl::GLint,
-                                   height: gl::GLint,
-                                   format: gl::GLuint,
-                                   data: &[u8]) {
-        self.gl.tex_sub_image_2d(target,
-                                  0,
-                                  x0, y0,
-                                  width, height,
-                                  format,
-                                  gl::UNSIGNED_BYTE,
-                                  data);
-    }
-
     pub fn update_texture(&mut self,
                           texture_id: TextureId,
                           x0: u32,
@@ -1670,19 +1668,20 @@ impl Device {
 
         let mut expanded_data = Vec::new();
 
-        let (gl_format, bpp, data) = match self.textures.get(&texture_id).unwrap().format {
+        let (gl_format, bpp, data, data_type) = match self.textures.get(&texture_id).unwrap().format {
             ImageFormat::A8 => {
                 if cfg!(any(target_arch="arm", target_arch="aarch64")) {
                     expanded_data.extend(data.iter().flat_map(|byte| repeat(*byte).take(4)));
-                    (get_gl_format_bgra(self.gl()), 4, expanded_data.as_slice())
+                    (get_gl_format_bgra(self.gl()), 4, expanded_data.as_slice(), gl::UNSIGNED_BYTE)
                 } else {
-                    (GL_FORMAT_A, 1, data)
+                    (GL_FORMAT_A, 1, data, gl::UNSIGNED_BYTE)
                 }
             }
-            ImageFormat::RGB8 => (gl::RGB, 3, data),
-            ImageFormat::RGBA8 => (get_gl_format_bgra(self.gl()), 4, data),
-            ImageFormat::RG8 => (gl::RG, 2, data),
-            ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
+            ImageFormat::RGB8 => (gl::RGB, 3, data, gl::UNSIGNED_BYTE),
+            ImageFormat::RGBA8 => (get_gl_format_bgra(self.gl()), 4, data, gl::UNSIGNED_BYTE),
+            ImageFormat::RG8 => (gl::RG, 2, data, gl::UNSIGNED_BYTE),
+            ImageFormat::RGBAF32 => (gl::RGBA, 16, data, gl::FLOAT),
+            ImageFormat::Invalid => unreachable!(),
         };
 
         let row_length = match stride {
@@ -1700,13 +1699,16 @@ impl Device {
         }
 
         self.bind_texture(DEFAULT_TEXTURE, texture_id);
-        self.update_image_for_2d_texture(texture_id.target,
-                                         x0 as gl::GLint,
-                                         y0 as gl::GLint,
-                                         width as gl::GLint,
-                                         height as gl::GLint,
-                                         gl_format,
-                                         data);
+
+        self.gl.tex_sub_image_2d(texture_id.target,
+                                 0,
+                                 x0 as gl::GLint,
+                                 y0 as gl::GLint,
+                                 width as gl::GLint,
+                                 height as gl::GLint,
+                                 gl_format,
+                                 data_type,
+                                 data);
 
         // Reset row length to 0, otherwise the stride would apply to all texture uploads.
         if let Some(..) = stride {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -10,7 +10,7 @@ use internal_types::{LowLevelFilterOp};
 use internal_types::{RendererFrame};
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use clip_scroll_tree::{ClipScrollTree, ScrollStates};
-use profiler::TextureCacheProfileCounters;
+use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::ResourceCache;
 use scene::{Scene, SceneProperties};
 use std::cmp;
@@ -971,13 +971,15 @@ impl Frame {
                  display_lists: &DisplayListMap,
                  device_pixel_ratio: f32,
                  pan: LayerPoint,
-                 texture_cache_profile: &mut TextureCacheProfileCounters)
+                 texture_cache_profile: &mut TextureCacheProfileCounters,
+                 gpu_cache_profile: &mut GpuCacheProfileCounters)
                  -> RendererFrame {
         self.clip_scroll_tree.update_all_node_transforms(pan);
         let frame = self.build_frame(resource_cache,
                                      display_lists,
                                      device_pixel_ratio,
-                                     texture_cache_profile);
+                                     texture_cache_profile,
+                                     gpu_cache_profile);
         // Expire any resources that haven't been used for `cache_expiry_frames`.
         let num_frames_back = self.frame_builder_config.cache_expiry_frames;
         let expiry_frame = FrameId(cmp::max(num_frames_back, self.id.0) - num_frames_back);
@@ -989,7 +991,8 @@ impl Frame {
                    resource_cache: &mut ResourceCache,
                    display_lists: &DisplayListMap,
                    device_pixel_ratio: f32,
-                   texture_cache_profile: &mut TextureCacheProfileCounters)
+                   texture_cache_profile: &mut TextureCacheProfileCounters,
+                   gpu_cache_profile: &mut GpuCacheProfileCounters)
                    -> RendererFrame {
         let mut frame_builder = self.frame_builder.take();
         let frame = frame_builder.as_mut().map(|builder|
@@ -998,7 +1001,8 @@ impl Frame {
                           &mut self.clip_scroll_tree,
                           display_lists,
                           device_pixel_ratio,
-                          texture_cache_profile)
+                          texture_cache_profile,
+                          gpu_cache_profile)
         );
         self.frame_builder = frame_builder;
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -13,7 +13,7 @@ use prim_store::{ImagePrimitiveKind, PrimitiveContainer, PrimitiveGeometry, Prim
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu, RadialGradientPrimitiveGpu};
 use prim_store::{RectanglePrimitive, SplitGeometry, TextRunPrimitiveCpu, TextRunPrimitiveGpu};
 use prim_store::{BoxShadowPrimitiveGpu, TexelRect, YuvImagePrimitiveCpu, YuvImagePrimitiveGpu};
-use profiler::{FrameProfileCounters, TextureCacheProfileCounters};
+use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_task::{AlphaRenderItem, MaskCacheKey, MaskResult, RenderTask, RenderTaskIndex};
 use render_task::{RenderTaskId, RenderTaskLocation};
 use resource_cache::ResourceCache;
@@ -656,6 +656,8 @@ impl FrameBuilder {
             extend_mode: extend_mode,
             reverse_stops: reverse_stops,
             cache_dirty: true,
+            gpu_data_address: GpuStoreAddress(0),
+            gpu_data_count: 0,
         };
 
         // To get reftests exactly matching with reverse start/end
@@ -702,6 +704,8 @@ impl FrameBuilder {
             stops_range: stops,
             extend_mode: extend_mode,
             cache_dirty: true,
+            gpu_data_address: GpuStoreAddress(0),
+            gpu_data_count: 0,
         };
 
         let radial_gradient_gpu = RadialGradientPrimitiveGpu {
@@ -781,6 +785,8 @@ impl FrameBuilder {
             render_mode: render_mode,
             glyph_options: glyph_options,
             resource_address: GpuStoreAddress(0),
+            gpu_data_address: GpuStoreAddress(0),
+            gpu_data_count: 0,
         };
 
         let prim_gpu = TextRunPrimitiveGpu {
@@ -1370,13 +1376,15 @@ impl FrameBuilder {
                  clip_scroll_tree: &mut ClipScrollTree,
                  display_lists: &DisplayListMap,
                  device_pixel_ratio: f32,
-                 texture_cache_profile: &mut TextureCacheProfileCounters)
+                 texture_cache_profile: &mut TextureCacheProfileCounters,
+                 gpu_cache_profile: &mut GpuCacheProfileCounters)
                  -> Frame {
         profile_scope!("build");
 
         let mut profile_counters = FrameProfileCounters::new();
         profile_counters.total_primitives.set(self.prim_store.prim_count());
 
+        self.prim_store.gpu_cache.begin_frame();
         resource_cache.begin_frame(frame_id);
 
         let screen_rect = DeviceIntRect::new(
@@ -1419,6 +1427,8 @@ impl FrameBuilder {
         let deferred_resolves = self.prim_store.resolve_primitives(resource_cache,
                                                                    device_pixel_ratio);
 
+        let gpu_cache_updates = self.prim_store.end_frame(gpu_cache_profile);
+
         let mut passes = Vec::new();
 
         // Do the allocations now, assigning each tile's tasks to a render
@@ -1460,12 +1470,12 @@ impl FrameBuilder {
             gpu_data16: self.prim_store.gpu_data16.build(),
             gpu_data32: self.prim_store.gpu_data32.build(),
             gpu_data64: self.prim_store.gpu_data64.build(),
-            gpu_data128: self.prim_store.gpu_data128.build(),
             gpu_geometry: self.prim_store.gpu_geometry.build(),
             gpu_gradient_data: self.prim_store.gpu_gradient_data.build(),
             gpu_split_geometry: self.prim_store.gpu_split_geometry.build(),
             gpu_resource_rects: self.prim_store.gpu_resource_rects.build(),
             deferred_resolves: deferred_resolves,
+            gpu_cache_updates: Some(gpu_cache_updates),
         }
     }
 

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -1,0 +1,493 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Overview of the GPU cache.
+//!
+//! The main goal of the GPU cache is to allow on-demand
+//! allocation and construction of GPU resources for the
+//! vertex shaders to consume.
+//!
+//! Every item that wants to be stored in the GPU cache
+//! should create a GpuCacheHandle that is used to refer
+//! to a cached GPU resource. Creating a handle is a
+//! cheap operation, that does *not* allocate room in the
+//! cache.
+//!
+//! On any frame when that data is required, the caller
+//! must request that handle, via ```request```. If the
+//! data is not in the cache, the user provided closure
+//! will be invoked to build the data.
+//!
+//! After ```end_frame``` has occurred, callers can
+//! use the ```get_address``` API to get the allocated
+//! address in the GPU cache of a given resource slot
+//! for this frame.
+
+use device::FrameId;
+use profiler::GpuCacheProfileCounters;
+use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+use std::mem;
+use webrender_traits::ColorF;
+
+pub const GPU_CACHE_INITIAL_HEIGHT: u32 = 512;
+const FRAMES_BEFORE_EVICTION: usize = 10;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+struct Epoch(u32);
+
+#[derive(Debug, Copy, Clone)]
+struct CacheLocation {
+    block_index: BlockIndex,
+    epoch: Epoch,
+}
+
+/// A single texel in RGBAF32 texture - 16 bytes.
+#[derive(Copy, Clone, Debug)]
+pub struct GpuBlockData {
+    pub data: [f32; 4],
+}
+
+/// Conversion helpers for GpuBlockData
+impl Into<GpuBlockData> for ColorF {
+    fn into(self) -> GpuBlockData {
+        GpuBlockData {
+            data: [self.r, self.g, self.b, self.a],
+        }
+    }
+}
+
+impl Into<GpuBlockData> for [f32; 4] {
+    fn into(self) -> GpuBlockData {
+        GpuBlockData {
+            data: self,
+        }
+    }
+}
+
+// Any data type that can be stored in the GPU cache should
+// implement this trait.
+pub trait ToGpuBlocks {
+    // Append an arbitrary number of GPU blocks to the
+    // provided array.
+    fn write_gpu_blocks(&self, blocks: &mut Vec<GpuBlockData>);
+}
+
+// A handle to a GPU resource.
+#[derive(Debug, Copy, Clone)]
+pub struct GpuCacheHandle {
+    location: Option<CacheLocation>,
+}
+
+impl GpuCacheHandle {
+    pub fn new() -> GpuCacheHandle {
+        GpuCacheHandle {
+            location: None,
+        }
+    }
+}
+
+// A unique address in the GPU cache. These are uploaded
+// as part of the primitive instances, to allow the vertex
+// shader to fetch the specific data.
+#[derive(Copy, Debug, Clone)]
+pub struct GpuCacheAddress {
+    pub u: u16,
+    pub v: u16,
+}
+
+impl GpuCacheAddress {
+    fn new(u: usize, v: usize) -> GpuCacheAddress {
+        GpuCacheAddress {
+            u: u as u16,
+            v: v as u16,
+        }
+    }
+}
+
+// An entry in a free-list of blocks in the GPU cache.
+#[derive(Debug)]
+struct Block {
+    // The location in the cache of this block.
+    address: GpuCacheAddress,
+    // Index of the next free block in the list it
+    // belongs to (either a free-list or the
+    // occupied list).
+    next: Option<BlockIndex>,
+    // The current epoch (generation) of this block.
+    epoch: Epoch,
+    // The last frame this block was referenced.
+    last_access_time: FrameId,
+}
+
+impl Block {
+    fn new(address: GpuCacheAddress,
+           next: Option<BlockIndex>,
+           frame_id: FrameId) -> Block {
+        Block {
+            address: address,
+            next: next,
+            last_access_time: frame_id,
+            epoch: Epoch(0),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct BlockIndex(usize);
+
+// A row in the cache texture.
+struct Row {
+    // The fixed size of blocks that this row supports.
+    // Each row becomes a slab allocator for a fixed block size.
+    // This means no dealing with fragmentation within a cache
+    // row as items are allocated and freed.
+    block_count_per_item: usize,
+}
+
+impl Row {
+    fn new(block_count_per_item: usize) -> Row {
+        Row {
+            block_count_per_item: block_count_per_item,
+        }
+    }
+}
+
+// A list of update operations that can be applied on the cache
+// this frame. The list of updates is created by the render backend
+// during frame construction. It's passed to the render thread
+// where GL commands can be applied.
+pub enum GpuCacheUpdate {
+    Copy {
+        block_index: usize,
+        block_count: usize,
+        address: GpuCacheAddress,
+    }
+}
+
+pub struct GpuCacheUpdateList {
+    // The current height of the texture. The render thread
+    // should resize the texture if required.
+    pub height: u32,
+    // List of updates to apply.
+    pub updates: Vec<GpuCacheUpdate>,
+    // A flat list of GPU blocks that are pending upload
+    // to GPU memory.
+    pub blocks: Vec<GpuBlockData>,
+}
+
+// Holds the free lists of fixed size blocks. Mostly
+// just serves to work around the borrow checker.
+struct FreeBlockLists {
+    free_list_1: Option<BlockIndex>,
+    free_list_2: Option<BlockIndex>,
+    free_list_4: Option<BlockIndex>,
+    free_list_8: Option<BlockIndex>,
+    free_list_large: Option<BlockIndex>,
+}
+
+impl FreeBlockLists {
+    fn new() -> FreeBlockLists {
+        FreeBlockLists {
+            free_list_1: None,
+            free_list_2: None,
+            free_list_4: None,
+            free_list_8: None,
+            free_list_large: None,
+        }
+    }
+
+    fn clear(&mut self) {
+        *self = Self::new();
+    }
+
+    fn get_actual_block_count_and_free_list(&mut self,
+                                            block_count: usize) -> (usize, &mut Option<BlockIndex>) {
+        // Find the appropriate free list to use
+        // based on the block size.
+        match block_count {
+            0 => panic!("Can't allocate zero sized blocks!"),
+            1 => (1, &mut self.free_list_1),
+            2 => (2, &mut self.free_list_2),
+            3...4 => (4, &mut self.free_list_4),
+            5...8 => (8, &mut self.free_list_8),
+            9...MAX_VERTEX_TEXTURE_WIDTH => (MAX_VERTEX_TEXTURE_WIDTH, &mut self.free_list_large),
+            _ => panic!("Can't allocate > MAX_VERTEX_TEXTURE_WIDTH per resource!"),
+        }
+    }
+}
+
+// CPU-side representation of the GPU resource cache texture.
+struct Texture {
+    // Current texture height
+    height: u32,
+    // All blocks that have been created for this texture
+    blocks: Vec<Block>,
+    // Metadata about each allocated row.
+    rows: Vec<Row>,
+    // Free lists of available blocks for each supported
+    // block size in the texture. These are intrusive
+    // linked lists.
+    free_lists: FreeBlockLists,
+    // Linked list of currently occupied blocks. This
+    // makes it faster to iterate blocks looking for
+    // candidates to be evicted from the cache.
+    occupied_list_head: Option<BlockIndex>,
+    // Pending blocks that have been written this frame
+    // and will need to be sent to the GPU.
+    pending_blocks: Vec<GpuBlockData>,
+    // Pending update commands.
+    updates: Vec<GpuCacheUpdate>,
+    // Profile stats
+    allocated_block_count: usize,
+}
+
+impl Texture {
+    fn new() -> Texture {
+        Texture {
+            height: GPU_CACHE_INITIAL_HEIGHT,
+            blocks: Vec::new(),
+            rows: Vec::new(),
+            free_lists: FreeBlockLists::new(),
+            pending_blocks: Vec::new(),
+            updates: Vec::new(),
+            occupied_list_head: None,
+            allocated_block_count: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.blocks.clear();
+        self.rows.clear();
+        self.free_lists.clear();
+        self.pending_blocks.clear();
+        self.updates.clear();
+        self.occupied_list_head = None;
+        self.allocated_block_count = 0;
+
+        // TODO(gw): Right now, we never shrink the size of the backing
+        // texture. We could consider shrinking the texture here, if
+        // you navigate away from a page that required a very large
+        // texture backing store.
+    }
+
+    // Push new data into the cache. The ```pending_block_index``` field represents
+    // where the data was pushed into the texture ```pending_blocks``` array.
+    // Return the allocated address for this data.
+    fn push_data(&mut self,
+                 pending_block_index: usize,
+                 block_count: usize,
+                 frame_id: FrameId) -> CacheLocation {
+        // Find the appropriate free list to use based on the block size.
+        let (alloc_size, free_list) = self.free_lists
+                                          .get_actual_block_count_and_free_list(block_count);
+
+        // See if we need a new row (if free-list has nothing available)
+        if free_list.is_none() {
+            // TODO(gw): Handle the case where we need to resize
+            //           the cache texture itself!
+            if self.rows.len() as u32 == self.height {
+                panic!("need to re-alloc texture!!");
+            }
+
+            // Create a new row.
+            let items_per_row = MAX_VERTEX_TEXTURE_WIDTH / alloc_size;
+            let row_index = self.rows.len();
+            self.rows.push(Row::new(alloc_size));
+
+            // Create a ```Block``` for each possible allocation address
+            // in this row, and link it in to the free-list for this
+            // block size.
+            let mut prev_block_index = None;
+            for i in 0..items_per_row {
+                let address = GpuCacheAddress::new(i * alloc_size, row_index);
+                let block_index = BlockIndex(self.blocks.len());
+                let block = Block::new(address, prev_block_index, frame_id);
+                self.blocks.push(block);
+                prev_block_index = Some(block_index);
+            }
+
+            *free_list = prev_block_index;
+        }
+
+        // Given the code above, it's now guaranteed that there is a block
+        // available in the appropriate free-list. Pull a block from the
+        // head of the list.
+        let free_block_index = free_list.take().unwrap();
+        let block = &mut self.blocks[free_block_index.0 as usize];
+        *free_list = block.next;
+
+        // Add the block to the occupied linked list.
+        block.next = self.occupied_list_head;
+        self.occupied_list_head = Some(free_block_index);
+        self.allocated_block_count += alloc_size;
+
+        // Add this update to the pending list of blocks that need
+        // to be updated on the GPU.
+        self.updates.push(GpuCacheUpdate::Copy {
+            block_index: pending_block_index,
+            block_count: block_count,
+            address: block.address,
+        });
+
+        CacheLocation {
+            block_index: free_block_index,
+            epoch: block.epoch,
+        }
+    }
+
+    // Run through the list of occupied cache blocks and evict
+    // any old blocks that haven't been referenced for a while.
+    fn evict_old_blocks(&mut self, frame_id: FrameId) {
+        // Prune any old items from the list to make room.
+        // Traverse the occupied linked list and see
+        // which items have not been used for a long time.
+        let mut current_block = self.occupied_list_head;
+        let mut prev_block: Option<BlockIndex> = None;
+
+        while let Some(index) = current_block {
+            let (next_block, should_unlink) = {
+                let block = &mut self.blocks[index.0 as usize];
+
+                let next_block = block.next;
+                let mut should_unlink = false;
+
+                // If this resource has not been used in the last
+                // few frames, free it from the texture and mark
+                // as empty.
+                if block.last_access_time + FRAMES_BEFORE_EVICTION < frame_id {
+                    should_unlink = true;
+
+                    // Get the row metadata from the address.
+                    let row = &mut self.rows[block.address.v as usize];
+
+                    // Use the row metadata to determine which free-list
+                    // this block belongs to.
+                    let (_, free_list) = self.free_lists
+                                             .get_actual_block_count_and_free_list(row.block_count_per_item);
+
+                    block.epoch = Epoch(block.epoch.0 + 1);
+                    block.next = *free_list;
+                    *free_list = Some(index);
+
+                    self.allocated_block_count -= row.block_count_per_item;
+                };
+
+                (next_block, should_unlink)
+            };
+
+            // If the block was released, we will need to remove it
+            // from the occupied linked list.
+            if should_unlink {
+                match prev_block {
+                    Some(prev_block) => {
+                        self.blocks[prev_block.0 as usize].next = next_block;
+                    }
+                    None => {
+                        self.occupied_list_head = next_block;
+                    }
+                }
+            } else {
+                prev_block = current_block;
+            }
+
+            current_block = next_block;
+        }
+    }
+}
+
+/// The main LRU cache interface.
+pub struct GpuCache {
+    /// Current frame ID.
+    frame_id: FrameId,
+    /// CPU-side texture allocator.
+    texture: Texture,
+}
+
+impl GpuCache {
+    pub fn new() -> GpuCache {
+        GpuCache {
+            frame_id: FrameId::new(0),
+            texture: Texture::new(),
+        }
+    }
+
+    /// Begin a new frame.
+    pub fn begin_frame(&mut self) {
+        debug_assert!(self.texture.pending_blocks.is_empty());
+        self.frame_id = self.frame_id + 1;
+        self.texture.evict_old_blocks(self.frame_id);
+    }
+
+    /// Request a resource be added to the cache. If the resource
+    /// is already in the cache, the closure to build the data
+    /// will be skipped.
+    pub fn request<F>(&mut self,
+                      handle: &mut GpuCacheHandle,
+                      f: F) where F: Fn(&mut Vec<GpuBlockData>) {
+        // First, check if the allocation for this handle is still valid.
+        let need_to_build = match handle.location {
+            Some(ref location) => {
+                let block = &mut self.texture.blocks[location.block_index.0];
+                if block.epoch == location.epoch {
+                    // Mark last access time to avoid evicting this block.
+                    block.last_access_time = self.frame_id;
+                    false
+                } else {
+                    true
+                }
+            }
+            None => true,
+        };
+
+        if need_to_build {
+            // Build it!
+            let start_index = self.texture.pending_blocks.len();
+            f(&mut self.texture.pending_blocks);
+            let block_count = self.texture.pending_blocks.len() - start_index;
+
+            // Push the data to the texture pending updates list.
+            let location = self.texture.push_data(start_index,
+                                                  block_count,
+                                                  self.frame_id);
+
+            handle.location = Some(location);
+        }
+    }
+
+    /// Recycle the GPU cache for a new display list. This allows
+    /// re-using existing backing allocations rather than calling
+    /// the system memory allocator again.
+    pub fn recycle(mut self) -> GpuCache {
+        self.texture.clear();
+
+        self
+    }
+
+    /// End the frame. Return the list of updates to apply to the
+    /// device specific cache texture.
+    pub fn end_frame(&mut self,
+                     profile_counters: &mut GpuCacheProfileCounters) -> GpuCacheUpdateList {
+        profile_counters.allocated_rows.set(self.texture.rows.len());
+        profile_counters.allocated_blocks.set(self.texture.allocated_block_count);
+
+        GpuCacheUpdateList {
+            height: self.texture.height,
+            updates: mem::replace(&mut self.texture.updates, Vec::new()),
+            blocks: mem::replace(&mut self.texture.pending_blocks, Vec::new()),
+        }
+    }
+
+    /// Get the actual GPU address in the texture for a given slot ID.
+    /// It's assumed at this point that the given slot has been requested
+    /// and built for this frame. Attempting to get the address for a
+    /// freed or pending slot will panic!
+    pub fn get_address(&self, id: &GpuCacheHandle) -> GpuCacheAddress {
+        let location = id.location
+                         .expect("handle not requested or allocated!");
+        let block = &self.texture.blocks[location.block_index.0];
+        debug_assert_eq!(block.epoch, location.epoch);
+        debug_assert_eq!(block.last_access_time, self.frame_id);
+        block.address
+    }
+}

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -70,7 +70,7 @@ pub enum TextureSampler {
     Data16,
     Data32,
     Data64,
-    Data128,
+    ResourceCache,
     Layers,
     RenderTasks,
     Geometry,

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -58,6 +58,7 @@ mod frame_builder;
 mod freelist;
 mod geometry;
 mod glyph_rasterizer;
+mod gpu_cache;
 mod gpu_store;
 mod internal_types;
 mod mask_cache;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,10 +6,12 @@ use app_units::Au;
 use border::{BorderCornerClipData, BorderCornerDashClipData, BorderCornerDotClipData};
 use border::BorderCornerInstance;
 use euclid::{Size2D};
+use gpu_cache::{GpuBlockData, GpuCache, GpuCacheUpdateList, GpuCacheHandle, ToGpuBlocks};
 use gpu_store::GpuStoreAddress;
 use internal_types::{SourceTexture, PackedTexel};
 use mask_cache::{ClipMode, ClipSource, MaskCacheInfo};
-use renderer::{VertexDataStore, GradientDataStore, SplitGeometryStore};
+use profiler::GpuCacheProfileCounters;
+use renderer::{VertexDataStore, GradientDataStore, SplitGeometryStore, MAX_VERTEX_TEXTURE_WIDTH};
 use render_task::{RenderTask, RenderTaskLocation};
 use resource_cache::{CacheItem, ImageProperties, ResourceCache};
 use std::mem;
@@ -72,12 +74,6 @@ pub struct DeferredResolve {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SpecificPrimitiveIndex(pub usize);
 
-impl SpecificPrimitiveIndex {
-    pub fn invalid() -> SpecificPrimitiveIndex {
-        SpecificPrimitiveIndex(usize::MAX)
-    }
-}
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PrimitiveIndex(pub usize);
 
@@ -116,6 +112,33 @@ pub enum PrimitiveCacheKey {
     TextShadow(PrimitiveIndex),
 }
 
+// TODO(gw): This enum is temporary. It allows primitives to use either
+//           the GPU store or the GPU cache. Once all primitives are
+//           ported to use the GPU cache, we should remove this enum!
+#[derive(Debug)]
+pub enum GpuLocation {
+    GpuCache(GpuCacheHandle),
+    GpuStore(GpuStoreAddress),
+}
+
+impl GpuLocation {
+    pub fn as_int(&self, gpu_cache: &GpuCache) -> i32 {
+        match *self {
+            GpuLocation::GpuCache(cache_id) => {
+                let address = gpu_cache.get_address(&cache_id);
+
+                // TODO(gw): Temporarily encode GPU Cache addresses as a single int.
+                //           In the future, we can change the PrimitiveInstance struct
+                //           to use 2x u16 for the vertex attribute instead of an i32.
+                address.v as i32 * MAX_VERTEX_TEXTURE_WIDTH as i32 + address.u as i32
+            }
+            GpuLocation::GpuStore(address) => {
+                address.0
+            }
+        }
+    }
+}
+
 // TODO(gw): Pack the fields here better!
 #[derive(Debug)]
 pub struct PrimitiveMetadata {
@@ -124,9 +147,7 @@ pub struct PrimitiveMetadata {
     pub clip_cache_info: Option<MaskCacheInfo>,
     pub prim_kind: PrimitiveKind,
     pub cpu_prim_index: SpecificPrimitiveIndex,
-    pub gpu_prim_index: GpuStoreAddress,
-    pub gpu_data_address: GpuStoreAddress,
-    pub gpu_data_count: i32,
+    pub gpu_location: GpuLocation,
     // An optional render task that is a dependency of
     // drawing this primitive. For instance, box shadows
     // use this to draw a portion of the box shadow to
@@ -163,6 +184,12 @@ impl Default for SplitGeometry {
 #[repr(C)]
 pub struct RectanglePrimitive {
     pub color: ColorF,
+}
+
+impl ToGpuBlocks for RectanglePrimitive {
+    fn write_gpu_blocks(&self, blocks: &mut Vec<GpuBlockData>) {
+        blocks.push(self.color.into());
+    }
 }
 
 #[derive(Debug)]
@@ -220,15 +247,13 @@ impl YuvImagePrimitiveGpu {
 #[derive(Debug, Clone)]
 pub struct BorderPrimitiveCpu {
     pub corner_instances: [BorderCornerInstance; 4],
+    pub gpu_blocks: [GpuBlockData; 8],
 }
 
-#[derive(Debug, Clone)]
-#[repr(C)]
-pub struct BorderPrimitiveGpu {
-    pub style: [f32; 4],
-    pub widths: [f32; 4],
-    pub colors: [ColorF; 4],
-    pub radii: [LayerSize; 4],
+impl ToGpuBlocks for BorderPrimitiveCpu {
+    fn write_gpu_blocks(&self, blocks: &mut Vec<GpuBlockData>) {
+        blocks.extend_from_slice(&self.gpu_blocks);
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -237,6 +262,13 @@ pub struct BoxShadowPrimitiveCacheKey {
     pub border_radius: Au,
     pub blur_radius: Au,
     pub inverted: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoxShadowPrimitiveCpu {
+    pub gpu_data_address: GpuStoreAddress,
+    pub gpu_data_count: i32,
+    pub edge_size: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -277,6 +309,8 @@ pub struct GradientPrimitiveCpu {
     pub extend_mode: ExtendMode,
     pub reverse_stops: bool,
     pub cache_dirty: bool,
+    pub gpu_data_address: GpuStoreAddress,
+    pub gpu_data_count: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -298,6 +332,8 @@ pub struct RadialGradientPrimitiveCpu {
     pub stops_range: ItemRange<GradientStop>,
     pub extend_mode: ExtendMode,
     pub cache_dirty: bool,
+    pub gpu_data_address: GpuStoreAddress,
+    pub gpu_data_count: i32,
 }
 
 // The gradient entry index for the first color stop
@@ -490,6 +526,8 @@ pub struct TextRunPrimitiveCpu {
     pub render_mode: FontRenderMode,
     pub resource_address: GpuStoreAddress,
     pub glyph_options: Option<GlyphOptions>,
+    pub gpu_data_address: GpuStoreAddress,
+    pub gpu_data_count: i32,
 }
 
 #[derive(Debug, Clone)]
@@ -631,7 +669,7 @@ pub enum PrimitiveContainer {
     TextRun(TextRunPrimitiveCpu, TextRunPrimitiveGpu),
     Image(ImagePrimitiveCpu, ImagePrimitiveGpu),
     YuvImage(YuvImagePrimitiveCpu, YuvImagePrimitiveGpu),
-    Border(BorderPrimitiveCpu, BorderPrimitiveGpu),
+    Border(BorderPrimitiveCpu),
     AlignedGradient(GradientPrimitiveCpu, GradientPrimitiveGpu),
     AngleGradient(GradientPrimitiveCpu, GradientPrimitiveGpu),
     RadialGradient(RadialGradientPrimitiveCpu, RadialGradientPrimitiveGpu),
@@ -641,6 +679,7 @@ pub enum PrimitiveContainer {
 pub struct PrimitiveStore {
     /// CPU side information only.
     pub cpu_bounding_rects: Vec<Option<DeviceIntRect>>,
+    pub cpu_rectangles: Vec<RectanglePrimitive>,
     pub cpu_text_runs: Vec<TextRunPrimitiveCpu>,
     pub cpu_images: Vec<ImagePrimitiveCpu>,
     pub cpu_yuv_images: Vec<YuvImagePrimitiveCpu>,
@@ -648,13 +687,13 @@ pub struct PrimitiveStore {
     pub cpu_radial_gradients: Vec<RadialGradientPrimitiveCpu>,
     pub cpu_metadata: Vec<PrimitiveMetadata>,
     pub cpu_borders: Vec<BorderPrimitiveCpu>,
+    pub cpu_box_shadows: Vec<BoxShadowPrimitiveCpu>,
 
     /// Gets uploaded directly to GPU via vertex texture.
     pub gpu_geometry: VertexDataStore<PrimitiveGeometry>,
     pub gpu_data16: VertexDataStore<GpuBlock16>,
     pub gpu_data32: VertexDataStore<GpuBlock32>,
     pub gpu_data64: VertexDataStore<GpuBlock64>,
-    pub gpu_data128: VertexDataStore<GpuBlock128>,
     pub gpu_gradient_data: GradientDataStore,
 
     /// Geometry generated by plane splitting.
@@ -662,6 +701,8 @@ pub struct PrimitiveStore {
 
     /// Resolved resource rects.
     pub gpu_resource_rects: VertexDataStore<TexelRect>,
+
+    pub gpu_cache: GpuCache,
 
     /// General
     prims_to_resolve: Vec<PrimitiveIndex>,
@@ -671,6 +712,7 @@ impl PrimitiveStore {
     pub fn new() -> PrimitiveStore {
         PrimitiveStore {
             cpu_metadata: Vec::new(),
+            cpu_rectangles: Vec::new(),
             cpu_bounding_rects: Vec::new(),
             cpu_text_runs: Vec::new(),
             cpu_images: Vec::new(),
@@ -678,21 +720,23 @@ impl PrimitiveStore {
             cpu_gradients: Vec::new(),
             cpu_radial_gradients: Vec::new(),
             cpu_borders: Vec::new(),
+            cpu_box_shadows: Vec::new(),
             prims_to_resolve: Vec::new(),
             gpu_geometry: VertexDataStore::new(),
             gpu_data16: VertexDataStore::new(),
             gpu_data32: VertexDataStore::new(),
             gpu_data64: VertexDataStore::new(),
-            gpu_data128: VertexDataStore::new(),
             gpu_gradient_data: GradientDataStore::new(),
             gpu_split_geometry: SplitGeometryStore::new(),
             gpu_resource_rects: VertexDataStore::new(),
+            gpu_cache: GpuCache::new(),
         }
     }
 
     pub fn recycle(self) -> Self {
         PrimitiveStore {
             cpu_metadata: recycle_vec(self.cpu_metadata),
+            cpu_rectangles: recycle_vec(self.cpu_rectangles),
             cpu_bounding_rects: recycle_vec(self.cpu_bounding_rects),
             cpu_text_runs: recycle_vec(self.cpu_text_runs),
             cpu_images: recycle_vec(self.cpu_images),
@@ -700,15 +744,16 @@ impl PrimitiveStore {
             cpu_gradients: recycle_vec(self.cpu_gradients),
             cpu_radial_gradients: recycle_vec(self.cpu_radial_gradients),
             cpu_borders: recycle_vec(self.cpu_borders),
+            cpu_box_shadows: recycle_vec(self.cpu_box_shadows),
             prims_to_resolve: recycle_vec(self.prims_to_resolve),
             gpu_geometry: self.gpu_geometry.recycle(),
             gpu_data16: self.gpu_data16.recycle(),
             gpu_data32: self.gpu_data32.recycle(),
             gpu_data64: self.gpu_data64.recycle(),
-            gpu_data128: self.gpu_data128.recycle(),
             gpu_gradient_data: self.gpu_gradient_data.recycle(),
             gpu_split_geometry: self.gpu_split_geometry.recycle(),
             gpu_resource_rects: self.gpu_resource_rects.recycle(),
+            gpu_cache: self.gpu_cache.recycle(),
         }
     }
 
@@ -732,20 +777,19 @@ impl PrimitiveStore {
         let metadata = match container {
             PrimitiveContainer::Rectangle(rect) => {
                 let is_opaque = rect.color.a == 1.0;
-                let gpu_address = self.gpu_data16.push(rect);
 
                 let metadata = PrimitiveMetadata {
                     is_opaque: is_opaque,
                     clips: clips,
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::Rectangle,
-                    cpu_prim_index: SpecificPrimitiveIndex::invalid(),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: GpuStoreAddress(0),
-                    gpu_data_count: 0,
+                    cpu_prim_index: SpecificPrimitiveIndex(self.cpu_rectangles.len()),
+                    gpu_location: GpuLocation::GpuCache(GpuCacheHandle::new()),
                     render_task: None,
                     clip_task: None,
                 };
+
+                self.cpu_rectangles.push(rect);
 
                 metadata
             }
@@ -753,6 +797,8 @@ impl PrimitiveStore {
                 let gpu_address = self.gpu_data16.push(text_gpu);
                 let gpu_glyphs_address = self.gpu_data16.alloc(text_cpu.glyph_count);
                 text_cpu.resource_address = self.gpu_resource_rects.alloc(text_cpu.glyph_count);
+                text_cpu.gpu_data_address = gpu_glyphs_address;
+                text_cpu.gpu_data_count = text_cpu.glyph_count as i32;
 
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
@@ -760,9 +806,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::TextRun,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_text_runs.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: gpu_glyphs_address,
-                    gpu_data_count: text_cpu.glyph_count as i32,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -781,9 +825,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::Image,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_images.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: GpuStoreAddress(0),
-                    gpu_data_count: 0,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -802,9 +844,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::YuvImage,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_yuv_images.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: GpuStoreAddress(0),
-                    gpu_data_count: 0,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -812,18 +852,14 @@ impl PrimitiveStore {
                 self.cpu_yuv_images.push(image_cpu);
                 metadata
             }
-            PrimitiveContainer::Border(border_cpu, border_gpu) => {
-                let gpu_address = self.gpu_data128.push(border_gpu);
-
+            PrimitiveContainer::Border(border_cpu) => {
                 let metadata = PrimitiveMetadata {
                     is_opaque: false,
                     clips: clips,
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::Border,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_borders.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: GpuStoreAddress(0),
-                    gpu_data_count: 0,
+                    gpu_location: GpuLocation::GpuCache(GpuCacheHandle::new()),
                     render_task: None,
                     clip_task: None,
                 };
@@ -831,9 +867,12 @@ impl PrimitiveStore {
                 self.cpu_borders.push(border_cpu);
                 metadata
             }
-            PrimitiveContainer::AlignedGradient(gradient_cpu, gradient_gpu) => {
+            PrimitiveContainer::AlignedGradient(mut gradient_cpu, gradient_gpu) => {
                 let gpu_address = self.gpu_data64.push(gradient_gpu);
                 let gpu_stops_address = self.gpu_data32.alloc(gradient_cpu.stops_count);
+
+                gradient_cpu.gpu_data_address = gpu_stops_address;
+                gradient_cpu.gpu_data_count = gradient_cpu.stops_count as i32;
 
                 let metadata = PrimitiveMetadata {
                     // TODO: calculate if the gradient is actually opaque
@@ -842,9 +881,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::AlignedGradient,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_gradients.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: gpu_stops_address,
-                    gpu_data_count: gradient_cpu.stops_count as i32,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -852,9 +889,12 @@ impl PrimitiveStore {
                 self.cpu_gradients.push(gradient_cpu);
                 metadata
             }
-            PrimitiveContainer::AngleGradient(gradient_cpu, gradient_gpu) => {
+            PrimitiveContainer::AngleGradient(mut gradient_cpu, gradient_gpu) => {
                 let gpu_address = self.gpu_data64.push(gradient_gpu);
                 let gpu_gradient_address = self.gpu_gradient_data.alloc(1);
+
+                gradient_cpu.gpu_data_address = gpu_gradient_address;
+                gradient_cpu.gpu_data_count = 1;
 
                 let metadata = PrimitiveMetadata {
                     // TODO: calculate if the gradient is actually opaque
@@ -863,9 +903,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::AngleGradient,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_gradients.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: gpu_gradient_address,
-                    gpu_data_count: 1,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -873,9 +911,12 @@ impl PrimitiveStore {
                 self.cpu_gradients.push(gradient_cpu);
                 metadata
             }
-            PrimitiveContainer::RadialGradient(radial_gradient_cpu, radial_gradient_gpu) => {
+            PrimitiveContainer::RadialGradient(mut radial_gradient_cpu, radial_gradient_gpu) => {
                 let gpu_address = self.gpu_data64.push(radial_gradient_gpu);
                 let gpu_gradient_address = self.gpu_gradient_data.alloc(1);
+
+                radial_gradient_cpu.gpu_data_address = gpu_gradient_address;
+                radial_gradient_cpu.gpu_data_count = 1;
 
                 let metadata = PrimitiveMetadata {
                     // TODO: calculate if the gradient is actually opaque
@@ -884,9 +925,7 @@ impl PrimitiveStore {
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::RadialGradient,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_radial_gradients.len()),
-                    gpu_prim_index: gpu_address,
-                    gpu_data_address: gpu_gradient_address,
-                    gpu_data_count: 1,
+                    gpu_location: GpuLocation::GpuStore(gpu_address),
                     render_task: None,
                     clip_task: None,
                 };
@@ -920,6 +959,7 @@ impl PrimitiveStore {
                                                              cache_size,
                                                              PrimitiveIndex(prim_index));
 
+                let edge_size = box_shadow_gpu.edge_size;
                 let gpu_prim_address = self.gpu_data64.push(box_shadow_gpu);
                 let gpu_data_address = self.gpu_data16.get_next_address();
 
@@ -928,12 +968,16 @@ impl PrimitiveStore {
                     clips: clips,
                     clip_cache_info: clip_info,
                     prim_kind: PrimitiveKind::BoxShadow,
-                    cpu_prim_index: SpecificPrimitiveIndex::invalid(),
-                    gpu_prim_index: gpu_prim_address,
-                    gpu_data_address: gpu_data_address,
-                    gpu_data_count: instance_rects.len() as i32,
+                    cpu_prim_index: SpecificPrimitiveIndex(self.cpu_box_shadows.len()),
+                    gpu_location: GpuLocation::GpuStore(gpu_prim_address),
                     render_task: Some(render_task),
                     clip_task: None,
+                };
+
+                let box_shadow_cpu = BoxShadowPrimitiveCpu {
+                    gpu_data_address: gpu_data_address,
+                    gpu_data_count: instance_rects.len() as i32,
+                    edge_size: edge_size,
                 };
 
                 for rect in instance_rects {
@@ -942,6 +986,7 @@ impl PrimitiveStore {
                     });
                 }
 
+                self.cpu_box_shadows.push(box_shadow_cpu);
                 metadata
             }
         };
@@ -1112,6 +1157,11 @@ impl PrimitiveStore {
         deferred_resolves
     }
 
+    pub fn end_frame(&mut self,
+                     profile_counters: &mut GpuCacheProfileCounters) -> GpuCacheUpdateList {
+        self.gpu_cache.end_frame(profile_counters)
+    }
+
     pub fn set_clip_source(&mut self, index: PrimitiveIndex, source: Option<ClipSource>) {
         let metadata = &mut self.cpu_metadata[index.0];
         metadata.clips = match source {
@@ -1176,6 +1226,31 @@ impl PrimitiveStore {
         let mut prim_needs_resolve = false;
         let mut rebuild_bounding_rect = false;
 
+        if let GpuLocation::GpuCache(ref mut cache_id) = metadata.gpu_location {
+            let gpu_cache = &mut self.gpu_cache;
+            let cpu_borders = &self.cpu_borders;
+            let cpu_rectangles = &self.cpu_rectangles;
+            let cpu_prim_index = metadata.cpu_prim_index;
+            let prim_kind = metadata.prim_kind;
+
+            // Mark this GPU resource as required for this frame.
+            gpu_cache.request(cache_id, |blocks| {
+                match prim_kind {
+                    PrimitiveKind::Rectangle => {
+                        let rect = &cpu_rectangles[cpu_prim_index.0];
+                        rect.write_gpu_blocks(blocks);
+                    }
+                    PrimitiveKind::Border => {
+                        let border = &cpu_borders[cpu_prim_index.0];
+                        border.write_gpu_blocks(blocks);
+                    }
+                    _ => {
+                        unreachable!("Only rects and borders use GPU cache so far!");
+                    }
+                }
+            });
+        }
+
         if let Some(ref mut clip_info) = metadata.clip_cache_info {
             clip_info.update(&metadata.clips,
                              layer_transform,
@@ -1201,10 +1276,8 @@ impl PrimitiveStore {
                 // in device space. The shader adds a 1-pixel border around
                 // the patch, in order to prevent bilinear filter artifacts as
                 // the patch is clamped / mirrored across the box shadow rect.
-                let box_shadow_gpu: &BoxShadowPrimitiveGpu = unsafe {
-                    mem::transmute(self.gpu_data64.get(metadata.gpu_prim_index))
-                };
-                let edge_size = box_shadow_gpu.edge_size.ceil() * device_pixel_ratio;
+                let box_shadow_cpu = &self.cpu_box_shadows[metadata.cpu_prim_index.0];
+                let edge_size = box_shadow_cpu.edge_size.ceil() * device_pixel_ratio;
                 let edge_size = edge_size as i32 + 2;   // Account for bilinear filtering
                 let cache_size = DeviceIntSize::new(edge_size, edge_size);
                 let location = RenderTaskLocation::Dynamic(None, cache_size);
@@ -1221,10 +1294,10 @@ impl PrimitiveStore {
                     rebuild_bounding_rect = true;
                     text.cache_dirty = false;
 
-                    debug_assert!(metadata.gpu_data_count == src_glyphs.len() as i32);
+                    debug_assert!(text.gpu_data_count == src_glyphs.len() as i32);
                     debug_assert!(text.glyph_instances.is_empty());
 
-                    let dest_glyphs = self.gpu_data16.get_slice_mut(metadata.gpu_data_address,
+                    let dest_glyphs = self.gpu_data16.get_slice_mut(text.gpu_data_address,
                                                                     src_glyphs.len());
 
                     let mut glyph_key = GlyphKey::new(text.font_key,
@@ -1293,7 +1366,7 @@ impl PrimitiveStore {
                                                   prim_index))
                     };
 
-                    metadata.gpu_data_count = actual_glyph_count as i32;
+                    text.gpu_data_count = actual_glyph_count as i32;
                     metadata.render_task = render_task;
                     self.gpu_geometry.get_mut(GpuStoreAddress(prim_index.0 as i32)).local_rect = local_rect;
                 }
@@ -1343,8 +1416,8 @@ impl PrimitiveStore {
                 if gradient.cache_dirty {
                     let src_stops = display_list.get(gradient.stops_range);
 
-                    debug_assert!(metadata.gpu_data_count == src_stops.len() as i32);
-                    let dest_stops = self.gpu_data32.get_slice_mut(metadata.gpu_data_address,
+                    debug_assert!(gradient.gpu_data_count == src_stops.len() as i32);
+                    let dest_stops = self.gpu_data32.get_slice_mut(gradient.gpu_data_address,
                                                                    src_stops.len());
 
                     for (src, dest) in src_stops.zip(dest_stops.iter_mut()) {
@@ -1363,7 +1436,7 @@ impl PrimitiveStore {
                 if gradient.cache_dirty {
                     let src_stops = display_list.get(gradient.stops_range);
 
-                    let dest_gradient = self.gpu_gradient_data.get_mut(metadata.gpu_data_address);
+                    let dest_gradient = self.gpu_gradient_data.get_mut(gradient.gpu_data_address);
                     dest_gradient.build(src_stops, gradient.reverse_stops);
                     gradient.cache_dirty = false;
                 }
@@ -1373,7 +1446,7 @@ impl PrimitiveStore {
                 if gradient.cache_dirty {
                     let src_stops = display_list.get(gradient.stops_range);
 
-                    let dest_gradient = self.gpu_gradient_data.get_mut(metadata.gpu_data_address);
+                    let dest_gradient = self.gpu_gradient_data.get_mut(gradient.gpu_data_address);
                     dest_gradient.build(src_stops, false);
                     gradient.cache_dirty = false;
                 }
@@ -1425,9 +1498,6 @@ define_gpu_block!(GpuBlock32: [f32; 8] =
 );
 define_gpu_block!(GpuBlock64: [f32; 16] =
     GradientPrimitiveGpu, RadialGradientPrimitiveGpu, BoxShadowPrimitiveGpu
-);
-define_gpu_block!(GpuBlock128: [f32; 32] =
-    BorderPrimitiveGpu
 );
 
 

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -290,6 +290,21 @@ impl TextureCacheProfileCounters {
 }
 
 #[derive(Clone)]
+pub struct GpuCacheProfileCounters {
+    pub allocated_rows: IntProfileCounter,
+    pub allocated_blocks: IntProfileCounter,
+}
+
+impl GpuCacheProfileCounters {
+    pub fn new() -> GpuCacheProfileCounters {
+        GpuCacheProfileCounters {
+            allocated_rows: IntProfileCounter::new("GPU cache rows"),
+            allocated_blocks: IntProfileCounter::new("GPU cache blocks"),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct BackendProfileCounters {
     pub total_time: TimeProfileCounter,
     pub resources: ResourceProfileCounters,
@@ -301,6 +316,7 @@ pub struct ResourceProfileCounters {
     pub font_templates: ResourceProfileCounter,
     pub image_templates: ResourceProfileCounter,
     pub texture_cache: TextureCacheProfileCounters,
+    pub gpu_cache: GpuCacheProfileCounters,
 }
 
 #[derive(Clone)]
@@ -332,6 +348,7 @@ impl BackendProfileCounters {
                 font_templates: ResourceProfileCounter::new("Font Templates"),
                 image_templates: ResourceProfileCounter::new("Image Templates"),
                 texture_cache: TextureCacheProfileCounters::new(),
+                gpu_cache: GpuCacheProfileCounters::new(),
             },
             ipc: IpcProfileCounters {
                 build_time: TimeProfileCounter::new("Display List Build Time", false),
@@ -339,7 +356,7 @@ impl BackendProfileCounters {
                 send_time: TimeProfileCounter::new("Display List Send Time", false),
                 total_time: TimeProfileCounter::new("Total Display List Time", false),
                 display_lists: ResourceProfileCounter::new("Display Lists Sent"),
-            }
+            },
         }
     }
 
@@ -721,6 +738,8 @@ impl Profiler {
             &frame_profile.passes,
             &frame_profile.color_targets,
             &frame_profile.alpha_targets,
+            &backend_profile.resources.gpu_cache.allocated_rows,
+            &backend_profile.resources.gpu_cache.allocated_blocks,
         ], debug_renderer, true);
 
         self.draw_counters(&[
@@ -753,9 +772,6 @@ impl Profiler {
             &renderer_timers.cpu_time,
             &renderer_timers.gpu_time,
         ], debug_renderer, false);
-        
-
-
 
         self.backend_time.push(backend_profile.total_time.nanoseconds);
         self.compositor_time.push(renderer_timers.cpu_time.nanoseconds);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -18,6 +18,7 @@ use euclid::Matrix4D;
 use fnv::FnvHasher;
 use frame_builder::FrameBuilderConfig;
 use gleam::gl;
+use gpu_cache::{GpuCacheUpdate, GpuCacheUpdateList};
 use gpu_store::{GpuStore, GpuStoreLayout};
 use internal_types::{CacheTextureId, RendererFrame, ResultMsg, TextureUpdateOp};
 use internal_types::{TextureUpdateList, PackedVertex, RenderTargetMode};
@@ -38,6 +39,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::slice;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
@@ -189,6 +191,70 @@ pub enum BlendMode {
 
     // Use the color of the text itself as a constant color blend factor.
     Subpixel(ColorF),
+}
+
+/// The device-specific representation of the cache texture in gpu_cache.rs
+struct CacheTexture {
+    id: TextureId,
+}
+
+impl CacheTexture {
+    fn new(device: &mut Device) -> CacheTexture {
+        let id = device.create_texture_ids(1, TextureTarget::Default)[0];
+
+        CacheTexture {
+            id: id,
+        }
+    }
+
+    fn update(&mut self, device: &mut Device, updates: &GpuCacheUpdateList) {
+        // See if we need to create or resize the texture.
+        let current_dimensions = device.get_texture_dimensions(self.id);
+
+        if updates.height > current_dimensions.height {
+            // TODO(gw): Handle resizing an existing cache texture.
+            if current_dimensions.height > 0 {
+                panic!("TODO: Implement texture copy!!!");
+            }
+
+            // Create a f32 texture that can be used for the vertex shader
+            // to fetch data from.
+            device.init_texture(self.id,
+                                MAX_VERTEX_TEXTURE_WIDTH as u32,
+                                updates.height as u32,
+                                ImageFormat::RGBAF32,
+                                TextureFilter::Nearest,
+                                RenderTargetMode::None,
+                                None);
+        }
+
+        for update in &updates.updates {
+            match update {
+                &GpuCacheUpdate::Copy { block_index, block_count, address } => {
+                    // Apply an incremental update to the cache texture.
+                    // TODO(gw): For the initial implementation, we will just
+                    //           use update_texture() since it's simple. If / when
+                    //           we profile this and find it to be slow on some / all
+                    //           devices - we can look into other options, such as
+                    //           using glMapBuffer() with the unsynchronized bit,
+                    //           and managing the synchronization ourselves with fences.
+                    let data: &[u8] = unsafe {
+                        let ptr = updates.blocks
+                                         .as_ptr()
+                                         .offset(block_index as isize);
+                        slice::from_raw_parts(ptr as *const _, block_count * 16)
+                    };
+                    device.update_texture(self.id,
+                                          address.u as u32,
+                                          address.v as u32,
+                                          block_count as u32,
+                                          1,
+                                          None,
+                                          data);
+                }
+            }
+        }
+    }
 }
 
 struct GpuDataTexture<L> {
@@ -468,7 +534,6 @@ struct GpuDataTextures {
     data16_texture: VertexDataTexture,
     data32_texture: VertexDataTexture,
     data64_texture: VertexDataTexture,
-    data128_texture: VertexDataTexture,
     resource_rects_texture: VertexDataTexture,
     gradient_data_texture: GradientDataTexture,
     split_geometry_texture: SplitGeometryTexture,
@@ -483,7 +548,6 @@ impl GpuDataTextures {
             data16_texture: VertexDataTexture::new(device),
             data32_texture: VertexDataTexture::new(device),
             data64_texture: VertexDataTexture::new(device),
-            data128_texture: VertexDataTexture::new(device),
             resource_rects_texture: VertexDataTexture::new(device),
             gradient_data_texture: GradientDataTexture::new(device),
             split_geometry_texture: SplitGeometryTexture::new(device),
@@ -494,7 +558,6 @@ impl GpuDataTextures {
         self.data16_texture.init(device, &mut frame.gpu_data16);
         self.data32_texture.init(device, &mut frame.gpu_data32);
         self.data64_texture.init(device, &mut frame.gpu_data64);
-        self.data128_texture.init(device, &mut frame.gpu_data128);
         self.prim_geom_texture.init(device, &mut frame.gpu_geometry);
         self.resource_rects_texture.init(device, &mut frame.gpu_resource_rects);
         self.layer_texture.init(device, &mut frame.layer_texture_data);
@@ -508,7 +571,6 @@ impl GpuDataTextures {
         device.bind_texture(TextureSampler::Data16, self.data16_texture.id);
         device.bind_texture(TextureSampler::Data32, self.data32_texture.id);
         device.bind_texture(TextureSampler::Data64, self.data64_texture.id);
-        device.bind_texture(TextureSampler::Data128, self.data128_texture.id);
         device.bind_texture(TextureSampler::ResourceRects, self.resource_rects_texture.id);
         device.bind_texture(TextureSampler::Gradients, self.gradient_data_texture.id);
         device.bind_texture(TextureSampler::SplitGeometry, self.split_geometry_texture.id);
@@ -527,6 +589,7 @@ pub struct Renderer {
     result_rx: Receiver<ResultMsg>,
     device: Device,
     pending_texture_updates: Vec<TextureUpdateList>,
+    pending_gpu_cache_updates: Vec<GpuCacheUpdateList>,
     pending_shader_updates: Vec<PathBuf>,
     current_frame: Option<RendererFrame>,
 
@@ -594,6 +657,8 @@ pub struct Renderer {
 
     gdt_index: usize,
     gpu_data_textures: [GpuDataTextures; GPU_DATA_TEXTURE_POOL],
+
+    gpu_cache_texture: CacheTexture,
 
     pipeline_epoch_map: HashMap<PipelineId, Epoch, BuildHasherDefault<FnvHasher>>,
     /// Used to dispatch functions to the main thread's event loop.
@@ -1092,6 +1157,8 @@ impl Renderer {
             backend.run(backend_profile_counters);
         })};
 
+        let gpu_cache_texture = CacheTexture::new(&mut device);
+
         let gpu_profile = GpuProfiler::new(device.rc_gl());
 
         let renderer = Renderer {
@@ -1099,6 +1166,7 @@ impl Renderer {
             device: device,
             current_frame: None,
             pending_texture_updates: Vec::new(),
+            pending_gpu_cache_updates: Vec::new(),
             pending_shader_updates: Vec::new(),
             cs_box_shadow: cs_box_shadow,
             cs_text_run: cs_text_run,
@@ -1154,6 +1222,7 @@ impl Renderer {
             vr_compositor_handler: vr_compositor,
             cpu_profiles: VecDeque::new(),
             gpu_profiles: VecDeque::new(),
+            gpu_cache_texture: gpu_cache_texture,
         };
 
         let sender = RenderApiSender::new(api_tx, payload_tx);
@@ -1218,8 +1287,15 @@ impl Renderer {
         // Pull any pending results and return the most recent.
         while let Ok(msg) = self.result_rx.try_recv() {
             match msg {
-                ResultMsg::NewFrame(frame, texture_update_list, profile_counters) => {
+                ResultMsg::NewFrame(mut frame, texture_update_list, profile_counters) => {
                     self.pending_texture_updates.push(texture_update_list);
+                    if let Some(ref mut frame) = frame.frame {
+                        // TODO(gw): This whole message / Frame / RendererFrame stuff
+                        //           is really messy and needs to be refactored!!
+                        if let Some(update_list) = frame.gpu_cache_updates.take() {
+                            self.pending_gpu_cache_updates.push(update_list);
+                        }
+                    }
                     self.backend_profile_counters = profile_counters;
 
                     // Update the list of available epochs for use during reftests.
@@ -1309,6 +1385,9 @@ impl Renderer {
                         //self.update_shaders();
                         self.update_texture_cache();
 
+                        self.update_gpu_cache();
+                        self.device.bind_texture(TextureSampler::ResourceCache, self.gpu_cache_texture.id);
+
                         frame_id
                     };
 
@@ -1380,6 +1459,13 @@ impl Renderer {
         }
     }
 */
+
+    fn update_gpu_cache(&mut self) {
+        let _gm = GpuMarker::new(self.device.rc_gl(), "gpu cache update");
+        for update_list in self.pending_gpu_cache_updates.drain(..) {
+            self.gpu_cache_texture.update(&mut self.device, &update_list);
+        }
+    }
 
     fn update_texture_cache(&mut self) {
         let _gm = GpuMarker::new(self.device.rc_gl(), "texture cache update");

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -6,11 +6,12 @@ use app_units::Au;
 use border::{BorderCornerInstance, BorderCornerSide};
 use device::TextureId;
 use fnv::FnvHasher;
+use gpu_cache::GpuCacheUpdateList;
 use gpu_store::GpuStoreAddress;
 use internal_types::{ANGLE_FLOAT_TO_FIXED, BatchTextures, CacheTextureId, LowLevelFilterOp};
 use internal_types::SourceTexture;
 use mask_cache::MaskCacheInfo;
-use prim_store::{CLIP_DATA_GPU_SIZE, DeferredResolve, GpuBlock128, GpuBlock16, GpuBlock32};
+use prim_store::{CLIP_DATA_GPU_SIZE, DeferredResolve, GpuBlock16, GpuBlock32};
 use prim_store::{GpuBlock64, GradientData, SplitGeometry, PrimitiveCacheKey, PrimitiveGeometry};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore, TexelRect};
 use profiler::FrameProfileCounters;
@@ -398,8 +399,11 @@ impl AlphaRenderItem {
                                      transform_kind == TransformedRectKind::Complex;
                 let blend_mode = ctx.prim_store.get_blend_mode(needs_blending, prim_metadata);
 
+                let prim_cache_address = prim_metadata.gpu_location
+                                                      .as_int(&ctx.prim_store.gpu_cache);
+
                 let base_instance = SimplePrimitiveInstance::new(prim_index,
-                                                                 prim_metadata.gpu_prim_index,
+                                                                 prim_cache_address,
                                                                  task_index,
                                                                  clip_task_index,
                                                                  packed_layer_index,
@@ -488,34 +492,37 @@ impl AlphaRenderItem {
                             None => 0,
                         };
 
-                        for glyph_index in 0..prim_metadata.gpu_data_count {
+                        for glyph_index in 0..text_cpu.gpu_data_count {
                             let user_data1 = match batch_kind {
                                 AlphaBatchKind::TextRun => text_cpu.resource_address.0 + glyph_index,
                                 AlphaBatchKind::CacheImage => cache_task_index,
                                 _ => unreachable!(),
                             };
 
-                            batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + glyph_index,
+                            batch.add_instance(base_instance.build(text_cpu.gpu_data_address.0 + glyph_index,
                                                                    user_data1));
                         }
                     }
                     PrimitiveKind::AlignedGradient => {
+                        let gradient_cpu = &ctx.prim_store.cpu_gradients[prim_metadata.cpu_prim_index.0];
                         let key = AlphaBatchKey::new(AlphaBatchKind::AlignedGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        for part_index in 0..(prim_metadata.gpu_data_count - 1) {
-                            batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + part_index, 0));
+                        for part_index in 0..(gradient_cpu.gpu_data_count - 1) {
+                            batch.add_instance(base_instance.build(gradient_cpu.gpu_data_address.0 + part_index, 0));
                         }
                     }
                     PrimitiveKind::AngleGradient => {
+                        let gradient_cpu = &ctx.prim_store.cpu_gradients[prim_metadata.cpu_prim_index.0];
                         let key = AlphaBatchKey::new(AlphaBatchKind::AngleGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0,
+                        batch.add_instance(base_instance.build(gradient_cpu.gpu_data_address.0,
                                                                0));
                     }
                     PrimitiveKind::RadialGradient => {
+                        let gradient_cpu = &ctx.prim_store.cpu_radial_gradients[prim_metadata.cpu_prim_index.0];
                         let key = AlphaBatchKey::new(AlphaBatchKind::RadialGradient, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0,
+                        batch.add_instance(base_instance.build(gradient_cpu.gpu_data_address.0,
                                                                0));
                     }
                     PrimitiveKind::YuvImage => {
@@ -557,6 +564,7 @@ impl AlphaRenderItem {
                                                                0));
                     }
                     PrimitiveKind::BoxShadow => {
+                        let box_shadow_cpu = &ctx.prim_store.cpu_box_shadows[prim_metadata.cpu_prim_index.0];
                         let cache_task_id = &prim_metadata.render_task.as_ref().unwrap().id;
                         let cache_task_index = render_tasks.get_task_index(cache_task_id,
                                                                            child_pass_index);
@@ -564,8 +572,8 @@ impl AlphaRenderItem {
                         let key = AlphaBatchKey::new(AlphaBatchKind::BoxShadow, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
 
-                        for rect_index in 0..prim_metadata.gpu_data_count {
-                            batch.add_instance(base_instance.build(prim_metadata.gpu_data_address.0 + rect_index,
+                        for rect_index in 0..box_shadow_cpu.gpu_data_count {
+                            batch.add_instance(base_instance.build(box_shadow_cpu.gpu_data_address.0 + rect_index,
                                                                    cache_task_index.0 as i32));
                         }
                     }
@@ -947,10 +955,13 @@ impl RenderTarget for ColorRenderTarget {
             RenderTaskKind::CachePrimitive(prim_index) => {
                 let prim_metadata = ctx.prim_store.get_metadata(prim_index);
 
+                let prim_address = prim_metadata.gpu_location
+                                                .as_int(&ctx.prim_store.gpu_cache);
+
                 match prim_metadata.prim_kind {
                     PrimitiveKind::BoxShadow => {
                         let instance = SimplePrimitiveInstance::new(prim_index,
-                                                                    prim_metadata.gpu_prim_index,
+                                                                    prim_address,
                                                                     render_tasks.get_task_index(&task.id, pass_index),
                                                                     RenderTaskIndex(0),
                                                                     PackedLayerIndex(0),
@@ -975,14 +986,14 @@ impl RenderTarget for ColorRenderTarget {
                         self.text_run_textures = textures;
 
                         let instance = SimplePrimitiveInstance::new(prim_index,
-                                                                    prim_metadata.gpu_prim_index,
+                                                                    prim_address,
                                                                     render_tasks.get_task_index(&task.id, pass_index),
                                                                     RenderTaskIndex(0),
                                                                     PackedLayerIndex(0),
                                                                     0);     // z is disabled for rendering cache primitives
 
-                        for glyph_index in 0..prim_metadata.gpu_data_count {
-                            self.text_run_cache_prims.push(instance.build(prim_metadata.gpu_data_address.0 + glyph_index,
+                        for glyph_index in 0..text.gpu_data_count {
+                            self.text_run_cache_prims.push(instance.build(text.gpu_data_address.0 + glyph_index,
                                                                           text.resource_address.0 + glyph_index));
                         }
                     }
@@ -1272,6 +1283,12 @@ pub struct PrimitiveInstance {
 
 struct SimplePrimitiveInstance {
     pub global_prim_index: i32,
+    // TODO(gw): specific_prim_address is encoded as an i32, since
+    //           some primitives use GPU Cache and some still use
+    //           GPU Store. Once everything is converted to use the
+    //           on-demand GPU cache, then we change change this to
+    //           be an ivec2 of u16 - and encode the UV directly
+    //           so that the vertex shader can fetch directly.
     pub specific_prim_address: i32,
     pub task_index: i32,
     pub clip_task_index: i32,
@@ -1281,14 +1298,14 @@ struct SimplePrimitiveInstance {
 
 impl SimplePrimitiveInstance {
     fn new(prim_index: PrimitiveIndex,
-           specific_prim_address: GpuStoreAddress,
+           specific_prim_address: i32,
            task_index: RenderTaskIndex,
            clip_task_index: RenderTaskIndex,
            layer_index: PackedLayerIndex,
            z_sort_index: i32) -> SimplePrimitiveInstance {
         SimplePrimitiveInstance {
             global_prim_index: prim_index.0 as i32,
-            specific_prim_address: specific_prim_address.0 as i32,
+            specific_prim_address: specific_prim_address,
             task_index: task_index.0 as i32,
             clip_task_index: clip_task_index.0 as i32,
             layer_index: layer_index.0 as i32,
@@ -1603,11 +1620,14 @@ pub struct Frame {
     pub gpu_data16: Vec<GpuBlock16>,
     pub gpu_data32: Vec<GpuBlock32>,
     pub gpu_data64: Vec<GpuBlock64>,
-    pub gpu_data128: Vec<GpuBlock128>,
     pub gpu_geometry: Vec<PrimitiveGeometry>,
     pub gpu_gradient_data: Vec<GradientData>,
     pub gpu_split_geometry: Vec<SplitGeometry>,
     pub gpu_resource_rects: Vec<TexelRect>,
+
+    // List of updates that need to be pushed to the
+    // gpu resource cache.
+    pub gpu_cache_updates: Option<GpuCacheUpdateList>,
 
     // List of textures that we don't know about yet
     // from the backend thread. The render thread


### PR DESCRIPTION
This adds an incremental LRU cache that can be used to store values
that vertex shaders need to access.

The intent is to replace the use of the GPU store type, which
currently uploads the entire buffer each frame, and has a lot
of limitations (such as requiring allocation up front).

The new interface supports building GPU data on demand, as required,
which will improve CPU a lot for large pages.

For now, I have ported borders and rectangles to use the new type.
The patch is already large enough - this will allow us to port
each primitive type to use the GPU cache incrementally. The current
code also doesn't actually take advantage of building the data on
demand yet - they are just copied when needed.

Follow up work includes:
 * Porting more types to use the GPU cache.
 * Removing the old gpu store interfaces.
 * Profiling and optimizing various GL incremental update APIs.
 * Supporting resizing of the GPU cache backing store.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1299)
<!-- Reviewable:end -->
