### PR TITLE
Add filter setting for yuv image.

### DIFF
--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::path::PathBuf;
 use webrender_traits::{ColorF, Epoch};
 use webrender_traits::{DeviceIntPoint, DeviceUintSize, LayoutPoint, LayoutRect, LayoutSize};
-use webrender_traits::{ImageData, ImageDescriptor, ImageFormat};
+use webrender_traits::{ImageData, ImageDescriptor, ImageFormat, ImageRendering};
 use webrender_traits::{PipelineId, TransformStyle};
 use webrender_traits::{YuvColorSpace, YuvData};
 
@@ -282,6 +282,7 @@ fn main() {
         clip,
         YuvData::NV12(yuv_chanel1, yuv_chanel2),
         YuvColorSpace::Rec601,
+        ImageRendering::Auto,
     );
 
     let clip = builder.push_clip_region(&bounds, vec![], None);
@@ -290,6 +291,7 @@ fn main() {
         clip,
         YuvData::PlanarYCbCr(yuv_chanel1, yuv_chanel2_1, yuv_chanel3),
         YuvColorSpace::Rec601,
+        ImageRendering::Auto,
     );
 
     builder.pop_stacking_context();

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -468,7 +468,8 @@ impl Frame {
                                               item.rect(),
                                               item.clip_region(),
                                               info.yuv_data,
-                                              info.color_space);
+                                              info.color_space,
+                                              info.image_rendering);
             }
             SpecificDisplayItem::Text(ref text_info) => {
                 context.builder.add_text(clip_and_scroll,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1075,7 +1075,8 @@ impl FrameBuilder {
                          rect: LayerRect,
                          clip_region: &ClipRegion,
                          yuv_data: YuvData,
-                         color_space: YuvColorSpace) {
+                         color_space: YuvColorSpace,
+                         image_rendering: ImageRendering) {
         let format = yuv_data.get_format();
         let yuv_key = match yuv_data {
             YuvData::NV12(plane_0, plane_1) => [plane_0, plane_1, ImageKey::new(0, 0)],
@@ -1091,6 +1092,7 @@ impl FrameBuilder {
             yuv_resource_address: GpuStoreAddress(0),
             format: format,
             color_space: color_space,
+            image_rendering: image_rendering,
         };
 
         let prim_gpu = YuvImagePrimitiveGpu::new(rect.size);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -197,6 +197,8 @@ pub struct YuvImagePrimitiveCpu {
     // The first address of yuv resource_address. Use "yuv_resource_address + N-th" to get the N-th channel data.
     // e.g. yuv_resource_address + 0 => y channel resource_address
     pub yuv_resource_address: GpuStoreAddress,
+
+    pub image_rendering: ImageRendering,
 }
 
 #[derive(Debug, Clone)]
@@ -1092,7 +1094,7 @@ impl PrimitiveStore {
                                                           &mut deferred_resolves,
                                                           image_cpu.yuv_key[channel],
                                                           resource_address,
-                                                          ImageRendering::Auto,
+                                                          image_cpu.image_rendering,
                                                           None);
                         // texture_id
                         image_cpu.yuv_texture_id[channel] = texture_id;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1332,7 +1332,7 @@ impl PrimitiveStore {
                 let channel_num = image_cpu.format.get_plane_num();
                 debug_assert!(channel_num <= 3);
                 for channel in 0..channel_num {
-                    resource_cache.request_image(image_cpu.yuv_key[channel], ImageRendering::Auto, None);
+                    resource_cache.request_image(image_cpu.yuv_key[channel], image_cpu.image_rendering, None);
                 }
 
                 // TODO(nical): Currently assuming no tile_spacing for yuv images.

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -427,7 +427,7 @@ pub struct ClipRegion {
     pub complex_clips: ItemRange<ComplexClipRegion>,
     #[serde(default, skip_serializing, skip_deserializing)]
     pub complex_clip_count: usize,
-} 
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -350,6 +350,7 @@ pub enum ImageRendering {
 pub struct YuvImageDisplayItem {
     pub yuv_data: YuvData,
     pub color_space: YuvColorSpace,
+    pub image_rendering: ImageRendering
 }
 
 #[repr(u32)]

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -535,10 +535,12 @@ impl DisplayListBuilder {
                           rect: LayoutRect,
                           _token: ClipRegionToken,
                           yuv_data: YuvData,
-                          color_space: YuvColorSpace) {
+                          color_space: YuvColorSpace,
+                          image_rendering: ImageRendering) {
         let item = SpecificDisplayItem::YuvImage(YuvImageDisplayItem {
             yuv_data: yuv_data,
             color_space: color_space,
+            image_rendering: image_rendering,
         });
         self.push_item(item, rect);
     }


### PR DESCRIPTION
r? @kvark @glennw @nical 

Some reftests in gecko need the nearest sampling. Bypass the filter setting for yuv image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1310)
<!-- Reviewable:end -->
