### PR TITLE
Remove glyph raster profile scope, for now.

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -191,7 +191,7 @@ impl GlyphRasterizer {
         // glyphs in the thread pool.
         self.workers.spawn_async(move || {
             let jobs = glyphs.par_iter().map(|request: &GlyphRequest| {
-                profile_scope!("glyph-raster");
+                //profile_scope!("glyph-raster");
                 let mut context = font_contexts.lock_current_context();
                 let job = GlyphRasterJob {
                     request: request.clone(),


### PR DESCRIPTION
This spams out errors to the console about running on an unregistered profiler thread.

This is a quick fix until we get the rayon worker threads to register with the profiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1313)
<!-- Reviewable:end -->
