### PR TITLE
Require at least plane-split 0.4.

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -30,7 +30,7 @@ webrender_traits = {path = "../webrender_traits"}
 bitflags = "0.7"
 gamma-lut = "0.2"
 thread_profiler = "0.1.1"
-plane-split = ">= 0.3, < 0.5"
+plane-split = "0.4"
 
 [dev-dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}


### PR DESCRIPTION
Older versions of plane-split (e.g. 0.3.0) use an older version of
euclid (0.11 instead of 0.13), and so webrender doesn't actually compile
with that. The compilation failures come from a mismatch of type names,
such as euclid::rect::TypedRect vs euclid::TypedRect.

The Cargo.lock file already uses plane-split 0.4.0 but downstream
dependencies of webrender that try to use it with an older plane-split
will run into this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1315)
<!-- Reviewable:end -->
