### PR TITLE
Avoid calculating a tight bounding box for text runs.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -746,6 +746,9 @@ impl FrameBuilder {
             return
         }
 
+        // Expand the rectangle of the text run by the blur radius.
+        let rect = rect.inflate(blur_radius, blur_radius);
+
         // TODO(gw): Use a proper algorithm to select
         // whether this item should be rendered with
         // subpixel AA!
@@ -1754,17 +1757,11 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                                                                  &packed_layer.transform,
                                                                  &packed_layer.local_clip_rect,
                                                                  self.device_pixel_ratio) {
-                if self.frame_builder.prim_store.prepare_prim_for_render(prim_index,
-                                                                         self.resource_cache,
-                                                                         &packed_layer.transform,
-                                                                         self.device_pixel_ratio,
-                                                                         display_list) {
-                    self.frame_builder.prim_store.build_bounding_rect(prim_index,
-                                                                      self.screen_rect,
+                self.frame_builder.prim_store.prepare_prim_for_render(prim_index,
+                                                                      self.resource_cache,
                                                                       &packed_layer.transform,
-                                                                      &packed_layer.local_clip_rect,
-                                                                      self.device_pixel_ratio);
-                }
+                                                                      self.device_pixel_ratio,
+                                                                      display_list);
 
                 // If the primitive is visible, consider culling it via clip rect(s).
                 // If it is visible but has clips, create the clip task for it.

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1220,11 +1220,10 @@ impl PrimitiveStore {
                                    resource_cache: &mut ResourceCache,
                                    layer_transform: &LayerToWorldTransform,
                                    device_pixel_ratio: f32,
-                                   display_list: &BuiltDisplayList) -> bool {
+                                   display_list: &BuiltDisplayList) {
 
         let metadata = &mut self.cpu_metadata[prim_index.0];
         let mut prim_needs_resolve = false;
-        let mut rebuild_bounding_rect = false;
 
         if let GpuLocation::GpuCache(ref mut cache_id) = metadata.gpu_location {
             let gpu_cache = &mut self.gpu_cache;
@@ -1291,7 +1290,6 @@ impl PrimitiveStore {
                 prim_needs_resolve = true;
 
                 if text.cache_dirty {
-                    rebuild_bounding_rect = true;
                     text.cache_dirty = false;
 
                     debug_assert!(text.gpu_data_count == src_glyphs.len() as i32);
@@ -1306,7 +1304,6 @@ impl PrimitiveStore {
                                                       0,
                                                       LayoutPoint::new(0.0, 0.0),
                                                       text.render_mode);
-                    let mut local_rect = LayerRect::zero();
                     let mut actual_glyph_count = 0;
 
                     for src in src_glyphs {
@@ -1324,28 +1321,20 @@ impl PrimitiveStore {
                         let x = src.point.x + dimensions.left as f32 / device_pixel_ratio;
                         let y = src.point.y - dimensions.top as f32 / device_pixel_ratio;
 
-                        let width = dimensions.width as f32 / device_pixel_ratio;
-                        let height = dimensions.height as f32 / device_pixel_ratio;
-
-                        let local_glyph_rect = LayerRect::new(LayerPoint::new(x, y),
-                                                              LayerSize::new(width, height));
-                        local_rect = local_rect.union(&local_glyph_rect);
+                        let glyph_pos = LayerPoint::new(x, y);
 
                         dest_glyphs[actual_glyph_count] = GpuBlock16::from(GlyphPrimitive {
                             padding: LayerPoint::zero(),
-                            offset: local_glyph_rect.origin,
+                            offset: glyph_pos,
                         });
 
                         text.glyph_instances.push(GlyphInstance {
                             index: src.index,
-                            point: LayoutPoint::new(src.point.x, src.point.y),
+                            point: glyph_pos,
                         });
 
                         actual_glyph_count += 1;
                     }
-
-                    // Expand the rectangle of the text run by the blur radius.
-                    let local_rect = local_rect.inflate(text.blur_radius, text.blur_radius);
 
                     let render_task = if text.blur_radius == 0.0 {
                         None
@@ -1354,8 +1343,9 @@ impl PrimitiveStore {
                         // render the text run to a target, and then apply a gaussian
                         // blur to that text run in order to build the actual primitive
                         // which will be blitted to the framebuffer.
-                        let cache_width = (local_rect.size.width * device_pixel_ratio).ceil() as i32;
-                        let cache_height = (local_rect.size.height * device_pixel_ratio).ceil() as i32;
+                        let geom = &self.gpu_geometry.get(GpuStoreAddress(prim_index.0 as i32));
+                        let cache_width = (geom.local_rect.size.width * device_pixel_ratio).ceil() as i32;
+                        let cache_height = (geom.local_rect.size.height * device_pixel_ratio).ceil() as i32;
                         let cache_size = DeviceIntSize::new(cache_width, cache_height);
                         let cache_key = PrimitiveCacheKey::TextShadow(prim_index);
                         let blur_radius = device_length(text.blur_radius,
@@ -1368,7 +1358,6 @@ impl PrimitiveStore {
 
                     text.gpu_data_count = actual_glyph_count as i32;
                     metadata.render_task = render_task;
-                    self.gpu_geometry.get_mut(GpuStoreAddress(prim_index.0 as i32)).local_rect = local_rect;
                 }
 
                 resource_cache.request_glyphs(text.font_key,
@@ -1456,8 +1445,6 @@ impl PrimitiveStore {
         if prim_needs_resolve {
             self.prims_to_resolve.push(prim_index);
         }
-
-        rebuild_bounding_rect
     }
 }
 


### PR DESCRIPTION
With the previous tiling code, this was quite important. However,
it's no longer necessary and was showing up high in CPU profiles.

On some sites (such as Wikipedia and HN) that contain a lot of
text, this saves ~17% of the CPU time per frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1320)
<!-- Reviewable:end -->
