### PR TITLE
Port box shadows to use the GPU cache.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -184,6 +184,16 @@ vec4[8] fetch_from_resource_cache_8(int address) {
     );
 }
 
+vec4[4] fetch_from_resource_cache_4(int address) {
+    ivec2 uv = get_resource_cache_uv(address);
+    return vec4[4](
+        texelFetchOffset(sResourceCache, uv, 0, ivec2(0, 0)),
+        texelFetchOffset(sResourceCache, uv, 0, ivec2(1, 0)),
+        texelFetchOffset(sResourceCache, uv, 0, ivec2(2, 0)),
+        texelFetchOffset(sResourceCache, uv, 0, ivec2(3, 0))
+    );
+}
+
 vec4 fetch_from_resource_cache_1(int address) {
     ivec2 uv = get_resource_cache_uv(address);
     return texelFetch(sResourceCache, uv, 0);
@@ -419,8 +429,8 @@ Glyph fetch_glyph(int index) {
     return Glyph(data);
 }
 
-RectWithSize fetch_instance_geometry(int index) {
-    vec4 data = fetch_data_1(index);
+RectWithSize fetch_instance_geometry(int address) {
+    vec4 data = fetch_from_resource_cache_1(address);
     return RectWithSize(data.xy, data.zw);
 }
 
@@ -811,8 +821,8 @@ struct BoxShadow {
     vec4 border_radius_edge_size_blur_radius_inverted;
 };
 
-BoxShadow fetch_boxshadow(int index) {
-    vec4 data[4] = fetch_data_4(index);
+BoxShadow fetch_boxshadow(int address) {
+    vec4 data[4] = fetch_from_resource_cache_4(address);
     return BoxShadow(data[0], data[1], data[2], data[3]);
 }
 

--- a/webrender/res/ps_box_shadow.vs.glsl
+++ b/webrender/res/ps_box_shadow.vs.glsl
@@ -3,10 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#define BS_HEADER_VECS 4
+
 void main(void) {
     Primitive prim = load_primitive();
     BoxShadow bs = fetch_boxshadow(prim.prim_index);
-    RectWithSize segment_rect = fetch_instance_geometry(prim.user_data0);
+    RectWithSize segment_rect = fetch_instance_geometry(prim.prim_index + BS_HEADER_VECS + prim.user_data0);
 
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -12,7 +12,7 @@ use prim_store::{GradientPrimitiveCpu, GradientPrimitiveGpu, ImagePrimitiveCpu, 
 use prim_store::{ImagePrimitiveKind, PrimitiveContainer, PrimitiveGeometry, PrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu, RadialGradientPrimitiveGpu};
 use prim_store::{RectanglePrimitive, SplitGeometry, TextRunPrimitiveCpu, TextRunPrimitiveGpu};
-use prim_store::{BoxShadowPrimitiveGpu, TexelRect, YuvImagePrimitiveCpu, YuvImagePrimitiveGpu};
+use prim_store::{BoxShadowPrimitiveCpu, TexelRect, YuvImagePrimitiveCpu, YuvImagePrimitiveGpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_task::{AlphaRenderItem, MaskCacheKey, MaskResult, RenderTask, RenderTaskIndex};
 use render_task::{RenderTaskId, RenderTaskLocation};
@@ -989,7 +989,7 @@ impl FrameBuilder {
                                                 extra_clip_mode));
                 }
 
-                let prim_gpu = BoxShadowPrimitiveGpu {
+                let prim_cpu = BoxShadowPrimitiveCpu {
                     src_rect: *box_bounds,
                     bs_rect: bs_rect,
                     color: *color,
@@ -997,13 +997,14 @@ impl FrameBuilder {
                     border_radius: border_radius,
                     edge_size: edge_size,
                     inverted: inverted,
+                    rects: rects,
                 };
 
                 self.add_primitive(clip_and_scroll,
                                    &outer_rect,
                                    clip_region,
                                    extra_clips.as_slice(),
-                                   PrimitiveContainer::BoxShadow(prim_gpu, rects));
+                                   PrimitiveContainer::BoxShadow(prim_cpu));
             }
         }
     }

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -28,7 +28,7 @@ use device::FrameId;
 use profiler::GpuCacheProfileCounters;
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 use std::mem;
-use webrender_traits::ColorF;
+use webrender_traits::{ColorF, LayerRect};
 
 pub const GPU_CACHE_INITIAL_HEIGHT: u32 = 512;
 const FRAMES_BEFORE_EVICTION: usize = 10;
@@ -61,6 +61,17 @@ impl Into<GpuBlockData> for [f32; 4] {
     fn into(self) -> GpuBlockData {
         GpuBlockData {
             data: self,
+        }
+    }
+}
+
+impl Into<GpuBlockData> for LayerRect {
+    fn into(self) -> GpuBlockData {
+        GpuBlockData {
+            data: [ self.origin.x,
+                    self.origin.y,
+                    self.size.width,
+                    self.size.height ],
         }
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -564,7 +564,7 @@ impl AlphaRenderItem {
                                                                0));
                     }
                     PrimitiveKind::BoxShadow => {
-                        let box_shadow_cpu = &ctx.prim_store.cpu_box_shadows[prim_metadata.cpu_prim_index.0];
+                        let box_shadow = &ctx.prim_store.cpu_box_shadows[prim_metadata.cpu_prim_index.0];
                         let cache_task_id = &prim_metadata.render_task.as_ref().unwrap().id;
                         let cache_task_index = render_tasks.get_task_index(cache_task_id,
                                                                            child_pass_index);
@@ -572,8 +572,8 @@ impl AlphaRenderItem {
                         let key = AlphaBatchKey::new(AlphaBatchKind::BoxShadow, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
 
-                        for rect_index in 0..box_shadow_cpu.gpu_data_count {
-                            batch.add_instance(base_instance.build(box_shadow_cpu.gpu_data_address.0 + rect_index,
+                        for rect_index in 0..box_shadow.rects.len() {
+                            batch.add_instance(base_instance.build(rect_index as i32,
                                                                    cache_task_index.0 as i32));
                         }
                     }


### PR DESCRIPTION
Previously, two allocations were made - one for the main box shadow
structure and one for the instance rectangle geometry.

Now, a single allocation is used and the instance rectangles follow
the box shadow structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1323)
<!-- Reviewable:end -->
