### PR TITLE
Move GPU cache from prim store to resource cache.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1385,7 +1385,6 @@ impl FrameBuilder {
         let mut profile_counters = FrameProfileCounters::new();
         profile_counters.total_primitives.set(self.prim_store.prim_count());
 
-        self.prim_store.gpu_cache.begin_frame();
         resource_cache.begin_frame(frame_id);
 
         let screen_rect = DeviceIntRect::new(
@@ -1428,7 +1427,8 @@ impl FrameBuilder {
         let deferred_resolves = self.prim_store.resolve_primitives(resource_cache,
                                                                    device_pixel_ratio);
 
-        let gpu_cache_updates = self.prim_store.end_frame(gpu_cache_profile);
+        let gpu_cache_updates = resource_cache.gpu_cache
+                                              .end_frame(gpu_cache_profile);
 
         let mut passes = Vec::new();
 

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -208,10 +208,6 @@ impl FreeBlockLists {
         }
     }
 
-    fn clear(&mut self) {
-        *self = Self::new();
-    }
-
     fn get_actual_block_count_and_free_list(&mut self,
                                             block_count: usize) -> (usize, &mut Option<BlockIndex>) {
         // Find the appropriate free list to use
@@ -265,21 +261,6 @@ impl Texture {
             occupied_list_head: None,
             allocated_block_count: 0,
         }
-    }
-
-    fn clear(&mut self) {
-        self.blocks.clear();
-        self.rows.clear();
-        self.free_lists.clear();
-        self.pending_blocks.clear();
-        self.updates.clear();
-        self.occupied_list_head = None;
-        self.allocated_block_count = 0;
-
-        // TODO(gw): Right now, we never shrink the size of the backing
-        // texture. We could consider shrinking the texture here, if
-        // you navigate away from a page that required a very large
-        // texture backing store.
     }
 
     // Push new data into the cache. The ```pending_block_index``` field represents
@@ -464,15 +445,6 @@ impl GpuCache {
 
             handle.location = Some(location);
         }
-    }
-
-    /// Recycle the GPU cache for a new display list. This allows
-    /// re-using existing backing allocations rather than calling
-    /// the system memory allocator again.
-    pub fn recycle(mut self) -> GpuCache {
-        self.texture.clear();
-
-        self
     }
 
     /// End the frame. Return the list of updates to apply to the

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,11 +6,10 @@ use app_units::Au;
 use border::{BorderCornerClipData, BorderCornerDashClipData, BorderCornerDotClipData};
 use border::BorderCornerInstance;
 use euclid::{Size2D};
-use gpu_cache::{GpuBlockData, GpuCache, GpuCacheUpdateList, GpuCacheHandle, ToGpuBlocks};
+use gpu_cache::{GpuBlockData, GpuCache, GpuCacheHandle, ToGpuBlocks};
 use gpu_store::GpuStoreAddress;
 use internal_types::{SourceTexture, PackedTexel};
 use mask_cache::{ClipMode, ClipSource, MaskCacheInfo};
-use profiler::GpuCacheProfileCounters;
 use renderer::{VertexDataStore, GradientDataStore, SplitGeometryStore, MAX_VERTEX_TEXTURE_WIDTH};
 use render_task::{RenderTask, RenderTaskLocation};
 use resource_cache::{CacheItem, ImageProperties, ResourceCache};
@@ -712,8 +711,6 @@ pub struct PrimitiveStore {
     /// Resolved resource rects.
     pub gpu_resource_rects: VertexDataStore<TexelRect>,
 
-    pub gpu_cache: GpuCache,
-
     /// General
     prims_to_resolve: Vec<PrimitiveIndex>,
 }
@@ -739,7 +736,6 @@ impl PrimitiveStore {
             gpu_gradient_data: GradientDataStore::new(),
             gpu_split_geometry: SplitGeometryStore::new(),
             gpu_resource_rects: VertexDataStore::new(),
-            gpu_cache: GpuCache::new(),
         }
     }
 
@@ -763,7 +759,6 @@ impl PrimitiveStore {
             gpu_gradient_data: self.gpu_gradient_data.recycle(),
             gpu_split_geometry: self.gpu_split_geometry.recycle(),
             gpu_resource_rects: self.gpu_resource_rects.recycle(),
-            gpu_cache: self.gpu_cache.recycle(),
         }
     }
 
@@ -1151,11 +1146,6 @@ impl PrimitiveStore {
         deferred_resolves
     }
 
-    pub fn end_frame(&mut self,
-                     profile_counters: &mut GpuCacheProfileCounters) -> GpuCacheUpdateList {
-        self.gpu_cache.end_frame(profile_counters)
-    }
-
     pub fn set_clip_source(&mut self, index: PrimitiveIndex, source: Option<ClipSource>) {
         let metadata = &mut self.cpu_metadata[index.0];
         metadata.clips = match source {
@@ -1221,7 +1211,6 @@ impl PrimitiveStore {
         let mut rebuild_bounding_rect = false;
 
         if let GpuLocation::GpuCache(ref mut cache_id) = metadata.gpu_location {
-            let gpu_cache = &mut self.gpu_cache;
             let cpu_borders = &self.cpu_borders;
             let cpu_box_shadows = &self.cpu_box_shadows;
             let cpu_rectangles = &self.cpu_rectangles;
@@ -1229,7 +1218,7 @@ impl PrimitiveStore {
             let prim_kind = metadata.prim_kind;
 
             // Mark this GPU resource as required for this frame.
-            gpu_cache.request(cache_id, |blocks| {
+            resource_cache.gpu_cache.request(cache_id, |blocks| {
                 match prim_kind {
                     PrimitiveKind::Rectangle => {
                         let rect = &cpu_rectangles[cpu_prim_index.0];

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -6,6 +6,7 @@ use app_units::Au;
 use device::TextureFilter;
 use fnv::FnvHasher;
 use frame::FrameId;
+use gpu_cache::GpuCache;
 use internal_types::{FontTemplate, SourceTexture, TextureUpdateList};
 use profiler::TextureCacheProfileCounters;
 use std::collections::{HashMap, HashSet};
@@ -198,6 +199,7 @@ pub struct ResourceCache {
     current_frame_id: FrameId,
 
     texture_cache: TextureCache,
+    pub gpu_cache: GpuCache,
 
     // TODO(gw): We should expire (parts of) this cache semi-regularly!
     cached_glyph_dimensions: HashMap<GlyphKey, Option<GlyphDimensions>, BuildHasherDefault<FnvHasher>>,
@@ -220,6 +222,7 @@ impl ResourceCache {
             image_templates: ImageTemplates::new(),
             cached_glyph_dimensions: HashMap::default(),
             texture_cache: texture_cache,
+            gpu_cache: GpuCache::new(),
             state: State::Idle,
             current_frame_id: FrameId(0),
             pending_image_requests: Vec::new(),
@@ -564,6 +567,7 @@ impl ResourceCache {
         debug_assert_eq!(self.state, State::Idle);
         self.state = State::AddResources;
         self.current_frame_id = frame_id;
+        self.gpu_cache.begin_frame();
     }
 
     pub fn block_until_all_resources_added(&mut self,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -400,7 +400,7 @@ impl AlphaRenderItem {
                 let blend_mode = ctx.prim_store.get_blend_mode(needs_blending, prim_metadata);
 
                 let prim_cache_address = prim_metadata.gpu_location
-                                                      .as_int(&ctx.prim_store.gpu_cache);
+                                                      .as_int(&ctx.resource_cache.gpu_cache);
 
                 let base_instance = SimplePrimitiveInstance::new(prim_index,
                                                                  prim_cache_address,
@@ -956,7 +956,7 @@ impl RenderTarget for ColorRenderTarget {
                 let prim_metadata = ctx.prim_store.get_metadata(prim_index);
 
                 let prim_address = prim_metadata.gpu_location
-                                                .as_int(&ctx.prim_store.gpu_cache);
+                                                .as_int(&ctx.resource_cache.gpu_cache);
 
                 match prim_metadata.prim_kind {
                     PrimitiveKind::BoxShadow => {


### PR DESCRIPTION
The benefit of this is it will allow us to allocate GPU blocks
for the resource rects (the UV rects of items in the texture cache)
which will allow us to simplify and optimize the CPU and shader code
for primitives that use texture cache items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1327)
<!-- Reviewable:end -->
