### PR TITLE
Fix a bug setting the gpu cache last access time.

### DIFF
--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -311,6 +311,7 @@ impl Texture {
 
         // Add the block to the occupied linked list.
         block.next = self.occupied_list_head;
+        block.last_access_time = frame_id;
         self.occupied_list_head = Some(free_block_index);
         self.allocated_block_count += alloc_size;
 


### PR DESCRIPTION
The last access time for a block is initialized when the free
list for a row is created.

The bug manifests in the following way:
 * New row is allocated on frame 1 - blocks access time = 1
 * New display list is received on frame 2.
 * Blocks are allocated from the same row, but the last_access_time was not set.
 * A debug assert occurs during get_address - where it checks that the block was requested this frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1329)
<!-- Reviewable:end -->
