### PR TITLE
Avoid unnecessary struct field shorthand

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1123,7 +1123,7 @@ impl Renderer {
 
         let config = FrameBuilderConfig {
             enable_scrollbars: options.enable_scrollbars,
-            default_font_render_mode,
+            default_font_render_mode: default_font_render_mode,
             debug: options.debug,
             cache_expiry_frames: options.cache_expiry_frames,
         };


### PR DESCRIPTION
This was inadvertently added in 3ab7de9, and unnecessarily requires
rustc 1.17 (struct field shorthands were unstable before that).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1330)
<!-- Reviewable:end -->
