### PR TITLE
Don't apply local clip rect to snap rectangle calculation.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -583,18 +583,15 @@ vec4 get_layer_pos(vec2 pos, Layer layer) {
 vec2 compute_snap_offset(vec2 local_pos,
                          RectWithSize local_clip_rect,
                          Layer layer,
-                         RectWithSize raw_snap_rect) {
+                         RectWithSize snap_rect) {
     // Ensure that the snap rect is at *least* one device pixel in size.
     // TODO(gw): It's not clear to me that this is "correct". Specifically,
     //           how should it interact with sub-pixel snap rects when there
     //           is a layer transform with scale present? But it does fix
     //           the test cases we have in Servo that are failing without it
     //           and seem better than not having this at all.
-    raw_snap_rect.size = max(raw_snap_rect.size, vec2(1.0 / uDevicePixelRatio));
+    snap_rect.size = max(snap_rect.size, vec2(1.0 / uDevicePixelRatio));
 
-    // Clamp the snap rectangle.
-    RectWithSize snap_rect = intersect_rect(intersect_rect(raw_snap_rect, local_clip_rect),
-                                            layer.local_clip_rect);
     // Transform the snap corners to the world space.
     vec4 world_snap_p0 = layer.transform * vec4(snap_rect.p0, 0.0, 1.0);
     vec4 world_snap_p1 = layer.transform * vec4(snap_rect.p0 + snap_rect.size, 0.0, 1.0);


### PR DESCRIPTION
This fixes the remaining WPT/CSS fails in the pending WR update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1331)
<!-- Reviewable:end -->
