### PR TITLE
Return the clip id from push_clip_node.

### DIFF
--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -881,9 +881,11 @@ impl DisplayListBuilder {
     pub fn push_clip_node(&mut self,
                           content_rect: LayoutRect,
                           token: ClipRegionToken,
-                          id: Option<ClipId>){
+                          id: Option<ClipId>)
+                          -> ClipId {
         let id = self.define_clip(content_rect, token, id);
         self.clip_stack.push(ClipAndScrollInfo::simple(id));
+        id
     }
 
     pub fn push_clip_id(&mut self, id: ClipId) {


### PR DESCRIPTION
In cases where the caller doesn't pass in an explicit clip id, it is
still useful for the caller to get back the generated clip id. This is
because the caller may later need to call push_clip_and_scroll_info with
the clip id that was generated. If this function doesn't return the clip
id the caller would basically have to inline this function and define
the clip manually, which seems much less convenient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1333)
<!-- Reviewable:end -->
