### PR TITLE
Run CI with rustc 1.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: rust
 rust:
-  - stable
+  - 1.15.1
   - nightly
 os:
   - linux


### PR DESCRIPTION
This is the minimum version supported by Gecko, and would avoid things
like 3ab7de9 slipping in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1334)
<!-- Reviewable:end -->
