### PR TITLE
Move PrimitiveGeometry to be stored inline in the GPU cache.

### DIFF
--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -8,18 +8,16 @@
 // as text-shadow.
 
 void main(void) {
-    PrimitiveInstance pi = fetch_prim_instance();
-    RenderTaskData task = fetch_render_task(pi.render_task_index);
-    TextRun text = fetch_text_run(pi.specific_prim_address);
-    Glyph glyph = fetch_glyph(pi.user_data0);
-    PrimitiveGeometry pg = fetch_prim_geometry(pi.global_prim_index);
-    ResourceRect res = fetch_resource_rect(pi.user_data1);
+    Primitive prim = load_primitive();
+    TextRun text = fetch_text_run(prim.specific_prim_address);
+    Glyph glyph = fetch_glyph(prim.user_data0);
+    ResourceRect res = fetch_resource_rect(prim.user_data1);
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by
     // the glyph offset, relative to its primitive bounding rect.
     vec2 size = res.uv_rect.zw - res.uv_rect.xy;
-    vec2 origin = task.data0.xy + uDevicePixelRatio * (glyph.offset.xy - pg.local_rect.p0);
+    vec2 origin = prim.task.screen_space_origin + uDevicePixelRatio * (glyph.offset.xy - prim.local_rect.p0);
     vec4 local_rect = vec4(origin, size);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));

--- a/webrender/res/ps_angle_gradient.vs.glsl
+++ b/webrender/res/ps_angle_gradient.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    Gradient gradient = fetch_gradient(prim.prim_index);
+    Gradient gradient = fetch_gradient(prim.specific_prim_address);
 
     VertexInfo vi = write_vertex(prim.local_rect,
                                  prim.local_clip_rect,

--- a/webrender/res/ps_border_corner.vs.glsl
+++ b/webrender/res/ps_border_corner.vs.glsl
@@ -117,7 +117,7 @@ int select_style(int color_select, vec2 fstyle) {
 
 void main(void) {
     Primitive prim = load_primitive();
-    Border border = fetch_border(prim.prim_index);
+    Border border = fetch_border(prim.specific_prim_address);
     int sub_part = prim.user_data0;
     BorderCorners corners = get_border_corners(border, prim.local_rect);
 

--- a/webrender/res/ps_border_edge.vs.glsl
+++ b/webrender/res/ps_border_edge.vs.glsl
@@ -104,7 +104,7 @@ void write_clip_params(float style,
 
 void main(void) {
     Primitive prim = load_primitive();
-    Border border = fetch_border(prim.prim_index);
+    Border border = fetch_border(prim.specific_prim_address);
     int sub_part = prim.user_data0;
     BorderCorners corners = get_border_corners(border, prim.local_rect);
     vec4 color = border.colors[sub_part];

--- a/webrender/res/ps_box_shadow.vs.glsl
+++ b/webrender/res/ps_box_shadow.vs.glsl
@@ -7,8 +7,8 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    BoxShadow bs = fetch_boxshadow(prim.prim_index);
-    RectWithSize segment_rect = fetch_instance_geometry(prim.prim_index + BS_HEADER_VECS + prim.user_data0);
+    BoxShadow bs = fetch_boxshadow(prim.specific_prim_address);
+    RectWithSize segment_rect = fetch_instance_geometry(prim.specific_prim_address + BS_HEADER_VECS + prim.user_data0);
 
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,

--- a/webrender/res/ps_gradient.vs.glsl
+++ b/webrender/res/ps_gradient.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    Gradient gradient = fetch_gradient(prim.prim_index);
+    Gradient gradient = fetch_gradient(prim.specific_prim_address);
 
     vec4 abs_start_end_point = gradient.start_end_point + prim.local_rect.p0.xyxy;
 

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    Image image = fetch_image(prim.prim_index);
+    Image image = fetch_image(prim.specific_prim_address);
     ResourceRect res = fetch_resource_rect(prim.user_data0);
 
 #ifdef WR_FEATURE_TRANSFORM

--- a/webrender/res/ps_radial_gradient.vs.glsl
+++ b/webrender/res/ps_radial_gradient.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    RadialGradient gradient = fetch_radial_gradient(prim.prim_index);
+    RadialGradient gradient = fetch_radial_gradient(prim.specific_prim_address);
 
     VertexInfo vi = write_vertex(prim.local_rect,
                                  prim.local_clip_rect,

--- a/webrender/res/ps_rectangle.vs.glsl
+++ b/webrender/res/ps_rectangle.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    Rectangle rect = fetch_rectangle(prim.prim_index);
+    Rectangle rect = fetch_rectangle(prim.specific_prim_address);
     vColor = rect.color;
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(prim.local_rect,

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -5,7 +5,7 @@
 
 void main(void) {
     Primitive prim = load_primitive();
-    TextRun text = fetch_text_run(prim.prim_index);
+    TextRun text = fetch_text_run(prim.specific_prim_address);
     Glyph glyph = fetch_glyph(prim.user_data0);
     ResourceRect res = fetch_resource_rect(prim.user_data1);
 

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -67,7 +67,7 @@ void main(void) {
 #endif
 #endif
 
-    YuvImage image = fetch_yuv_image(prim.prim_index);
+    YuvImage image = fetch_yuv_image(prim.specific_prim_address);
     vStretchSize = image.size;
 
     vHalfTexelY = vec2(0.5) / y_texture_size_normalization_factor;

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1554,11 +1554,6 @@ impl Device {
             self.gl.uniform_1i(u_tasks, TextureSampler::RenderTasks as i32);
         }
 
-        let u_prim_geom = self.gl.get_uniform_location(program.id, "sPrimGeometry");
-        if u_prim_geom != -1 {
-            self.gl.uniform_1i(u_prim_geom, TextureSampler::Geometry as i32);
-        }
-
         let u_data16 = self.gl.get_uniform_location(program.id, "sData16");
         if u_data16 != -1 {
             self.gl.uniform_1i(u_data16, TextureSampler::Data16 as i32);

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -72,7 +72,6 @@ pub enum TextureSampler {
     ResourceCache,
     Layers,
     RenderTasks,
-    Geometry,
     ResourceRects,
     Gradients,
     SplitGeometry,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -530,7 +530,6 @@ fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program
 struct GpuDataTextures {
     layer_texture: VertexDataTexture,
     render_task_texture: VertexDataTexture,
-    prim_geom_texture: VertexDataTexture,
     data16_texture: VertexDataTexture,
     data32_texture: VertexDataTexture,
     resource_rects_texture: VertexDataTexture,
@@ -543,7 +542,6 @@ impl GpuDataTextures {
         GpuDataTextures {
             layer_texture: VertexDataTexture::new(device),
             render_task_texture: VertexDataTexture::new(device),
-            prim_geom_texture: VertexDataTexture::new(device),
             data16_texture: VertexDataTexture::new(device),
             data32_texture: VertexDataTexture::new(device),
             resource_rects_texture: VertexDataTexture::new(device),
@@ -555,7 +553,6 @@ impl GpuDataTextures {
     fn init_frame(&mut self, device: &mut Device, frame: &mut Frame) {
         self.data16_texture.init(device, &mut frame.gpu_data16);
         self.data32_texture.init(device, &mut frame.gpu_data32);
-        self.prim_geom_texture.init(device, &mut frame.gpu_geometry);
         self.resource_rects_texture.init(device, &mut frame.gpu_resource_rects);
         self.layer_texture.init(device, &mut frame.layer_texture_data);
         self.render_task_texture.init(device, &mut frame.render_task_data);
@@ -564,7 +561,6 @@ impl GpuDataTextures {
 
         device.bind_texture(TextureSampler::Layers, self.layer_texture.id);
         device.bind_texture(TextureSampler::RenderTasks, self.render_task_texture.id);
-        device.bind_texture(TextureSampler::Geometry, self.prim_geom_texture.id);
         device.bind_texture(TextureSampler::Data16, self.data16_texture.id);
         device.bind_texture(TextureSampler::Data32, self.data32_texture.id);
         device.bind_texture(TextureSampler::ResourceRects, self.resource_rects_texture.id);


### PR DESCRIPTION
The local rect and local clip rect are stored as a common header
to each primitive in the GPU cache. This removes the need for
providing the global primitive index in the primitive instances.

Also add a method for invalidating an entry in the GPU cache, which
is used for updating scroll bar primitives.

Add a few extra free lists so that we avoid using entire cache
rows for items > 8 blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1340)
<!-- Reviewable:end -->
