### PR TITLE
Add resizing support to the GPU cache.

### DIFF
--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -32,6 +32,7 @@ use webrender_traits::{ColorF, LayerRect};
 
 pub const GPU_CACHE_INITIAL_HEIGHT: u32 = 512;
 const FRAMES_BEFORE_EVICTION: usize = 10;
+const NEW_ROWS_PER_RESIZE: u32 = 512;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 struct Epoch(u32);
@@ -293,10 +294,8 @@ impl Texture {
 
         // See if we need a new row (if free-list has nothing available)
         if free_list.is_none() {
-            // TODO(gw): Handle the case where we need to resize
-            //           the cache texture itself!
             if self.rows.len() as u32 == self.height {
-                panic!("need to re-alloc texture!!");
+                self.height += NEW_ROWS_PER_RESIZE;
             }
 
             // Create a new row.


### PR DESCRIPTION
When the allocated rows exceed 512, add another 512 rows to
the texture. Maintain two texture IDs and blit between them
to copy existing data when resizing.

Resizing should be very rare - most pages that I've tested on
never exceed 50 rows in the GPU cache at a time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1342)
<!-- Reviewable:end -->
