### PR TITLE
Rename RGBA8 to BGRA8 to match what it actually does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,8 +22,8 @@ dependencies = [
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.41.0",
- "webrender_traits 0.41.0",
+ "webrender 0.42.0",
+ "webrender_traits 0.42.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -987,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1013,12 +1013,12 @@ dependencies = [
  "servo-glutin 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.41.0",
+ "webrender_traits 0.42.0",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "app_units 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -77,7 +77,7 @@ fn render_blob(
             let tc = if tile_checker { 0 } else { (1 - checker) * 40 };
 
             match descriptor.format {
-                wt::ImageFormat::RGBA8 => {
+                wt::ImageFormat::BGRA8 => {
                     texels.push(color.b * checker + tc);
                     texels.push(color.g * checker + tc);
                     texels.push(color.r * checker + tc);
@@ -221,7 +221,7 @@ fn body(api: &wt::RenderApi,
     let blob_img1 = api.generate_image_key();
     api.add_image(
         blob_img1,
-        wt::ImageDescriptor::new(500, 500, wt::ImageFormat::RGBA8, true),
+        wt::ImageDescriptor::new(500, 500, wt::ImageFormat::BGRA8, true),
         wt::ImageData::new_blob_image(serialize_blob(wt::ColorU::new(50, 50, 150, 255))),
         Some(128),
     );
@@ -229,7 +229,7 @@ fn body(api: &wt::RenderApi,
     let blob_img2 = api.generate_image_key();
     api.add_image(
         blob_img2,
-        wt::ImageDescriptor::new(200, 200, wt::ImageFormat::RGBA8, true),
+        wt::ImageDescriptor::new(200, 200, wt::ImageFormat::BGRA8, true),
         wt::ImageData::new_blob_image(serialize_blob(wt::ColorU::new(50, 150, 50, 255))),
         None,
     );

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1650,7 +1650,7 @@ impl Device {
                 }
             }
             ImageFormat::RGB8 => (gl::RGB, 3, data, gl::UNSIGNED_BYTE),
-            ImageFormat::RGBA8 => (get_gl_format_bgra(self.gl()), 4, data, gl::UNSIGNED_BYTE),
+            ImageFormat::BGRA8 => (get_gl_format_bgra(self.gl()), 4, data, gl::UNSIGNED_BYTE),
             ImageFormat::RG8 => (gl::RG, 2, data, gl::UNSIGNED_BYTE),
             ImageFormat::RGBAF32 => (gl::RGBA, 16, data, gl::FLOAT),
             ImageFormat::Invalid => unreachable!(),
@@ -2030,7 +2030,7 @@ fn gl_texture_formats_for_image_format(gl: &gl::Gl, format: ImageFormat) -> (gl:
             }
         },
         ImageFormat::RGB8 => (gl::RGB as gl::GLint, gl::RGB),
-        ImageFormat::RGBA8 => {
+        ImageFormat::BGRA8 => {
             match gl.get_type() {
                 gl::GlType::Gl =>  {
                     (gl::RGBA as gl::GLint, get_gl_format_bgra(gl))

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -264,7 +264,7 @@ impl GlyphRasterizer {
                             width: glyph.width,
                             height: glyph.height,
                             stride: None,
-                            format: ImageFormat::RGBA8,
+                            format: ImageFormat::BGRA8,
                             is_opaque: false,
                             offset: 0,
                         },

--- a/webrender/src/gpu_store.rs
+++ b/webrender/src/gpu_store.rs
@@ -38,7 +38,7 @@ pub trait GpuStoreLayout {
 
     fn texel_size() -> usize {
         match Self::image_format() {
-            ImageFormat::RGBA8 => 4,
+            ImageFormat::BGRA8 => 4,
             ImageFormat::RGBAF32 => 16,
             _ => unreachable!(),
         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -960,7 +960,7 @@ impl Renderer {
         device.init_texture(dummy_cache_texture_id,
                             1,
                             1,
-                            ImageFormat::RGBA8,
+                            ImageFormat::BGRA8,
                             TextureFilter::Linear,
                             RenderTargetMode::LayerRenderTarget(1),
                             None);
@@ -2042,7 +2042,7 @@ impl Renderer {
                 self.device.init_texture(texture_id,
                                          frame.cache_size.width as u32,
                                          frame.cache_size.height as u32,
-                                         ImageFormat::RGBA8,
+                                         ImageFormat::BGRA8,
                                          TextureFilter::Linear,
                                          RenderTargetMode::LayerRenderTarget(target_count as i32),
                                          None);

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -644,7 +644,7 @@ impl TextureCache {
         let mode = RenderTargetMode::SimpleRenderTarget;
         let (page_list, page_profile) = match format {
             ImageFormat::A8 => (&mut self.arena.pages_a8, &mut profile.pages_a8),
-            ImageFormat::RGBA8 => (&mut self.arena.pages_rgba8, &mut profile.pages_rgba8),
+            ImageFormat::BGRA8 => (&mut self.arena.pages_rgba8, &mut profile.pages_rgba8),
             ImageFormat::RGB8 => (&mut self.arena.pages_rgb8, &mut profile.pages_rgb8),
             ImageFormat::RG8 => (&mut self.arena.pages_rg8, &mut profile.pages_rg8),
             ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),

--- a/webrender_traits/Cargo.toml
+++ b/webrender_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_traits"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -46,7 +46,7 @@ pub enum ImageFormat {
     Invalid  = 0,
     A8       = 1,
     RGB8     = 2,
-    RGBA8    = 3,
+    BGRA8    = 3,
     RGBAF32  = 4,
     RG8      = 5,
 }
@@ -56,7 +56,7 @@ impl ImageFormat {
         match self {
             ImageFormat::A8 => Some(1),
             ImageFormat::RGB8 => Some(3),
-            ImageFormat::RGBA8 => Some(4),
+            ImageFormat::BGRA8 => Some(4),
             ImageFormat::RGBAF32 => Some(16),
             ImageFormat::RG8 => Some(2),
             ImageFormat::Invalid => None,

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -147,7 +147,7 @@ impl JsonFrameWriter {
                     false
                 }
             }
-            ImageFormat::RGBA8 => {
+            ImageFormat::BGRA8 => {
                 if data.stride == data.width * 4 {
                     unpremultiply(bytes.as_mut_slice());
                     save_buffer(&path_file, &bytes, data.width, data.height, ColorType::RGBA(8)).unwrap();

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -309,11 +309,11 @@ impl Wrench {
                 let format = match image {
                     image::ImageLuma8(_) => ImageFormat::A8,
                     image::ImageRgb8(_) => ImageFormat::RGB8,
-                    image::ImageRgba8(_) => ImageFormat::RGBA8,
+                    image::ImageRgba8(_) => ImageFormat::BGRA8,
                     _ => panic!("We don't support whatever your crazy image type is, come on"),
                 };
                 let mut bytes = image.raw_pixels();
-                if format == ImageFormat::RGBA8 {
+                if format == ImageFormat::BGRA8 {
                     premultiply(bytes.as_mut_slice());
                 }
                 let descriptor = ImageDescriptor::new(image_dims.0,
@@ -423,7 +423,7 @@ impl Wrench {
 
 fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
     match format {
-        ImageFormat::RGBA8 => {
+        ImageFormat::BGRA8 => {
             let mut is_opaque = true;
             for i in 0..(bytes.len() / 4) {
                 if bytes[i * 4 + 3] != 255 {
@@ -453,7 +453,7 @@ fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, ImageData) {
     }
 
     (
-        ImageDescriptor::new(w, h, ImageFormat::RGBA8, true),
+        ImageDescriptor::new(w, h, ImageFormat::BGRA8, true),
         ImageData::new(pixels)
     )
 }
@@ -476,7 +476,7 @@ fn generate_solid_color_image(r: u8, g: u8, b: u8, a: u8, w: u32, h: u32) -> (Im
     }
 
     (
-        ImageDescriptor::new(w, h, ImageFormat::RGBA8, a == 255),
+        ImageDescriptor::new(w, h, ImageFormat::BGRA8, a == 255),
         ImageData::new(pixels)
     )
 }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -399,7 +399,7 @@ impl YamlFrameWriter {
             ImageFormat::RGB8 => {
                 (ColorType::RGB(8), 3)
             }
-            ImageFormat::RGBA8 => {
+            ImageFormat::BGRA8 => {
                 (ColorType::RGBA(8), 4)
             }
             ImageFormat::A8 => {
@@ -413,7 +413,7 @@ impl YamlFrameWriter {
         };
 
         if data.stride == data.width * bpp {
-            if data.format == ImageFormat::RGBA8 {
+            if data.format == ImageFormat::BGRA8 {
                 unpremultiply(bytes.as_mut_slice());
             }
             save_buffer(&path_file, &bytes, data.width, data.height, color_type).unwrap();
@@ -423,7 +423,7 @@ impl YamlFrameWriter {
             let mut tmp: Vec<_>  = bytes[..].chunks(data.stride as usize)
                                             .flat_map(|chunk| chunk[..(data.width * bpp) as usize].iter().cloned())
                                             .collect();
-            if data.format == ImageFormat::RGBA8 {
+            if data.format == ImageFormat::BGRA8 {
                 unpremultiply(tmp.as_mut_slice());
             }
 


### PR DESCRIPTION
~~`glTexSubImage2D`'s format parameter is the format of the data that
is being uploaded not the format of the target texture. This was
causing RGBA textures to have their red and blue channels swapped.~~

~~Edit: Servo seems to byte-swap here https://github.com/servo/servo/blob/9656341f43cc1bc415e07a0a0c919740280ad2ab/components/net_traits/image/base.rs#L74 so maybe this is intended? Seems confusing given the format is called RGBA~~

Reworked into just rename RGBA8 to BGRA8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1360)
<!-- Reviewable:end -->
