### PR TITLE
Start splitting apart ScrollFrames and Clips

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -72,14 +72,14 @@ pub enum NodeType {
 
     /// Other nodes just do clipping, but no transformation.
     Clip(ClipInfo),
+
+    /// Other nodes just do clipping, but no transformation.
+    ScrollFrame(ScrollingState),
 }
 
-/// Contains scrolling and transform information stacking contexts.
+/// Contains information common among all types of ClipScrollTree nodes.
 #[derive(Clone, Debug)]
 pub struct ClipScrollNode {
-    /// Manages scrolling offset, overscroll state etc.
-    pub scrolling: ScrollingState,
-
     /// Size of the content inside the scroll region (in logical pixels)
     pub content_size: LayerSize,
 
@@ -121,6 +121,26 @@ pub struct ClipScrollNode {
 }
 
 impl ClipScrollNode {
+    pub fn new_scroll_frame(pipeline_id: PipelineId,
+                            parent_id: ClipId,
+                            content_rect: &LayerRect,
+                            frame_rect: &LayerRect)
+                            -> ClipScrollNode {
+        ClipScrollNode {
+            content_size: content_rect.size,
+            local_viewport_rect: *frame_rect,
+            local_clip_rect: *frame_rect,
+            combined_local_viewport_rect: LayerRect::zero(),
+            world_viewport_transform: LayerToWorldTransform::identity(),
+            world_content_transform: LayerToWorldTransform::identity(),
+            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
+            parent: Some(parent_id),
+            children: Vec::new(),
+            pipeline_id: pipeline_id,
+            node_type: NodeType::ScrollFrame(ScrollingState::new()),
+        }
+    }
+
     pub fn new(pipeline_id: PipelineId,
                parent_id: ClipId,
                content_rect: &LayerRect,
@@ -131,7 +151,6 @@ impl ClipScrollNode {
         // of the node.
         let local_viewport_rect = LayerRect::new(content_rect.origin, clip_rect.size);
         ClipScrollNode {
-            scrolling: ScrollingState::new(),
             content_size: content_rect.size,
             local_viewport_rect: local_viewport_rect,
             local_clip_rect: local_viewport_rect,
@@ -153,7 +172,6 @@ impl ClipScrollNode {
                                pipeline_id: PipelineId)
                                -> ClipScrollNode {
         ClipScrollNode {
-            scrolling: ScrollingState::new(),
             content_size: content_size,
             local_viewport_rect: *local_viewport_rect,
             local_clip_rect: *local_viewport_rect,
@@ -172,44 +190,25 @@ impl ClipScrollNode {
         self.children.push(child);
     }
 
-    pub fn finalize(&mut self, scrolling: &ScrollingState) {
-        self.scrolling = *scrolling;
-    }
-
-    pub fn overscroll_amount(&self) -> LayerVector2D {
-        let scrollable_width = self.scrollable_width();
-        let overscroll_x = if self.scrolling.offset.x > 0.0 {
-            -self.scrolling.offset.x
-        } else if self.scrolling.offset.x < -scrollable_width {
-            -scrollable_width - self.scrolling.offset.x
-        } else {
-            0.0
-        };
-
-        let scrollable_height = self.scrollable_height();
-        let overscroll_y = if self.scrolling.offset.y > 0.0 {
-            -self.scrolling.offset.y
-        } else if self.scrolling.offset.y < -scrollable_height {
-            -scrollable_height - self.scrolling.offset.y
-        } else {
-            0.0
-        };
-
-        LayerVector2D::new(overscroll_x, overscroll_y)
+    pub fn finalize(&mut self, new_scrolling: &ScrollingState) {
+        match self.node_type {
+            NodeType::ReferenceFrame(_) | NodeType::Clip(_) =>
+                warn!("Tried to scroll a non-scroll node."),
+            NodeType::ScrollFrame(ref mut scrolling) => *scrolling = *new_scrolling,
+        }
     }
 
     pub fn set_scroll_origin(&mut self, origin: &LayerPoint, clamp: ScrollClamping) -> bool {
-        match self.node_type {
-            NodeType::ReferenceFrame(_) => {
-                warn!("Tried to scroll a reference frame.");
-                return false;
-            }
-            NodeType::Clip(_) => {}
-        };
-
-
         let scrollable_height = self.scrollable_height();
         let scrollable_width = self.scrollable_width();
+
+        let scrolling = match self.node_type {
+            NodeType::ReferenceFrame(_) | NodeType::Clip(_) => {
+                warn!("Tried to scroll a non-scroll node.");
+                return false;
+            }
+             NodeType::ScrollFrame(ref mut scrolling) => scrolling,
+        };
 
         let new_offset = match clamp {
             ScrollClamping::ToContentBounds => {
@@ -224,13 +223,13 @@ impl ClipScrollNode {
             ScrollClamping::NoClamping => LayerPoint::zero() - *origin,
         };
 
-        if new_offset == self.scrolling.offset {
+        if new_offset == scrolling.offset {
             return false;
         }
 
-        self.scrolling.offset = new_offset;
-        self.scrolling.bouncing_back = false;
-        self.scrolling.started_bouncing_back = false;
+        scrolling.offset = new_offset;
+        scrolling.bouncing_back = false;
+        scrolling.started_bouncing_back = false;
         true
     }
 
@@ -241,12 +240,12 @@ impl ClipScrollNode {
                             parent_accumulated_scroll_offset: LayerVector2D) {
         self.reference_frame_relative_scroll_offset = match self.node_type {
             NodeType::ReferenceFrame(_) => LayerVector2D::zero(),
-            NodeType::Clip(_) => parent_accumulated_scroll_offset,
+            NodeType::Clip(_) | NodeType::ScrollFrame(..) => parent_accumulated_scroll_offset,
         };
 
         let local_transform = match self.node_type {
             NodeType::ReferenceFrame(transform) => transform,
-            NodeType::Clip(_) => LayerToScrollTransform::identity(),
+            NodeType::Clip(_) | NodeType::ScrollFrame(..) => LayerToScrollTransform::identity(),
         };
 
         let inv_transform = match local_transform.inverse() {
@@ -272,7 +271,7 @@ impl ClipScrollNode {
         // we do the intersection and get our combined viewport rect in the coordinate system
         // starting from our origin.
         self.combined_local_viewport_rect = match self.node_type {
-            NodeType::Clip(_) => {
+            NodeType::Clip(_) | NodeType::ScrollFrame(..) => {
                 parent_combined_viewport_in_local_space.intersection(&self.local_clip_rect)
                                                        .unwrap_or(LayerRect::zero())
             }
@@ -296,8 +295,9 @@ impl ClipScrollNode {
 
         // The transformation for any content inside of us is the viewport transformation, plus
         // whatever scrolling offset we supply as well.
+        let scroll_offset = self.scroll_offset();
         self.world_content_transform =
-            self.world_viewport_transform.pre_translate(self.scrolling.offset.to_3d());
+            self.world_viewport_transform.pre_translate(scroll_offset.to_3d());
     }
 
     pub fn scrollable_height(&self) -> f32 {
@@ -309,35 +309,43 @@ impl ClipScrollNode {
     }
 
     pub fn scroll(&mut self, scroll_location: ScrollLocation, phase: ScrollEventPhase) -> bool {
-        if self.scrolling.started_bouncing_back && phase == ScrollEventPhase::Move(false) {
+        let scrollable_width = self.scrollable_width();
+        let scrollable_height = self.scrollable_height();
+
+        let scrolling = match self.node_type {
+            NodeType::ReferenceFrame(_) | NodeType::Clip(_) => return false,
+            NodeType::ScrollFrame(ref mut scrolling) => scrolling,
+        };
+
+        if scrolling.started_bouncing_back && phase == ScrollEventPhase::Move(false) {
             return false;
         }
 
         let mut delta = match scroll_location {
             ScrollLocation::Delta(delta) => delta,
             ScrollLocation::Start => {
-                if self.scrolling.offset.y.round() >= 0.0 {
+                if scrolling.offset.y.round() >= 0.0 {
                     // Nothing to do on this layer.
                     return false;
                 }
 
-                self.scrolling.offset.y = 0.0;
+                scrolling.offset.y = 0.0;
                 return true;
             },
             ScrollLocation::End => {
                 let end_pos = self.local_viewport_rect.size.height - self.content_size.height;
 
-                if self.scrolling.offset.y.round() <= end_pos {
+                if scrolling.offset.y.round() <= end_pos {
                     // Nothing to do on this layer.
                     return false;
                 }
 
-                self.scrolling.offset.y = end_pos;
+                scrolling.offset.y = end_pos;
                 return true;
             }
         };
 
-        let overscroll_amount = self.overscroll_amount();
+        let overscroll_amount = scrolling.overscroll_amount(scrollable_width, scrollable_height);
         let overscrolling = CAN_OVERSCROLL && (overscroll_amount.x != 0.0 ||
                                                overscroll_amount.y != 0.0);
         if overscrolling {
@@ -349,56 +357,41 @@ impl ClipScrollNode {
             }
         }
 
-        let scrollable_width = self.scrollable_width();
-        let scrollable_height = self.scrollable_height();
         let is_unscrollable = scrollable_width <= 0. && scrollable_height <= 0.;
-        let original_layer_scroll_offset = self.scrolling.offset;
+        let original_layer_scroll_offset = scrolling.offset;
 
         if scrollable_width > 0. {
-            self.scrolling.offset.x = self.scrolling.offset.x + delta.x;
+            scrolling.offset.x = scrolling.offset.x + delta.x;
             if is_unscrollable || !CAN_OVERSCROLL {
-                self.scrolling.offset.x =
-                    self.scrolling.offset.x.min(0.0).max(-scrollable_width).round();
+                scrolling.offset.x = scrolling.offset.x.min(0.0).max(-scrollable_width).round();
             }
         }
 
         if scrollable_height > 0. {
-            self.scrolling.offset.y = self.scrolling.offset.y + delta.y;
+            scrolling.offset.y = scrolling.offset.y + delta.y;
             if is_unscrollable || !CAN_OVERSCROLL {
-                self.scrolling.offset.y =
-                    self.scrolling.offset.y.min(0.0).max(-scrollable_height).round();
+                scrolling.offset.y = scrolling.offset.y.min(0.0).max(-scrollable_height).round();
             }
         }
 
         if phase == ScrollEventPhase::Start || phase == ScrollEventPhase::Move(true) {
-            self.scrolling.started_bouncing_back = false
+            scrolling.started_bouncing_back = false
         } else if overscrolling &&
                 ((delta.x < 1.0 && delta.y < 1.0) || phase == ScrollEventPhase::End) {
-            self.scrolling.started_bouncing_back = true;
-            self.scrolling.bouncing_back = true
+            scrolling.started_bouncing_back = true;
+            scrolling.bouncing_back = true
         }
 
         if CAN_OVERSCROLL {
-            self.stretch_overscroll_spring();
+            scrolling.stretch_overscroll_spring(overscroll_amount);
         }
 
-        self.scrolling.offset != original_layer_scroll_offset ||
-            self.scrolling.started_bouncing_back
-    }
-
-    pub fn stretch_overscroll_spring(&mut self) {
-        let overscroll_amount = self.overscroll_amount();
-        let scroll_position = self.scrolling.offset.to_point();
-        self.scrolling.spring.coords(scroll_position,
-                                     scroll_position,
-                                     scroll_position + overscroll_amount);
+        scrolling.offset != original_layer_scroll_offset || scrolling.started_bouncing_back
     }
 
     pub fn tick_scrolling_bounce_animation(&mut self) {
-        let finished = self.scrolling.spring.animate();
-        self.scrolling.offset = self.scrolling.spring.current().to_vector();
-        if finished {
-            self.scrolling.bouncing_back = false
+       if let NodeType::ScrollFrame(ref mut scrolling) = self.node_type {
+           scrolling.tick_scrolling_bounce_animation();
         }
     }
 
@@ -416,11 +409,21 @@ impl ClipScrollNode {
         ray_intersects_rect(p0.to_untyped(), p1.to_untyped(), self.local_viewport_rect.to_untyped())
     }
 
-    pub fn scroll_offset(&self) -> Option<LayerVector2D> {
+    pub fn scroll_offset(&self) -> LayerVector2D {
         match self.node_type {
-            NodeType::Clip(_) if self.scrollable_width() > 0. || self.scrollable_height() > 0. =>
-                Some(self.scrolling.offset),
-            _ => None,
+            NodeType::ScrollFrame(ref scrolling) => scrolling.offset,
+            _ => LayerVector2D::zero(),
+        }
+    }
+
+    pub fn is_overscrolling(&self) -> bool {
+        match self.node_type {
+            NodeType::ScrollFrame(ref scrolling) => {
+                let overscroll_amount = scrolling.overscroll_amount(self.scrollable_width(),
+                                                                    self.scrollable_height());
+                overscroll_amount.x != 0.0 || overscroll_amount.y != 0.0
+            }
+            _ => false,
         }
     }
 }
@@ -434,6 +437,7 @@ pub struct ScrollingState {
     pub should_handoff_scroll: bool
 }
 
+/// Manages scrolling offset, overscroll state, etc.
 impl ScrollingState {
     pub fn new() -> ScrollingState {
         ScrollingState {
@@ -443,6 +447,42 @@ impl ScrollingState {
             bouncing_back: false,
             should_handoff_scroll: false
         }
+    }
+
+    pub fn stretch_overscroll_spring(&mut self, overscroll_amount: LayerVector2D) {
+        let offset = self.offset.to_point();
+        self.spring.coords(offset, offset, offset + overscroll_amount);
+    }
+
+    pub fn tick_scrolling_bounce_animation(&mut self) {
+        let finished = self.spring.animate();
+        self.offset = self.spring.current().to_vector();
+        if finished {
+            self.bouncing_back = false
+        }
+    }
+
+    pub fn overscroll_amount(&self,
+                             scrollable_width: f32,
+                             scrollable_height: f32)
+                             -> LayerVector2D {
+        let overscroll_x = if self.offset.x > 0.0 {
+            -self.offset.x
+        } else if self.offset.x < -scrollable_width {
+            -scrollable_width - self.offset.x
+        } else {
+            0.0
+        };
+
+        let overscroll_y = if self.offset.y > 0.0 {
+            -self.offset.y
+        } else if self.offset.y < -scrollable_height {
+            -scrollable_height - self.offset.y
+        } else {
+            0.0
+        };
+
+        LayerVector2D::new(overscroll_x, overscroll_y)
     }
 }
 

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -22,10 +22,10 @@ pub struct ClipScrollTree {
     /// node to scroll even if a touch operation leaves the boundaries of that node.
     pub currently_scrolling_node_id: Option<ClipId>,
 
-    /// The current reference frame id, used for giving a unique id to all new
-    /// reference frames. The ClipScrollTree increments this by one every time a
-    /// reference frame is created.
-    current_reference_frame_id: u64,
+    /// The current frame id, used for giving a unique id to all new dynamically
+    /// added frames and clips. The ClipScrollTree increments this by one every
+    /// time a new dynamic frame is created.
+    current_new_node_item: u64,
 
     /// The root reference frame, which is the true root of the ClipScrollTree. Initially
     /// this ID is not valid, which is indicated by ```node``` being empty.
@@ -49,7 +49,7 @@ impl ClipScrollTree {
             currently_scrolling_node_id: None,
             root_reference_frame_id: ClipId::root_reference_frame(dummy_pipeline),
             topmost_scrolling_node_id: ClipId::root_scroll_node(dummy_pipeline),
-            current_reference_frame_id: 0,
+            current_new_node_item: 1,
             pipelines_to_discard: HashSet::new(),
         }
     }
@@ -72,8 +72,10 @@ impl ClipScrollTree {
                                        -> HashSet<ClipId, BuildHasherDefault<FnvHasher>> {
         let mut nodes_bouncing_back = HashSet::default();
         for (clip_id, node) in self.nodes.iter() {
-            if node.scrolling.bouncing_back {
-                nodes_bouncing_back.insert(*clip_id);
+            if let NodeType::ScrollFrame(ref scrolling) = node.node_type {
+                if scrolling.bouncing_back {
+                    nodes_bouncing_back.insert(*clip_id);
+                }
             }
         }
         nodes_bouncing_back
@@ -85,14 +87,15 @@ impl ClipScrollTree {
                                             -> Option<ClipId> {
         self.nodes.get(&clip_id).and_then(|node| {
             for child_layer_id in node.children.iter().rev() {
-            if let Some(layer_id) =
-                self.find_scrolling_node_at_point_in_node(cursor, *child_layer_id) {
+                if let Some(layer_id) =
+                   self.find_scrolling_node_at_point_in_node(cursor, *child_layer_id) {
                     return Some(layer_id);
                 }
             }
 
-            if clip_id.is_reference_frame() {
-                return None;
+            match node.node_type {
+                NodeType::ScrollFrame(..) => {},
+                _ => return None,
             }
 
             if node.ray_intersects_node(cursor) {
@@ -111,21 +114,24 @@ impl ClipScrollTree {
     pub fn get_scroll_node_state(&self) -> Vec<ScrollLayerState> {
         let mut result = vec![];
         for (id, node) in self.nodes.iter() {
-            match node.scroll_offset() {
-                Some(offset) => result.push(ScrollLayerState { id: *id, scroll_offset: offset }),
-                None => {}
+            if let NodeType::ScrollFrame(scrolling) = node.node_type {
+                result.push(ScrollLayerState { id: *id, scroll_offset: scrolling.offset })
             }
         }
         result
     }
 
     pub fn drain(&mut self) -> ScrollStates {
-        self.current_reference_frame_id = 1;
+        self.current_new_node_item = 1;
 
         let mut scroll_states = HashMap::default();
         for (layer_id, old_node) in &mut self.nodes.drain() {
-            if !self.pipelines_to_discard.contains(&layer_id.pipeline_id()) {
-                scroll_states.insert(layer_id, old_node.scrolling);
+            if self.pipelines_to_discard.contains(&layer_id.pipeline_id()) {
+                continue;
+            }
+
+            if let NodeType::ScrollFrame(scrolling) = old_node.node_type {
+                scroll_states.insert(layer_id, scrolling);
             }
         }
 
@@ -134,11 +140,6 @@ impl ClipScrollTree {
     }
 
     pub fn scroll_node(&mut self, origin: LayerPoint, id: ClipId, clamp: ScrollClamping) -> bool {
-        if id.is_reference_frame() {
-            warn!("Tried to scroll a reference frame.");
-            return false;
-        }
-
         if self.nodes.is_empty() {
             self.pending_scroll_offsets.insert(id, (origin, clamp));
             return false;
@@ -184,37 +185,33 @@ impl ClipScrollTree {
 
         let topmost_scrolling_node_id = self.topmost_scrolling_node_id();
         let non_root_overscroll = if clip_id != topmost_scrolling_node_id {
-            // true if the current node is overscrolling,
-            // and it is not the root scroll node.
-            let child_node = self.nodes.get(&clip_id).unwrap();
-            let overscroll_amount = child_node.overscroll_amount();
-            overscroll_amount.x != 0.0 || overscroll_amount.y != 0.0
+            self.nodes.get(&clip_id).unwrap().is_overscrolling()
         } else {
             false
         };
 
-        let switch_node = match phase {
-            ScrollEventPhase::Start => {
-                // if this is a new gesture, we do not switch node,
-                // however we do save the state of non_root_overscroll,
-                // for use in the subsequent Move phase.
-                let mut current_node = self.nodes.get_mut(&clip_id).unwrap();
-                current_node.scrolling.should_handoff_scroll = non_root_overscroll;
-                false
-            },
-            ScrollEventPhase::Move(_) => {
-                // Switch node if movement originated in a new gesture,
-                // from a non root node in overscroll.
-                let current_node = self.nodes.get_mut(&clip_id).unwrap();
-                current_node.scrolling.should_handoff_scroll && non_root_overscroll
-            },
-            ScrollEventPhase::End => {
-                // clean-up when gesture ends.
-                let mut current_node = self.nodes.get_mut(&clip_id).unwrap();
-                current_node.scrolling.should_handoff_scroll = false;
-                false
-            },
-        };
+        let mut switch_node = false;
+        if let Some(node) = self.nodes.get_mut(&clip_id) {
+            if let NodeType::ScrollFrame(ref mut scrolling) = node.node_type {
+                match phase {
+                    ScrollEventPhase::Start => {
+                        // if this is a new gesture, we do not switch node,
+                        // however we do save the state of non_root_overscroll,
+                        // for use in the subsequent Move phase.
+                        scrolling.should_handoff_scroll = non_root_overscroll;
+                    },
+                    ScrollEventPhase::Move(_) => {
+                        // Switch node if movement originated in a new gesture,
+                        // from a non root node in overscroll.
+                        switch_node = scrolling.should_handoff_scroll && non_root_overscroll
+                    },
+                    ScrollEventPhase::End => {
+                        // clean-up when gesture ends.
+                        scrolling.should_handoff_scroll = false;
+                    }
+                }
+            }
+        }
 
         let clip_id = if switch_node {
             topmost_scrolling_node_id
@@ -265,11 +262,14 @@ impl ClipScrollTree {
                     // we need to reset both these values.
                     let (transform, offset, accumulated_scroll_offset) = match node.node_type {
                         NodeType::ReferenceFrame(..) =>
-                            (node.world_viewport_transform, LayerVector2D::zero(), LayerVector2D::zero()),
-                        NodeType::Clip(_) => {
+                            (node.world_viewport_transform,
+                             LayerVector2D::zero(),
+                             LayerVector2D::zero()),
+                        _ => {
+                            let scroll_offset = node.scroll_offset();
                             (*parent_reference_frame_transform,
-                             node.scrolling.offset,
-                             node.scrolling.offset + parent_accumulated_scroll_offset)
+                             scroll_offset,
+                             scroll_offset + parent_accumulated_scroll_offset)
                         }
                     };
 
@@ -316,17 +316,19 @@ impl ClipScrollTree {
 
     }
 
+    pub fn generate_new_clip_id(&mut self, pipeline_id: PipelineId) -> ClipId {
+        let new_id = ClipId::DynamicallyAddedNode(self.current_new_node_item, pipeline_id);
+        self.current_new_node_item += 1;
+        new_id
+    }
+
     pub fn add_reference_frame(&mut self,
                                rect: &LayerRect,
                                transform: &LayerToScrollTransform,
                                pipeline_id: PipelineId,
                                parent_id: Option<ClipId>)
                                -> ClipId {
-
-        let reference_frame_id =
-            ClipId::ReferenceFrame(self.current_reference_frame_id, pipeline_id);
-        self.current_reference_frame_id += 1;
-
+        let reference_frame_id = self.generate_new_clip_id(pipeline_id);
         let node = ClipScrollNode::new_reference_frame(parent_id,
                                                        rect,
                                                        rect.size,
@@ -373,10 +375,13 @@ impl ClipScrollTree {
             NodeType::ReferenceFrame(ref transform) => {
                 pt.new_level(format!("ReferenceFrame {:?}", transform));
             }
+            NodeType::ScrollFrame(scrolling_info) => {
+                pt.new_level(format!("ScrollFrame"));
+                pt.add_item(format!("scroll.offset: {:?}", scrolling_info.offset));
+            }
         }
 
         pt.add_item(format!("content_size: {:?}", node.content_size));
-        pt.add_item(format!("scroll.offset: {:?}", node.scrolling.offset));
         pt.add_item(format!("combined_local_viewport_rect: {:?}", node.combined_local_viewport_rect));
         pt.add_item(format!("local_viewport_rect: {:?}", node.local_viewport_rect));
         pt.add_item(format!("local_clip_rect: {:?}", node.local_clip_rect));

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -583,7 +583,7 @@ impl ComplexClipRegion {
 pub enum ClipId {
     Clip(u64, PipelineId),
     ClipExternalId(u64, PipelineId),
-    ReferenceFrame(u64, PipelineId),
+    DynamicallyAddedNode(u64, PipelineId),
 }
 
 impl ClipId {
@@ -592,7 +592,7 @@ impl ClipId {
     }
 
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ClipId {
-        ClipId::ReferenceFrame(0, pipeline_id)
+        ClipId::DynamicallyAddedNode(0, pipeline_id)
     }
 
     pub fn new(id: u64, pipeline_id: PipelineId) -> ClipId {
@@ -609,14 +609,7 @@ impl ClipId {
         match *self {
             ClipId::Clip(_, pipeline_id) |
             ClipId::ClipExternalId(_, pipeline_id) |
-            ClipId::ReferenceFrame(_, pipeline_id) => pipeline_id,
-        }
-    }
-
-    pub fn is_reference_frame(&self) -> bool {
-        match *self {
-            ClipId::ReferenceFrame(..) => true,
-            _ => false,
+            ClipId::DynamicallyAddedNode(_, pipeline_id) => pipeline_id,
         }
     }
 

--- a/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
+++ b/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
@@ -2,7 +2,7 @@ root:
   items:
     - type: scroll-layer
       bounds: [10, 10, 50, 100]
-      content-size: [50, 100]
+      clip: [10, 10, 50, 100]
       scroll-offset: [0, 50]
       items:
         - type: rect


### PR DESCRIPTION
ScrollFrames and clips are currently represented by one node type in
the ClipScrollTree, which means that many nodes are doing more work
than they need to do. This makes even less sense in a world where all
clips are added to the ClipScrollTree and handled the same way in the
API and internally. This change is the first step to splitting apart
these two types of items.

In order to minimize the changes, existing clips/ScrollFrame are
pushed as two nodes. This might almost double the depth of the tree,
but a later patch should expose API for pushing a clip without a
ScrollFrame attached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1364)
<!-- Reviewable:end -->
