### PR TITLE
Give blob images access to font data

### DIFF
--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -154,10 +154,10 @@ impl wt::BlobImageRenderer for CheckerboardRenderer {
     }
 
     fn request(&mut self,
+               resources: &wt::BlobImageResources,
                request: wt::BlobImageRequest,
                descriptor: &wt::BlobImageDescriptor,
-               _dirty_rect: Option<wt::DeviceUintRect>,
-               _images: &wt::ImageStore) {
+               _dirty_rect: Option<wt::DeviceUintRect>) {
         // This method is where we kick off our rendering jobs.
         // It should avoid doing work on the calling thread as much as possible.
         // In this example we will use the thread pool to render individual tiles.
@@ -210,6 +210,7 @@ impl wt::BlobImageRenderer for CheckerboardRenderer {
         // If we break out of the loop above it means the channel closed unexpectedly.
         Err(wt::BlobImageError::Other("Channel closed".into()))
     }
+    fn delete_font(&mut self, font: wt::FontKey) {}
 }
 
 fn body(api: &wt::RenderApi,

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -15,7 +15,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::collections::HashSet;
 use std::mem;
 use texture_cache::{TextureCacheItemId, TextureCache};
-use internal_types::FontTemplate;
+use webrender_traits::FontTemplate;
 use webrender_traits::{FontKey, FontRenderMode, ImageData, ImageFormat};
 use webrender_traits::{ImageDescriptor, ColorF, LayoutPoint};
 use webrender_traits::{GlyphKey, GlyphOptions, GlyphInstance, GlyphDimensions};

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -53,12 +53,6 @@ pub const ANGLE_FLOAT_TO_FIXED: f32 = 65535.0;
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;
 pub const ORTHO_FAR_PLANE: f32 = 1000000.0;
 
-#[derive(Clone)]
-pub enum FontTemplate {
-    Raw(Arc<Vec<u8>>, u32),
-    Native(NativeFontHandle),
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub enum TextureSampler {
     Color0,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -5,7 +5,7 @@
 use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
-use internal_types::{FontTemplate, SourceTexture, ResultMsg, RendererFrame};
+use internal_types::{SourceTexture, ResultMsg, RendererFrame};
 use profiler::{BackendProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
@@ -24,6 +24,7 @@ use webrender_traits::{ApiMsg, BlobImageRenderer, BuiltDisplayList, DeviceIntPoi
 use webrender_traits::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, IdNamespace, ImageData};
 use webrender_traits::{LayerPoint, PipelineId, RenderDispatcher, RenderNotifier};
 use webrender_traits::{VRCompositorCommand, VRCompositorHandler, WebGLCommand, WebGLContextId};
+use webrender_traits::{FontTemplate};
 
 #[cfg(feature = "webgl")]
 use offscreen_gl_context::GLContextDispatcher;

--- a/webrender_traits/src/font.rs
+++ b/webrender_traits/src/font.rs
@@ -4,6 +4,7 @@
 
 use app_units::Au;
 use {ColorU, ColorF, LayoutPoint};
+use std::sync::Arc;
 
 #[cfg(target_os = "macos")] use core_foundation::string::CFString;
 #[cfg(target_os = "macos")] use core_graphics::font::CGFont;
@@ -61,6 +62,13 @@ impl FontKey {
     pub fn new(key0: u32, key1: u32) -> FontKey {
         FontKey(key0, key1)
     }
+}
+
+
+#[derive(Clone)]
+pub enum FontTemplate {
+    Raw(Arc<Vec<u8>>, u32),
+    Native(NativeFontHandle),
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 use {DeviceUintRect, DevicePoint};
 use {TileOffset, TileSize};
+use font::{FontKey, FontTemplate};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -135,6 +136,11 @@ impl ImageData {
     }
 }
 
+pub trait BlobImageResources {
+    fn get_font_data(&self, key: FontKey) -> &FontTemplate;
+    fn get_image(&self, key: ImageKey) -> Option<(&ImageData, &ImageDescriptor)>;
+}
+
 pub trait BlobImageRenderer: Send {
     fn add(&mut self, key: ImageKey, data: BlobImageData, tiling: Option<TileSize>);
 
@@ -143,12 +149,14 @@ pub trait BlobImageRenderer: Send {
     fn delete(&mut self, key: ImageKey);
 
     fn request(&mut self,
+               services: &BlobImageResources,
                key: BlobImageRequest,
                descriptor: &BlobImageDescriptor,
-               dirty_rect: Option<DeviceUintRect>,
-               images: &ImageStore);
+               dirty_rect: Option<DeviceUintRect>);
 
     fn resolve(&mut self, key: BlobImageRequest) -> BlobImageResult;
+
+    fn delete_font(&mut self, key: FontKey);
 }
 
 pub type BlobImageData = Vec<u8>;
@@ -182,8 +190,4 @@ pub enum BlobImageError {
 pub struct BlobImageRequest {
     pub key: ImageKey,
     pub tile: Option<TileOffset>,
-}
-
-pub trait ImageStore {
-    fn get_image(&self, key: ImageKey) -> Option<(&ImageData, &ImageDescriptor)>;
 }


### PR DESCRIPTION
This factors out the ImageStore trait into a more
general BlobImageResources trait and allows the renderer to
access it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1365)
<!-- Reviewable:end -->
