### PR TITLE
share the render backend thread

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -90,6 +90,8 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
 
     let (width, height) = window.get_inner_size_pixels().unwrap();
 
+    let mut backend_thread = webrender::RenderBackendThread::new("Backend".to_string()).unwrap();
+
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,
         debug: true,
@@ -99,7 +101,7 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
     };
 
     let size = DeviceUintSize::new(width, height);
-    let (mut renderer, sender) = webrender::renderer::Renderer::new(gl, opts, size).unwrap();
+    let (mut renderer, sender) = backend_thread.new_renderer(gl, opts, size).unwrap();
     let api = sender.create_api();
 
     let notifier = Box::new(Notifier::new(window.create_window_proxy()));

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -77,6 +77,8 @@ mod util;
 #[doc(hidden)] // for benchmarks
 pub use texture_cache::TexturePage;
 
+pub use render_backend::RenderBackendThread;
+
 #[cfg(feature = "webgl")]
 mod webgl_types;
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use gleam::gl;
 use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
@@ -12,19 +13,23 @@ use resource_cache::ResourceCache;
 use scene::Scene;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Sender, channel};
+use std::thread;
+use std::io;
+use std::rc::Rc;
+use renderer::{Renderer, RendererOptions, InitError};
 use texture_cache::TextureCache;
 use time::precise_time_ns;
 use thread_profiler::register_thread_with_profiler;
 use rayon::ThreadPool;
 use webgl_types::{GLContextHandleWrapper, GLContextWrapper};
-use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
+use api::channel::{MsgSender, msg_channel, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
 use api::{ApiMsg, BlobImageRenderer, BuiltDisplayList, DeviceIntPoint};
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, IdNamespace, ImageData};
-use api::{LayerPoint, PipelineId, RenderDispatcher, RenderNotifier};
+use api::{LayerPoint, PipelineId, RenderDispatcher, RenderNotifier, RenderApiSender};
 use api::{VRCompositorCommand, VRCompositorHandler, WebGLCommand, WebGLContextId};
-use api::{FontTemplate};
+use api::{FontTemplate, RendererId};
 
 #[cfg(feature = "webgl")]
 use offscreen_gl_context::GLContextDispatcher;
@@ -37,7 +42,6 @@ use webgl_types::GLContextDispatcher;
 ///
 /// The render backend operates on its own thread.
 pub struct RenderBackend {
-    api_rx: MsgReceiver<ApiMsg>,
     payload_rx: PayloadReceiver,
     payload_tx: PayloadSender,
     result_tx: Sender<ResultMsg>,
@@ -75,54 +79,61 @@ pub struct RenderBackend {
     // the first frame would produce inconsistent rendering results, because
     // scroll events are not necessarily received in deterministic order.
     render_on_scroll: bool,
+    frame_counter: u32,
+}
+
+pub struct RenderBackendInit {
+    pub payload_rx: PayloadReceiver,
+    pub payload_tx: PayloadSender,
+    pub result_tx: Sender<ResultMsg>,
+    pub hidpi_factor: f32,
+    pub max_texture_size: u32,
+    pub workers: Arc<ThreadPool>,
+    pub notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
+    pub webrender_context_handle: Option<GLContextHandleWrapper>,
+    pub frame_builder_config: FrameBuilderConfig,
+    pub recorder: Option<Box<ApiRecordingReceiver>>,
+    pub main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
+    pub blob_image_renderer: Option<Box<BlobImageRenderer>>,
+    pub vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
+    pub initial_window_size: DeviceUintSize,
+    pub renderer_id: RendererId,
 }
 
 impl RenderBackend {
-    pub fn new(api_rx: MsgReceiver<ApiMsg>,
-               payload_rx: PayloadReceiver,
-               payload_tx: PayloadSender,
-               result_tx: Sender<ResultMsg>,
-               hidpi_factor: f32,
-               texture_cache: TextureCache,
-               workers: Arc<ThreadPool>,
-               notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
-               webrender_context_handle: Option<GLContextHandleWrapper>,
-               config: FrameBuilderConfig,
-               recorder: Option<Box<ApiRecordingReceiver>>,
-               main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
-               blob_image_renderer: Option<Box<BlobImageRenderer>>,
-               vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
-               initial_window_size: DeviceUintSize) -> RenderBackend {
+    pub fn new(init: RenderBackendInit) -> Self {
 
-        let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer);
-
-        register_thread_with_profiler("Backend".to_string());
+        let resource_cache = ResourceCache::new(
+            TextureCache::new(init.max_texture_size),
+            init.workers,
+            init.blob_image_renderer
+        );
 
         RenderBackend {
-            api_rx,
-            payload_rx,
-            payload_tx,
-            result_tx,
-            hidpi_factor,
+            payload_rx: init.payload_rx,
+            payload_tx: init.payload_tx,
+            result_tx: init.result_tx,
+            hidpi_factor: init.hidpi_factor,
             page_zoom_factor: 1.0,
             pinch_zoom_factor: 1.0,
             pan: DeviceIntPoint::zero(),
             resource_cache,
             gpu_cache: GpuCache::new(),
             scene: Scene::new(),
-            frame: Frame::new(config),
+            frame: Frame::new(init.frame_builder_config),
             next_namespace_id: IdNamespace(1),
-            notifier,
-            webrender_context_handle,
+            notifier: init.notifier,
+            webrender_context_handle: init.webrender_context_handle,
             webgl_contexts: HashMap::new(),
             dirty_webgl_contexts: HashSet::new(),
             current_bound_webgl_context_id: None,
-            recorder,
-            main_thread_dispatcher,
+            recorder: init.recorder,
+            main_thread_dispatcher: init.main_thread_dispatcher,
             next_webgl_id: 0,
-            vr_compositor_handler,
-            window_size: initial_window_size,
-            inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), initial_window_size),
+            vr_compositor_handler: init.vr_compositor_handler,
+            window_size: init.initial_window_size,
+            inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), init.initial_window_size),
+            frame_counter: 0,
             render_on_scroll: false,
         }
     }
@@ -138,340 +149,317 @@ impl RenderBackend {
         }
     }
 
-    pub fn run(&mut self, mut profile_counters: BackendProfileCounters) {
-        let mut frame_counter: u32 = 0;
-
-        loop {
-            let msg = self.api_rx.recv();
-            profile_scope!("handle_msg");
-            match msg {
-                Ok(msg) => {
-                    if let Some(ref mut r) = self.recorder {
-                        r.write_msg(frame_counter, &msg);
-                    }
-                    match msg {
-                        ApiMsg::AddRawFont(id, bytes, index) => {
-                            profile_counters.resources.font_templates.inc(bytes.len());
-                            self.resource_cache
-                                .add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
-                        }
-                        ApiMsg::AddNativeFont(id, native_font_handle) => {
-                            self.resource_cache
-                                .add_font_template(id, FontTemplate::Native(native_font_handle));
-                        }
-                        ApiMsg::DeleteFont(id) => {
-                            self.resource_cache.delete_font_template(id);
-                        }
-                        ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
-                            let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
-                            for glyph_key in &glyph_keys {
-                                let glyph_dim = self.resource_cache.get_glyph_dimensions(glyph_key);
-                                glyph_dimensions.push(glyph_dim);
-                            };
-                            tx.send(glyph_dimensions).unwrap();
-                        }
-                        ApiMsg::AddImage(id, descriptor, data, tiling) => {
-                            if let ImageData::Raw(ref bytes) = data {
-                                profile_counters.resources.image_templates.inc(bytes.len());
-                            }
-                            self.resource_cache.add_image_template(id, descriptor, data, tiling);
-                        }
-                        ApiMsg::UpdateImage(id, descriptor, bytes, dirty_rect) => {
-                            self.resource_cache.update_image_template(id, descriptor, bytes, dirty_rect);
-                        }
-                        ApiMsg::DeleteImage(id) => {
-                            self.resource_cache.delete_image_template(id);
-                        }
-                        ApiMsg::SetPageZoom(factor) => {
-                            self.page_zoom_factor = factor.get();
-                        }
-                        ApiMsg::SetPinchZoom(factor) => {
-                            self.pinch_zoom_factor = factor.get();
-                        }
-                        ApiMsg::SetPan(pan) => {
-                            self.pan = pan;
-                        }
-                        ApiMsg::SetWindowParameters(window_size, inner_rect) => {
-                            self.window_size = window_size;
-                            self.inner_rect = inner_rect;
-                        }
-                        ApiMsg::CloneApi(sender) => {
-                            let result = self.next_namespace_id;
-
-                            let IdNamespace(id_namespace) = self.next_namespace_id;
-                            self.next_namespace_id = IdNamespace(id_namespace + 1);
-
-                            sender.send(result).unwrap();
-                        }
-                        ApiMsg::SetDisplayList(background_color,
-                                               epoch,
-                                               pipeline_id,
-                                               viewport_size,
-                                               content_size,
-                                               display_list_descriptor,
-                                               preserve_frame_state) => {
-                            profile_scope!("SetDisplayList");
-                            let mut leftover_data = vec![];
-                            let mut data;
-                            loop {
-                                data = self.payload_rx.recv_payload().unwrap();
-                                {
-                                    if data.epoch == epoch &&
-                                       data.pipeline_id == pipeline_id {
-                                        break
-                                    }
-                                }
-                                leftover_data.push(data)
-                            }
-                            for leftover_data in leftover_data {
-                                self.payload_tx.send_payload(leftover_data).unwrap()
-                            }
-                            if let Some(ref mut r) = self.recorder {
-                                r.write_payload(frame_counter, &data.to_data());
-                            }
-
-                            let built_display_list =
-                                BuiltDisplayList::from_data(data.display_list_data,
-                                                            display_list_descriptor);
-
-                            if !preserve_frame_state {
-                                self.discard_frame_state_for_pipeline(pipeline_id);
-                            }
-
-                            let display_list_len = built_display_list.data().len();
-                            let (builder_start_time, builder_finish_time) = built_display_list.times();
-
-                            let display_list_received_time = precise_time_ns();
-
-                            profile_counters.total_time.profile(|| {
-                                self.scene.set_display_list(pipeline_id,
-                                                            epoch,
-                                                            built_display_list,
-                                                            background_color,
-                                                            viewport_size,
-                                                            content_size);
-                                self.build_scene();
-                            });
-
-                            self.render_on_scroll = false; //wait for `GenerateFrame`
-
-                            // Note: this isn't quite right as auxiliary values will be
-                            // pulled out somewhere in the prim_store, but aux values are
-                            // really simple and cheap to access, so it's not a big deal.
-                            let display_list_consumed_time = precise_time_ns();
-
-                            profile_counters.ipc.set(builder_start_time, builder_finish_time,
-                                                     display_list_received_time, display_list_consumed_time,
-                                                     display_list_len);
-                        }
-                        ApiMsg::SetRootPipeline(pipeline_id) => {
-                            profile_scope!("SetRootPipeline");
-                            self.scene.set_root_pipeline_id(pipeline_id);
-
-                            if self.scene.display_lists.get(&pipeline_id).is_none() {
-                                continue;
-                            }
-
-                            profile_counters.total_time.profile(|| {
-                                self.build_scene();
-                            })
-                        }
-                        ApiMsg::Scroll(delta, cursor, move_phase) => {
-                            profile_scope!("Scroll");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll(delta, cursor, move_phase) && self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::ScrollNodeWithId(origin, id, clamp) => {
-                            profile_scope!("ScrollNodeWithScrollId");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll_node(origin, id, clamp) && self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::TickScrollingBounce => {
-                            profile_scope!("TickScrollingBounce");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    self.frame.tick_scrolling_bounce_animations();
-                                    if self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::TranslatePointToLayerSpace(..) => {
-                            panic!("unused api - remove from webrender_api");
-                        }
-                        ApiMsg::GetScrollNodeState(tx) => {
-                            profile_scope!("GetScrollNodeState");
-                            tx.send(self.frame.get_scroll_node_state()).unwrap()
-                        }
-                        ApiMsg::RequestWebGLContext(size, attributes, tx) => {
-                            if let Some(ref wrapper) = self.webrender_context_handle {
-                                let dispatcher: Option<Box<GLContextDispatcher>> = if cfg!(target_os = "windows") {
-                                    Some(Box::new(WebRenderGLDispatcher {
-                                        dispatcher: Arc::clone(&self.main_thread_dispatcher)
-                                    }))
-                                } else {
-                                    None
-                                };
-
-                                let result = wrapper.new_context(size, attributes, dispatcher);
-                                // Creating a new GLContext may make the current bound context_id dirty.
-                                // Clear it to ensure that  make_current() is called in subsequent commands.
-                                self.current_bound_webgl_context_id = None;
-
-                                match result {
-                                    Ok(ctx) => {
-                                        let id = WebGLContextId(self.next_webgl_id);
-                                        self.next_webgl_id += 1;
-
-                                        let (real_size, texture_id, limits) = ctx.get_info();
-
-                                        self.webgl_contexts.insert(id, ctx);
-
-                                        self.resource_cache
-                                            .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
-                                                               real_size);
-                                        self.dirty_webgl_contexts.insert(id);
-
-                                        tx.send(Ok((id, limits))).unwrap();
-                                    },
-                                    Err(msg) => {
-                                        tx.send(Err(msg.to_owned())).unwrap();
-                                    }
-                                }
-                            } else {
-                                tx.send(Err("Not implemented yet".to_owned())).unwrap();
-                            }
-                        }
-                        ApiMsg::ResizeWebGLContext(context_id, size) => {
-                            let ctx = self.webgl_contexts.get_mut(&context_id).unwrap();
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                ctx.make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            match ctx.resize(&size) {
-                                Ok(_) => {
-                                    // Update webgl texture size. Texture id may change too.
-                                    let (real_size, texture_id, _) = ctx.get_info();
-                                    self.resource_cache
-                                        .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
-                                                              real_size);
-                                    self.dirty_webgl_contexts.insert(context_id);
-                                },
-                                Err(msg) => {
-                                    error!("Error resizing WebGLContext: {}", msg);
-                                }
-                            }
-                        }
-                        ApiMsg::WebGLCommand(context_id, command) => {
-                            // TODO: Buffer the commands and only apply them here if they need to
-                            // be synchronous.
-                            let ctx = &self.webgl_contexts[&context_id];
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                ctx.make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            ctx.apply_command(command);
-                            self.dirty_webgl_contexts.insert(context_id);
-                        },
-
-                        ApiMsg::VRCompositorCommand(context_id, command) => {
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                self.webgl_contexts[&context_id].make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            self.handle_vr_compositor_command(context_id, command);
-                            self.dirty_webgl_contexts.insert(context_id);
-                        }
-                        ApiMsg::GenerateFrame(property_bindings) => {
-                            profile_scope!("GenerateFrame");
-
-                            // Ideally, when there are property bindings present,
-                            // we won't need to rebuild the entire frame here.
-                            // However, to avoid conflicts with the ongoing work to
-                            // refactor how scroll roots + transforms work, this
-                            // just rebuilds the frame if there are animated property
-                            // bindings present for now.
-                            // TODO(gw): Once the scrolling / reference frame changes
-                            //           are completed, optimize the internals of
-                            //           animated properties to not require a full
-                            //           rebuild of the frame!
-                            if let Some(property_bindings) = property_bindings {
-                                self.scene.properties.set_properties(property_bindings);
-                                profile_counters.total_time.profile(|| {
-                                    self.build_scene();
-                                });
-                            }
-
-                            self.render_on_scroll = true;
-
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    self.render(counters, gpu_cache_counters)
-                                })
-                            };
-                            if self.scene.root_pipeline_id.is_some() {
-                                self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
-                                frame_counter += 1;
-                            }
-                        }
-                        ApiMsg::ExternalEvent(evt) => {
-                            let notifier = self.notifier.lock();
-                            notifier.unwrap()
-                                    .as_mut()
-                                    .unwrap()
-                                    .external_event(evt);
-                        }
-                        ApiMsg::ShutDown => {
-                            let notifier = self.notifier.lock();
-                            notifier.unwrap()
-                                    .as_mut()
-                                    .unwrap()
-                                    .shut_down();
-                            break;
-                        }
-                    }
+    pub fn process_message(&mut self, msg: ApiMsg, profile_counters: &mut BackendProfileCounters) -> BackendStatus {
+        match msg {
+            ApiMsg::AddRawFont(id, bytes, index) => {
+                profile_counters.resources.font_templates.inc(bytes.len());
+                self.resource_cache
+                    .add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
+            }
+            ApiMsg::AddNativeFont(id, native_font_handle) => {
+                self.resource_cache
+                    .add_font_template(id, FontTemplate::Native(native_font_handle));
+            }
+            ApiMsg::DeleteFont(id) => {
+                self.resource_cache.delete_font_template(id);
+            }
+            ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
+                let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
+                for glyph_key in &glyph_keys {
+                    let glyph_dim = self.resource_cache.get_glyph_dimensions(glyph_key);
+                    glyph_dimensions.push(glyph_dim);
+                };
+                tx.send(glyph_dimensions).unwrap();
+            }
+            ApiMsg::AddImage(id, descriptor, data, tiling) => {
+                if let ImageData::Raw(ref bytes) = data {
+                    profile_counters.resources.image_templates.inc(bytes.len());
                 }
-                Err(..) => {
-                    let notifier = self.notifier.lock();
-                    notifier.unwrap()
-                            .as_mut()
-                            .unwrap()
-                            .shut_down();
-                    break;
+                self.resource_cache.add_image_template(id, descriptor, data, tiling);
+            }
+            ApiMsg::UpdateImage(id, descriptor, bytes, dirty_rect) => {
+                self.resource_cache.update_image_template(id, descriptor, bytes, dirty_rect);
+            }
+            ApiMsg::DeleteImage(id) => {
+                self.resource_cache.delete_image_template(id);
+            }
+            ApiMsg::SetPageZoom(factor) => {
+                self.page_zoom_factor = factor.get();
+            }
+            ApiMsg::SetPinchZoom(factor) => {
+                self.pinch_zoom_factor = factor.get();
+            }
+            ApiMsg::SetPan(pan) => {
+                self.pan = pan;
+            }
+            ApiMsg::SetWindowParameters(window_size, inner_rect) => {
+                self.window_size = window_size;
+                self.inner_rect = inner_rect;
+            }
+            ApiMsg::CloneApi(sender) => {
+                let result = self.next_namespace_id;
+
+                let IdNamespace(id_namespace) = self.next_namespace_id;
+                self.next_namespace_id = IdNamespace(id_namespace + 1);
+
+                sender.send(result).unwrap();
+            }
+            ApiMsg::SetDisplayList(background_color,
+                                   epoch,
+                                   pipeline_id,
+                                   viewport_size,
+                                   content_size,
+                                   display_list_descriptor,
+                                   preserve_frame_state) => {
+                profile_scope!("SetDisplayList");
+                let mut leftover_data = vec![];
+                let mut data;
+                loop {
+                    data = self.payload_rx.recv_payload().unwrap();
+                    {
+                        if data.epoch == epoch &&
+                           data.pipeline_id == pipeline_id {
+                            break
+                        }
+                    }
+                    leftover_data.push(data)
+                }
+                for leftover_data in leftover_data {
+                    self.payload_tx.send_payload(leftover_data).unwrap()
+                }
+                if let Some(ref mut r) = self.recorder {
+                    r.write_payload(self.frame_counter, &data.to_data());
+                }
+
+                let built_display_list =
+                    BuiltDisplayList::from_data(data.display_list_data,
+                                                display_list_descriptor);
+
+                if !preserve_frame_state {
+                    self.discard_frame_state_for_pipeline(pipeline_id);
+                }
+
+                let display_list_len = built_display_list.data().len();
+                let (builder_start_time, builder_finish_time) = built_display_list.times();
+
+                let display_list_received_time = precise_time_ns();
+
+                profile_counters.total_time.profile(|| {
+                    self.scene.set_display_list(pipeline_id,
+                                                epoch,
+                                                built_display_list,
+                                                background_color,
+                                                viewport_size,
+                                                content_size);
+                    self.build_scene();
+                });
+
+                self.render_on_scroll = false; //wait for `GenerateFrame`
+
+                // Note: this isn't quite right as auxiliary values will be
+                // pulled out somewhere in the prim_store, but aux values are
+                // really simple and cheap to access, so it's not a big deal.
+                let display_list_consumed_time = precise_time_ns();
+
+                profile_counters.ipc.set(builder_start_time, builder_finish_time,
+                                         display_list_received_time, display_list_consumed_time,
+                                         display_list_len);
+            }
+            ApiMsg::SetRootPipeline(pipeline_id) => {
+                profile_scope!("SetRootPipeline");
+                self.scene.set_root_pipeline_id(pipeline_id);
+
+                if self.scene.display_lists.get(&pipeline_id).is_none() {
+                    return BackendStatus::Continue;
+                }
+
+                profile_counters.total_time.profile(|| {
+                    self.build_scene();
+                })
+            }
+            ApiMsg::Scroll(delta, cursor, move_phase) => {
+                profile_scope!("Scroll");
+                let frame = {
+                    let counters = &mut profile_counters.resources.texture_cache;
+                    let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
+                    profile_counters.total_time.profile(|| {
+                        if self.frame.scroll(delta, cursor, move_phase) {
+                            Some(self.render(counters, gpu_cache_counters))
+                        } else {
+                            None
+                        }
+                    })
+                };
+
+                self.scroll_frame(frame, profile_counters);
+            }
+            ApiMsg::ScrollNodeWithId(origin, id, clamp) => {
+                profile_scope!("ScrollNodeWithScrollId");
+                let frame = {
+                    let counters = &mut profile_counters.resources.texture_cache;
+                    let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
+                    profile_counters.total_time.profile(|| {
+                        if self.frame.scroll_node(origin, id, clamp) {
+                            Some(self.render(counters, gpu_cache_counters))
+                        } else {
+                            None
+                        }
+                    })
+                };
+
+                self.scroll_frame(frame, profile_counters);
+            }
+            ApiMsg::TickScrollingBounce => {
+                profile_scope!("TickScrollingBounce");
+                let frame = {
+                    let counters = &mut profile_counters.resources.texture_cache;
+                    let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
+                    profile_counters.total_time.profile(|| {
+                        self.frame.tick_scrolling_bounce_animations();
+                        if self.render_on_scroll {
+                            Some(self.render(counters, gpu_cache_counters))
+                        } else {
+                            None
+                        }
+                    })
+                };
+
+                self.scroll_frame(frame, profile_counters);
+            }
+            ApiMsg::TranslatePointToLayerSpace(..) => {
+                panic!("unused api - remove from webrender_traits");
+            }
+            ApiMsg::GetScrollNodeState(tx) => {
+                profile_scope!("GetScrollNodeState");
+                tx.send(self.frame.get_scroll_node_state()).unwrap()
+            }
+            ApiMsg::RequestWebGLContext(size, attributes, tx) => {
+                if let Some(ref wrapper) = self.webrender_context_handle {
+                    let dispatcher: Option<Box<GLContextDispatcher>> = if cfg!(target_os = "windows") {
+                        Some(Box::new(WebRenderGLDispatcher {
+                            dispatcher: Arc::clone(&self.main_thread_dispatcher)
+                        }))
+                    } else {
+                        None
+                    };
+
+                    let result = wrapper.new_context(size, attributes, dispatcher);
+                    // Creating a new GLContext may make the current bound context_id dirty.
+                    // Clear it to ensure that  make_current() is called in subsequent commands.
+                    self.current_bound_webgl_context_id = None;
+
+                    match result {
+                        Ok(ctx) => {
+                            let id = WebGLContextId(self.next_webgl_id);
+                            self.next_webgl_id += 1;
+
+                            let (real_size, texture_id, limits) = ctx.get_info();
+
+                            self.webgl_contexts.insert(id, ctx);
+
+                            self.resource_cache
+                                .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
+                                                   real_size);
+
+                            tx.send(Ok((id, limits))).unwrap();
+                        },
+                        Err(msg) => {
+                            tx.send(Err(msg.to_owned())).unwrap();
+                        }
+                    }
+                } else {
+                    tx.send(Err("Not implemented yet".to_owned())).unwrap();
                 }
             }
+            ApiMsg::ResizeWebGLContext(context_id, size) => {
+                let ctx = self.webgl_contexts.get_mut(&context_id).unwrap();
+                if Some(context_id) != self.current_bound_webgl_context_id {
+                    ctx.make_current();
+                    self.current_bound_webgl_context_id = Some(context_id);
+                }
+                match ctx.resize(&size) {
+                    Ok(_) => {
+                        // Update webgl texture size. Texture id may change too.
+                        let (real_size, texture_id, _) = ctx.get_info();
+                        self.resource_cache
+                            .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
+                                                  real_size);
+                    },
+                    Err(msg) => {
+                        error!("Error resizing WebGLContext: {}", msg);
+                    }
+                }
+            }
+            ApiMsg::WebGLCommand(context_id, command) => {
+                // TODO: Buffer the commands and only apply them here if they need to
+                // be synchronous.
+                let ctx = &self.webgl_contexts[&context_id];
+                if Some(context_id) != self.current_bound_webgl_context_id {
+                    ctx.make_current();
+                    self.current_bound_webgl_context_id = Some(context_id);
+                }
+                ctx.apply_command(command);
+            },
+
+            ApiMsg::VRCompositorCommand(context_id, command) => {
+                if Some(context_id) != self.current_bound_webgl_context_id {
+                    self.webgl_contexts[&context_id].make_current();
+                    self.current_bound_webgl_context_id = Some(context_id);
+                }
+                self.handle_vr_compositor_command(context_id, command);
+            }
+            ApiMsg::GenerateFrame(property_bindings) => {
+                profile_scope!("GenerateFrame");
+
+                // Ideally, when there are property bindings present,
+                // we won't need to rebuild the entire frame here.
+                // However, to avoid conflicts with the ongoing work to
+                // refactor how scroll roots + transforms work, this
+                // just rebuilds the frame if there are animated property
+                // bindings present for now.
+                // TODO(gw): Once the scrolling / reference frame changes
+                //           are completed, optimize the internals of
+                //           animated properties to not require a full
+                //           rebuild of the frame!
+                if let Some(property_bindings) = property_bindings {
+                    self.scene.properties.set_properties(property_bindings);
+                    profile_counters.total_time.profile(|| {
+                        self.build_scene();
+                    });
+                }
+
+                self.render_on_scroll = true;
+
+                let frame = {
+                    let counters = &mut profile_counters.resources.texture_cache;
+                    let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
+                    profile_counters.total_time.profile(|| {
+                        self.render(counters, gpu_cache_counters)
+                    })
+                };
+                if self.scene.root_pipeline_id.is_some() {
+                    self.publish_frame_and_notify_compositor(frame, profile_counters);
+                    self.frame_counter += 1;
+                }
+            }
+            ApiMsg::ExternalEvent(evt) => {
+                let notifier = self.notifier.lock();
+                notifier.unwrap()
+                        .as_mut()
+                        .unwrap()
+                        .external_event(evt);
+            }
+            ApiMsg::ShutDown => {
+                let notifier = self.notifier.lock();
+                notifier.unwrap()
+                        .as_mut()
+                        .unwrap()
+                        .shut_down();
+                return BackendStatus::Remove;
+            }
         }
+
+        return BackendStatus::Continue;
     }
 
     fn discard_frame_state_for_pipeline(&mut self, pipeline_id: PipelineId) {
@@ -592,5 +580,101 @@ impl GLContextDispatcher for WebRenderGLDispatcher {
     fn dispatch(&self, f: Box<Fn() + Send>) {
         let mut dispatcher = self.dispatcher.lock();
         dispatcher.as_mut().unwrap().as_mut().unwrap().dispatch(f);
+    }
+}
+
+pub enum BackendMsg {
+    NewRenderBackend(RenderBackendInit),
+    DeleteRenderBackend(RendererId),
+}
+
+pub struct RenderBackendThread {
+    api_tx: MsgSender<(ApiMsg, RendererId)>,
+    init_tx: Sender<BackendMsg>,
+    next_renderer_id: RendererId,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum BackendStatus {
+    Continue,
+    Remove,
+}
+
+impl RenderBackendThread {
+    pub fn new(thread_name: String) -> Result<Self, io::Error> {
+        let (api_tx, api_rx) = try! { msg_channel() };
+        let (init_tx, init_rx) = channel();
+
+        thread::Builder::new().name(thread_name.clone()).spawn(move || {
+            register_thread_with_profiler(thread_name);
+
+            let mut render_backends = HashMap::new();
+
+            while let Ok((api_msg, id)) = api_rx.recv() {
+
+                while let Ok(init_msg) = init_rx.try_recv() {
+                    match init_msg {
+                        BackendMsg::NewRenderBackend(backend_init) => {
+                            let counters = BackendProfileCounters::new();
+                            let id = backend_init.renderer_id;
+                            let backend = RenderBackend::new(backend_init);
+                            render_backends.insert(id, (backend, counters));
+                        }
+                        BackendMsg::DeleteRenderBackend(id) => {
+                            render_backends.remove(&id);
+                        }
+                    }
+                }
+
+                let should_remove = match render_backends.get_mut(&id) {
+                    Some(&mut (ref mut backend, ref mut counters)) => {
+                        profile_scope!("handle_msg");
+                        backend.process_message(api_msg, counters) == BackendStatus::Remove
+                    }
+                    None => {
+                        println!("Failed to deliver message to non-existant render backend!");
+                        false
+                    }
+                };
+
+                if should_remove {
+                    render_backends.remove(&id);
+                }
+            }
+        })?;
+
+        Ok(RenderBackendThread {
+            api_tx: api_tx,
+            init_tx: init_tx,
+            next_renderer_id: RendererId(0),
+        })
+    }
+
+    pub fn new_renderer(
+        &mut self,
+        gl: Rc<gl::Gl>,
+        options: RendererOptions,
+        initial_window_size: DeviceUintSize,
+    ) -> Result<(Renderer, RenderApiSender), InitError> {
+        Renderer::new(gl, options, initial_window_size, self)
+    }
+
+    pub fn alloc_renderer_id(&mut self) -> RendererId {
+        let id = self.next_renderer_id;
+        self.next_renderer_id = RendererId(self.next_renderer_id.0 + 1);
+
+        id
+    }
+
+    pub fn clone_api_sender(&self) -> MsgSender<(ApiMsg, RendererId)> {
+        self.api_tx.clone()
+    }
+
+    pub fn add_render_backend(&self, init: RenderBackendInit) {
+        self.init_tx.send(BackendMsg::NewRenderBackend(init)).unwrap();
+    }
+
+    pub fn delete_render_backend(&self, id: RendererId) {
+        self.init_tx.send(BackendMsg::DeleteRenderBackend(id)).unwrap()
     }
 }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -100,6 +100,10 @@ impl fmt::Debug for ApiMsg {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct RendererId(pub u32);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Epoch(pub u32);
 
 #[cfg(not(feature = "webgl"))]
@@ -155,47 +159,57 @@ pub enum ScrollClamping {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct RenderApiSender {
-    api_sender: MsgSender<ApiMsg>,
+    api_sender: MsgSender<(ApiMsg, RendererId)>,
     payload_sender: PayloadSender,
+    renderer_id: RendererId,
 }
 
 impl RenderApiSender {
-    pub fn new(api_sender: MsgSender<ApiMsg>,
-               payload_sender: PayloadSender)
+    pub fn new(api_sender: MsgSender<(ApiMsg, RendererId)>,
+               payload_sender: PayloadSender,
+               id: RendererId)
                -> RenderApiSender {
         RenderApiSender {
             api_sender,
             payload_sender,
+            renderer_id: id,
         }
     }
 
     pub fn create_api(&self) -> RenderApi {
         let RenderApiSender {
             ref api_sender,
-            ref payload_sender
+            ref payload_sender,
+            renderer_id,
         } = *self;
         let (sync_tx, sync_rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::CloneApi(sync_tx);
-        api_sender.send(msg).unwrap();
+        api_sender.send((msg, self.renderer_id)).unwrap();
         RenderApi {
             api_sender: api_sender.clone(),
             payload_sender: payload_sender.clone(),
             id_namespace: sync_rx.recv().unwrap(),
             next_id: Cell::new(ResourceId(0)),
+            renderer_id: renderer_id,
         }
     }
 }
 
 pub struct RenderApi {
-    pub api_sender: MsgSender<ApiMsg>,
+    pub api_sender: MsgSender<(ApiMsg, RendererId)>,
     pub payload_sender: PayloadSender,
     pub id_namespace: IdNamespace,
     pub next_id: Cell<ResourceId>,
+    pub renderer_id: RendererId,
 }
 
 impl RenderApi {
     pub fn clone_sender(&self) -> RenderApiSender {
-        RenderApiSender::new(self.api_sender.clone(), self.payload_sender.clone())
+        RenderApiSender::new(self.api_sender.clone(), self.payload_sender.clone(), self.renderer_id)
+    }
+
+    pub fn send_api_msg(&self, msg: ApiMsg) {
+        self.api_sender.send((msg, self.renderer_id)).unwrap()
     }
 
     pub fn generate_font_key(&self) -> FontKey {
@@ -205,17 +219,17 @@ impl RenderApi {
 
     pub fn add_raw_font(&self, key: FontKey, bytes: Vec<u8>, index: u32) {
         let msg = ApiMsg::AddRawFont(key, bytes, index);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn add_native_font(&self, key: FontKey, native_font_handle: NativeFontHandle) {
         let msg = ApiMsg::AddNativeFont(key, native_font_handle);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn delete_font(&self, key: FontKey) {
         let msg = ApiMsg::DeleteFont(key);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Gets the dimensions for the supplied glyph keys
@@ -227,7 +241,7 @@ impl RenderApi {
                                 -> Vec<Option<GlyphDimensions>> {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::GetGlyphDimensions(glyph_keys, tx);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
         rx.recv().unwrap()
     }
 
@@ -244,7 +258,7 @@ impl RenderApi {
                      data: ImageData,
                      tiling: Option<TileSize>) {
         let msg = ApiMsg::AddImage(key, descriptor, data, tiling);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Updates a specific image.
@@ -257,13 +271,13 @@ impl RenderApi {
                         data: ImageData,
                         dirty_rect: Option<DeviceUintRect>) {
         let msg = ApiMsg::UpdateImage(key, descriptor, data, dirty_rect);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Deletes the specific image.
     pub fn delete_image(&self, key: ImageKey) {
         let msg = ApiMsg::DeleteImage(key);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Sets the root pipeline.
@@ -281,7 +295,7 @@ impl RenderApi {
     /// ```
     pub fn set_root_pipeline(&self, pipeline_id: PipelineId) {
         let msg = ApiMsg::SetRootPipeline(pipeline_id);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Supplies a new frame to WebRender.
@@ -319,7 +333,7 @@ impl RenderApi {
                                          content_size,
                                          display_list_descriptor,
                                          preserve_frame_state);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
 
         self.payload_sender.send_payload(Payload {
             epoch,
@@ -334,39 +348,39 @@ impl RenderApi {
     /// which has `ScrollPolicy::Scrollable` set.
     pub fn scroll(&self, scroll_location: ScrollLocation, cursor: WorldPoint, phase: ScrollEventPhase) {
         let msg = ApiMsg::Scroll(scroll_location, cursor, phase);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn scroll_node_with_id(&self, origin: LayoutPoint, id: ClipId, clamp: ScrollClamping) {
         let msg = ApiMsg::ScrollNodeWithId(origin, id, clamp);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn set_page_zoom(&self, page_zoom: ZoomFactor) {
         let msg = ApiMsg::SetPageZoom(page_zoom);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn set_pinch_zoom(&self, pinch_zoom: ZoomFactor) {
         let msg = ApiMsg::SetPinchZoom(pinch_zoom);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn set_pan(&self, pan: DeviceIntPoint) {
         let msg = ApiMsg::SetPan(pan);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn set_window_parameters(&self,
                                  window_size: DeviceUintSize,
                                  inner_rect: DeviceUintRect) {
         let msg = ApiMsg::SetWindowParameters(window_size, inner_rect);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn tick_scrolling_bounce_animations(&self) {
         let msg = ApiMsg::TickScrollingBounce;
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Translates a point from viewport coordinates to layer space
@@ -374,14 +388,14 @@ impl RenderApi {
                                           -> (LayoutPoint, PipelineId) {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::TranslatePointToLayerSpace(*point, tx);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
         rx.recv().unwrap()
     }
 
     pub fn get_scroll_node_state(&self) -> Vec<ScrollLayerState> {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::GetScrollNodeState(tx);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
         rx.recv().unwrap()
     }
 
@@ -389,18 +403,18 @@ impl RenderApi {
                                  -> Result<(WebGLContextId, GLLimits), String> {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::RequestWebGLContext(*size, attributes, tx);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
         rx.recv().unwrap()
     }
 
     pub fn resize_webgl_context(&self, context_id: WebGLContextId, size: &DeviceIntSize) {
         let msg = ApiMsg::ResizeWebGLContext(context_id, *size);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn send_webgl_command(&self, context_id: WebGLContextId, command: WebGLCommand) {
         let msg = ApiMsg::WebGLCommand(context_id, command);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     /// Generate a new frame. Optionally, supply a list of animated
@@ -408,21 +422,21 @@ impl RenderApi {
     /// in the current display list.
     pub fn generate_frame(&self, property_bindings: Option<DynamicProperties>) {
         let msg = ApiMsg::GenerateFrame(property_bindings);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn send_vr_compositor_command(&self, context_id: WebGLContextId, command: VRCompositorCommand) {
         let msg = ApiMsg::VRCompositorCommand(context_id, command);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn send_external_event(&self, evt: ExternalEvent) {
         let msg = ApiMsg::ExternalEvent(evt);
-        self.api_sender.send(msg).unwrap();
+        self.api_sender.send((msg, self.renderer_id)).unwrap();
     }
 
     pub fn shut_down(&self) {
-        self.api_sender.send(ApiMsg::ShutDown).unwrap();
+        self.api_sender.send((ApiMsg::ShutDown, self.renderer_id)).unwrap();
     }
 
     /// Create a new unique key that can be used for

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -183,7 +183,7 @@ impl WrenchThing for BinaryFrameReader {
                 match item {
                     Item::Message(msg) => {
                         if !self.should_skip_upload_msg(&msg) {
-                            wrench.api.api_sender.send(msg).unwrap();
+                            wrench.api.send_api_msg(msg);
                         }
                     }
                     Item::Data(buf) => {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -22,6 +22,7 @@ use time;
 use webrender;
 use webrender::api::*;
 use webrender::renderer::{CpuProfile, GpuProfile, GraphicsApiInfo};
+use webrender::RenderBackendThread;
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use yaml_rust::Yaml;
 use {WHITE_COLOR, BLACK_COLOR};
@@ -119,7 +120,7 @@ pub struct Wrench {
     window_size: DeviceUintSize,
     device_pixel_ratio: f32,
 
-    pub renderer: webrender::renderer::Renderer,
+    pub renderer: webrender::Renderer,
     pub api: RenderApi,
     pub root_pipeline_id: PipelineId,
 
@@ -177,7 +178,10 @@ impl Wrench {
             .. Default::default()
         };
 
-        let (renderer, sender) = webrender::renderer::Renderer::new(window.clone_gl(), opts, size).unwrap();
+        let mut backend_thread = RenderBackendThread::new("Backend".to_string()).unwrap();
+
+        let (renderer, sender) = backend_thread.new_renderer(window.clone_gl(), opts, size).unwrap();
+
         let api = sender.create_api();
 
         let proxy = window.create_window_proxy();


### PR DESCRIPTION
It would be good to share the render backend thread between several windows. This would waste less resources and more importantly make it a lot easier to share larger resources between render backends (fonts, etc.).

This attempt achieves that by letting you create a RenderBackendThread struct and pass it as parameter in the creation of the Renderer. All api senders push commands to the same message channel with an id to select the render backend. Having to pass an Id isn't great, I hope that there aren't cases where this could be a security issue (if, says, a compromised child process can spoof the id).

The alternative is to use a condition variable to wake up the render backend thread. It is probably better but I don't know if we have a cross-plaftorm and cross-process condvar handy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1370)
<!-- Reviewable:end -->
