### PR TITLE
Optimize CPU time spent in building glyph instances.

### DIFF
--- a/webrender/res/cs_clip_image.vs.glsl
+++ b/webrender/res/cs_clip_image.vs.glsl
@@ -18,7 +18,7 @@ void main(void) {
     Layer layer = fetch_layer(cci.layer_index);
     ImageMaskData mask = fetch_mask_data(cci.data_index);
     RectWithSize local_rect = mask.local_rect;
-    ResourceRect res = fetch_resource_rect(cci.resource_address);
+    ImageResource res = fetch_image_resource(cci.resource_address);
 
     ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
                                                layer,

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -14,13 +14,14 @@ void main(void) {
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data2;
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
-    ResourceRect res = fetch_resource_rect(resource_address);
+    GlyphResource res = fetch_glyph_resource(resource_address);
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by
     // the glyph offset, relative to its primitive bounding rect.
     vec2 size = res.uv_rect.zw - res.uv_rect.xy;
-    vec2 origin = prim.task.screen_space_origin + uDevicePixelRatio * (glyph.offset - prim.local_rect.p0);
+    vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
+    vec2 origin = prim.task.screen_space_origin + uDevicePixelRatio * (local_pos - prim.local_rect.p0);
     vec4 local_rect = vec4(origin, size);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -725,13 +725,23 @@ TransformVertexInfo write_transform_vertex(RectWithSize instance_rect,
 
 #endif //WR_FEATURE_TRANSFORM
 
-struct ResourceRect {
+struct GlyphResource {
+    vec4 uv_rect;
+    vec2 offset;
+};
+
+GlyphResource fetch_glyph_resource(int address) {
+    vec4 data[2] = fetch_from_resource_cache_2(address);
+    return GlyphResource(data[0], data[1].xy);
+}
+
+struct ImageResource {
     vec4 uv_rect;
 };
 
-ResourceRect fetch_resource_rect(int address) {
+ImageResource fetch_image_resource(int address) {
     vec4 data = fetch_from_resource_cache_1(address);
-    return ResourceRect(data);
+    return ImageResource(data);
 }
 
 struct Rectangle {

--- a/webrender/res/ps_image.vs.glsl
+++ b/webrender/res/ps_image.vs.glsl
@@ -6,7 +6,7 @@
 void main(void) {
     Primitive prim = load_primitive();
     Image image = fetch_image(prim.specific_prim_address);
-    ResourceRect res = fetch_resource_rect(prim.user_data0);
+    ImageResource res = fetch_image_resource(prim.user_data0);
 
 #ifdef WR_FEATURE_TRANSFORM
     TransformVertexInfo vi = write_transform_vertex(prim.local_rect,

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -10,9 +10,11 @@ void main(void) {
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data2;
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
-    ResourceRect res = fetch_resource_rect(resource_address);
+    GlyphResource res = fetch_glyph_resource(resource_address);
 
-    RectWithSize local_rect = RectWithSize(glyph.offset,
+    vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
+
+    RectWithSize local_rect = RectWithSize(local_pos,
                                            (res.uv_rect.zw - res.uv_rect.xy) / uDevicePixelRatio);
 
 #ifdef WR_FEATURE_TRANSFORM

--- a/webrender/res/ps_yuv_image.vs.glsl
+++ b/webrender/res/ps_yuv_image.vs.glsl
@@ -25,11 +25,11 @@ void main(void) {
 
     write_clip(vi.screen_pos, prim.clip_area);
 
-    ResourceRect y_rect = fetch_resource_rect(prim.user_data0);
+    ImageResource y_rect = fetch_image_resource(prim.user_data0);
 #ifndef WR_FEATURE_INTERLEAVED_Y_CB_CR  // only 1 channel
-    ResourceRect u_rect = fetch_resource_rect(prim.user_data1);
+    ImageResource u_rect = fetch_image_resource(prim.user_data1);
 #ifndef WR_FEATURE_NV12 // 2 channel
-    ResourceRect v_rect = fetch_resource_rect(prim.user_data2);
+    ImageResource v_rect = fetch_image_resource(prim.user_data2);
 #endif
 #endif
 

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -25,6 +25,7 @@
 //! for this frame.
 
 use device::FrameId;
+use internal_types::UvRect;
 use profiler::GpuCacheProfileCounters;
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 use std::{mem, u32};
@@ -79,6 +80,17 @@ impl Into<GpuBlockData> for LayerRect {
                     self.origin.y,
                     self.size.width,
                     self.size.height ],
+        }
+    }
+}
+
+impl Into<GpuBlockData> for UvRect {
+    fn into(self) -> GpuBlockData {
+        GpuBlockData {
+            data: [ self.uv0.x,
+                    self.uv0.y,
+                    self.uv1.x,
+                    self.uv1.y ],
         }
     }
 }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -4,7 +4,6 @@
 
 use app_units::Au;
 use device::TextureFilter;
-use euclid::{TypedPoint2D, UnknownUnit};
 use fnv::FnvHasher;
 use profiler::BackendProfileCounters;
 use std::collections::{HashMap, HashSet};
@@ -16,7 +15,7 @@ use std::sync::Arc;
 use tiling;
 use renderer::BlendMode;
 use webrender_traits::{ClipId, ColorF, DeviceUintRect, Epoch, ExternalImageData, ExternalImageId};
-use webrender_traits::{ImageData, ImageFormat, PipelineId};
+use webrender_traits::{DevicePoint, ImageData, ImageFormat, PipelineId};
 
 // An ID for a texture that is owned by the
 // texture cache module. This can include atlases
@@ -303,11 +302,9 @@ pub enum AxisDirection {
 pub struct StackingContextIndex(pub usize);
 
 #[derive(Clone, Copy, Debug)]
-pub struct RectUv<T, U = UnknownUnit> {
-    pub top_left: TypedPoint2D<T, U>,
-    pub top_right: TypedPoint2D<T, U>,
-    pub bottom_left: TypedPoint2D<T, U>,
-    pub bottom_right: TypedPoint2D<T, U>,
+pub struct UvRect {
+    pub uv0: DevicePoint,
+    pub uv1: DevicePoint,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -31,6 +31,8 @@ pub struct FontContext {
 unsafe impl Send for FontContext {}
 
 pub struct RasterizedGlyph {
+    pub top: f32,
+    pub left: f32,
     pub width: u32,
     pub height: u32,
     pub bytes: Vec<u8>,
@@ -39,6 +41,8 @@ pub struct RasterizedGlyph {
 impl RasterizedGlyph {
     pub fn blank() -> RasterizedGlyph {
         RasterizedGlyph {
+            top: 0.0,
+            left: 0.0,
             width: 0,
             height: 0,
             bytes: vec![],
@@ -400,6 +404,8 @@ impl FontContext {
                                   key.color);
 
         Some(RasterizedGlyph {
+            left: metrics.rasterized_left as f32,
+            top: metrics.rasterized_ascent as f32,
             width: metrics.rasterized_width,
             height: metrics.rasterized_height,
             bytes: rasterized_pixels,

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -33,6 +33,8 @@ pub struct FontContext {
 unsafe impl Send for FontContext {}
 
 pub struct RasterizedGlyph {
+    pub top: f32,
+    pub left: f32,
     pub width: u32,
     pub height: u32,
     pub bytes: Vec<u8>,
@@ -258,6 +260,8 @@ impl FontContext {
         }
 
         Some(RasterizedGlyph {
+            left: dimensions.left as f32,
+            top: dimensions.top as f32,
             width: dimensions.width as u32,
             height: dimensions.height as u32,
             bytes: final_buffer,

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -29,6 +29,8 @@ pub struct FontContext {
 unsafe impl Send for FontContext {}
 
 pub struct RasterizedGlyph {
+    pub top: f32,
+    pub left: f32,
     pub width: u32,
     pub height: u32,
     pub bytes: Vec<u8>,
@@ -309,6 +311,8 @@ impl FontContext {
         let rgba_pixels = self.convert_to_rgba(&mut pixels, render_mode);
 
         Some(RasterizedGlyph {
+            left: bounds.left as f32,
+            top: -bounds.top as f32,
             width: width as u32,
             height: height as u32,
             bytes: rgba_pixels,


### PR DESCRIPTION
Previously, the CPU would query the dimensions of each glyph, and
then apply the dimensions offset from the rasterized glyph to the
instance data. This results in a lot of hash lookups to query the
dimensions (and also some additional math on the CPU).

Instead, allow storing "user data" with each texture cache item. This
allows the glyph offsets to be applied in the vertex shader instead
of on the CPU.

Because this is such a hot code path, it provides significant CPU time
wins - often up to 20% of the CPU time on real pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1376)
<!-- Reviewable:end -->
