### PR TITLE
Add support for new clips within nested display lists

### DIFF
--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate gleam;
+extern crate glutin;
+extern crate webrender;
+extern crate webrender_traits;
+
+#[macro_use]
+extern crate lazy_static;
+
+#[path="common/boilerplate.rs"]
+mod boilerplate;
+
+use boilerplate::HandyDandyRectBuilder;
+use std::sync::Mutex;
+use webrender_traits::*;
+
+fn body(_api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        pipeline_id: &PipelineId,
+        layout_size: &LayoutSize)
+{
+    let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);
+    builder.push_stacking_context(webrender_traits::ScrollPolicy::Scrollable,
+                                  bounds,
+                                  None,
+                                  TransformStyle::Flat,
+                                  None,
+                                  webrender_traits::MixBlendMode::Normal,
+                                  Vec::new());
+
+    let outer_scroll_frame_rect = (100, 100).to(600, 400);
+    let token = builder.push_clip_region(&outer_scroll_frame_rect, vec![], None);
+    builder.push_rect(outer_scroll_frame_rect,
+                      token, ColorF::new(1.0, 1.0, 1.0, 1.0));
+    let token = builder.push_clip_region(&outer_scroll_frame_rect, vec![], None);
+    let nested_clip_id = builder.define_clip((100, 100).to(1000, 1000), token, None);
+    builder.push_clip_id(nested_clip_id);
+
+    let mut builder2 = webrender_traits::DisplayListBuilder::new(*pipeline_id, *layout_size);
+    let mut builder3 = webrender_traits::DisplayListBuilder::new(*pipeline_id, *layout_size);
+
+    let rect = (110, 110).to(210, 210);
+    let token = builder3.push_clip_region(&rect, vec![], None);
+    builder3.push_rect(rect, token, ColorF::new(0.0, 1.0, 0.0, 1.0));
+
+    // A fixed position rectangle should be fixed to the reference frame that starts
+    // in the outer display list.
+    builder3.push_stacking_context(webrender_traits::ScrollPolicy::Fixed,
+                                  (220, 110).to(320, 210),
+                                  None,
+                                  TransformStyle::Flat,
+                                  None,
+                                  webrender_traits::MixBlendMode::Normal,
+                                  Vec::new());
+    let rect = (0, 0).to(100, 100);
+    let token = builder3.push_clip_region(&rect, vec![], None);
+    builder3.push_rect(rect, token, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder3.pop_stacking_context();
+
+    // Now we push an inner scroll frame that should have the same id as the outer one,
+    // but the WebRender nested display list replacement code should convert it into
+    // a unique ClipId.
+    let inner_scroll_frame_rect = (330, 110).to(530, 360);
+    let token = builder3.push_clip_region(&inner_scroll_frame_rect, vec![], None);
+    builder3.push_rect(inner_scroll_frame_rect, token, ColorF::new(1.0, 0.0, 1.0, 0.5));
+    let token = builder3.push_clip_region(&inner_scroll_frame_rect, vec![], None);
+    let inner_nested_clip_id = builder3.define_clip((330, 110).to(2000, 2000), token, None);
+    builder3.push_clip_id(inner_nested_clip_id);
+    let rect = (340, 120).to(440, 220);
+    let token = builder3.push_clip_region(&rect, vec![], None);
+    builder3.push_rect(rect, token, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder3.pop_clip_id();
+
+    let (_, _, built_list) = builder3.finalize();
+    builder2.push_nested_display_list(&built_list);
+    let (_, _, built_list) = builder2.finalize();
+    builder.push_nested_display_list(&built_list);
+
+    builder.pop_clip_id();
+
+    builder.pop_stacking_context();
+}
+
+lazy_static! {
+    static ref CURSOR_POSITION: Mutex<WorldPoint> = Mutex::new(WorldPoint::zero());
+}
+
+fn event_handler(event: &glutin::Event,
+                 api: &RenderApi)
+{
+    match *event {
+        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+            let offset = match key {
+                 glutin::VirtualKeyCode::Down => (0.0, -10.0),
+                 glutin::VirtualKeyCode::Up => (0.0, 10.0),
+                 glutin::VirtualKeyCode::Right => (-10.0, 0.0),
+                 glutin::VirtualKeyCode::Left => (10.0, 0.0),
+                 _ => return,
+            };
+
+            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
+                       *CURSOR_POSITION.lock().unwrap(),
+                       ScrollEventPhase::Start);
+        }
+        glutin::Event::MouseMoved(x, y) => {
+            *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
+        }
+        glutin::Event::MouseWheel(delta, _, event_cursor_position) => {
+            if let Some((x, y)) = event_cursor_position {
+                *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
+            }
+
+            const LINE_HEIGHT: f32 = 38.0;
+            let (dx, dy) = match delta {
+                glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
+                glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
+            };
+
+            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
+                       *CURSOR_POSITION.lock().unwrap(),
+                       ScrollEventPhase::Start);
+        }
+        _ => ()
+    }
+}
+
+fn main() {
+    boilerplate::main_wrapper(body, event_handler, None);
+}

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -32,12 +32,63 @@ pub struct FrameId(pub u32);
 
 static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF { r: 0.3, g: 0.3, b: 0.3, a: 0.6 };
 
+/// Nested display lists cause two types of replacements to ClipIds inside the nesting:
+///     1. References to the root scroll frame are replaced by the ClipIds that
+///        contained the nested display list.
+///     2. Other ClipIds (that aren't custom or reference frames) are assumed to be
+///        local to the nested display list and are converted to an id that is unique
+///        outside of the nested display list as well.
+///
+/// This structure keeps track of what ids are the "root" for one particular level of
+/// nesting as well as keeping and index, which can make ClipIds used internally unique
+/// in the full ClipScrollTree.
+struct NestedDisplayListInfo {
+    /// The index of this nested display list, which is used to generate
+    /// new ClipIds for clips that are defined inside it.
+    nest_index: u64,
+
+    /// The ClipId of the scroll frame node which contains this nested
+    /// display list. This is used to replace references to the root with
+    /// the proper ClipId.
+    scroll_node_id: ClipId,
+
+    /// The ClipId of the clip node which contains this nested display list.
+    /// This is used to replace references to the root with the proper ClipId.
+    clip_node_id: ClipId,
+}
+
+impl NestedDisplayListInfo {
+    fn convert_id_to_nested(&self, id: &ClipId) -> ClipId {
+        match *id {
+            ClipId::Clip(id, _, pipeline_id) => ClipId::Clip(id, self.nest_index, pipeline_id),
+            _ => *id,
+        }
+    }
+
+    fn convert_scroll_id_to_nested(&self, id: &ClipId) -> ClipId {
+        if id.is_root_scroll_node() {
+            self.scroll_node_id
+        } else {
+            self.convert_id_to_nested(id)
+        }
+    }
+
+    fn convert_clip_id_to_nested(&self, id: &ClipId) -> ClipId {
+        if id.is_root_scroll_node() {
+            self.clip_node_id
+        } else {
+            self.convert_id_to_nested(id)
+        }
+    }
+}
+
 struct FlattenContext<'a> {
     scene: &'a Scene,
     builder: &'a mut FrameBuilder,
     resource_cache: &'a mut ResourceCache,
     replacements: Vec<(ClipId, ClipId)>,
-    nested_display_list_info: Vec<(ClipId, ClipId)>,
+    nested_display_list_info: Vec<NestedDisplayListInfo>,
+    current_nested_display_list_index: u64,
 }
 
 impl<'a> FlattenContext<'a> {
@@ -51,51 +102,55 @@ impl<'a> FlattenContext<'a> {
             resource_cache: resource_cache,
             replacements: Vec::new(),
             nested_display_list_info: Vec::new(),
+            current_nested_display_list_index: 0,
         }
     }
 
     fn push_nested_display_list_ids(&mut self, info: ClipAndScrollInfo) {
-        self.nested_display_list_info.push((info.scroll_node_id, info.clip_node_id()));
+        self.current_nested_display_list_index += 1;
+        self.nested_display_list_info.push(NestedDisplayListInfo {
+            nest_index: self.current_nested_display_list_index,
+            scroll_node_id: info.scroll_node_id,
+            clip_node_id: info.clip_node_id(),
+        });
     }
 
     fn pop_nested_display_list_ids(&mut self) {
         self.nested_display_list_info.pop();
     }
 
-    fn apply_clip_and_scroll_info_replacements(&self, info: &mut ClipAndScrollInfo) {
-        info.scroll_node_id = self.apply_scroll_frame_id_replacement(info.scroll_node_id);
-
-        let mut clip_node_id = match info.clip_node_id {
-            Some(id) => id,
-            None => return,
-        };
-
-        for &(_, nested_clip_node_id) in self.nested_display_list_info.iter().rev() {
-            if clip_node_id.is_root_scroll_node() {
-                clip_node_id = nested_clip_node_id;
-            } else {
-                break;
-            }
+    fn convert_new_id_to_neested(&self, id: &ClipId) -> ClipId {
+        if let Some(nested_info) = self.nested_display_list_info.last() {
+            nested_info.convert_id_to_nested(id)
+        } else {
+            *id
         }
-
-        info.clip_node_id = Some(clip_node_id);
     }
 
-    fn apply_scroll_frame_id_replacement(&self, id: ClipId) -> ClipId {
-        let mut id = match self.replacements.last() {
-            Some(&(to_replace, replacement)) if to_replace == id => replacement,
-            _ => id,
-        };
-
-        for &(nested_scroll_id, _) in self.nested_display_list_info.iter().rev() {
-            if id.is_root_scroll_node() {
-                id = nested_scroll_id;
-            } else {
-                break;
-            }
+    fn convert_clip_scroll_info_to_nested(&self, info: &mut ClipAndScrollInfo) {
+        if let Some(nested_info) = self.nested_display_list_info.last() {
+            info.scroll_node_id = nested_info.convert_scroll_id_to_nested(&info.scroll_node_id);
+            info.clip_node_id =
+                info.clip_node_id.map(|ref id| nested_info.convert_clip_id_to_nested(id));
         }
 
-        id
+        // We only want to produce nested ClipIds if we are in a nested display
+        // list situation.
+        debug_assert!(!info.scroll_node_id.is_nested() ||
+                      !self.nested_display_list_info.is_empty());
+        debug_assert!(!info.clip_node_id().is_nested() ||
+                      !self.nested_display_list_info.is_empty());
+    }
+
+    /// Since WebRender still handles fixed position and reference frame content internally
+    /// we need to apply this table of id replacements only to the id that affects the
+    /// position of a node. We can eventually remove this when clients start handling
+    /// reference frames themselves. This method applies these replacements.
+    fn apply_scroll_frame_id_replacement(&self, id: ClipId) -> ClipId {
+        match self.replacements.last() {
+            Some(&(to_replace, replacement)) if to_replace == id => replacement,
+            _ => id,
+        }
     }
 }
 
@@ -314,7 +369,8 @@ impl Frame {
                                              &clip_viewport,
                                              clip,
                                              &mut self.clip_scroll_tree);
-        context.builder.add_scroll_frame(item.id,
+        let new_id = context.convert_new_id_to_neested(&item.id);
+        context.builder.add_scroll_frame(new_id,
                                          new_clip_id,
                                          pipeline_id,
                                          &content_rect,
@@ -353,8 +409,6 @@ impl Frame {
             return;
         }
 
-        let mut clip_id = context.apply_scroll_frame_id_replacement(context_scroll_node_id);
-
         if stacking_context.scroll_policy == ScrollPolicy::Fixed {
             context.replacements.push((context_scroll_node_id,
                                        context.builder.current_reference_frame_id()));
@@ -378,6 +432,7 @@ impl Frame {
                                         .pre_mul(&perspective);
 
             let reference_frame_bounds = LayerRect::new(LayerPoint::zero(), bounds.size);
+            let mut clip_id = context.apply_scroll_frame_id_replacement(context_scroll_node_id);
             clip_id = context.builder.push_reference_frame(Some(clip_id),
                                                            pipeline_id,
                                                            &reference_frame_bounds,
@@ -474,7 +529,11 @@ impl Frame {
                             reference_frame_relative_offset: LayerVector2D)
                             -> Option<BuiltDisplayListIter<'a>> {
         let mut clip_and_scroll = item.clip_and_scroll();
-        context.apply_clip_and_scroll_info_replacements(&mut clip_and_scroll);
+        context.convert_clip_scroll_info_to_nested(&mut clip_and_scroll);
+
+        let unreplaced_scroll_id = clip_and_scroll.scroll_node_id;
+        clip_and_scroll.scroll_node_id =
+            context.apply_scroll_frame_id_replacement(clip_and_scroll.scroll_node_id);
 
         match *item.item() {
             SpecificDisplayItem::WebGL(ref info) => {
@@ -610,7 +669,7 @@ impl Frame {
                 self.flatten_stacking_context(&mut subtraversal,
                                               pipeline_id,
                                               context,
-                                              item.clip_and_scroll().scroll_node_id,
+                                              unreplaced_scroll_id,
                                               reference_frame_relative_offset,
                                               &item.rect(),
                                               &info.stacking_context,
@@ -635,7 +694,11 @@ impl Frame {
                                   item.clip_region());
             }
             SpecificDisplayItem::PushNestedDisplayList => {
-                context.push_nested_display_list_ids(item.clip_and_scroll());
+                // Using the clip and scroll already processed for nesting here
+                // means that in the case of multiple nested display lists, we
+                // will enter the outermost ids into the table and avoid having
+                // to do a replacement for every level of nesting.
+                context.push_nested_display_list_ids(clip_and_scroll);
             }
             SpecificDisplayItem::PopNestedDisplayList => context.pop_nested_display_list_ids(),
 

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -581,16 +581,18 @@ impl ComplexClipRegion {
     }
 }
 
+pub type NestingIndex = u64;
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ClipId {
-    Clip(u64, PipelineId),
+    Clip(u64, NestingIndex, PipelineId),
     ClipExternalId(u64, PipelineId),
     DynamicallyAddedNode(u64, PipelineId),
 }
 
 impl ClipId {
     pub fn root_scroll_node(pipeline_id: PipelineId) -> ClipId {
-        ClipId::Clip(0, pipeline_id)
+        ClipId::Clip(0, 0, pipeline_id)
     }
 
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ClipId {
@@ -609,7 +611,7 @@ impl ClipId {
 
     pub fn pipeline_id(&self) -> PipelineId {
         match *self {
-            ClipId::Clip(_, pipeline_id) |
+            ClipId::Clip(_, _, pipeline_id) |
             ClipId::ClipExternalId(_, pipeline_id) |
             ClipId::DynamicallyAddedNode(_, pipeline_id) => pipeline_id,
         }
@@ -624,7 +626,14 @@ impl ClipId {
 
     pub fn is_root_scroll_node(&self) -> bool {
         match *self {
-            ClipId::Clip(id, _) if id == 0 => true,
+            ClipId::Clip(0, 0, _)  => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_nested(&self) -> bool {
+        match *self {
+            ClipId::Clip(_, nesting_level, _) => nesting_level != 0,
             _ => false,
         }
     }

--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -861,7 +861,7 @@ impl DisplayListBuilder {
             Some(id) => id,
             None => {
                 self.next_clip_id += 1;
-                ClipId::Clip(self.next_clip_id - 1, self.pipeline_id)
+                ClipId::Clip(self.next_clip_id - 1, 0, self.pipeline_id)
             }
         };
 
@@ -910,9 +910,6 @@ impl DisplayListBuilder {
     // lists so that we can regenerate them without building Gecko display items. WebRender
     // will replace references to the root scroll frame id with the current scroll frame
     // id.
-    //
-    // New clips and scroll frames are only supported if they can be guaranteed to have
-    // a unique id (ie a unique id must be passed when creating them).
     pub fn push_nested_display_list(&mut self, built_display_list: &BuiltDisplayList) {
         self.push_clip_region(&LayoutRect::zero(), vec![], None);
         self.push_new_empty_item(SpecificDisplayItem::PushNestedDisplayList);


### PR DESCRIPTION
This will be necessary in order to support removal of the per-item
complex clip and mask on display items.

Fixes #1379.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1386)
<!-- Reviewable:end -->
