### PR TITLE
Apply clip-and-scroll wrench property to stacking contexts

### DIFF
--- a/wrench/reftests/scrolling/clip-and-scroll-property-ref.yaml
+++ b/wrench/reftests/scrolling/clip-and-scroll-property-ref.yaml
@@ -1,0 +1,5 @@
+root:
+    items:
+      - type: rect
+        bounds: [0, 0, 200, 200]
+        color: green

--- a/wrench/reftests/scrolling/clip-and-scroll-property.yaml
+++ b/wrench/reftests/scrolling/clip-and-scroll-property.yaml
@@ -1,0 +1,35 @@
+---
+root:
+  items:
+    -
+      bounds: [0, 0, 200, 200]
+      clip: [0, 0, 0, 0]
+      "clip-and-scroll": 0
+      type: "stacking-context"
+      "scroll-policy": scrollable
+      items:
+        -
+          bounds: [0, 0, 200, 200]
+          clip: [0, 0, 200, 200]
+          "clip-and-scroll": 0
+          type: clip
+          id: 1
+        # Here we are testing that the clip-and-scroll property applies to
+        # both stacking contexts and items.
+        -
+          bounds: [0, 0, 200, 200]
+          clip: [0, 0, 0, 0]
+          "clip-and-scroll": 1
+          type: "stacking-context"
+          "scroll-policy": scrollable
+          transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, 0, 0, 1]
+          "transform-style": flat
+          items:
+            -
+              bounds: [100, 0, 200, 200]
+              clip: [-8947849, -8947849, 17895698, 17895698]
+              "clip-and-scroll": 1
+              type: rect
+              color: green
+  id: [0, 0]
+pipelines: []

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -7,3 +7,4 @@
 == scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
 == scroll-layer.yaml scroll-layer-ref.yaml
 == simple.yaml simple-ref.yaml
+== clip-and-scroll-property.yaml clip-and-scroll-property-ref.yaml

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -570,13 +570,10 @@ impl YamlFrameReader {
                     item["type"].as_str().unwrap_or("unknown")
                 };
 
-            if item_type == "stacking-context" {
-                self.add_stacking_context_from_yaml(wrench, item, false);
-                continue;
-            }
-
-
-            if !self.include_only.is_empty() && !self.include_only.contains(&item_type.to_owned()) {
+            // We never skip stacking contexts because they are structural elements
+            // of the display list.
+            if item_type != "stacking-context" &&
+               self.include_only.contains(&item_type.to_owned()) {
                 continue;
             }
 
@@ -597,7 +594,7 @@ impl YamlFrameReader {
                 "radial-gradient" => self.handle_radial_gradient(wrench, &full_clip_region, item),
                 "box-shadow" => self.handle_box_shadow(wrench, &full_clip_region, item),
                 "iframe" => self.handle_iframe(wrench, &full_clip_region, item),
-                "stacking-context" => { },
+                "stacking-context" => self.add_stacking_context_from_yaml(wrench, item, false),
                 _ => println!("Skipping unknown item type: {:?}", item),
             }
 


### PR DESCRIPTION
Due to a bug in wrench the clip-and-scroll property was not being
applied to stacking contexts. This change fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1387)
<!-- Reviewable:end -->
