### PR TITLE
[RFC] Add a rawtest framework

### DIFF
--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -114,6 +114,8 @@ subcommands:
               help: a specific reftest or directory to run
               required: false
               index: 1
+    - rawtest:
+        about: run rawtests
     - perf:
         about: run benchmarks
         args:

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// A very basic BlobImageRenderer that can only render a checkerboard pattern.
+
+use std::collections::HashMap;
+use webrender::api::*;
+
+
+// Serialize/deserialze the blob.
+
+pub fn serialize_blob(color: ColorU) -> Vec<u8> {
+    vec![color.r, color.g, color.b, color.a]
+}
+
+fn deserialize_blob(blob: &[u8]) -> Result<ColorU, ()> {
+    let mut iter = blob.iter();
+    return match (iter.next(), iter.next(), iter.next(), iter.next()) {
+        (Some(&r), Some(&g), Some(&b), Some(&a)) => Ok(ColorU::new(r, g, b, a)),
+        (Some(&a), None, None, None) => Ok(ColorU::new(a, a, a, a)),
+        _ => Err(()),
+    }
+}
+
+// This is the function that applies the deserialized drawing commands and generates
+// actual image data.
+fn render_blob(
+    color: ColorU,
+    descriptor: &BlobImageDescriptor,
+    tile: Option<TileOffset>,
+) -> BlobImageResult {
+    // Allocate storage for the result. Right now the resource cache expects the
+    // tiles to have have no stride or offset.
+    let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
+
+    // Generate a per-tile pattern to see it in the demo. For a real use case it would not
+    // make sense for the rendered content to depend on its tile.
+    let tile_checker = match tile {
+        Some(tile) => (tile.x % 2 == 0) != (tile.y % 2 == 0),
+        None => true,
+    };
+
+    for y in 0..descriptor.height {
+        for x in 0..descriptor.width {
+            // Apply the tile's offset. This is important: all drawing commands should be
+            // translated by this offset to give correct results with tiled blob images.
+            let x2 = x + descriptor.offset.x as u32;
+            let y2 = y + descriptor.offset.y as u32;
+
+            // Render a simple checkerboard pattern
+            let checker = if (x2 % 20 >= 10) != (y2 % 20 >= 10) { 1 } else { 0 };
+            // ..nested in the per-tile cherkerboard pattern
+            let tc = if tile_checker { 0 } else { (1 - checker) * 40 };
+
+            match descriptor.format {
+                ImageFormat::BGRA8 => {
+                    texels.push(color.b * checker + tc);
+                    texels.push(color.g * checker + tc);
+                    texels.push(color.r * checker + tc);
+                    texels.push(color.a * checker + tc);
+                }
+                ImageFormat::A8 => {
+                    texels.push(color.a * checker + tc);
+                }
+                _ => {
+                    return Err(BlobImageError::Other(format!(
+                        "Usupported image format {:?}",
+                        descriptor.format
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(RasterizedBlobImage {
+        data: texels,
+        width: descriptor.width,
+        height: descriptor.height,
+    })
+}
+
+pub struct CheckerboardRenderer {
+    image_cmds: HashMap<ImageKey, ColorU>,
+
+    // The images rendered in the current frame (not kept here between frames).
+    rendered_images: HashMap<BlobImageRequest, BlobImageResult>,
+}
+
+impl CheckerboardRenderer {
+    pub fn new() -> Self {
+        CheckerboardRenderer {
+            image_cmds: HashMap::new(),
+            rendered_images: HashMap::new(),
+        }
+    }
+}
+
+impl BlobImageRenderer for CheckerboardRenderer {
+    fn add(&mut self, key: ImageKey, cmds: BlobImageData, _: Option<TileSize>) {
+        self.image_cmds.insert(key, deserialize_blob(&cmds[..]).unwrap());
+    }
+
+    fn update(&mut self, key: ImageKey, cmds: BlobImageData) {
+        // Here, updating is just replacing the current version of the commands with
+        // the new one (no incremental updates).
+        self.image_cmds.insert(key, deserialize_blob(&cmds[..]).unwrap());
+    }
+
+    fn delete(&mut self, key: ImageKey) {
+        self.image_cmds.remove(&key);
+    }
+
+    fn request(&mut self,
+               _resources: &BlobImageResources,
+               request: BlobImageRequest,
+               descriptor: &BlobImageDescriptor,
+               _dirty_rect: Option<DeviceUintRect>) {
+        assert!(!self.rendered_images.contains_key(&request));
+        // This method is where we kick off our rendering jobs.
+        // It should avoid doing work on the calling thread as much as possible.
+        // In this example we will use the thread pool to render individual tiles.
+
+        // Gather the input data to send to a worker thread.
+        let cmds = self.image_cmds.get(&request.key).unwrap();
+
+        let result = render_blob(*cmds, descriptor, request.tile);
+
+        self.rendered_images.insert(request, result);
+    }
+
+    fn resolve(&mut self, request: BlobImageRequest) -> BlobImageResult {
+        self.rendered_images.remove(&request).unwrap()
+    }
+
+    fn delete_font(&mut self, _key: FontKey) { }
+}
+
+

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -31,11 +31,13 @@ extern crate webrender;
 extern crate yaml_rust;
 
 mod binary_frame_reader;
+mod blob;
 mod json_frame_writer;
 mod parse_function;
 mod perf;
 mod png;
 mod premultiply;
+mod rawtest;
 mod reftest;
 mod scene;
 mod wrench;
@@ -48,6 +50,7 @@ use gleam::gl;
 use glutin::{ElementState, VirtualKeyCode, WindowProxy};
 use perf::PerfHarness;
 use png::save_flipped;
+use rawtest::RawtestHarness;
 use reftest::{ReftestHarness, ReftestOptions};
 use std::cmp::{max, min};
 #[cfg(feature = "headless")]
@@ -349,6 +352,13 @@ fn main() {
                 reftest_options.allow_num_differences = w as usize * h as usize;
             }
             harness.run(base_manifest, specific_reftest, &reftest_options);
+            return;
+        } else if let Some(_) = args.subcommand_matches("rawtest") {
+            {
+                let harness = RawtestHarness::new(&mut wrench, &mut window);
+                harness.run();
+            }
+            wrench.renderer.deinit();
             return;
         } else if let Some(subargs) = args.subcommand_matches("perf") {
             // Perf mode wants to benchmark the total cost of drawing

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use WindowWrapper;
+use blob;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use webrender::api::*;
+use wrench::Wrench;
+
+pub struct RawtestHarness<'a> {
+    wrench: &'a mut Wrench,
+    rx: Receiver<()>,
+    window: &'a mut WindowWrapper,
+}
+
+impl<'a> RawtestHarness<'a> {
+    pub fn new(wrench: &'a mut Wrench,
+               window: &'a mut WindowWrapper) -> RawtestHarness<'a>
+    {
+        // setup a notifier so we can wait for frames to be finished
+        struct Notifier {
+            tx: Sender<()>,
+        };
+        impl RenderNotifier for Notifier {
+            fn new_frame_ready(&mut self) { self.tx.send(()).unwrap(); }
+            fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
+        }
+        let (tx, rx) = channel();
+        wrench.renderer.set_render_notifier(Box::new(Notifier { tx: tx }));
+
+        RawtestHarness {
+            wrench: wrench,
+            rx: rx,
+            window: window,
+        }
+    }
+
+    pub fn run(mut self) {
+        self.retained_blob_images_test();
+    }
+
+    fn render_and_get_pixels(&mut self, window_rect: DeviceUintRect) -> Vec<u8> {
+        self.rx.recv().unwrap();
+        self.wrench.render();
+        self.wrench.renderer.read_pixels_rgba8(window_rect)
+    }
+
+    fn retained_blob_images_test(&mut self) {
+        let blob_img;
+        let window_size = self.window.get_inner_size_pixels();
+        let window_size = DeviceUintSize::new(window_size.0, window_size.1);
+
+        let test_size = DeviceUintSize::new(400, 400);
+        let document_id = self.wrench.document_id;
+
+        let window_rect = DeviceUintRect::new(DeviceUintPoint::new(0, window_size.height - test_size.height),
+                                              test_size);
+        let layout_size = LayoutSize::new(400., 400.);
+        let mut resources = ResourceUpdates::new();
+        {
+            let api = &self.wrench.api;
+
+            blob_img = api.generate_image_key();
+            resources.add_image(blob_img,
+                          ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+                          ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
+                          None,
+            );
+        }
+        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
+
+        // draw the blob the first time
+        let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
+        builder.push_image(
+            LayoutRect::new(LayoutPoint::new(0.0, 60.0), LayoutSize::new(200.0, 200.0)),
+            None,
+            LayoutSize::new(200.0, 200.0),
+            LayoutSize::new(0.0, 0.0),
+            ImageRendering::Auto,
+            blob_img,
+        );
+
+        self.wrench.api.set_display_list(document_id,
+                                         Epoch(0),
+                                         root_background_color,
+                                         layout_size,
+                                         builder.finalize(),
+                                         false,
+                                         resources);
+        self.wrench.api.generate_frame(document_id, None);
+
+
+        // draw the blob image a second time at a different location
+
+        // make a new display list that refers to the first image
+        let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
+        builder.push_image(
+            LayoutRect::new(LayoutPoint::new(1.0, 60.0), LayoutSize::new(200.0, 200.0)),
+            None,
+            LayoutSize::new(200.0, 200.0),
+            LayoutSize::new(0.0, 0.0),
+            ImageRendering::Auto,
+            blob_img,
+        );
+
+        self.wrench.api.set_display_list(document_id,
+                                         Epoch(1),
+                                         root_background_color,
+                                         layout_size,
+                                         builder.finalize(),
+                                         false,
+                                         ResourceUpdates::new());
+
+        self.wrench.api.generate_frame(document_id, None);
+
+        let pixels_first = self.render_and_get_pixels(window_rect);
+        let pixels_second = self.render_and_get_pixels(window_rect);
+
+        // use png;
+        // png::save_flipped("out1.png", &pixels_first, window_rect.size);
+        // png::save_flipped("out2.png", &pixels_second, window_rect.size);
+
+        assert!(pixels_first != pixels_second);
+
+    }
+}

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -4,6 +4,7 @@
 
 
 use app_units::Au;
+use blob;
 use crossbeam::sync::chase_lev;
 #[cfg(windows)]
 use dwrote;
@@ -114,7 +115,7 @@ pub struct Wrench {
 
     pub renderer: webrender::renderer::Renderer,
     pub api: RenderApi,
-    document_id: DocumentId,
+    pub document_id: DocumentId,
     pub root_pipeline_id: PipelineId,
 
     window_title_to_set: Option<String>,
@@ -168,6 +169,7 @@ impl Wrench {
             enable_clear_scissor: !no_scissor,
             enable_batcher: !no_batch,
             max_recorded_profiles: 16,
+            blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new())),
             .. Default::default()
         };
 


### PR DESCRIPTION
This adds a rawtesting framework that lets tests do anything
that the webrender api allows. This allows writing tests
that do more sophisticated things then the yaml can express.

The framework includes a single test that tests that when
we draw a blob image a second time we get the same results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1389)
<!-- Reviewable:end -->
