### PR TITLE
Fix FLOAT texture sampling precision problems on some mobile GPUs

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -10,7 +10,16 @@
         #else
         precision mediump sampler2DArray;
         #endif
+
+        // Sampler default precision is lowp on mobile GPUs.
+        // This causes RGBA32F texture data to be clamped to 16 bit floats on some GPUs (e.g. Mali-T880).
+        // Define highp precision macro to allow lossless FLOAT texture sampling.
+        #define HIGHP_SAMPLER_FLOAT highp
+    #else
+        #define HIGHP_SAMPLER_FLOAT
     #endif
+#else
+    #define HIGHP_SAMPLER_FLOAT
 #endif
 
 #define PST_TOP_LEFT     0
@@ -118,7 +127,7 @@ ivec2 get_resource_cache_uv(int address) {
                  address / WR_MAX_VERTEX_TEXTURE_WIDTH);
 }
 
-uniform sampler2D sResourceCache;
+uniform HIGHP_SAMPLER_FLOAT sampler2D sResourceCache;
 
 vec4[2] fetch_from_resource_cache_2(int address) {
     ivec2 uv = get_resource_cache_uv(address);
@@ -137,10 +146,10 @@ vec4[2] fetch_from_resource_cache_2(int address) {
 #define VECS_PER_GRADIENT           3
 #define VECS_PER_GRADIENT_STOP      2
 
-uniform sampler2D sLayers;
-uniform sampler2D sRenderTasks;
+uniform HIGHP_SAMPLER_FLOAT sampler2D sLayers;
+uniform HIGHP_SAMPLER_FLOAT sampler2D sRenderTasks;
 
-uniform sampler2D sData32;
+uniform HIGHP_SAMPLER_FLOAT sampler2D sData32;
 
 // Instanced attributes
 in ivec4 aData0;


### PR DESCRIPTION
Hi,

I'm working on running WebGL/WebVR demos on a Samsung Galaxy S7. I found that WR renders a white screen in all WebGL or CSS demos, even the simple ones. It's weird because it works correctly on other old Android phones such as Nexus 4 (released 5-6 years ago). I thought that it was caused by a GPU driver issue but after heavy debugging I found that texelFetch was getting corrupt values for big float values (e.g. local_clip_rect). They are stored correctly on the texture data but clamped to maximum half_float value (65504.0) when computed in the shaders.

Adding highp precision qualifier to the FLOAT sampler2D fixes the issue. Samsung Galaxy S7 has Mali-T880 GPU. The precision qualifier wasn't need on other Android mobiles I have tested (mostly Adreno GPUs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1395)
<!-- Reviewable:end -->
