### PR TITLE
Add DisplayListBuilder::with_capacity for finer capacity management by servo/gecko

### DIFF
--- a/webrender_traits/src/display_list.rs
+++ b/webrender_traits/src/display_list.rs
@@ -430,13 +430,19 @@ pub struct DisplayListBuilder {
 
 impl DisplayListBuilder {
     pub fn new(pipeline_id: PipelineId, content_size: LayoutSize) -> DisplayListBuilder {
+        Self::with_capacity(pipeline_id, content_size, 0)
+    }
+
+    pub fn with_capacity(pipeline_id: PipelineId,
+                         content_size: LayoutSize,
+                         capacity: usize) -> DisplayListBuilder {
         let start_time = precise_time_ns();
 
         // We start at 1 here, because the root scroll id is always 0.
         const FIRST_CLIP_ID : u64 = 1;
 
         DisplayListBuilder {
-            data: Vec::with_capacity(1024 * 1024),
+            data: Vec::with_capacity(capacity),
             pipeline_id: pipeline_id,
             clip_stack: vec![ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id))],
             next_clip_id: FIRST_CLIP_ID,


### PR DESCRIPTION
Gecko makes tons of tiny ones, servo makes one huge one. They need different strategies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1399)
<!-- Reviewable:end -->
