### PR TITLE
Fix z-buffer usage, and calculate if aligned gradients are opaque.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1857,7 +1857,13 @@ impl Renderer {
         self.device.enable_depth();
         self.device.enable_depth_write();
 
-        for batch in &target.alpha_batcher.batch_list.opaque_batches {
+        // Draw opaque batches front-to-back for maximum
+        // z-buffer efficiency!
+        for batch in target.alpha_batcher
+                           .batch_list
+                           .opaque_batches
+                           .iter()
+                           .rev() {
             self.submit_batch(batch,
                               &projection,
                               render_task_data,


### PR DESCRIPTION
I accidentally broke z-buffering some time ago - when a change was
introduced that meant opaque batches were no longer being submitted
front-to-back.

This patch fixes that, and also correctly calculates if aligned
gradients can be part of the opaque pass. This results in big
GPU performance wins with large background gradients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1404)
<!-- Reviewable:end -->
