### PR TITLE
Mark types as repr(C)

### DIFF
--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -507,7 +507,6 @@ impl PropertyBindingId {
 
 /// A unique key that is used for connecting animated property
 /// values to bindings in the display list.
-#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PropertyBindingKey<T> {
     pub id: PropertyBindingId,

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -118,6 +118,7 @@ pub enum RepeatMode {
     Space,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct NinePatchDescriptor {
     pub width: u32,
@@ -163,6 +164,7 @@ pub struct BorderDisplayItem {
     pub details: BorderDetails,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BorderRadius {
     pub top_left: LayoutSize,
@@ -171,6 +173,7 @@ pub struct BorderRadius {
     pub bottom_right: LayoutSize,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct BorderWidths {
     pub left: f32,
@@ -435,6 +438,7 @@ impl YuvFormat {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageMask {
     pub image: ImageKey,
@@ -452,6 +456,7 @@ pub struct ClipRegion {
     pub complex_clip_count: usize,
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.

--- a/webrender_traits/src/image.rs
+++ b/webrender_traits/src/image.rs
@@ -33,6 +33,7 @@ pub enum ExternalImageType {
     ExternalBuffer,
 }
 
+#[repr(C)]
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ExternalImageData {
     pub id: ExternalImageId,


### PR DESCRIPTION
This commit marks types that can be repr(C) and are used in the Gecko
FFI to be repr(C). This also removes the repr(C) from PropertyBindingKey
as it has a type that isn't repr(C), and I don't think it is used in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1415)
<!-- Reviewable:end -->
