### PR TITLE
res: fix indentation in cs_text_run vertex shader.

### DIFF
--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -31,8 +31,9 @@ void main(void) {
     vec2 pos = mix(local_rect.xy,
                    local_rect.xy + local_rect.zw,
                    aPosition.xy);
-	vUv = mix(st0, st1, aPosition.xy);
-	vColor = text.color;
+
+    vUv = mix(st0, st1, aPosition.xy);
+    vColor = text.color;
 
     gl_Position = uTransform * vec4(pos, 0.0, 1.0);
 }


### PR DESCRIPTION
Kind of an unimpressive patch, but I saw this when investigating https://github.com/servo/servo/issues/17464 and thought it may be worth fixing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1420)
<!-- Reviewable:end -->
