### PR TITLE
frame_builder: Don't use subpixel AA for non-opaque text.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -774,6 +774,10 @@ impl FrameBuilder {
                 render_mode = FontRenderMode::Alpha;
             }
 
+            if color.a != 1.0 {
+                render_mode = FontRenderMode::Alpha;
+            }
+
             // text on a stacking context that has filters
             // (e.g. opacity) can't use sub-pixel.
             // TODO(gw): It's possible we can relax this in

--- a/wrench/reftests/text/non-opaque-notref.yaml
+++ b/wrench/reftests/text/non-opaque-notref.yaml
@@ -1,0 +1,10 @@
+---
+root:
+  items:
+    -
+      bounds: [0, 0, 200, 200]
+      glyphs: [55]
+      offsets: [200, 200]
+      size: 100
+      color: [0, 0, 0]
+      font: "VeraBd.ttf"

--- a/wrench/reftests/text/non-opaque.yaml
+++ b/wrench/reftests/text/non-opaque.yaml
@@ -1,0 +1,10 @@
+---
+root:
+  items:
+    -
+      bounds: [0, 0, 200, 200]
+      glyphs: [55]
+      offsets: [200, 200]
+      size: 100
+      color: [0, 0, 0, 0.5]
+      font: "VeraBd.ttf"

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -2,3 +2,4 @@
 != negative-pos.yaml blank.yaml
 != shadow.yaml text.yaml
 != shadow-single.yaml blank.yaml
+!= non-opaque.yaml non-opaque-notref.yaml


### PR DESCRIPTION
This fixes https://github.com/servo/servo/issues/17464.

Not 100% sure it's the correct fix, but it seemed reasonable given we disable it
for non-opaque stacking contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1423)
<!-- Reviewable:end -->
