### PR TITLE
Improve the clipping and scrolling API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.46.0",
+ "webrender 0.47.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1022,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1048,12 +1048,12 @@ dependencies = [
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.46.0",
+ "webrender_api 0.47.0",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.46.0"
+version = "0.47.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -36,9 +36,7 @@ fn body(_api: &RenderApi,
                                   Vec::new());
 
     // Fill it with a white rect
-    builder.push_rect(bounds,
-                      bounds,
-                      ColorF::new(1.0, 1.0, 1.0, 1.0));
+    builder.push_rect(bounds, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
 
     builder.pop_stacking_context();
 }

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -197,7 +197,8 @@ fn body(api: &RenderApi,
         repeat: false,
     };
     let complex = ComplexClipRegion::new((50, 50).to(150, 150), BorderRadius::uniform(20.0));
-    builder.push_clip_node(None, bounds, bounds, vec![complex], Some(mask));
+    let id = builder.define_clip(None, bounds, vec![complex], Some(mask));
+    builder.push_clip_id(id);
 
     let bounds = (100, 100).to(200, 200);
     builder.push_rect(bounds, bounds, ColorF::new(0.0, 1.0, 0.0, 1.0));
@@ -319,7 +320,7 @@ fn body(api: &RenderApi,
                                 box_shadow_type);
     }
 
-    builder.pop_clip_node();
+    builder.pop_clip_id();
     builder.pop_stacking_context();
 }
 

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -201,12 +201,10 @@ fn body(api: &RenderApi,
     builder.push_clip_id(id);
 
     let bounds = (100, 100).to(200, 200);
-    builder.push_rect(bounds, bounds, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder.push_rect(bounds, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
 
     let bounds = (250, 100).to(350, 200);
-    builder.push_rect(bounds,
-                      bounds,
-                      ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder.push_rect(bounds, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
     let border_side = BorderSide {
         color: ColorF::new(0.0, 0.0, 1.0, 1.0),
         style: BorderStyle::Groove,
@@ -226,10 +224,7 @@ fn body(api: &RenderApi,
     });
 
     let bounds = (100, 100).to(200, 200);
-    builder.push_border(bounds,
-                        bounds,
-                        border_widths,
-                        border_details);
+    builder.push_border(bounds, None, border_widths, border_details);
 
 
     if false { // draw text?
@@ -290,7 +285,7 @@ fn body(api: &RenderApi,
         ];
 
         builder.push_text(text_bounds,
-                          text_bounds,
+                          None,
                           &glyphs,
                           font_key,
                           ColorF::new(1.0, 1.0, 0.0, 1.0),
@@ -310,7 +305,7 @@ fn body(api: &RenderApi,
         let box_shadow_type = BoxShadowClipMode::Inset;
 
         builder.push_box_shadow(rect,
-                                bounds,
+                                Some(LocalClip::from(bounds)),
                                 simple_box_bounds,
                                 offset,
                                 color,

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -243,7 +243,7 @@ fn body(api: &api::RenderApi,
 
     builder.push_image(
         (30, 30).by(500, 500),
-        bounds,
+        Some(api::LocalClip::from(bounds)),
         api::LayoutSize::new(500.0, 500.0),
         api::LayoutSize::new(0.0, 0.0),
         api::ImageRendering::Auto,
@@ -252,7 +252,7 @@ fn body(api: &api::RenderApi,
 
     builder.push_image(
         (600, 600).by(200, 200),
-        bounds,
+        Some(api::LocalClip::from(bounds)),
         api::LayoutSize::new(200.0, 200.0),
         api::LayoutSize::new(0.0, 0.0),
         api::ImageRendering::Auto,

--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -30,9 +30,7 @@ fn body(_api: &RenderApi,
                                   Vec::new());
 
     let outer_scroll_frame_rect = (100, 100).to(600, 400);
-    builder.push_rect(outer_scroll_frame_rect,
-                      outer_scroll_frame_rect,
-                      ColorF::new(1.0, 1.0, 1.0, 1.0));
+    builder.push_rect(outer_scroll_frame_rect, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
 
     let nested_clip_id = builder.define_scroll_frame(None,
                                                      (100, 100).to(1000, 1000),
@@ -45,7 +43,7 @@ fn body(_api: &RenderApi,
     let mut builder3 = DisplayListBuilder::new(*pipeline_id, *layout_size);
 
     let rect = (110, 110).to(210, 210);
-    builder3.push_rect(rect, rect, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
 
     // A fixed position rectangle should be fixed to the reference frame that starts
     // in the outer display list.
@@ -57,16 +55,14 @@ fn body(_api: &RenderApi,
                                   MixBlendMode::Normal,
                                   Vec::new());
     let rect = (0, 0).to(100, 100);
-    builder3.push_rect(rect, rect, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
     builder3.pop_stacking_context();
 
     // Now we push an inner scroll frame that should have the same id as the outer one,
     // but the WebRender nested display list replacement code should convert it into
     // a unique ClipId.
     let inner_scroll_frame_rect = (330, 110).to(530, 360);
-    builder3.push_rect(inner_scroll_frame_rect,
-                       inner_scroll_frame_rect,
-                       ColorF::new(1.0, 0.0, 1.0, 0.5));
+    builder3.push_rect(inner_scroll_frame_rect, None, ColorF::new(1.0, 0.0, 1.0, 0.5));
     let inner_nested_clip_id = builder3.define_scroll_frame(None,
                                                             (330, 110).to(2000, 2000),
                                                             inner_scroll_frame_rect,
@@ -74,7 +70,7 @@ fn body(_api: &RenderApi,
                                                             None);
     builder3.push_clip_id(inner_nested_clip_id);
     let rect = (340, 120).to(440, 220);
-    builder3.push_rect(rect, rect, ColorF::new(0.0, 1.0, 0.0, 1.0));
+    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
     builder3.pop_clip_id();
 
     let (_, _, built_list) = builder3.finalize();

--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -34,11 +34,11 @@ fn body(_api: &RenderApi,
                       outer_scroll_frame_rect,
                       ColorF::new(1.0, 1.0, 1.0, 1.0));
 
-    let nested_clip_id = builder.define_clip(None,
-                                             (100, 100).to(1000, 1000),
-                                             outer_scroll_frame_rect,
-                                             vec![],
-                                             None);
+    let nested_clip_id = builder.define_scroll_frame(None,
+                                                     (100, 100).to(1000, 1000),
+                                                     outer_scroll_frame_rect,
+                                                     vec![],
+                                                     None);
     builder.push_clip_id(nested_clip_id);
 
     let mut builder2 = DisplayListBuilder::new(*pipeline_id, *layout_size);
@@ -67,11 +67,11 @@ fn body(_api: &RenderApi,
     builder3.push_rect(inner_scroll_frame_rect,
                        inner_scroll_frame_rect,
                        ColorF::new(1.0, 0.0, 1.0, 0.5));
-    let inner_nested_clip_id = builder3.define_clip(None,
-                                                    (330, 110).to(2000, 2000),
-                                                    inner_scroll_frame_rect,
-                                                    vec![],
-                                                    None);
+    let inner_nested_clip_id = builder3.define_scroll_frame(None,
+                                                            (330, 110).to(2000, 2000),
+                                                            inner_scroll_frame_rect,
+                                                            vec![],
+                                                            None);
     builder3.push_clip_id(inner_nested_clip_id);
     let rect = (340, 120).to(440, 220);
     builder3.push_rect(rect, rect, ColorF::new(0.0, 1.0, 0.0, 1.0));

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -41,7 +41,11 @@ fn body(_api: &RenderApi,
                                       MixBlendMode::Normal,
                                       Vec::new());
         // set the scrolling clip
-        let clip_id = builder.define_clip(None, (0, 0).by(1000, 1000), scrollbox, vec![], None);
+        let clip_id = builder.define_scroll_frame(None,
+                                                  (0, 0).by(1000, 1000),
+                                                  scrollbox,
+                                                  vec![],
+                                                  None);
         builder.push_clip_id(clip_id);
 
         // now put some content into it.
@@ -62,11 +66,11 @@ fn body(_api: &RenderApi,
         // Below the above rectangles, set up a nested scrollbox. It's still in
         // the same stacking context, so note that the rects passed in need to
         // be relative to the stacking context.
-        let nested_clip_id = builder.define_clip(None,
-                                                 (0, 100).to(300, 400),
-                                                 (0, 100).to(200, 300),
-                                                 vec![],
-                                                 None);
+        let nested_clip_id = builder.define_scroll_frame(None,
+                                                         (0, 100).to(300, 400),
+                                                         (0, 100).to(200, 300),
+                                                         vec![],
+                                                         None);
         builder.push_clip_id(nested_clip_id);
 
         // give it a giant gray background just to distinguish it and to easily

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -50,17 +50,15 @@ fn body(_api: &RenderApi,
 
         // now put some content into it.
         // start with a white background
-        builder.push_rect((0, 0).to(1000, 1000),
-                          (0, 0).to(1000, 1000),
-                          ColorF::new(1.0, 1.0, 1.0, 1.0));
+        builder.push_rect((0, 0).to(1000, 1000), None, ColorF::new(1.0, 1.0, 1.0, 1.0));
+
         // let's make a 50x50 blue square as a visual reference
-        builder.push_rect((0, 0).to(50, 50),
-                          (0, 0).to(50, 50),
-                          ColorF::new(0.0, 0.0, 1.0, 1.0));
+        builder.push_rect((0, 0).to(50, 50), None, ColorF::new(0.0, 0.0, 1.0, 1.0));
+
         // and a 50x50 green square next to it with an offset clip
         // to see what that looks like
         builder.push_rect((50, 0).to(100, 50),
-                          (60, 10).to(110, 60),
+                          Some(LocalClip::from((60, 10).to(110, 60))),
                           ColorF::new(0.0, 1.0, 0.0, 1.0));
 
         // Below the above rectangles, set up a nested scrollbox. It's still in
@@ -75,20 +73,17 @@ fn body(_api: &RenderApi,
 
         // give it a giant gray background just to distinguish it and to easily
         // visually identify the nested scrollbox
-        builder.push_rect((-1000, -1000).to(5000, 5000),
-                          (-1000, -1000).to(5000, 5000),
-                          ColorF::new(0.5, 0.5, 0.5, 1.0));
+        builder.push_rect((-1000, -1000).to(5000, 5000), None, ColorF::new(0.5, 0.5, 0.5, 1.0));
+
         // add a teal square to visualize the scrolling/clipping behaviour
         // as you scroll the nested scrollbox with WASD keys
-        builder.push_rect((0, 100).to(50, 150),
-                          (0, 100).to(50, 150),
-                          ColorF::new(0.0, 1.0, 1.0, 1.0));
+        builder.push_rect((0, 100).to(50, 150), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
+
         // just for good measure add another teal square in the bottom-right
         // corner of the nested scrollframe content, which can be scrolled into
         // view by the user
-        builder.push_rect((250, 350).to(300, 400),
-                          (250, 350).to(300, 400),
-                          ColorF::new(0.0, 1.0, 1.0, 1.0));
+        builder.push_rect((250, 350).to(300, 400), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
+
         builder.pop_clip_id(); // nested_clip_id
 
         builder.pop_clip_id(); // clip_id

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -206,7 +206,7 @@ fn body(api: &RenderApi,
 
     builder.push_yuv_image(
         LayoutRect::new(LayoutPoint::new(100.0, 0.0), LayoutSize::new(100.0, 100.0)),
-        bounds,
+        Some(LocalClip::from(bounds)),
         YuvData::NV12(yuv_chanel1, yuv_chanel2),
         YuvColorSpace::Rec601,
         ImageRendering::Auto,
@@ -214,7 +214,7 @@ fn body(api: &RenderApi,
 
     builder.push_yuv_image(
         LayoutRect::new(LayoutPoint::new(300.0, 0.0), LayoutSize::new(100.0, 100.0)),
-        bounds,
+        Some(LocalClip::from(bounds)),
         YuvData::PlanarYCbCr(yuv_chanel1, yuv_chanel2_1, yuv_chanel3),
         YuvColorSpace::Rec601,
         ImageRendering::Auto,

--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use api::{BorderSide, BorderStyle, BorderWidths, ClipAndScrollInfo, ColorF, LayerPoint, LayerRect};
+use api::{LayerSize, LocalClip, NormalBorder};
 use ellipse::Ellipse;
 use gpu_cache::GpuDataRequest;
 use frame_builder::FrameBuilder;
@@ -9,8 +11,6 @@ use mask_cache::ClipSource;
 use prim_store::{BorderPrimitiveCpu, PrimitiveContainer};
 use tiling::PrimitiveFlags;
 use util::{lerp, pack_as_float};
-use api::{BorderSide, BorderStyle, BorderWidths, ClipAndScrollInfo, ColorF};
-use api::{LayerPoint, LayerRect, LayerSize, NormalBorder};
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -226,7 +226,7 @@ impl FrameBuilder {
                                    border: &NormalBorder,
                                    widths: &BorderWidths,
                                    clip_and_scroll: ClipAndScrollInfo,
-                                   clip_rect: &LayerRect,
+                                   local_clip: &LocalClip,
                                    corner_instances: [BorderCornerInstance; 4],
                                    extra_clips: &[ClipSource]) {
         let radius = &border.radius;
@@ -273,7 +273,7 @@ impl FrameBuilder {
 
         self.add_primitive(clip_and_scroll,
                            &rect,
-                           clip_rect,
+                           local_clip,
                            extra_clips,
                            PrimitiveContainer::Border(prim_cpu));
     }
@@ -287,7 +287,7 @@ impl FrameBuilder {
                              border: &NormalBorder,
                              widths: &BorderWidths,
                              clip_and_scroll: ClipAndScrollInfo,
-                             clip_rect: &LayerRect) {
+                             local_clip: &LocalClip) {
         // The border shader is quite expensive. For simple borders, we can just draw
         // the border with a few rectangles. This generally gives better batching, and
         // a GPU win in fragment shader time.
@@ -367,7 +367,7 @@ impl FrameBuilder {
             if top_edge == BorderEdgeKind::Solid {
                 self.add_solid_rectangle(clip_and_scroll,
                                          &LayerRect::new(p0, LayerSize::new(rect_width, top_len)),
-                                         clip_rect,
+                                         local_clip,
                                          &border.top.color,
                                          PrimitiveFlags::None);
             }
@@ -376,7 +376,7 @@ impl FrameBuilder {
                                          &LayerRect::new(LayerPoint::new(p0.x, p0.y + top_len),
                                                          LayerSize::new(left_len,
                                                                         rect_height - top_len - bottom_len)),
-                                         clip_rect,
+                                         local_clip,
                                          &border.left.color,
                                          PrimitiveFlags::None);
             }
@@ -386,7 +386,7 @@ impl FrameBuilder {
                                                                          p0.y + top_len),
                                                          LayerSize::new(right_len,
                                                                         rect_height - top_len - bottom_len)),
-                                         clip_rect,
+                                         local_clip,
                                          &border.right.color,
                                          PrimitiveFlags::None);
             }
@@ -394,7 +394,7 @@ impl FrameBuilder {
                 self.add_solid_rectangle(clip_and_scroll,
                                          &LayerRect::new(LayerPoint::new(p0.x, p1.y - bottom_len),
                                                          LayerSize::new(rect_width, bottom_len)),
-                                         clip_rect,
+                                         local_clip,
                                          &border.bottom.color,
                                          PrimitiveFlags::None);
             }
@@ -423,7 +423,7 @@ impl FrameBuilder {
                                              border,
                                              widths,
                                              clip_and_scroll,
-                                             clip_rect,
+                                             local_clip,
                                              corner_instances,
                                              &extra_clips);
         }

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -9,7 +9,7 @@ use geometry::ray_intersects_rect;
 use mask_cache::{ClipRegion, ClipSource, MaskCacheInfo};
 use spring::{DAMPING, STIFFNESS, Spring};
 use tiling::PackedLayerIndex;
-use util::{ComplexClipRegionHelpers, MatrixHelpers, TransformedRectKind};
+use util::{MatrixHelpers, TransformedRectKind};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -392,32 +392,6 @@ impl ClipScrollNode {
             }
             _ => false,
         }
-    }
-
-    pub fn find_unclipped_rectangle(&self, rect: &LayerRect) -> Option<LayerRect> {
-        let clip_sources = match self.node_type {
-            NodeType::Clip(ref clip_info) => &clip_info.clip_sources,
-            _ => return None,
-        };
-
-        let clip_region = match clip_sources.last() {
-            Some(&ClipSource::Region(ref clip_region)) if clip_sources.len() == 1 => clip_region,
-            _ => return None,
-        };
-
-        if clip_region.image_mask.is_some() || clip_region.complex_clips.is_empty() {
-            return None;
-        }
-
-        let offset = &self.local_viewport_rect.origin.to_vector();
-        let base_rect = clip_region.main.translate(offset).intersection(rect);
-        clip_region.complex_clips.iter().fold(base_rect, |inner_combined, ccr| {
-            inner_combined.and_then(|combined| {
-                ccr.get_inner_rect_full().and_then(|ir| {
-                    ir.translate(offset).intersection(&combined)
-                })
-            })
-        })
     }
 }
 

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use api::{BorderRadius, ComplexClipRegion, DeviceIntRect, ImageMask, LayerPoint};
+use api::{LayerRect, LayerSize, LayerToWorldTransform};
 use border::BorderCornerClipSource;
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use prim_store::{CLIP_DATA_GPU_BLOCKS, ClipData, ImageMaskData};
@@ -12,6 +14,40 @@ use api::{LayerRect, LayerPoint, LayerSize};
 use std::ops::Not;
 
 const MAX_CLIP: f32 = 1000000.0;
+
+#[derive(Clone, Debug)]
+pub struct ClipRegion {
+    pub origin: LayerPoint,
+    pub main: LayerRect,
+    pub image_mask: Option<ImageMask>,
+    pub complex_clips: Vec<ComplexClipRegion>,
+}
+
+impl ClipRegion {
+    pub fn new(main: LayerRect,
+               mut image_mask: Option<ImageMask>,
+               mut complex_clips: Vec<ComplexClipRegion>)
+               -> ClipRegion {
+        let negative_origin = -main.origin.to_vector();
+
+        // All the coordinates we receive are relative to the stacking context, but we want
+        // to convert them to something relative to the origin of the clip.
+        if let Some(ref mut image_mask) = image_mask {
+            image_mask.rect = image_mask.rect.translate(&negative_origin);
+        }
+
+        for ref mut complex_clip in complex_clips.iter_mut() {
+            complex_clip.rect = complex_clip.rect.translate(&negative_origin);
+        }
+
+        ClipRegion {
+            origin: main.origin,
+            main: LayerRect::new(LayerPoint::zero(), main.size),
+            image_mask,
+            complex_clips,
+        }
+    }
+}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -158,7 +194,7 @@ impl MaskCacheInfo {
                         debug_assert!(image.is_none());     // TODO(gw): Support >1 image mask!
                         image = Some((info, GpuCacheHandle::new()));
                     }
-                    complex_clip_count += region.complex_clip_count;
+                    complex_clip_count += region.complex_clips.len();
                     layer_clip_count += 1;
                 }
                 ClipSource::BorderCorner(ref source) => {
@@ -183,8 +219,8 @@ impl MaskCacheInfo {
                   sources: &[ClipSource],
                   transform: &LayerToWorldTransform,
                   gpu_cache: &mut GpuCache,
-                  device_pixel_ratio: f32,
-                  display_list: &BuiltDisplayList) -> &MaskBounds {
+                  device_pixel_ratio: f32)
+                  -> &MaskBounds {
 
         // Step[1] - compute the local bounds
         //TODO: move to initialization stage?
@@ -220,7 +256,7 @@ impl MaskCacheInfo {
                             None => local_rect,
                         };
 
-                        for clip in display_list.get(region.complex_clips) {
+                        for clip in &region.complex_clips {
                             local_rect = local_rect.and_then(|r| r.intersection(&clip.rect));
                             local_inner = local_inner.and_then(|r| clip.get_inner_rect_safe()
                                                                        .and_then(|ref inner| r.intersection(inner)));
@@ -264,7 +300,7 @@ impl MaskCacheInfo {
                             data.write(&mut request);
                         }
                         ClipSource::Region(ref region) => {
-                            for clip in display_list.get(region.complex_clips) {
+                            for clip in &region.complex_clips {
                                 let data = ClipData::from_clip_region(&clip);
                                 data.write(&mut request);
                             }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2,23 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntSize, DevicePoint};
+use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
+use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
+use api::{LayerToWorldTransform, TileOffset, WebGLContextId, YuvColorSpace, YuvFormat};
+use api::device_length;
 use app_units::Au;
 use border::BorderCornerInstance;
 use euclid::{Size2D};
 use gpu_cache::{GpuCacheAddress, GpuBlockData, GpuCache, GpuCacheHandle, GpuDataRequest, ToGpuBlocks};
-use mask_cache::{ClipMode, ClipSource, MaskCacheInfo};
+use mask_cache::{ClipMode, ClipRegion, ClipSource, MaskCacheInfo};
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 use render_task::{RenderTask, RenderTaskLocation};
 use resource_cache::{ImageProperties, ResourceCache};
 use std::{mem, usize};
 use util::{TransformedRect, recycle_vec};
-use api::{BuiltDisplayList, ColorF, ImageKey, ImageRendering, YuvColorSpace};
-use api::{YuvFormat, ClipRegion, ComplexClipRegion, ItemRange};
-use api::{FontKey, FontRenderMode, WebGLContextId};
-use api::{device_length, DeviceIntRect, DeviceIntSize};
-use api::{DevicePoint, LayerRect, LayerSize, LayerPoint};
-use api::{LayerToWorldTransform, GlyphInstance, GlyphOptions};
-use api::{ExtendMode, GradientStop, TileOffset};
 
 
 pub const CLIP_DATA_GPU_BLOCKS: usize = 10;
@@ -969,11 +967,7 @@ impl PrimitiveStore {
         let metadata = &mut self.cpu_metadata[prim_index.0];
 
         if let Some(ref mut clip_info) = metadata.clip_cache_info {
-            clip_info.update(&metadata.clips,
-                             layer_transform,
-                             gpu_cache,
-                             device_pixel_ratio,
-                             display_list);
+            clip_info.update(&metadata.clips, layer_transform, gpu_cache, device_pixel_ratio);
 
             //TODO-LCCR: we could tighten up the `local_clip_rect` here
             // but that would require invalidating the whole GPU block

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.46.0"
+version = "0.47.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -50,6 +50,7 @@ pub struct DisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),
+    ScrollFrame(ClipDisplayItem),
     Rectangle(RectangleDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),
@@ -71,7 +72,8 @@ pub enum SpecificDisplayItem {
 pub struct ClipDisplayItem {
     pub id: ClipId,
     pub parent_id: ClipId,
-    pub clip_region: ClipRegion,
+    pub content_rect: LayoutRect,
+    pub image_mask: Option<ImageMask>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -4,9 +4,8 @@
 
 use app_units::Au;
 use euclid::SideOffsets2D;
-use {ColorF, FontKey, ImageKey, ItemRange, PipelineId, WebGLContextId};
-use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
-use {PropertyBinding};
+use {ColorF, FontKey, ImageKey, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
+use {LayoutVector2D, PipelineId, PropertyBinding, WebGLContextId};
 
 // NOTE: some of these structs have an "IMPLICIT" comment.
 // This indicates that the BuiltDisplayList will have serialized
@@ -72,7 +71,6 @@ pub enum SpecificDisplayItem {
 pub struct ClipDisplayItem {
     pub id: ClipId,
     pub parent_id: ClipId,
-    pub content_rect: LayoutRect,
     pub image_mask: Option<ImageMask>,
 }
 
@@ -450,17 +448,6 @@ pub struct ImageMask {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ClipRegion {
-    pub main: LayoutRect,
-    pub image_mask: Option<ImageMask>,
-    #[serde(default, skip_serializing, skip_deserializing)]
-    pub complex_clips: ItemRange<ComplexClipRegion>,
-    #[serde(default, skip_serializing, skip_deserializing)]
-    pub complex_clip_count: usize,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.
     pub rect: LayoutRect,
@@ -520,41 +507,6 @@ impl BorderRadius {
         } else {
             false
         }
-    }
-}
-
-impl ClipRegion {
-    pub fn new(rect: &LayoutRect,
-               image_mask: Option<ImageMask>)
-               -> ClipRegion {
-        ClipRegion {
-            main: *rect,
-            image_mask,
-            complex_clips: ItemRange::default(),
-            complex_clip_count: 0,
-        }
-    }
-
-    pub fn simple(rect: &LayoutRect) -> ClipRegion {
-        ClipRegion {
-            main: *rect,
-            image_mask: None,
-            complex_clips: ItemRange::default(),
-            complex_clip_count: 0,
-        }
-    }
-
-    pub fn empty() -> ClipRegion {
-        ClipRegion {
-            main: LayoutRect::zero(),
-            image_mask: None,
-            complex_clips: ItemRange::default(),
-            complex_clip_count: 0,
-        }
-    }
-
-    pub fn is_complex(&self) -> bool {
-        self.complex_clip_count != 0 || self.image_mask.is_some()
     }
 }
 

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -42,7 +42,7 @@ impl ClipAndScrollInfo {
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
     pub rect: LayoutRect,
-    pub clip_rect: LayoutRect,
+    pub local_clip: LocalClip,
     pub clip_and_scroll: ClipAndScrollInfo,
 }
 
@@ -448,6 +448,27 @@ pub struct ImageMask {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum LocalClip {
+    Rect(LayoutRect),
+    RoundedRect(LayoutRect, ComplexClipRegion),
+}
+
+impl From<LayoutRect> for LocalClip {
+    fn from(rect: LayoutRect) -> Self {
+        LocalClip::Rect(rect)
+    }
+}
+
+impl LocalClip {
+    pub fn clip_rect(&self) -> &LayoutRect {
+        match *self {
+            LocalClip::Rect(ref rect) => rect,
+            LocalClip::RoundedRect(ref rect, _) => &rect,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComplexClipRegion {
     /// The boundaries of the rectangle.
     pub rect: LayoutRect,
@@ -615,3 +636,4 @@ define_empty_heap_size_of!(RepeatMode);
 define_empty_heap_size_of!(ImageKey);
 define_empty_heap_size_of!(MixBlendMode);
 define_empty_heap_size_of!(TransformStyle);
+define_empty_heap_size_of!(LocalClip);

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -853,7 +853,6 @@ impl DisplayListBuilder {
             id: id,
             parent_id: self.clip_stack.last().unwrap().scroll_node_id,
             image_mask: image_mask,
-            content_rect: content_rect,
         });
 
         self.push_item(item, content_rect, clip_rect);
@@ -874,7 +873,6 @@ impl DisplayListBuilder {
             id,
             parent_id: self.clip_stack.last().unwrap().scroll_node_id,
             image_mask: image_mask,
-            content_rect: clip_rect,
         });
 
         self.push_item(item, clip_rect, clip_rect);

--- a/wrench/reftests/aa/rounded-rects.yaml
+++ b/wrench/reftests/aa/rounded-rects.yaml
@@ -8,7 +8,7 @@ root:
         - type: clip
           bounds: [50, 50, 200, 200]
           complex:
-            - rect: [0, 0, 200, 200]
+            - rect: [50, 50, 200, 200]
               radius: 8
           items:
           - type: rect
@@ -18,7 +18,7 @@ root:
         - type: clip
           bounds: [270, 50, 200, 200]
           complex:
-            - rect: [0, 0, 200, 200]
+            - rect: [270, 50, 200, 200]
               radius: [16, 32, 48, 64]
           items:
           - type: rect
@@ -28,7 +28,7 @@ root:
         - type: clip
           bounds: [490, 50, 200, 200]
           complex:
-            - rect: [0, 0, 200, 200]
+            - rect: [490, 50, 200, 200]
               radius: {
                 top-left: [32, 16],
                 top-right: [40, 24],

--- a/wrench/reftests/border/degenerate-curve.yaml
+++ b/wrench/reftests/border/degenerate-curve.yaml
@@ -9,7 +9,7 @@ root:
       "transform-style": flat
       items: 
         - type: clip
-          bounds: [0, 0, 1000, 1000]
+          bounds: [28, 18, 144, 122]
           complex:
             - rect: [28, 18, 144, 122]
               radius:
@@ -38,7 +38,7 @@ root:
             "bottom-left": [0, 0]
             "bottom-right": [61, 61]
         - type: clip
-          bounds: [0, 0, 1000, 1000]
+          bounds: [28, 160, 144, 122]
           complex:
             - rect: [28, 160, 144, 122]
               radius: [61, 61]
@@ -60,7 +60,7 @@ root:
             - none
           radius: [61, 61]
         - type: clip
-          bounds: [0, 0, 1000, 1000]
+          bounds: [28, 302, 154, 122]
           complex:
             - rect: [28, 302, 154, 122]
               radius: 
@@ -93,7 +93,7 @@ root:
             "bottom-left": [0, 0]
             "bottom-right": [61, 61]
         - type: clip
-          bounds: [0, 0, 1000, 1000]
+          bounds: [202, 18, 145, 122]
           complex:
             - rect: [202, 18, 144.03334, 122]
               radius: 
@@ -124,7 +124,7 @@ root:
         - type: clip
           bounds: [202, 160, 144, 122]
           complex:
-            - rect: [0, 0, 144, 122]
+            - rect: [202, 160, 144, 122]
               radius: [61, 61]
           items:
             - type: rect
@@ -145,7 +145,7 @@ root:
         - type: clip
           bounds: [202, 302, 154, 122]
           complex:
-            - rect: [0, 0, 154, 122]
+            - rect: [202, 302, 154, 122]
               radius: 
                 "top-left": [0, 0]
                 "top-right": [72, 72]
@@ -179,7 +179,7 @@ root:
         - type: clip
           bounds: [376, 18, 144, 122]
           complex:
-            - rect: [0, 0, 144, 122]
+            - rect: [376, 18, 144, 122]
               radius: [61, 61]
           items:
           - type: rect
@@ -205,7 +205,7 @@ root:
         - type: clip
           bounds: [376, 160, 144, 122]
           complex:
-            - rect: [0, 0, 144, 122]
+            - rect: [376, 160, 144, 122]
               radius: [61, 61]
           items:
           - type: rect
@@ -232,7 +232,7 @@ root:
         - type: clip
           bounds: [376, 302, 144, 122]
           complex:
-            - rect: [0, 0, 144, 122]
+            - rect: [376, 302, 144, 122]
               radius:
                 "top-left": [0, 0]
                 "top-right": [72, 72]

--- a/wrench/reftests/mask/aligned-layer-rect.yaml
+++ b/wrench/reftests/mask/aligned-layer-rect.yaml
@@ -1,11 +1,11 @@
 ---
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [9, 9, 10, 10]
       content-size: [95, 88]
       items:
-        - type: scroll-layer
+        - type: scroll-frame
           bounds: [0, 0, 100, 100]
           items:
             - type: rect

--- a/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
+++ b/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
@@ -7,7 +7,7 @@ root:
       z-index: 4
       transform: [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 150, -150, 1]
       items:
-        - type: scroll-layer
+        - type: clip
           bounds: [0, 0, 300, 300]
           # This image mask here assures that we will be forced to try to
           # mask instead of skipping it due to the mask rect becoming a

--- a/wrench/reftests/mask/nested-mask.yaml
+++ b/wrench/reftests/mask/nested-mask.yaml
@@ -1,14 +1,14 @@
 ---
 root:
   items:
-    - type: scroll-layer
+    - type: clip
       bounds: [0, 0, 95, 88]
       image-mask:
         image: "mask.png"
         rect: [0, 0, 35, 35]
         repeat: false
       items:
-        - type: scroll-layer
+        - type: clip
           bounds: [0, 0, 95, 88]
           image-mask:
             image: "mask.png"

--- a/wrench/reftests/mask/out-of-bounds.yaml
+++ b/wrench/reftests/mask/out-of-bounds.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: scroll-layer
+    - type: clip
       bounds: [0, 0, 10000, 10000]
       complex:
         - rect: [0, 0, 10000, 10000]

--- a/wrench/reftests/mask/rounded-corners.yaml
+++ b/wrench/reftests/mask/rounded-corners.yaml
@@ -1,7 +1,7 @@
 ---
 root:
   items:
-    - type: scroll-layer
+    - type: clip
       bounds: [0, 0, 100, 100]
       complex:
         - rect: [0, 0, 100, 100]

--- a/wrench/reftests/scrolling/empty-mask.yaml
+++ b/wrench/reftests/scrolling/empty-mask.yaml
@@ -3,7 +3,7 @@ root:
     - type: rect
       bounds: [0, 0, 100, 100]
       color: green
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [0, 0, 100, 100]
       items:
         - type: clip

--- a/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
+++ b/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
@@ -1,6 +1,6 @@
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [10, 10, 100, 300]
       content-size: [100, 700]
       id: 41

--- a/wrench/reftests/scrolling/nested-scroll-offset.yaml
+++ b/wrench/reftests/scrolling/nested-scroll-offset.yaml
@@ -1,14 +1,14 @@
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [0, 0, 500, 500]
       content-size: [1000, 1000]
       scroll-offset: [0, 300]
       items:
-      - type: scroll-layer
+      - type: scroll-frame
         bounds: [0, 300, 50, 50]
         items:
-        - type: scroll-layer
+        - type: scroll-frame
           bounds: [0, 300, 50, 50]
           items:
             - type: rect

--- a/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
+++ b/wrench/reftests/scrolling/out-of-bounds-scroll.yaml
@@ -1,6 +1,6 @@
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [10, 10, 50, 100]
       content-size: [50, 200]
       scroll-offset: [0, 50]

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -8,7 +8,7 @@ root:
       bounds: [10, 10, 100, 100]
       scroll-policy: scrollable
       items:
-      - type: scroll-layer
+      - type: scroll-frame
         bounds: [0, 0, 100, 100]
         image-mask:
           image: "mask.png"
@@ -25,7 +25,7 @@ root:
       bounds: [100, 0, 100, 100]
       scroll-policy: scrollable
       items:
-      - type: scroll-layer
+      - type: scroll-frame
         bounds: [10, 10, 100, 300]
         scroll-offset: [0, 100]
         image-mask:
@@ -40,7 +40,7 @@ root:
     # Same as the previous case, but this time we verify that a scroll layer that is
     # not at the origin works as well.
     -
-      type: scroll-layer
+      type: scroll-frame
       bounds: [210, 10, 100, 100]
       content-size: [100, 300]
       scroll-offset: [0, 100]

--- a/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
+++ b/wrench/reftests/scrolling/scroll-layer-with-mask.yaml
@@ -30,7 +30,7 @@ root:
         scroll-offset: [0, 100]
         image-mask:
           image: "mask.png"
-          rect: [0, 0, 100, 100]
+          rect: [10, 10, 100, 100]
           repeat: false
         items:
         - type: rect
@@ -46,7 +46,7 @@ root:
       scroll-offset: [0, 100]
       image-mask:
         image: "mask.png"
-        rect: [0, 0, 100, 100]
+        rect: [210, 10, 100, 100]
         repeat: false
       items:
       - type: rect

--- a/wrench/reftests/scrolling/scroll-layer.yaml
+++ b/wrench/reftests/scrolling/scroll-layer.yaml
@@ -1,6 +1,6 @@
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [0, 0, 100, 100]
       content-size: [1000, 1000]
       scroll-offset: [50, 50]

--- a/wrench/reftests/scrolling/simple.yaml
+++ b/wrench/reftests/scrolling/simple.yaml
@@ -1,13 +1,13 @@
 root:
   items:
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [10, 10, 50, 50]
       content-size: [100, 100]
       items:
         - type: rect
           bounds: [10, 10, 500, 500]
           color: green
-    - type: scroll-layer
+    - type: scroll-frame
       bounds: [70, 10, 50, 50]
       content-size: [100, 100]
       items:

--- a/wrench/reftests/scrolling/translate-nested.yaml
+++ b/wrench/reftests/scrolling/translate-nested.yaml
@@ -8,7 +8,7 @@ root:
       items: 
         - 
           bounds: [0, 0, 200, 200]
-          type: scroll-layer
+          type: clip
           id: 1
           items:
           -

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -572,10 +572,9 @@ impl YamlFrameReader {
     }
 
     pub fn handle_scroll_frame(&mut self, wrench: &mut Wrench, yaml: &Yaml) {
-        let bounds = yaml["bounds"].as_rect().expect("clip must have a bounds");
-        let content_size = yaml["content-size"].as_size().unwrap_or(bounds.size);
-        let content_rect = LayerRect::new(bounds.origin, content_size);
-        let clip_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
+        let clip_rect = yaml["bounds"].as_rect().expect("clip must have a bounds");
+        let content_size = yaml["content-size"].as_size().unwrap_or(clip_rect.size);
+        let content_rect = LayerRect::new(clip_rect.origin, content_size);
 
         let id = yaml["id"].as_i64().map(|id| ClipId::new(id as u64, self.builder().pipeline_id));
         let complex_clips = self.to_complex_clip_regions(&yaml["complex"]);

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -213,34 +213,34 @@ impl YamlFrameReader {
         }
     }
 
-    fn handle_rect(&mut self, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_rect(&mut self, item: &Yaml, local_clip: LocalClip) {
         let bounds_key = if item["type"].is_badvalue() { "rect" } else { "bounds" };
         let rect = item[bounds_key].as_rect().expect("rect type must have bounds");
         let color = item["color"].as_colorf().unwrap_or(*WHITE_COLOR);
-        self.builder().push_rect(rect, clip_rect, color);
+        self.builder().push_rect(rect, Some(local_clip), color);
     }
 
-    fn handle_gradient(&mut self, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_gradient(&mut self, item: &Yaml, local_clip: LocalClip) {
         let bounds_key = if item["type"].is_badvalue() { "gradient" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("gradient must have bounds");
         let gradient = self.to_gradient(item);
         let tile_size = item["tile-size"].as_size().unwrap_or(bounds.size);
         let tile_spacing = item["tile-spacing"].as_size().unwrap_or(LayoutSize::zero());
 
-        self.builder().push_gradient(bounds, clip_rect, gradient, tile_size, tile_spacing);
+        self.builder().push_gradient(bounds, Some(local_clip), gradient, tile_size, tile_spacing);
     }
 
-    fn handle_radial_gradient(&mut self, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_radial_gradient(&mut self, item: &Yaml, local_clip: LocalClip) {
         let bounds_key = if item["type"].is_badvalue() { "radial-gradient" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("radial gradient must have bounds");
         let gradient = self.to_radial_gradient(item);
         let tile_size = item["tile-size"].as_size().unwrap_or(bounds.size);
         let tile_spacing = item["tile-spacing"].as_size().unwrap_or(LayoutSize::zero());
 
-        self.builder().push_radial_gradient(bounds, clip_rect, gradient, tile_size, tile_spacing);
+        self.builder().push_radial_gradient(bounds, Some(local_clip), gradient, tile_size, tile_spacing);
     }
 
-    fn handle_border(&mut self, wrench: &mut Wrench, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_border(&mut self, wrench: &mut Wrench, item: &Yaml, local_clip: LocalClip) {
         let bounds_key = if item["type"].is_badvalue() { "border" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("borders must have bounds");
         let widths = item["width"].as_vec_f32().expect("borders must have width(s)");
@@ -350,11 +350,11 @@ impl YamlFrameReader {
             None
         };
         if let Some(details) = border_details {
-            self.builder().push_border(bounds, clip_rect, widths, details);
+            self.builder().push_border(bounds, Some(local_clip), widths, details);
         }
     }
 
-    fn handle_box_shadow(&mut self, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_box_shadow(&mut self, item: &Yaml, local_clip: LocalClip) {
         let bounds_key = if item["type"].is_badvalue() { "box-shadow" } else { "bounds" };
         let bounds = item[bounds_key].as_rect().expect("box shadow must have bounds");
         let box_bounds = item["box-bounds"].as_rect().unwrap_or(bounds);
@@ -375,7 +375,7 @@ impl YamlFrameReader {
         };
 
         self.builder().push_box_shadow(bounds,
-                                       clip_rect,
+                                       Some(local_clip),
                                        box_bounds,
                                        offset,
                                        color,
@@ -392,7 +392,7 @@ impl YamlFrameReader {
         file
     }
 
-    fn handle_image(&mut self, wrench: &mut Wrench, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_image(&mut self, wrench: &mut Wrench, item: &Yaml, local_clip: LocalClip) {
         let filename = &item[if item["type"].is_badvalue() { "image" } else { "src" }];
         let tiling = item["tile-size"].as_i64();
         let (image_key, image_dims) = wrench.add_or_get_image(&self.rsrc_path(filename), tiling);
@@ -419,14 +419,14 @@ impl YamlFrameReader {
             Some(_) => panic!("ImageRendering can be auto, crisp-edges, or pixelated -- got {:?}", item),
         };
         self.builder().push_image(bounds,
-                                  clip_rect,
+                                  Some(local_clip),
                                   stretch_size,
                                   tile_spacing,
                                   rendering,
                                   image_key);
     }
 
-    fn handle_text(&mut self, wrench: &mut Wrench, item: &Yaml, clip_rect: LayoutRect) {
+    fn handle_text(&mut self, wrench: &mut Wrench, item: &Yaml, local_clip: LocalClip) {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
         let blur_radius = item["blur-radius"].as_force_f32().unwrap_or(0.0);
@@ -493,7 +493,7 @@ impl YamlFrameReader {
         };
 
         self.builder().push_text(rect,
-                                 clip_rect,
+                                 Some(local_clip),
                                  &glyphs,
                                  font_key,
                                  color,
@@ -508,8 +508,18 @@ impl YamlFrameReader {
         self.builder().push_iframe(bounds, pipeline_id);
     }
 
+    pub fn get_local_clip_for_item(&mut self, yaml: &Yaml, full_clip: LayoutRect) -> LocalClip {
+        let rect = yaml["clip-rect"].as_rect().unwrap_or(full_clip);
+        let complex_clip = &yaml["complex-clip"];
+        if !complex_clip.is_badvalue() {
+            LocalClip::RoundedRect(rect, self.to_complex_clip_region(complex_clip))
+        } else {
+            LocalClip::from(rect)
+        }
+    }
+
     pub fn add_display_list_items_from_yaml(&mut self, wrench: &mut Wrench, yaml: &Yaml) {
-        let full_clip_rect = LayoutRect::new(LayoutPoint::zero(), wrench.window_size_f32());
+        let full_clip = LayoutRect::new(LayoutPoint::zero(), wrench.window_size_f32());
 
         for item in yaml.as_vec().unwrap() {
             // an explicit type can be skipped with some shorthand
@@ -548,18 +558,17 @@ impl YamlFrameReader {
                 self.builder().push_clip_and_scroll_info(clip_scroll_info);
             }
 
-            let clip_rect = item["clip-rect"].as_rect().unwrap_or(full_clip_rect);
-
+            let local_clip = self.get_local_clip_for_item(item, full_clip);
             match item_type {
-                "rect" => self.handle_rect(item, clip_rect),
-                "image" => self.handle_image(wrench, item, clip_rect),
-                "text" | "glyphs" => self.handle_text(wrench, item, clip_rect),
+                "rect" => self.handle_rect(item, local_clip),
+                "image" => self.handle_image(wrench, item, local_clip),
+                "text" | "glyphs" => self.handle_text(wrench, item, local_clip),
                 "scroll-frame" => self.handle_scroll_frame(wrench, item),
                 "clip" => self.handle_clip(wrench, item),
-                "border" => self.handle_border(wrench, item, clip_rect),
-                "gradient" => self.handle_gradient(item, clip_rect),
-                "radial-gradient" => self.handle_radial_gradient(item, clip_rect),
-                "box-shadow" => self.handle_box_shadow(item, clip_rect),
+                "border" => self.handle_border(wrench, item, local_clip),
+                "gradient" => self.handle_gradient(item, local_clip),
+                "radial-gradient" => self.handle_radial_gradient(item, local_clip),
+                "box-shadow" => self.handle_box_shadow(item, local_clip),
                 "iframe" => self.handle_iframe(item),
                 "stacking-context" => self.add_stacking_context_from_yaml(wrench, item, false),
                 _ => println!("Skipping unknown item type: {:?}", item),

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -747,7 +747,7 @@ impl YamlFrameWriter {
                 Clip(item) => {
                     str_node(&mut v, "type", "clip");
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));
-                    size_node(&mut v, "content-size", &item.content_rect.size);
+                    size_node(&mut v, "content-size", &base.rect().size);
 
                     let &(complex_clips, complex_clip_count) = base.complex_clip();
                     if let Some(complex) = self.make_clip_complex_node(complex_clip_count,
@@ -763,7 +763,8 @@ impl YamlFrameWriter {
                 ScrollFrame(item) => {
                     str_node(&mut v, "type", "scroll-frame");
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));
-                    size_node(&mut v, "content-size", &item.content_rect.size);
+                    size_node(&mut v, "content-size", &base.rect().size);
+                    rect_node(&mut v, "bounds", &base.clip_rect());
 
                     let &(complex_clips, complex_clip_count) = base.complex_clip();
                     if let Some(complex) = self.make_clip_complex_node(complex_clip_count,


### PR DESCRIPTION
This branch includes two improvements to the clipping and scrolling API:

1. Create `DisplayListBuilder::define_scroll_frame` API which avoids having to guess when a Clip item should create a ScrollFrame and when it shouldn't. Additionally, this removes a lot of weirdness around whether a ScrollFrame's clip starts at the origin of the ScrollFrame or not. It doesn't matter any longer, because the Clip created for the ScrollFrame is entirely independent.
2. Make all clipping coordinates relative to the StackingContext. This was whirlpool of weirdness in the API that only caused confusion. We now hide this detail, making clip coordinates the same as any other coordinates.

There are a few other small cleanups included with this, such as remove the `push_clip_node` and `pop_clip_node` APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1428)
<!-- Reviewable:end -->
