### PR TITLE
WIP: Text parts

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -292,11 +292,12 @@ fn body(api: &RenderApi,
         builder.push_text(text_bounds,
                           text_bounds,
                           &glyphs,
+                          &[],
                           font_key,
                           ColorF::new(1.0, 1.0, 0.0, 1.0),
                           Au::from_px(32),
-                          0.0,
-                          None);
+                          None,
+                          TextDecorations::default());
     }
 
     if false { // draw box shadow?

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -567,11 +567,12 @@ impl Frame {
                                          item.clip_rect(),
                                          text_info.font_key,
                                          text_info.size,
-                                         text_info.blur_radius,
                                          &text_info.color,
                                          item.glyphs(),
+                                         item.text_shadows(),
                                          item.display_list().get(item.glyphs()).count(),
-                                         text_info.glyph_options);
+                                         text_info.glyph_options,
+                                         &text_info.decorations);
             }
             SpecificDisplayItem::Rectangle(ref info) => {
                 if !self.try_to_add_rectangle_splitting_on_clip(context,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -33,7 +33,8 @@ use webrender_traits::{ClipId, ClipRegion, ColorF, DeviceIntPoint, DeviceIntRect
 use webrender_traits::{DeviceUintRect, DeviceUintSize, ExtendMode, FontKey, FontRenderMode};
 use webrender_traits::{GlyphInstance, GlyphOptions, GradientStop, ImageKey, ImageRendering};
 use webrender_traits::{ItemRange, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
-use webrender_traits::{PipelineId, RepeatMode, TileOffset, TransformStyle, WebGLContextId};
+use webrender_traits::{PipelineId, RepeatMode, TextDecorations, TextShadow};
+use webrender_traits::{TileOffset, TransformStyle, WebGLContextId};
 use webrender_traits::{WorldPixel, YuvColorSpace, YuvData, LayerVector2D};
 
 #[derive(Debug, Clone)]
@@ -739,11 +740,15 @@ impl FrameBuilder {
                     clip_rect: &LayerRect,
                     font_key: FontKey,
                     size: Au,
-                    blur_radius: f32,
                     color: &ColorF,
                     glyph_range: ItemRange<GlyphInstance>,
+                    shadow_range: ItemRange<TextShadow>,
                     glyph_count: usize,
-                    glyph_options: Option<GlyphOptions>) {
+                    glyph_options: Option<GlyphOptions>,
+                    decorations: &TextDecorations) {
+
+        let mut blur_radius = 0.0;
+
         if color.a == 0.0 {
             return
         }
@@ -788,13 +793,15 @@ impl FrameBuilder {
         let prim_cpu = TextRunPrimitiveCpu {
             font_key,
             logical_font_size: size,
-            blur_radius,
             glyph_range,
             glyph_count,
             glyph_instances: Vec::new(),
+            shadow_range,
             color: *color,
             render_mode,
             glyph_options,
+            decorations: *decorations,
+            blur_radius: blur_radius,
         };
 
         self.add_primitive(clip_and_scroll,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -18,7 +18,7 @@ use webrender_traits::{FontKey, FontRenderMode, WebGLContextId};
 use webrender_traits::{device_length, DeviceIntRect, DeviceIntSize};
 use webrender_traits::{DevicePoint, LayerRect, LayerSize, LayerPoint};
 use webrender_traits::{LayerToWorldTransform, GlyphInstance, GlyphOptions};
-use webrender_traits::{ExtendMode, GradientStop, TileOffset};
+use webrender_traits::{ExtendMode, GradientStop, TileOffset, TextDecorations, TextShadow};
 
 
 pub const CLIP_DATA_GPU_BLOCKS: usize = 10;
@@ -490,9 +490,11 @@ pub struct TextRunPrimitiveCpu {
     pub glyph_count: usize,
     // TODO(gw): Maybe make this an Arc for sharing with resource cache
     pub glyph_instances: Vec<GlyphInstance>,
+    pub shadow_range: ItemRange<TextShadow>,
     pub color: ColorF,
     pub render_mode: FontRenderMode,
     pub glyph_options: Option<GlyphOptions>,
+    pub decorations: TextDecorations,
 }
 
 impl ToGpuBlocks for TextRunPrimitiveCpu {

--- a/webrender_traits/src/display_item.rs
+++ b/webrender_traits/src/display_item.rs
@@ -84,9 +84,34 @@ pub struct TextDisplayItem {
     pub font_key: FontKey,
     pub size: Au,
     pub color: ColorF,
-    pub blur_radius: f32,
     pub glyph_options: Option<GlyphOptions>,
-} // IMPLICIT: glyphs: Vec<GlyphInstance>
+    pub decorations: TextDecorations,
+    // IMPLICIT: glyphs: Vec<GlyphInstance>,
+    // IMPLICIT: shadows: Vec<TextShadow>,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TextShadow {
+    pub offset: LayoutVector2D,
+    pub color: ColorF,
+    pub blur_radius: f32,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct TextDecorations {
+    pub underline: Option<TextDecoration>,
+    pub overline: Option<TextDecoration>,
+    pub line_through: Option<TextDecoration>,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum TextDecoration {
+    // FIXME: implement this variant:
+    // Native { height: f32, min_x: f32, max_x: f32,
+    //          color: ColorF, style: TextDecorationStyle }
+    // enum TextDecorationStyle { Solid, Double, Dotted, Dashed, Wavy }
+    Opaque(ImageKey),
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -2,4 +2,5 @@
 != negative-pos.yaml blank.yaml
 != shadow.yaml text.yaml
 != shadow-single.yaml blank.yaml
+!= shadow-many.yaml blank.yaml
 != non-opaque.yaml non-opaque-notref.yaml

--- a/wrench/reftests/text/shadow-many.yaml
+++ b/wrench/reftests/text/shadow-many.yaml
@@ -5,7 +5,15 @@ root:
           bounds: [14, 18, 205, 35]
           glyphs: [55, 75, 76, 86, 3, 76, 86, 3, 87, 75, 72, 3, 69, 72, 86, 87]
           offsets: [16, 43, 35.533333, 43, 51.533333, 43, 60.4, 43, 72.833336, 43, 80.833336, 43, 89.7, 43, 102.13333, 43, 110.13333, 43, 119, 43, 135, 43, 149.2, 43, 157.2, 43, 173.2, 43, 187.4, 43, 196.26666, 43]
-          shadows: { color: black, blur-radius: 5, offset: [0, 0] }
+          shadows:
+            -
+              color: black
+              blur-radius: 5
+              offset: [1, 3]
+            -
+              color: red
+              blur-radius: 3
+              offset: [-3, -2.5]
           size: 18
-          color: [0, 0, 0, 0] # hide the actual text
+          color: black
           font: "VeraBd.ttf"

--- a/wrench/reftests/text/shadow-single.yaml
+++ b/wrench/reftests/text/shadow-single.yaml
@@ -5,7 +5,7 @@ root:
           bounds: [14, 18, 205, 35]
           glyphs: [55]
           offsets: [16, 43]
+          shadows: { color: black, blur-radius: 5, offset: [0, 0] }
           size: 18
-          color: black
-          blur-radius: 5
+          color: [0, 0, 0, 0] # actual text hidden
           font: "VeraBd.ttf"

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -429,7 +429,11 @@ impl YamlFrameReader {
     fn handle_text(&mut self, wrench: &mut Wrench, item: &Yaml, clip_rect: LayoutRect) {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
-        let blur_radius = item["blur-radius"].as_force_f32().unwrap_or(0.0);
+        let shadows = item["shadows"].as_vec_text_shadow().unwrap_or(vec![]);
+        let decorations = item["text-decorations"].as_text_decorations()
+                                                  .unwrap_or(TextDecorations::default());
+
+        assert!(item["blur-radius"].is_badvalue(), "blur-radius has been replaced with shadows");
 
         let (font_key, native_key) = if !item["family"].is_badvalue() {
             wrench.font_key_from_yaml_table(item)
@@ -495,11 +499,12 @@ impl YamlFrameReader {
         self.builder().push_text(rect,
                                  clip_rect,
                                  &glyphs,
+                                 &shadows,
                                  font_key,
                                  color,
                                  size,
-                                 blur_radius,
-                                 None);
+                                 None,
+                                 decorations);
     }
 
     fn handle_iframe(&mut self, item: &Yaml) {

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -35,6 +35,11 @@ pub trait YamlHelper {
     fn as_scroll_policy(&self) -> Option<ScrollPolicy>;
     fn as_filter_op(&self) -> Option<FilterOp>;
     fn as_vec_filter_op(&self) -> Option<Vec<FilterOp>>;
+    fn as_text_decoration(&self) -> Option<TextDecoration>;
+    fn as_text_decorations(&self) -> Option<TextDecorations>;
+    fn as_text_shadow(&self) -> Option<TextShadow>;
+    fn as_vec_text_shadow(&self) -> Option<Vec<TextShadow>>;
+
 }
 
 fn string_to_color(color: &str) -> Option<ColorF> {
@@ -346,6 +351,54 @@ impl YamlHelper for Yaml {
             Some(v.iter().map(|v| v.as_colorf().unwrap()).collect())
         } else if let Some(color) = self.as_colorf() {
             Some(vec![color])
+        } else {
+            None
+        }
+    }
+
+    fn as_text_decoration(&self) -> Option<TextDecoration> {
+        if let Some(s) = self.as_str() {
+            match parse_function(s) {
+                ("opaque", ref args, _) if args.len() == 1 => {
+                    // TODO
+                    Some(unimplemented!())
+                }
+                _ => None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn as_text_decorations(&self) -> Option<TextDecorations> {
+        if let Yaml::Hash(_) = *self {
+            Some(TextDecorations {
+                underline: self["underline"].as_text_decoration(),
+                overline: self["overline"].as_text_decoration(),
+                line_through: self["line-through"].as_text_decoration(),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn as_text_shadow(&self) -> Option<TextShadow> {
+        if let Yaml::Hash(_) = *self {
+            Some(TextShadow {
+                offset: self["offset"].as_vector().expect("a"),
+                color: self["color"].as_colorf().expect("b"),
+                blur_radius: self["blur-radius"].as_f32().expect("c"),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn as_vec_text_shadow(&self) -> Option<Vec<TextShadow>> {
+        if let Some(v) = self.as_vec() {
+            Some(v.iter().map(|v| v.as_text_shadow().unwrap()).collect())
+        } else if let Some(shadow) = self.as_text_shadow() {
+            Some(vec![shadow])
         } else {
             None
         }


### PR DESCRIPTION
This is only WIP because this needs backend work that @kvark or @glennw should probably handle (significant design work needed).

Notes:

* Only blob text decorations are supported. That's fine, in the sense that implementation for those is "future work" that we can do in future weeks. Doesn't need to be done to land this.

* Wrench doesn't currently save Opaque TextDecorations because I'm unclear on how that should work.

* The backend hasn't been implemented. Currently the data just gets stuffed in the TextRunPrimitive struct. This also makes the PR currently a regression, as it just makes shadows not work. (`reftests/text/shadow-single.yaml`)

* To make the backend work easier, I've left in all references to blur_radius in there. That way y'all can remove it and chase down the compilation errors to find the places that need to be updated. A dummy variable has been added in frame_builder that is incorrectly mutable, so a warning will show up to tell you to remove that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1429)
<!-- Reviewable:end -->
