### PR TITLE
Add a way to remove all resources from the resource cache that have a certain namespace

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -446,6 +446,9 @@ impl RenderBackend {
                                     .unwrap()
                                     .external_event(evt);
                         }
+                        ApiMsg::RemoveAllResourcesWithNamespace(namespace) => {
+                            self.resource_cache.remove_all_resources_with_namespace(namespace);
+                        }
                         ApiMsg::ShutDown => {
                             let notifier = self.notifier.lock();
                             notifier.unwrap()

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -18,7 +18,7 @@ use std::mem;
 use std::sync::Arc;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use webrender_traits::{Epoch, FontKey, FontTemplate, GlyphKey, ImageKey, ImageRendering};
-use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
+use webrender_traits::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId, IdNamespace};
 use webrender_traits::{DevicePoint, DeviceIntSize, DeviceUintRect, ImageDescriptor, ColorF};
 use webrender_traits::{GlyphOptions, GlyphInstance, TileOffset, TileSize};
 use webrender_traits::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest, BlobImageData};
@@ -763,6 +763,11 @@ impl ResourceCache {
     pub fn end_frame(&mut self) {
         debug_assert_eq!(self.state, State::QueryResources);
         self.state = State::Idle;
+    }
+
+    pub fn remove_all_resources_with_namespace(&mut self, namespace: IdNamespace) {
+        self.resources.image_templates.images.retain(|key: &ImageKey, _|{ key.0 != namespace.0 });
+        self.resources.font_templates.retain(|key: &FontKey, _|{ key.0 != namespace.0 });
     }
 }
 

--- a/webrender_traits/src/api.rs
+++ b/webrender_traits/src/api.rs
@@ -62,6 +62,7 @@ pub enum ApiMsg {
     /// to forward gecko-specific messages to the render thread preserving the ordering
     /// within the other messages.
     ExternalEvent(ExternalEvent),
+    RemoveAllResourcesWithNamespace(IdNamespace),
     ShutDown,
 }
 
@@ -94,6 +95,7 @@ impl fmt::Debug for ApiMsg {
             ApiMsg::SetPinchZoom(..) => "ApiMsg::SetPinchZoom",
             ApiMsg::SetPan(..) => "ApiMsg::SetPan",
             ApiMsg::SetWindowParameters(..) => "ApiMsg::SetWindowParameters",
+            ApiMsg::RemoveAllResourcesWithNamespace(..) => "ApiMsg::RemoveAllResourcesWithNamespace",
         })
     }
 }
@@ -423,6 +425,10 @@ impl RenderApi {
 
     pub fn shut_down(&self) {
         self.api_sender.send(ApiMsg::ShutDown).unwrap();
+    }
+
+    pub fn remove_all_resources_with_namespace(&self, namespace: IdNamespace) {
+        self.api_sender.send(ApiMsg::RemoveAllResourcesWithNamespace(namespace)).unwrap();
     }
 
     /// Create a new unique key that can be used for


### PR DESCRIPTION
This is a tad ugly but it makes it a lot easier in firefox when a content-process crashes, to clean up every resources that were associated to it. The alternative is to maintain a map of all of the image and font keys in use in gecko-land.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1435)
<!-- Reviewable:end -->
