### PR TITLE
Removal of SC's local_bounds

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -443,7 +443,6 @@ impl Frame {
         context.builder.push_stacking_context(&reference_frame_relative_offset,
                                               pipeline_id,
                                               composition_operations,
-                                              *bounds,
                                               stacking_context.transform_style);
 
         self.flatten_items(traversal,
@@ -772,11 +771,9 @@ impl Frame {
                         pipeline_id: PipelineId,
                         context: &mut FlattenContext,
                         content_size: &LayoutSize) {
-        let root_bounds = LayerRect::new(LayerPoint::zero(), *content_size);
         context.builder.push_stacking_context(&LayerVector2D::zero(),
                                               pipeline_id,
                                               CompositeOps::default(),
-                                              root_bounds,
                                               TransformStyle::Flat);
 
         // We do this here, rather than above because we want any of the top-level
@@ -791,6 +788,7 @@ impl Frame {
         if context.scene.root_pipeline_id != Some(pipeline_id) {
             if let Some(pipeline) = context.scene.pipeline_map.get(&pipeline_id) {
                 if let Some(bg_color) = pipeline.background_color {
+                    let root_bounds = LayerRect::new(LayerPoint::zero(), *content_size);
                     context.builder.add_solid_rectangle(ClipAndScrollInfo::simple(clip_id),
                                                         &root_bounds,
                                                         &root_bounds,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -252,7 +252,6 @@ impl FrameBuilder {
                                  reference_frame_offset: &LayerVector2D,
                                  pipeline_id: PipelineId,
                                  composite_ops: CompositeOps,
-                                 local_bounds: LayerRect,
                                  transform_style: TransformStyle) {
         if let Some(parent_index) = self.stacking_context_stack.last() {
             let parent_is_root = self.stacking_context_store[parent_index.0].is_page_root;
@@ -275,7 +274,6 @@ impl FrameBuilder {
                                                               *reference_frame_offset,
                                                               !self.has_root_stacking_context,
                                                               reference_frame_id,
-                                                              local_bounds,
                                                               transform_style,
                                                               composite_ops));
         self.has_root_stacking_context = true;
@@ -1222,8 +1220,8 @@ impl FrameBuilder {
                         // is because we need to preserve the order of drawing for planes that match together.
                         let frame_node = clip_scroll_tree.nodes.get(&stacking_context.reference_frame_id).unwrap();
                         let sc_polygon = make_polygon(stacking_context, frame_node, stacking_context_index.0);
-                        debug!("\tsplitter[{}]: add {:?} -> {:?}", splitter_stack.len(), stacking_context_index, sc_polygon);
-                        debug!("\tisolation bounds {:?}, local bounds {:?}", stacking_context.isolated_items_bounds, stacking_context.local_bounds);
+                        debug!("\tsplitter[{}]: add {:?} -> {:?} with bounds {:?}", splitter_stack.len(),
+                            stacking_context_index, sc_polygon, stacking_context.isolated_items_bounds);
                         splitter_stack.last_mut().unwrap().add(sc_polygon);
                     }
 
@@ -1802,8 +1800,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                                      &clip_bounds,
                                      &packed_layer.transform,
                                      &packed_layer.local_clip_rect,
-                                     self.device_pixel_ratio)
-            {
+                                     self.device_pixel_ratio) {
                 Some(rects) => rects,
                 None => continue,
             };

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -87,16 +87,15 @@ impl ImageBorderSegment {
 /// Construct a polygon from stacking context boundaries.
 /// `anchor` here is an index that's going to be preserved in all the
 /// splits of the polygon.
-fn make_polygon(sc: &StackingContext, node: &ClipScrollNode, anchor: usize)
-                -> Polygon<f32, WorldPixel> {
-    //TODO: only work with `sc.local_bounds` worth of space
-    // This can be achieved by moving the `sc.local_bounds.origin` shift
+fn make_polygon(stacking_context: &StackingContext, node: &ClipScrollNode,
+                anchor: usize) -> Polygon<f32, WorldPixel> {
+    //TODO: only work with `isolated_items_bounds.size` worth of space
+    // This can be achieved by moving the `origin` shift
     // from the primitive local coordinates into the layer transformation.
     // Which in turn needs it to be a render task property obeyed by all primitives
     // upon rendering, possibly not limited to `write_*_vertex` implementations.
-    let size = sc.local_bounds.bottom_right();
-    //TODO-LCCR: it would be easier to work with `PackedLayer::transform` here
-    let bounds = LayerRect::new(sc.reference_frame_offset.to_point(), LayerSize::new(size.x, size.y));
+    let size = stacking_context.isolated_items_bounds.bottom_right();
+    let bounds = LayerRect::new(LayerPoint::zero(), LayerSize::new(size.x, size.y));
     Polygon::from_transformed_rect(bounds, node.world_content_transform, anchor)
 }
 
@@ -1223,7 +1222,8 @@ impl FrameBuilder {
                         // is because we need to preserve the order of drawing for planes that match together.
                         let frame_node = clip_scroll_tree.nodes.get(&stacking_context.reference_frame_id).unwrap();
                         let sc_polygon = make_polygon(stacking_context, frame_node, stacking_context_index.0);
-                        debug!("\tadd {:?} -> {:?}", stacking_context_index, sc_polygon);
+                        debug!("\tsplitter[{}]: add {:?} -> {:?}", splitter_stack.len(), stacking_context_index, sc_polygon);
+                        debug!("\tisolation bounds {:?}, local bounds {:?}", stacking_context.isolated_items_bounds, stacking_context.local_bounds);
                         splitter_stack.last_mut().unwrap().add(sc_polygon);
                     }
 
@@ -1299,11 +1299,11 @@ impl FrameBuilder {
 
                     if parent_isolation != Some(ContextIsolation::Items) &&
                        stacking_context.isolation == ContextIsolation::Items {
+                        debug!("\tsplitter[{}]: flush {:?}", splitter_stack.len(), current_task.id);
                         let mut splitter = splitter_stack.pop().unwrap();
                         // Flush the accumulated plane splits onto the task tree.
                         // Notice how this is done before splitting in order to avoid duplicate tasks.
                         current_task.children.extend(preserve_3d_map.values().cloned());
-                        debug!("\tplane splitting in {:?}", current_task.id);
                         // Z axis is directed at the screen, `sort` is ascending, and we need back-to-front order.
                         for poly in splitter.sort(vec3(0.0, 0.0, 1.0)) {
                             let sc_index = StackingContextIndex(poly.anchor);
@@ -1655,19 +1655,28 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
     fn handle_pop_stacking_context(&mut self) {
         let stacking_context_index = self.stacking_context_stack.pop().unwrap();
 
-        let (bounding_rect, is_visible) = {
+        let (bounding_rect, is_visible, is_preserve_3d, reference_frame_id, reference_frame_bounds) = {
             let stacking_context =
                 &mut self.frame_builder.stacking_context_store[stacking_context_index.0];
             stacking_context.screen_bounds = stacking_context.screen_bounds
                                                              .intersection(self.screen_rect)
                                                              .unwrap_or(DeviceIntRect::zero());
-            (stacking_context.screen_bounds.clone(), stacking_context.is_visible)
+            (stacking_context.screen_bounds.clone(),
+             stacking_context.is_visible,
+             stacking_context.isolation == ContextIsolation::Items,
+             stacking_context.reference_frame_id,
+             stacking_context.isolated_items_bounds.translate(&stacking_context.reference_frame_offset),
+            )
         };
 
         if let Some(ref mut parent_index) = self.stacking_context_stack.last_mut() {
             let parent = &mut self.frame_builder.stacking_context_store[parent_index.0];
             parent.screen_bounds = parent.screen_bounds.union(&bounding_rect);
-
+            // add children local bounds only for non-item-isolated contexts
+            if !is_preserve_3d && parent.reference_frame_id == reference_frame_id {
+                let child_bounds = reference_frame_bounds.translate(&-parent.reference_frame_offset);
+                parent.isolated_items_bounds = parent.isolated_items_bounds.union(&child_bounds);
+            }
             // The previous compute_stacking_context_visibility pass did not take into
             // account visibility of children, so we do that now.
             parent.is_visible = parent.is_visible || is_visible;
@@ -1685,6 +1694,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         let stacking_context = &mut self.frame_builder
                                         .stacking_context_store[stacking_context_index.0];
         stacking_context.screen_bounds = DeviceIntRect::zero();
+        stacking_context.isolated_items_bounds = LayerRect::zero();
     }
 
     fn rebuild_clip_info_stack_if_necessary(&mut self, clip_id: ClipId) -> Option<DeviceIntRect> {
@@ -1787,16 +1797,18 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
         for i in 0..prim_count {
             let prim_index = PrimitiveIndex(base_prim_index.0 + i);
             let prim_store = &mut self.frame_builder.prim_store;
-            let prim_bounding_rect = match prim_store.build_bounding_rect(prim_index,
-                                                                          &clip_bounds,
-                                                                          &packed_layer.transform,
-                                                                          &packed_layer.local_clip_rect,
-                                                                          self.device_pixel_ratio) {
-                Some(rect) => rect,
+            let (prim_local_rect, prim_screen_rect) = match prim_store
+                .build_bounding_rect(prim_index,
+                                     &clip_bounds,
+                                     &packed_layer.transform,
+                                     &packed_layer.local_clip_rect,
+                                     self.device_pixel_ratio)
+            {
+                Some(rects) => rects,
                 None => continue,
             };
 
-            debug!("\t\t{:?} bound is {:?}", prim_index, prim_bounding_rect);
+            debug!("\t\t{:?} bound is {:?}", prim_index, prim_screen_rect);
 
             let prim_metadata = prim_store.prepare_prim_for_render(prim_index,
                                                                    self.resource_cache,
@@ -1805,7 +1817,8 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                                                                    self.device_pixel_ratio,
                                                                    display_list);
 
-            stacking_context.screen_bounds = stacking_context.screen_bounds.union(&prim_bounding_rect);
+            stacking_context.screen_bounds = stacking_context.screen_bounds.union(&prim_screen_rect);
+            stacking_context.isolated_items_bounds = stacking_context.isolated_items_bounds.union(&prim_local_rect);
 
             // Try to create a mask if we may need to.
             if !self.current_clip_stack.is_empty() || prim_metadata.clip_cache_info.is_some() {
@@ -1819,12 +1832,12 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                         // mutate the current bounds accordingly.
                         let mask_rect = match info.bounds.outer {
                             Some(ref outer) => {
-                                match prim_bounding_rect.intersection(&outer.device_rect) {
+                                match prim_screen_rect.intersection(&outer.device_rect) {
                                     Some(rect) => rect,
                                     None => continue,
                                 }
                             }
-                            _ => prim_bounding_rect,
+                            _ => prim_screen_rect,
                         };
                         (MaskCacheKey::Primitive(prim_index),
                          mask_rect,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1536,6 +1536,11 @@ pub struct StackingContext {
     /// calculated based on the size and position of all its children.
     pub screen_bounds: DeviceIntRect,
 
+    /// Local bounding rectangle of this stacking context,
+    /// computed as the union of all contained items that are not
+    /// `ContextIsolation::Items` on their own
+    pub isolated_items_bounds: LayerRect,
+
     pub composite_ops: CompositeOps,
     pub clip_scroll_groups: Vec<ClipScrollGroupIndex>,
 
@@ -1570,6 +1575,7 @@ impl StackingContext {
             reference_frame_id,
             local_bounds,
             screen_bounds: DeviceIntRect::zero(),
+            isolated_items_bounds: LayerRect::zero(),
             composite_ops,
             clip_scroll_groups: Vec::new(),
             isolation,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1529,9 +1529,6 @@ pub struct StackingContext {
     /// The `ClipId` of the owning reference frame.
     pub reference_frame_id: ClipId,
 
-    /// Local bounding rectangle for this stacking context.
-    pub local_bounds: LayerRect,
-
     /// Screen space bounding rectangle for this stacking context,
     /// calculated based on the size and position of all its children.
     pub screen_bounds: DeviceIntRect,
@@ -1561,7 +1558,6 @@ impl StackingContext {
                reference_frame_offset: LayerVector2D,
                is_page_root: bool,
                reference_frame_id: ClipId,
-               local_bounds: LayerRect,
                transform_style: TransformStyle,
                composite_ops: CompositeOps)
                -> StackingContext {
@@ -1573,7 +1569,6 @@ impl StackingContext {
             pipeline_id,
             reference_frame_offset,
             reference_frame_id,
-            local_bounds,
             screen_bounds: DeviceIntRect::zero(),
             isolated_items_bounds: LayerRect::zero(),
             composite_ops,

--- a/wrench/reftests/split/nested-ref.yaml
+++ b/wrench/reftests/split/nested-ref.yaml
@@ -8,5 +8,5 @@ root:
           bounds: [150, 0, 300, 600]
           color: red
         - type: rect
-          bounds: [150, 0, 50, 100]
+          bounds: [150, 0, 300, 200]
           color: green

--- a/wrench/reftests/split/nested.yaml
+++ b/wrench/reftests/split/nested.yaml
@@ -1,8 +1,9 @@
-# This tests have a non-preserve3d stacking context nested within
-# preserve-3d sub-tree. This nested context is still getting baked in
-# and participates (as a whole) in plane splitting.
-# It is layed out in the same plane as the parent, so should be ordered
-# last, given that it's coming later than the parent.
+# This tests have a A(3D) -> B(2D) -> C(3D) context chain.
+# All 3 contexts end up getting baked, but C last one doesn't participate in the
+# same plane splitting pass as `A` and `B`, because it's separated from them by a
+# non-preserve-3D parent `B`.
+# `B` is layed out in the same plane as the parent, so should be ordered
+# after `A`, given that it's coming later than the parent.
 ---
 root:
   items:
@@ -23,3 +24,11 @@ root:
                 - type: rect
                   bounds: [0, 0, 600, 200]
                   color: green
+                - type: stacking-context
+                  bounds: [0, 0, 600, 200]
+                  transform-style: preserve-3d
+                  transform: rotate-x(60.0)
+                  items:
+                    - type: rect
+                      bounds: [0, 0, 600, 200]
+                      color: blue

--- a/wrench/reftests/split/nested.yaml
+++ b/wrench/reftests/split/nested.yaml
@@ -1,9 +1,8 @@
-# This tests have a A(3D) -> B(2D) -> C(3D) context chain.
-# All 3 contexts end up getting baked, but C last one doesn't participate in the
-# same plane splitting pass as `A` and `B`, because it's separated from them by a
-# non-preserve-3D parent `B`.
-# `B` is layed out in the same plane as the parent, so should be ordered
-# after `A`, given that it's coming later than the parent.
+# This tests have a non-preserve3d stacking context nested within
+# preserve-3d sub-tree. This nested context is still getting baked in
+# and participates (as a whole) in plane splitting.
+# It is layed out in the same plane as the parent, so should be ordered
+# last, given that it's coming later than the parent.
 ---
 root:
   items:
@@ -24,11 +23,3 @@ root:
                 - type: rect
                   bounds: [0, 0, 600, 200]
                   color: green
-                - type: stacking-context
-                  bounds: [0, 0, 600, 200]
-                  transform-style: preserve-3d
-                  transform: rotate-x(60.0)
-                  items:
-                    - type: rect
-                      bounds: [0, 0, 600, 200]
-                      color: blue


### PR DESCRIPTION
Fixes #1283
Includes #1446

The bounds are now specifically computed for the children of isolated stacking contexts that need to be baked in (thus, excluding isolated children contexts).

Note: the `nested` test used `local_bounds` previously and considered incorrect, thus it is fixed now.
Note: breaking change

r? @mrobinson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1448)
<!-- Reviewable:end -->
