### PR TITLE
WIP: Replace Text Blur with PushTextShadow and PopTextShadow DisplayItems

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -290,7 +290,6 @@ fn body(api: &RenderApi,
                           font_key,
                           ColorF::new(1.0, 1.0, 0.0, 1.0),
                           Au::from_px(32),
-                          0.0,
                           None);
     }
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -583,7 +583,6 @@ impl Frame {
                                          item.local_clip(),
                                          text_info.font_key,
                                          text_info.size,
-                                         text_info.blur_radius,
                                          &text_info.color,
                                          item.glyphs(),
                                          item.display_list().get(item.glyphs()).count(),
@@ -718,6 +717,12 @@ impl Frame {
 
             SpecificDisplayItem::PopStackingContext =>
                 unreachable!("Should have returned in parent method."),
+            SpecificDisplayItem::PushTextShadow(shadow) => {
+                context.builder.push_text_shadow(shadow);
+            }
+            SpecificDisplayItem::PopTextShadow => {
+                context.builder.pop_text_shadow();
+            }
         }
         None
     }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -65,6 +65,8 @@ pub enum SpecificDisplayItem {
     SetGradientStops,
     PushNestedDisplayList,
     PopNestedDisplayList,
+    PushTextShadow(TextShadow),
+    PopTextShadow,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -84,7 +86,6 @@ pub struct TextDisplayItem {
     pub font_key: FontKey,
     pub size: Au,
     pub color: ColorF,
-    pub blur_radius: f32,
     pub glyph_options: Option<GlyphOptions>,
 } // IMPLICIT: glyphs: Vec<GlyphInstance>
 
@@ -222,6 +223,13 @@ pub struct BoxShadowDisplayItem {
     pub spread_radius: f32,
     pub border_radius: f32,
     pub clip_mode: BoxShadowClipMode,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TextShadow {
+    pub offset: LayoutVector2D,
+    pub color: ColorF,
+    pub blur_radius: f32,
 }
 
 #[repr(u32)]

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -14,7 +14,7 @@ use {GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, Ima
 use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D, LocalClip};
 use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
 use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem};
-use {StackingContext, TextDisplayItem, TransformStyle, WebGLContextId, WebGLDisplayItem};
+use {StackingContext, TextDisplayItem, TextShadow, TransformStyle, WebGLContextId, WebGLDisplayItem};
 use {YuvColorSpace, YuvData, YuvImageDisplayItem};
 use std::marker::PhantomData;
 
@@ -543,7 +543,6 @@ impl DisplayListBuilder {
                      font_key: FontKey,
                      color: ColorF,
                      size: Au,
-                     blur_radius: f32,
                      glyph_options: Option<GlyphOptions>) {
         // Sanity check - anything with glyphs bigger than this
         // is probably going to consume too much memory to render
@@ -556,7 +555,6 @@ impl DisplayListBuilder {
                 color,
                 font_key,
                 size,
-                blur_radius,
                 glyph_options,
             });
 
@@ -912,6 +910,14 @@ impl DisplayListBuilder {
         self.push_new_empty_item(SpecificDisplayItem::PushNestedDisplayList);
         self.data.extend_from_slice(&built_display_list.data);
         self.push_new_empty_item(SpecificDisplayItem::PopNestedDisplayList);
+    }
+
+    pub fn push_text_shadow(&mut self, shadow: TextShadow) {
+        self.push_new_empty_item(SpecificDisplayItem::PushTextShadow(shadow));
+    }
+
+    pub fn pop_text_shadow(&mut self) {
+        self.push_new_empty_item(SpecificDisplayItem::PopTextShadow);
     }
 
     pub fn finalize(self) -> (PipelineId, LayoutSize, BuiltDisplayList) {

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -2,4 +2,6 @@
 != negative-pos.yaml blank.yaml
 != shadow.yaml text.yaml
 != shadow-single.yaml blank.yaml
+!= shadow-many.yaml shadow.yaml
+!= shadow-complex.yaml shadow-many.yaml
 != non-opaque.yaml non-opaque-notref.yaml

--- a/wrench/reftests/text/shadow-complex.yaml
+++ b/wrench/reftests/text/shadow-complex.yaml
@@ -1,0 +1,45 @@
+--- # The same as shadow-many.yaml, except the shadows only apply to parts of the text
+root:
+  items:
+        -
+          type: "text-shadow"
+          blur-radius: 5
+          offset: [0, 0]
+          color: black
+        -
+          type: "text-shadow"
+          blur-radius: 0
+          offset: [2, 3]
+          color: red
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [55, 75, 76, 86]
+          offsets: [16, 43, 35.533333, 43, 51.533333, 43, 60.4, 43]
+          size: 18
+          color: [0, 0, 0, 0] # actual text is transparent
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"
+        -
+          type: "text-shadow"
+          blur-radius: 3
+          offset: [-2, 3.5]
+          color: blue
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [3, 76, 86, 3, 87, 75]
+          offsets: [72.833336, 43, 80.833336, 43, 89.7, 43, 102.13333, 43, 110.13333, 43, 119, 43]
+          size: 18
+          color: [0, 0, 0, 0] # actual text is transparent
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [72, 3, 69, 72, 86, 87]
+          offsets: [135, 43, 149.2, 43, 157.2, 43, 173.2, 43, 187.4, 43, 196.26666, 43]
+          size: 18
+          color: [0, 0, 0, 0] # actual text is transparent
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"

--- a/wrench/reftests/text/shadow-many.yaml
+++ b/wrench/reftests/text/shadow-many.yaml
@@ -1,4 +1,4 @@
----
+--- # the same as shadow.yaml, except there are many shadows with different offsets and colors
 root:
   items:
         -
@@ -7,11 +7,25 @@ root:
           offset: [0, 0]
           color: black
         -
+          type: "text-shadow"
+          blur-radius: 0
+          offset: [2, 3]
+          color: red
+        -
+          type: "text-shadow"
+          blur-radius: 3
+          offset: [-2, 3.5]
+          color: blue
+        -
           bounds: [14, 18, 205, 35]
           glyphs: [55, 75, 76, 86, 3, 76, 86, 3, 87, 75, 72, 3, 69, 72, 86, 87]
           offsets: [16, 43, 35.533333, 43, 51.533333, 43, 60.4, 43, 72.833336, 43, 80.833336, 43, 89.7, 43, 102.13333, 43, 110.13333, 43, 119, 43, 135, 43, 149.2, 43, 157.2, 43, 173.2, 43, 187.4, 43, 196.26666, 43]
           size: 18
           color: [0, 0, 0, 0] # actual text is transparent
           font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"
+        -
+          type: "pop-text-shadow"
         -
           type: "pop-text-shadow"

--- a/wrench/reftests/text/shadow-single.yaml
+++ b/wrench/reftests/text/shadow-single.yaml
@@ -2,10 +2,16 @@
 root:
   items:
         -
+          type: "text-shadow"
+          blur-radius: 5
+          offset: [0, 0]
+          color: black
+        -
           bounds: [14, 18, 205, 35]
           glyphs: [55]
           offsets: [16, 43]
           size: 18
-          color: black
-          blur-radius: 5
+          color: [0, 0, 0, 0] # actual text is transparent
           font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -429,7 +429,9 @@ impl YamlFrameReader {
     fn handle_text(&mut self, wrench: &mut Wrench, item: &Yaml, local_clip: LocalClip) {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
-        let blur_radius = item["blur-radius"].as_force_f32().unwrap_or(0.0);
+
+        assert!(item["blur-radius"].is_badvalue(),
+            "text no longer has a blur radius, use PushTextShadow and PopTextShadow");
 
         let (font_key, native_key) = if !item["family"].is_badvalue() {
             wrench.font_key_from_yaml_table(item)
@@ -498,7 +500,6 @@ impl YamlFrameReader {
                                  font_key,
                                  color,
                                  size,
-                                 blur_radius,
                                  None);
     }
 
@@ -571,6 +572,8 @@ impl YamlFrameReader {
                 "box-shadow" => self.handle_box_shadow(item, local_clip),
                 "iframe" => self.handle_iframe(item),
                 "stacking-context" => self.add_stacking_context_from_yaml(wrench, item, false),
+                "text-shadow" => self.handle_push_text_shadow(item),
+                "pop-text-shadow" => self.handle_pop_text_shadow(),
                 _ => println!("Skipping unknown item type: {:?}", item),
             }
 
@@ -604,6 +607,20 @@ impl YamlFrameReader {
             self.add_display_list_items_from_yaml(wrench, &yaml["items"]);
         }
         self.builder().pop_clip_id();
+    }
+
+    pub fn handle_push_text_shadow(&mut self, yaml: &Yaml) {
+        let blur_radius = yaml["blur-radius"].as_f32().unwrap_or(0.0);
+        let offset = yaml["blur-radius"].as_vector().unwrap_or(LayoutVector2D::zero());
+        let color = yaml["color"].as_colorf().unwrap_or(*BLACK_COLOR);
+
+        self.builder().push_text_shadow(TextShadow {
+            blur_radius, offset, color
+        });
+    }
+
+    pub fn handle_pop_text_shadow(&mut self) {
+        self.builder().pop_text_shadow();
     }
 
     pub fn handle_clip(&mut self, wrench: &mut Wrench, yaml: &Yaml) {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -791,6 +791,15 @@ impl YamlFrameWriter {
                 PopNestedDisplayList => clip_id_mapper.pop_nested_display_list_ids(),
                 PopStackingContext => return,
                 SetGradientStops => { panic!("dummy item yielded?") },
+                PushTextShadow(shadow) => {
+                    str_node(&mut v, "type", "text-shadow");
+                    vector_node(&mut v, "offset", &shadow.offset);
+                    color_node(&mut v, "color", shadow.color);
+                    f32_node(&mut v, "blur-radius", shadow.blur_radius);
+                }
+                PopTextShadow => {
+                    str_node(&mut v, "type", "pop-text-shadow");
+                },
             }
             if !v.is_empty() {
                 list.push(Yaml::Hash(v));


### PR DESCRIPTION
**WIP because it doesn't implement the backend part of this -- someone else needs to do that.** As before I've made a dummy variable that will create a warning so that the code compiles but points you to what code needs to be audited. I've also added some tests that capture some interesting cases (I suggest actually rendering them to make sure they look the way you want).
 
This is the new version of  #1418, which instead of attaching shadows/decorations to text, uses a stateful PushTextShadow and PopTextShadow.

The semantics are that everything between a PushTextShadow and PopTextShadow should be rendered to a shadow with the given properties. (Should only expect glyphs, text-decorations, and blob-image versions of decorations here) 

Why is this necessary?

Well, basically the CSS spec requires us to put every shadow in a given StackingContext on the same "layer", behind all the *actual* content. However we receive text at too low of a granularity to do this if the shadows are attached to the text. (we get roughly one TextItem per line, but more if fonts or styles change mid-line -- this can happen without any extra html/css elements due to font fallback on kanji or emoji)

The Push/Pop model gives us a simple way to say "hey all this content? yeah put a shadow on all of this". I expect the backend implementation model to look something like:

> Before rendering any content in a given stacking context, for each PopTextShadow, render the enclosed elements with the given offset, blur, and color.

The PopTextShadow approach is also beneficial because it encourages us to put as much content as possible in the "same" shadow, preventing ugly artifacts from overlapping two parts of the "same" shadow. Technically the CSS spec gives us leeway to give each glyph its own shadow rendering, but we should try to avoid this as much as possible.

This approach also avoids us having to actually add a notion of text-decorations for the time-being. Although I think webrender should eventually have them, for now they can just be implemented as blob-images from firefox or boxes from servo. When we do add them, we also won't have to bloat text -- the client can just add separate top-level items for them.

r? @glennw (still up for the backend impl work?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1454)
<!-- Reviewable:end -->
