### PR TITLE
Use light hinting for Linux glyphs.

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -13,10 +13,21 @@ use freetype::freetype::{FT_Library, FT_Set_Char_Size};
 use freetype::freetype::{FT_Face, FT_Long, FT_UInt, FT_F26Dot6};
 use freetype::freetype::{FT_Init_FreeType, FT_Load_Glyph, FT_Render_Glyph};
 use freetype::freetype::{FT_New_Memory_Face, FT_GlyphSlot, FT_LcdFilter};
-use freetype::freetype::{FT_Done_Face, FT_Error};
+use freetype::freetype::{FT_Done_Face, FT_Error, FT_Int32};
 
 use std::{cmp, mem, ptr, slice};
 use std::collections::HashMap;
+
+// This constant is not present in the freetype
+// bindings due to bindgen not handling the way
+// the macro is defined.
+const FT_LOAD_TARGET_LIGHT: FT_Int32 = 1 << 16;
+
+// Default to slight hinting, which is what most
+// Linux distros use by default, and is a better
+// default than no hinting.
+// TODO(gw): Make this configurable.
+const GLYPH_LOAD_FLAGS: FT_Int32 = FT_LOAD_TARGET_LIGHT;
 
 struct Face {
     face: FT_Face,
@@ -122,7 +133,9 @@ impl FontContext {
         });
 
         let result = unsafe {
-            FT_Load_Glyph(face.face, character as FT_UInt, 0)
+            FT_Load_Glyph(face.face,
+                          character as FT_UInt,
+                          GLYPH_LOAD_FLAGS)
         };
 
         if result == SUCCESS {

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -51,14 +51,6 @@ pub struct RasterizedGlyph {
     pub bytes: Vec<u8>,
 }
 
-fn float_to_fixed(before: usize, f: f64) -> i32 {
-    ((1i32 << before) as f64 * f) as i32
-}
-
-fn float_to_fixed_ft(f: f64) -> i32 {
-    float_to_fixed(6, f)
-}
-
 const SUCCESS: FT_Error = FT_Error(0);
 
 impl FontContext {
@@ -126,7 +118,7 @@ impl FontContext {
 
         debug_assert!(self.faces.contains_key(&font_key));
         let face = self.faces.get(&font_key).unwrap();
-        let char_size = float_to_fixed_ft(size.to_f64_px());
+        let char_size = size.to_f64_px() * 64.0 + 0.5;
 
         assert_eq!(SUCCESS, unsafe {
             FT_Set_Char_Size(face.face, char_size as FT_F26Dot6, 0, 0, 0)


### PR DESCRIPTION
This is a better default and matches glyphs exactly as Gecko draws them by default.

In the future, we'll want to make the hinting level configurable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1457)
<!-- Reviewable:end -->
