### PR TITLE
Treat all clips as scroll frames (partial revert of #1412)

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -345,8 +345,10 @@ impl Frame {
                         item: &ClipDisplayItem,
                         content_rect: &LayerRect,
                         clip: &ClipRegion) {
-        let is_scroll_frame =
-            clip.main.origin != LayerPoint::zero() || clip.main.size != content_rect.size;
+        // Until we have an explicit API to allow WR users to create scroll
+        // frames, we treat all clips as scroll frames. Once that API is in
+        // place this can be updated accordingly.
+        let is_scroll_frame = true;
 
         let new_id = context.convert_new_id_to_neested(&item.id);
         let new_clip_id = if is_scroll_frame {


### PR DESCRIPTION
PR #1412 introduced a small semantic change mixed in with the removal of
per-item complex clipping and masking. The semantic change resulted in
numerous Gecko reftest failures as many scroll frames ended up being
treated as clips. Eventually WR will have an explicit API to allow
callers to distinguish scroll frames from clips, but until that is in
place we should maintain the old behaviour of just treating all clips as
potential scroll frames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1459)
<!-- Reviewable:end -->
