### PR TITLE
Remove incorrect warning.

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -197,8 +197,11 @@ impl ClipScrollNode {
 
     pub fn finalize(&mut self, new_scrolling: &ScrollingState) {
         match self.node_type {
-            NodeType::ReferenceFrame(_) | NodeType::Clip(_) =>
-                warn!("Tried to scroll a non-scroll node."),
+            NodeType::ReferenceFrame(_) | NodeType::Clip(_) => {
+                if new_scrolling.offset != LayerVector2D::zero() {
+                    warn!("Tried to scroll a non-scroll node.");
+                }
+            }
             NodeType::ScrollFrame(ref mut scrolling) => *scrolling = *new_scrolling,
         }
     }


### PR DESCRIPTION
Fixes #1424

It should be fine to call finalize() on a non-scroll node. It would not
be fine to call set_scroll_origin on a non-scroll node, but that
function emits a warning for that scenario anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1460)
<!-- Reviewable:end -->
