### PR TITLE
Refined text glyph snapping

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -261,6 +261,7 @@ impl GlyphRasterizer {
         for job in rasterized_glyphs {
             let image_id = job.result.and_then(
                 |glyph| if glyph.width > 0 && glyph.height > 0 {
+                    assert_eq!((glyph.left.fract(), glyph.top.fract()), (0.0, 0.0));
                     let image_id = texture_cache.insert(
                         ImageDescriptor {
                             width: glyph.width,
@@ -334,7 +335,7 @@ impl GlyphRequest {
         point: LayoutPoint,
         render_mode: FontRenderMode,
         glyph_options: Option<GlyphOptions>,
-    ) -> GlyphRequest {
+    ) -> Self {
         GlyphRequest {
             key: GlyphKey::new(font_key, size, color, index, point, render_mode),
             render_mode,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -536,10 +536,24 @@ impl TextRunPrimitiveCpu {
             // GPU block.
             let first_glyph = glyph_chunk.first().unwrap();
             let second_glyph = glyph_chunk.last().unwrap();
-            request.push([first_glyph.point.x,
-                          first_glyph.point.y,
-                          second_glyph.point.x,
-                          second_glyph.point.y]);
+            let data = match self.render_mode {
+                FontRenderMode::Mono |
+                FontRenderMode::Alpha => [
+                    first_glyph.point.x,
+                    first_glyph.point.y,
+                    second_glyph.point.x,
+                    second_glyph.point.y,
+                ],
+                // The sub-pixel offset has already been taken into account
+                // by the glyph rasterizer, thus the truncating here.
+                FontRenderMode::Subpixel => [
+                    first_glyph.point.x.trunc(),
+                    first_glyph.point.y.trunc(),
+                    second_glyph.point.x.trunc(),
+                    second_glyph.point.y.trunc(),
+                ],
+            };
+            request.push(data);
         }
     }
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -20,7 +20,7 @@ use texture_cache::{TextureCache, TextureCacheItemId};
 use api::{Epoch, FontKey, FontTemplate, GlyphKey, ImageKey, ImageRendering};
 use api::{FontRenderMode, ImageData, GlyphDimensions, WebGLContextId};
 use api::{DevicePoint, DeviceIntSize, DeviceUintRect, ImageDescriptor, ColorF};
-use api::{GlyphOptions, GlyphInstance, TileOffset, TileSize};
+use api::{GlyphOptions, GlyphInstance, SubpixelPoint, TileOffset, TileSize};
 use api::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest, BlobImageData};
 use api::BlobImageResources;
 use api::{ExternalImageData, ExternalImageType, LayoutPoint};
@@ -482,21 +482,21 @@ impl ResourceCache {
                          glyph_options: Option<GlyphOptions>,
                          mut f: F) -> SourceTexture where F: FnMut(usize, &GpuCacheHandle) {
         debug_assert_eq!(self.state, State::QueryResources);
-        let mut glyph_key = GlyphRequest::new(
+        let mut glyph_request = GlyphRequest::new(
             font_key,
             size,
             color,
             0,
-            LayoutPoint::new(0.0, 0.0),
+            LayoutPoint::zero(),
             render_mode,
             glyph_options
         );
         let mut texture_id = None;
         for (loop_index, glyph_instance) in glyph_instances.iter().enumerate() {
-            glyph_key.key.index = glyph_instance.index;
-            glyph_key.key.subpixel_point.set_offset(glyph_instance.point, render_mode);
+            glyph_request.key.index = glyph_instance.index;
+            glyph_request.key.subpixel_point = SubpixelPoint::new(glyph_instance.point, render_mode);
 
-            let image_id = self.cached_glyphs.get(&glyph_key, self.current_frame_id);
+            let image_id = self.cached_glyphs.get(&glyph_request, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
                 f(loop_index, &cache_item.uv_rect_handle);

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -149,11 +149,6 @@ impl SubpixelPoint {
     pub fn to_f64(&self) -> (f64, f64) {
         (self.x.into(), self.y.into())
     }
-
-    pub fn set_offset(&mut self, point: LayoutPoint, render_mode: FontRenderMode) {
-        self.x = render_mode.subpixel_quantize_offset(point.x);
-        self.y = render_mode.subpixel_quantize_offset(point.y);
-    }
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]


### PR DESCRIPTION
This PR truncates the sub-pixel offset of the glyphs coming to GPU in order to fix the snapping. With  `FontRenderMode::Subpixel`, that offset is already taken into account when the glyph is rasterized. With the other rendering modes, I'm not completely sure if it's fine to truncate the fractional part, but I also don't see how the current snapping code is better anyway.

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1465)
<!-- Reviewable:end -->
