### PR TITLE
Derive Debug in some structs/enums for easier printing

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -203,6 +203,7 @@ pub enum RenderTargetMode {
     LayerRenderTarget(i32),      // Number of texture layers
 }
 
+#[derive(Debug)]
 pub enum TextureUpdateOp {
     Create {
       width: u32,
@@ -238,6 +239,7 @@ pub enum TextureUpdateOp {
     Free,
 }
 
+#[derive(Debug)]
 pub struct TextureUpdate {
     pub id: CacheTextureId,
     pub op: TextureUpdateOp,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -43,6 +43,7 @@ pub struct CacheItem {
     pub uv_rect_handle: GpuCacheHandle,
 }
 
+#[derive(Debug)]
 pub struct ImageProperties {
     pub descriptor: ImageDescriptor,
     pub external_image: Option<ExternalImageData>,
@@ -56,6 +57,7 @@ enum State {
     QueryResources,
 }
 
+#[derive(Debug)]
 struct ImageResource {
     data: ImageData,
     descriptor: ImageDescriptor,

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -92,7 +92,7 @@ impl ImageDescriptor {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ImageData {
     Raw(Arc<Vec<u8>>),
     Blob(BlobImageData),


### PR DESCRIPTION
While trying to investigate bug 1378883 I found it useful to print out these data structures. Figured it might be worthwhile to check this in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1467)
<!-- Reviewable:end -->
