### PR TITLE
Let iframes accept a LocalClip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.47.0",
+ "webrender 0.48.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1022,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1048,12 +1048,12 @@ dependencies = [
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.47.0",
+ "webrender_api 0.48.0",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -483,6 +483,7 @@ impl Frame {
                           pipeline_id: PipelineId,
                           parent_id: ClipId,
                           bounds: &LayerRect,
+                          local_clip: &LocalClip,
                           context: &mut FlattenContext,
                           reference_frame_relative_offset: LayerVector2D) {
         let pipeline = match context.scene.pipeline_map.get(&pipeline_id) {
@@ -495,6 +496,16 @@ impl Frame {
             None => return,
         };
 
+        let mut clip_region = ClipRegion::create_for_clip_node_with_local_clip(local_clip);
+        clip_region.origin += reference_frame_relative_offset;
+        let parent_pipeline_id = parent_id.pipeline_id();
+        let clip_id = self.clip_scroll_tree.generate_new_clip_id(parent_pipeline_id);
+        context.builder.add_clip_node(clip_id,
+                                      parent_id,
+                                      parent_pipeline_id,
+                                      clip_region,
+                                      &mut self.clip_scroll_tree);
+
         self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
 
         let iframe_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
@@ -504,7 +515,7 @@ impl Frame {
             0.0);
 
         let iframe_reference_frame_id =
-            context.builder.push_reference_frame(Some(parent_id),
+            context.builder.push_reference_frame(Some(clip_id),
                                                  pipeline_id,
                                                  &iframe_rect,
                                                  &transform,
@@ -665,6 +676,7 @@ impl Frame {
                 self.flatten_iframe(info.pipeline_id,
                                     clip_and_scroll.scroll_node_id,
                                     &item.rect(),
+                                    &item.local_clip(),
                                     context,
                                     reference_frame_relative_offset);
             }

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -44,6 +44,14 @@ impl ClipRegion {
         }
     }
 
+    pub fn create_for_clip_node_with_local_clip(local_clip: &LocalClip) -> ClipRegion {
+        let complex_clips = match local_clip {
+            &LocalClip::Rect(_) => Vec::new(),
+            &LocalClip::RoundedRect(_, ref region) => vec![region.clone()],
+        };
+        ClipRegion::for_clip_node(*local_clip.clip_rect(), complex_clips, None)
+    }
+
     pub fn for_local_clip(local_clip: &LocalClip) -> ClipRegion {
         let complex_clips = match local_clip {
             &LocalClip::Rect(_) => Vec::new(),

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -895,9 +895,12 @@ impl DisplayListBuilder {
         assert!(self.clip_stack.len() > 0);
     }
 
-    pub fn push_iframe(&mut self, rect: LayoutRect, pipeline_id: PipelineId) {
+    pub fn push_iframe(&mut self,
+                       rect: LayoutRect,
+                       local_clip: Option<LocalClip>,
+                       pipeline_id: PipelineId) {
         let item = SpecificDisplayItem::Iframe(IframeDisplayItem { pipeline_id: pipeline_id });
-        self.push_item(item, rect, None);
+        self.push_item(item, rect, local_clip);
     }
 
     // Don't use this function. It will go away.

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -503,10 +503,10 @@ impl YamlFrameReader {
                                  None);
     }
 
-    fn handle_iframe(&mut self, item: &Yaml) {
+    fn handle_iframe(&mut self, item: &Yaml, local_clip: LocalClip) {
         let bounds = item["bounds"].as_rect().expect("iframe must have bounds");
         let pipeline_id = item["id"].as_pipeline_id().unwrap();
-        self.builder().push_iframe(bounds, pipeline_id);
+        self.builder().push_iframe(bounds, Some(local_clip), pipeline_id);
     }
 
     pub fn get_local_clip_for_item(&mut self, yaml: &Yaml, full_clip: LayoutRect) -> LocalClip {
@@ -570,7 +570,7 @@ impl YamlFrameReader {
                 "gradient" => self.handle_gradient(item, local_clip),
                 "radial-gradient" => self.handle_radial_gradient(item, local_clip),
                 "box-shadow" => self.handle_box_shadow(item, local_clip),
-                "iframe" => self.handle_iframe(item),
+                "iframe" => self.handle_iframe(item, local_clip),
                 "stacking-context" => self.add_stacking_context_from_yaml(wrench, item, false),
                 "text-shadow" => self.handle_push_text_shadow(item),
                 "pop-text-shadow" => self.handle_pop_text_shadow(),


### PR DESCRIPTION
This will make it easier for Servo iframes to clip their contents. The
LocalClip is converted into a containing ClipScrollTree node around the
content of the iframe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1472)
<!-- Reviewable:end -->
