### PR TITLE
Sort the list of resource files for sharers.rs to be deterministic

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -50,5 +50,9 @@ fn main() {
         }
     }
 
+    // Sort the file list so that the shaders.rs file is filled
+    // deterministically.
+    glsl_files.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
     write_shaders(glsl_files, &shaders_file);
 }


### PR DESCRIPTION
This causes sccache cache misses even when nothing changed, because the file system may not return the files in the same order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1475)
<!-- Reviewable:end -->
