### PR TITLE
Fix a number of issues with text-shadow.

### DIFF
--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -7,21 +7,28 @@
 // drawn un-transformed. These are used for effects such
 // as text-shadow.
 
+#define TEXT_RUN_HEADER_VECS 1
+
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
 
-    int glyph_index = prim.user_data0;
+    int rect_index = prim.user_data0;
+    int glyph_index = prim.user_data1;
     int resource_address = prim.user_data2;
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
     GlyphResource res = fetch_glyph_resource(resource_address);
+
+    vec2 offset = fetch_from_resource_cache_1(prim.specific_prim_address +
+                                              TEXT_RUN_HEADER_VECS +
+                                              rect_index).xy;
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by
     // the glyph offset, relative to its primitive bounding rect.
     vec2 size = res.uv_rect.zw - res.uv_rect.xy;
     vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
-    vec2 origin = prim.task.render_target_origin + uDevicePixelRatio * (local_pos - prim.local_rect.p0);
+    vec2 origin = prim.task.render_target_origin + uDevicePixelRatio * (offset + local_pos);
     vec4 local_rect = vec4(origin, size);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));


### PR DESCRIPTION
* Correctly handle text-shadow offset. The previous code
  was translating the local rect of the cache primitive correctly,
  however the local space offset between the text runs
  and the shadow rect itself weren't being handled.
* The paint order of non-transparent text runs added
  inside a push/pop text-shadow stack was incorrect. Now
  the code maintains a pending list of visual text runs
  encountered during a text-shadow stack, and pushes
  them as primitives after all shadows are popped.
* The text run cache shader was not correctly placing
  the glyphs in the middle of the render task that is
  used as input to the blur render tasks. This meant that
  the blur was not centered correctly, and may have
  resulted in artifacts around the edge of the blur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1482)
<!-- Reviewable:end -->
