### PR TITLE
Various improvements to text-shadow support.

### DIFF
--- a/webrender/res/cs_blur.vs.glsl
+++ b/webrender/res/cs_blur.vs.glsl
@@ -54,7 +54,8 @@ void main(void) {
             break;
     }
 
-    vUvRect = vec4(src_task.data0.xy, src_task.data0.xy + src_task.data0.zw);
+    vUvRect = vec4(src_task.data0.xy + vec2(0.5),
+                   src_task.data0.xy + src_task.data0.zw - vec2(0.5));
     vUvRect /= texture_size.xyxy;
 
     vec2 uv0 = src_task.data0.xy / texture_size;

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -7,28 +7,22 @@
 // drawn un-transformed. These are used for effects such
 // as text-shadow.
 
-#define TEXT_RUN_HEADER_VECS 1
-
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
 
-    int rect_index = prim.user_data0;
-    int glyph_index = prim.user_data1;
-    int resource_address = prim.user_data2;
+    int glyph_index = prim.user_data0;
+    int resource_address = prim.user_data1;
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
     GlyphResource res = fetch_glyph_resource(resource_address);
-
-    vec2 offset = fetch_from_resource_cache_1(prim.specific_prim_address +
-                                              TEXT_RUN_HEADER_VECS +
-                                              rect_index).xy;
 
     // Glyphs size is already in device-pixels.
     // The render task origin is in device-pixels. Offset that by
     // the glyph offset, relative to its primitive bounding rect.
     vec2 size = res.uv_rect.zw - res.uv_rect.xy;
     vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
-    vec2 origin = prim.task.render_target_origin + uDevicePixelRatio * (offset + local_pos);
+    vec2 origin = prim.task.render_target_origin +
+                  uDevicePixelRatio * (text.offset + local_pos);
     vec4 local_rect = vec4(origin, size);
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -133,7 +133,7 @@ vec4[2] fetch_from_resource_cache_2(int address) {
 #define VECS_PER_LAYER              9
 #define VECS_PER_RENDER_TASK        3
 #define VECS_PER_PRIM_HEADER        2
-#define VECS_PER_TEXT_RUN           1
+#define VECS_PER_TEXT_RUN           2
 #define VECS_PER_GRADIENT           3
 #define VECS_PER_GRADIENT_STOP      2
 
@@ -763,11 +763,12 @@ Rectangle fetch_rectangle(int address) {
 
 struct TextRun {
     vec4 color;
+    vec2 offset;
 };
 
 TextRun fetch_text_run(int address) {
-    vec4 data = fetch_from_resource_cache_1(address);
-    return TextRun(data);
+    vec4 data[2] = fetch_from_resource_cache_2(address);
+    return TextRun(data[0], data[1].xy);
 }
 
 struct Image {

--- a/webrender/res/ps_cache_image.fs.glsl
+++ b/webrender/res/ps_cache_image.fs.glsl
@@ -1,7 +1,9 @@
+#line 1
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 void main(void) {
-    oFragColor = texture(sCacheRGBA8, vUv);
+    vec2 uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
+    oFragColor = texture(sCacheRGBA8, vec3(uv, vUv.z));
 }

--- a/webrender/res/ps_cache_image.glsl
+++ b/webrender/res/ps_cache_image.glsl
@@ -3,3 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 varying vec3 vUv;
+flat varying vec4 vUvBounds;

--- a/webrender/res/ps_cache_image.vs.glsl
+++ b/webrender/res/ps_cache_image.vs.glsl
@@ -20,10 +20,13 @@ void main(void) {
     vUv.z = child_task.data1.x;
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
-    vec2 uv0 = child_task.data0.xy / texture_size;
-    vec2 uv1 = (child_task.data0.xy + child_task.data0.zw) / texture_size;
+    vec2 uv0 = child_task.data0.xy;
+    vec2 uv1 = (child_task.data0.xy + child_task.data0.zw);
 
     vec2 f = (vi.local_pos - prim.local_rect.p0) / prim.local_rect.size;
 
-    vUv.xy = mix(uv0, uv1, f);
+    vUv.xy = mix(uv0 / texture_size,
+                 uv1 / texture_size,
+                 f);
+    vUvBounds = vec4(uv0 + vec2(0.5), uv1 - vec2(0.5)) / texture_size.xyxy;
 }

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -12,7 +12,9 @@ void main(void) {
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
     GlyphResource res = fetch_glyph_resource(resource_address);
 
-    vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
+    vec2 local_pos = glyph.offset +
+                     text.offset +
+                     vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
 
     RectWithSize local_rect = RectWithSize(local_pos,
                                            (res.uv_rect.zw - res.uv_rect.xy) / uDevicePixelRatio);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntS
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, TextShadow};
 use api::{LayerToWorldTransform, TileOffset, WebGLContextId, YuvColorSpace, YuvFormat};
-use api::device_length;
+use api::{device_length, LayerVector2D};
 use app_units::Au;
 use border::BorderCornerInstance;
 use euclid::{Size2D};
@@ -483,41 +483,19 @@ impl RadialGradientPrimitiveCpu {
 #[derive(Debug, Clone)]
 pub struct TextRun {
     pub font_key: FontKey,
+    pub offset: LayerVector2D,
     pub logical_font_size: Au,
     pub glyph_range: ItemRange<GlyphInstance>,
     pub glyph_count: usize,
     // TODO(gw): Maybe make this an Arc for sharing with resource cache
     pub glyph_instances: Vec<GlyphInstance>,
     pub glyph_options: Option<GlyphOptions>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ShadowTextRun {
-    pub run: TextRun,
-    pub offset: LayerPoint,
-}
-
-impl ShadowTextRun {
-    fn prepare_for_render(&mut self,
-                          resource_cache: &mut ResourceCache,
-                          device_pixel_ratio: f32,
-                          display_list: &BuiltDisplayList) {
-        // The color used to request glyphs for shadow rendering
-        // doesn't actually matter (since we're not using subpixel
-        // rendering in this case). Passing a constant color here
-        // is a bit more efficient, since we don't need to rasterize
-        // glyphs multiple times for shadows of different colors.
-        self.run.prepare_for_render(ColorF::new(0.0, 0.0, 0.0, 1.0),
-                                    FontRenderMode::Alpha,
-                                    resource_cache,
-                                    device_pixel_ratio,
-                                    display_list);
-    }
+    pub render_mode: FontRenderMode,
 }
 
 #[derive(Debug, Clone)]
 pub struct TextShadowPrimitiveCpu {
-    pub runs: Vec<ShadowTextRun>,
+    pub runs: Vec<TextRun>,
     pub shadow: TextShadow,
 }
 
@@ -525,13 +503,11 @@ pub struct TextShadowPrimitiveCpu {
 pub struct TextRunPrimitiveCpu {
     pub run: TextRun,
     pub color: ColorF,
-    pub render_mode: FontRenderMode,
 }
 
 impl TextRun {
     fn prepare_for_render(&mut self,
                           color: ColorF,
-                          render_mode: FontRenderMode,
                           resource_cache: &mut ResourceCache,
                           device_pixel_ratio: f32,
                           display_list: &BuiltDisplayList) {
@@ -555,13 +531,16 @@ impl TextRun {
                                       font_size_dp,
                                       color,
                                       &self.glyph_instances,
-                                      render_mode,
+                                      self.render_mode,
                                       self.glyph_options);
     }
 
     fn write_gpu_blocks(&self,
-                        request: &mut GpuDataRequest,
-                        render_mode: FontRenderMode) {
+                        color: ColorF,
+                        request: &mut GpuDataRequest) {
+        request.push(color);
+        request.push([self.offset.x, self.offset.y, 0.0, 0.0]);
+
         // Two glyphs are packed per GPU block.
         for glyph_chunk in self.glyph_instances.chunks(2) {
             // In the case of an odd number of glyphs, the
@@ -569,7 +548,7 @@ impl TextRun {
             // GPU block.
             let first_glyph = glyph_chunk.first().unwrap();
             let second_glyph = glyph_chunk.last().unwrap();
-            let data = match render_mode {
+            let data = match self.render_mode {
                 FontRenderMode::Mono |
                 FontRenderMode::Alpha => [
                     first_glyph.point.x,
@@ -597,7 +576,6 @@ impl TextRunPrimitiveCpu {
                           device_pixel_ratio: f32,
                           display_list: &BuiltDisplayList) {
         self.run.prepare_for_render(self.color,
-                                    self.render_mode,
                                     resource_cache,
                                     device_pixel_ratio,
                                     display_list);
@@ -1113,7 +1091,13 @@ impl PrimitiveStore {
             PrimitiveKind::TextShadow => {
                 let shadow = &mut self.cpu_text_shadows[metadata.cpu_prim_index.0];
                 for text in &mut shadow.runs {
-                    text.prepare_for_render(resource_cache,
+                    // The color used to request glyphs for shadow rendering
+                    // doesn't actually matter (since we're not using subpixel
+                    // rendering in this case). Passing a constant color here
+                    // is a bit more efficient, since we don't need to rasterize
+                    // glyphs multiple times for shadows of different colors.
+                    text.prepare_for_render(ColorF::new(0.0, 0.0, 0.0, 1.0),
+                                            resource_cache,
                                             device_pixel_ratio,
                                             display_list);
                 }
@@ -1215,17 +1199,12 @@ impl PrimitiveStore {
                 }
                 PrimitiveKind::TextRun => {
                     let text = &self.cpu_text_runs[metadata.cpu_prim_index.0];
-                    request.push(text.color);
-                    text.run.write_gpu_blocks(&mut request, text.render_mode);
+                    text.run.write_gpu_blocks(text.color, &mut request);
                 }
                 PrimitiveKind::TextShadow => {
                     let prim = &self.cpu_text_shadows[metadata.cpu_prim_index.0];
-                    request.push(prim.shadow.color);
                     for text in &prim.runs {
-                        request.push([text.offset.x, text.offset.y, 0.0, 0.0]);
-                    }
-                    for text in &prim.runs {
-                        text.run.write_gpu_blocks(&mut request, FontRenderMode::Alpha);
+                        text.write_gpu_blocks(prim.shadow.color, &mut request);
                     }
                 }
             }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -494,6 +494,12 @@ pub struct TextRun {
 }
 
 #[derive(Debug, Clone)]
+pub struct TextDecoration {
+    pub local_rect: LayerRect,
+    pub prim: RectanglePrimitive,
+}
+
+#[derive(Debug, Clone)]
 pub struct TextShadowPrimitiveCpu {
     pub runs: Vec<TextRun>,
     pub shadow: TextShadow,


### PR DESCRIPTION
* Clamp UV fetches to 0.5 texels inside the UV rect for ps_cache and cs_blur shaders.
  Hopefully, this will fix the text-shadow artifacts that appear on some machines / tests.
* Add fast path for text that has blur radius of zero.
  This is a useful optimization, and also needed to pass some of the Servo reftests, which don't support fuzzy tests.
  Text runs with a zero shadow get pushed through the normal text run path, which now supports an offset parameter.
* Respect subpixel AA mode for text runs with zero blur radius.
  Fixes #1483.
* Respect disabled text AA mode for text runs with zero blur radius.
  This is needed by some of the Servo reftests.
* Simplify the GPU cache layout of text-shadow primitives.
  They now match that of a normal text run primitive, but have several runs concatenated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1488)
<!-- Reviewable:end -->
