### PR TITLE
Support resizing items in the texture cache.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -312,7 +312,6 @@ impl ResourceCache {
                                  mut data: ImageData,
                                  dirty_rect: Option<DeviceUintRect>) {
         let resource = if let Some(image) = self.resources.image_templates.get(image_key) {
-            assert_eq!(image.descriptor.format, descriptor.format);
 
             let next_epoch = Epoch(image.epoch.0 + 1);
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -312,8 +312,6 @@ impl ResourceCache {
                                  mut data: ImageData,
                                  dirty_rect: Option<DeviceUintRect>) {
         let resource = if let Some(image) = self.resources.image_templates.get(image_key) {
-            assert_eq!(image.descriptor.width, descriptor.width);
-            assert_eq!(image.descriptor.height, descriptor.height);
             assert_eq!(image.descriptor.format, descriptor.format);
 
             let next_epoch = Epoch(image.epoch.0 + 1);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -659,6 +659,11 @@ impl ResourceCache {
             image_template.data.clone()
         });
 
+        let filter = match request.rendering {
+            ImageRendering::Pixelated => TextureFilter::Nearest,
+            ImageRendering::Auto | ImageRendering::CrispEdges => TextureFilter::Linear,
+        };
+
         let descriptor = if let Some(tile) = request.tile {
             let tile_size = image_template.tiling.unwrap();
             let image_descriptor = &image_template.descriptor;
@@ -699,6 +704,7 @@ impl ResourceCache {
                 if entry.get().epoch != image_template.epoch {
                     self.texture_cache.update(image_id,
                                               descriptor,
+                                              filter,
                                               image_data,
                                               image_template.dirty_rect);
 

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -775,13 +775,15 @@ impl TextureCache {
         }
     }
 
-    pub fn update(&mut self,
-                  image_id: TextureCacheItemId,
-                  descriptor: ImageDescriptor,
-                  filter: TextureFilter,
-                  data: ImageData,
-                  dirty_rect: Option<DeviceUintRect>) {
-        let existing_item = self.items.get(image_id).clone();
+    pub fn update(
+        &mut self,
+        image_id: TextureCacheItemId,
+        descriptor: ImageDescriptor,
+        filter: TextureFilter,
+        data: ImageData,
+        mut dirty_rect: Option<DeviceUintRect>,
+    ) {
+        let mut existing_item = self.items.get(image_id).clone();
 
         if existing_item.allocated_rect.size.width != descriptor.width ||
            existing_item.allocated_rect.size.height != descriptor.height {
@@ -798,7 +800,10 @@ impl TextureCache {
                 Some(image_id),
             );
 
-            return;
+            // Fetch the item again because the rect most likely changed during reallocation.
+            existing_item = self.items.get(image_id).clone();
+            // If we reallocated, we need to upload the whole item again.
+            dirty_rect = None;
         }
 
         let op = match data {


### PR DESCRIPTION
I revived #925 to address #1367.

TextureCache::update now supports changing the size of the image by freeing and reallocating a rectangle in the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1490)
<!-- Reviewable:end -->
