### PR TITLE
Line item

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -621,6 +621,17 @@ impl Frame {
 
                 }
             }
+            SpecificDisplayItem::Line(ref info) => {
+                context.builder.add_line(clip_and_scroll,
+                                         item.local_clip(),
+                                         info.baseline,
+                                         info.start,
+                                         info.end,
+                                         info.orientation,
+                                         info.width,
+                                         &info.color,
+                                         info.style);
+            }
             SpecificDisplayItem::Gradient(ref info) => {
                 context.builder.add_gradient(clip_and_scroll,
                                              item.rect(),

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -6,8 +6,9 @@ use api::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipAndScrollInfo
 use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect, DeviceUintSize};
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
-use api::{LayerToScrollTransform, LayerVector2D, LocalClip, PipelineId, RepeatMode, TextShadow};
-use api::{TileOffset, TransformStyle, WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
+use api::{LayerToScrollTransform, LayerVector2D, LineOrientation, LineStyle, LocalClip};
+use api::{PipelineId, RepeatMode, TextShadow, TileOffset, TransformStyle};
+use api::{WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
 use app_units::Au;
 use frame::FrameId;
 use gpu_cache::GpuCache;
@@ -597,6 +598,42 @@ impl FrameBuilder {
                 });
             }
         }
+    }
+
+    pub fn add_line(&mut self,
+                    clip_and_scroll: ClipAndScrollInfo,
+                    local_clip: &LocalClip,
+                    baseline: f32,
+                    start: f32,
+                    end: f32,
+                    orientation: LineOrientation,
+                    width: f32,
+                    color: &ColorF,
+                    style: LineStyle) {
+
+        // Dummy impl for testing (replace this)
+        match style {
+            LineStyle::Solid => {
+                let new_rect = match orientation {
+                    LineOrientation::Horizontal => {
+                        LayerRect::new(LayerPoint::new(start, baseline),
+                                       LayerSize::new(end - start, width))
+                    }
+                    LineOrientation::Vertical => {
+                        LayerRect::new(LayerPoint::new(baseline, start),
+                                       LayerSize::new(width, end - start))
+                    }
+                };
+
+                self.add_solid_rectangle(clip_and_scroll,
+                                         &new_rect,
+                                         local_clip,
+                                         color,
+                                         PrimitiveFlags::None);
+            }
+            _ => unimplemented!(),
+        }
+
     }
 
     pub fn add_border(&mut self,

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -51,6 +51,7 @@ pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),
     ScrollFrame(ClipDisplayItem),
     Rectangle(RectangleDisplayItem),
+    Line(LineDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),
     YuvImage(YuvImageDisplayItem),
@@ -79,6 +80,33 @@ pub struct ClipDisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RectangleDisplayItem {
     pub color: ColorF,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct LineDisplayItem {
+    pub baseline: f32, // LayerPixel
+    pub start: f32,
+    pub end: f32,
+    pub orientation: LineOrientation, // toggles whether above values are interpreted as x/y values
+    pub width: f32,
+    pub color: ColorF,
+    pub style: LineStyle,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum LineOrientation {
+    Vertical,
+    Horizontal,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum LineStyle {
+    Solid,
+    Dotted,
+    Dashed,
+    Wavy,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -11,11 +11,12 @@ use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShado
 use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion, DisplayItem};
 use {ExtendMode, FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem};
 use {GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering};
-use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D, LocalClip};
-use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
-use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy, SpecificDisplayItem};
-use {StackingContext, TextDisplayItem, TextShadow, TransformStyle, WebGLContextId, WebGLDisplayItem};
-use {YuvColorSpace, YuvData, YuvImageDisplayItem};
+use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D, LineDisplayItem};
+use {LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId};
+use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
+use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy};
+use {SpecificDisplayItem, StackingContext, TextDisplayItem, TextShadow, TransformStyle};
+use {WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
 use std::marker::PhantomData;
 
 #[repr(C)]
@@ -492,6 +493,23 @@ impl DisplayListBuilder {
         });
 
         self.push_item(item, rect, local_clip);
+    }
+
+    pub fn push_line(&mut self,
+                     local_clip: Option<LocalClip>,
+                     baseline: f32,
+                     start: f32,
+                     end: f32,
+                     orientation: LineOrientation,
+                     width: f32,
+                     color: ColorF,
+                     style: LineStyle) {
+        let item = SpecificDisplayItem::Line(LineDisplayItem {
+            baseline, start, end, orientation,
+            width, color, style,
+        });
+
+        self.push_item(item, LayoutRect::zero(), local_clip);
     }
 
     pub fn push_image(&mut self,

--- a/wrench/reftests/text/decorations-ref.yaml
+++ b/wrench/reftests/text/decorations-ref.yaml
@@ -1,0 +1,19 @@
+---
+root:
+  items:
+    - type: rect                    # short, horizontal
+      bounds: [ 4, 2, 5, 1 ]
+      color: green
+    - type: rect                    # short, vertical
+      bounds: [ 12, 14, 1, 5 ]
+      color: red
+      style: solid
+    - type: rect                    # long, horizontal
+      bounds: [ 34, 32, 200, 3 ]
+      color: blue
+      style: solid
+    - type: rect                    # long, vertical
+      bounds: [ 52, 54, 3, 200 ]
+      color: black
+      style: solid
+

--- a/wrench/reftests/text/decorations.yaml
+++ b/wrench/reftests/text/decorations.yaml
@@ -1,0 +1,36 @@
+---
+root:
+  items:
+    - type: line                    # short, horizontal
+      baseline: 2
+      start: 4
+      end: 9
+      width: 1
+      orientation: horizontal
+      color: green
+      style: solid
+    - type: line                    # short, vertical
+      baseline: 12
+      start: 14
+      end: 19
+      width: 1
+      orientation: vertical
+      color: red
+      style: solid
+    - type: line                    # long, horizontal
+      baseline: 32
+      start: 34
+      end: 234
+      width: 3
+      orientation: horizontal
+      color: blue
+      style: solid
+    - type: line                    # long, vertical
+      baseline: 52
+      start: 54
+      end: 254
+      width: 3
+      orientation: vertical
+      color: black
+      style: solid
+

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -11,3 +11,4 @@
 != shadow-many.yaml shadow.yaml
 != shadow-complex.yaml shadow-many.yaml
 != non-opaque.yaml non-opaque-notref.yaml
+== decorations.yaml decorations-ref.yaml

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -510,6 +510,16 @@ impl YamlFrameWriter {
                     str_node(&mut v, "type", "rect");
                     color_node(&mut v, "color", item.color);
                 },
+                Line(item) => {
+                    str_node(&mut v, "type", "line");
+                    f32_node(&mut v, "baseline", item.baseline);
+                    f32_node(&mut v, "start", item.start);
+                    f32_node(&mut v, "end", item.end);
+                    str_node(&mut v, "orientation", item.orientation.as_str());
+                    f32_node(&mut v, "width", item.width);
+                    color_node(&mut v, "color", item.color);
+                    str_node(&mut v, "style", item.style.as_str());
+                }
                 Text(item) => {
                     let gi = display_list.get(base.glyphs());
                     let mut indices: Vec<u32> = vec![];

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -113,6 +113,18 @@ define_string_enum!(ScrollPolicy, [
     Fixed = "fixed",
 ]);
 
+define_string_enum!(LineOrientation, [
+    Horizontal = "horizontal",
+    Vertical = "vertical",
+]);
+
+define_string_enum!(LineStyle, [
+    Solid = "solid",
+    Dotted = "dotted",
+    Dashed = "dashed",
+    Wavy = "wavy",
+]);
+
 // Rotate around `axis` by `degrees` angle
 fn make_rotation(origin: &LayoutPoint, degrees: f32, axis_x: f32, axis_y: f32, axis_z: f32)
                  -> LayoutTransform {


### PR DESCRIPTION
This is an implementation of the API I proposed in #1480. The backend impl is basically WIP but gives me something to test, and also implements the only decoration Servo actually has (solid).

I was sitting on this hoping for feedback on the issue, but since @glennw had to hack in his own api to support Servo I figured I'd just push this up for him to use.

In implementing this, I can't help but wonder if this should just derive the line properties from the local_rect + an orientation flag. That said that's a bit weird for wavy lines. This api gives a uniform translation from CSS to webrender -- although perhaps this isn't that useful, considering the client needs to compute a larger bounding rect for the wavy lines anyway?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1491)
<!-- Reviewable:end -->
