### PR TITLE
Multi-doc support

### DIFF
--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -45,9 +45,7 @@ lazy_static! {
     static ref TRANSFORM: Mutex<LayoutTransform> = Mutex::new(LayoutTransform::identity());
 }
 
-fn event_handler(event: &glutin::Event,
-                 api: &RenderApi)
-{
+fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
     match *event {
         glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
             let offset = match key {
@@ -61,7 +59,7 @@ fn event_handler(event: &glutin::Event,
             // webrender using the generate_frame API. This will recomposite with
             // the updated transform.
             let new_transform = TRANSFORM.lock().unwrap().post_translate(LayoutVector3D::new(offset.0, offset.1, 0.0));
-            api.generate_frame(Some(DynamicProperties {
+            api.generate_frame(document_id, Some(DynamicProperties {
                 transforms: vec![
                   PropertyValue {
                     key: PropertyBindingKey::new(42),

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -322,17 +322,17 @@ lazy_static! {
     static ref TOUCH_STATE: Mutex<TouchState> = Mutex::new(TouchState::new());
 }
 
-fn event_handler(event: &glutin::Event, api: &RenderApi) {
+fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
     match *event {
         glutin::Event::Touch(touch) => {
             match TOUCH_STATE.lock().unwrap().handle_event(touch) {
                 TouchResult::Pan(pan) => {
-                    api.set_pan(pan);
-                    api.generate_frame(None);
+                    api.set_pan(document_id, pan);
+                    api.generate_frame(document_id, None);
                 }
                 TouchResult::Zoom(zoom) => {
-                    api.set_pinch_zoom(ZoomFactor::new(zoom));
-                    api.generate_frame(None);
+                    api.set_pinch_zoom(document_id, ZoomFactor::new(zoom));
+                    api.generate_frame(document_id, None);
                 }
                 TouchResult::None => {}
             }

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -262,9 +262,7 @@ fn body(api: &api::RenderApi,
     builder.pop_stacking_context();
 }
 
-fn event_handler(_event: &glutin::Event,
-                 _api: &api::RenderApi)
-{
+fn event_handler(_event: &glutin::Event, _document_id: api::DocumentId, _api: &api::RenderApi) {
 }
 
 fn main() {

--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -90,9 +90,7 @@ lazy_static! {
     static ref CURSOR_POSITION: Mutex<WorldPoint> = Mutex::new(WorldPoint::zero());
 }
 
-fn event_handler(event: &glutin::Event,
-                 api: &RenderApi)
-{
+fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
     match *event {
         glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
             let offset = match key {
@@ -103,7 +101,8 @@ fn event_handler(event: &glutin::Event,
                  _ => return,
             };
 
-            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
+            api.scroll(document_id,
+                       ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
                        *CURSOR_POSITION.lock().unwrap(),
                        ScrollEventPhase::Start);
         }
@@ -121,7 +120,8 @@ fn event_handler(event: &glutin::Event,
                 glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
             };
 
-            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
+            api.scroll(document_id,
+                       ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
                        *CURSOR_POSITION.lock().unwrap(),
                        ScrollEventPhase::Start);
         }

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -99,7 +99,7 @@ lazy_static! {
     static ref CURSOR_POSITION: Mutex<WorldPoint> = Mutex::new(WorldPoint::zero());
 }
 
-fn event_handler(event: &glutin::Event, api: &RenderApi) {
+fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
     match *event {
         glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
             let offset = match key {
@@ -110,7 +110,8 @@ fn event_handler(event: &glutin::Event, api: &RenderApi) {
                  _ => return,
             };
 
-            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
+            api.scroll(document_id,
+                       ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
                        *CURSOR_POSITION.lock().unwrap(),
                        ScrollEventPhase::Start);
         }
@@ -128,7 +129,8 @@ fn event_handler(event: &glutin::Event, api: &RenderApi) {
                 glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
             };
 
-            api.scroll(ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
+            api.scroll(document_id,
+                       ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
                        *CURSOR_POSITION.lock().unwrap(),
                        ScrollEventPhase::Start);
         }

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -228,17 +228,17 @@ lazy_static! {
 }
 
 
-fn event_handler(event: &glutin::Event, api: &RenderApi) {
+fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
     match *event {
         glutin::Event::Touch(touch) => {
             match TOUCH_STATE.lock().unwrap().handle_event(touch) {
                 TouchResult::Pan(pan) => {
-                    api.set_pan(pan);
-                    api.generate_frame(None);
+                    api.set_pan(document_id, pan);
+                    api.generate_frame(document_id, None);
                 }
                 TouchResult::Zoom(zoom) => {
-                    api.set_pinch_zoom(ZoomFactor::new(zoom));
-                    api.generate_frame(None);
+                    api.set_pinch_zoom(document_id, ZoomFactor::new(zoom));
+                    api.generate_frame(document_id, None);
                 }
                 TouchResult::None => {}
             }

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -41,7 +41,7 @@ pub struct ClipScrollTree {
 
 impl ClipScrollTree {
     pub fn new() -> ClipScrollTree {
-        let dummy_pipeline = PipelineId(0, 0);
+        let dummy_pipeline = PipelineId::dummy();
         ClipScrollTree {
             nodes: HashMap::default(),
             pending_scroll_offsets: HashMap::new(),

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -13,8 +13,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tiling;
 use renderer::BlendMode;
-use api::{ClipId, ColorU, DeviceUintRect, Epoch, ExternalImageData, ExternalImageId};
-use api::{DevicePoint, ImageData, ImageFormat, PipelineId};
+use api::{ClipId, ColorU, DevicePoint, DeviceUintRect, DocumentId, Epoch};
+use api::{ExternalImageData, ExternalImageId};
+use api::{ImageData, ImageFormat, PipelineId};
 
 // An ID for a texture that is owned by the
 // texture cache module. This can include atlases
@@ -263,7 +264,7 @@ impl RendererFrame {
 
 pub enum ResultMsg {
     RefreshShader(PathBuf),
-    NewFrame(RendererFrame, TextureUpdateList, BackendProfileCounters),
+    NewFrame(DocumentId, RendererFrame, TextureUpdateList, BackendProfileCounters),
 }
 
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -2,39 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! A GPU based renderer for the web.
-//!
-//! It serves as an experimental render backend for [Servo](https://servo.org/),
-//! but it can also be used as such in a standalone application.
-//!
-//! # External dependencies
-//! WebRender currently depends on [FreeType](https://www.freetype.org/)
-//!
-//! # Api Structure
-//! The main entry point to WebRender is the `webrender::renderer::Renderer`.
-//!
-//! By calling `Renderer::new(...)` you get a `Renderer`, as well as a `RenderApiSender`.
-//! Your `Renderer` is responsible to render the previously processed frames onto the screen.
-//!
-//! By calling `yourRenderApiSenderInstance.create_api()`, you'll get a `RenderApi` instance,
-//! which is responsible for the processing of new frames. A worker thread is used internally to
-//! untie the workload from the application thread and therefore be able
-//! to make better use of multicore systems.
-//!
-//! What is referred to as a `frame`, is the current geometry on the screen.
-//! A new Frame is created by calling [`set_display_list()`][newframe] on the `RenderApi`.
-//! When the geometry is processed, the application will be informed via a `RenderNotifier`,
-//! a callback which you employ with [set_render_notifier][notifier] on the `Renderer`
-//! More information about [stacking contexts][stacking_contexts].
-//!
-//! `set_display_list()` also needs to be supplied with `BuiltDisplayList`s.
-//! These are obtained by finalizing a `DisplayListBuilder`. These are used to draw your geometry.
-//! But it doesn't only contain trivial geometry, it can also store another StackingContext, as
-//! they're nestable.
-//!
-//! [stacking_contexts]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-//! [newframe]: ../webrender_api/struct.RenderApi.html#method.set_display_list
-//! [notifier]: renderer/struct.Renderer.html#method.set_render_notifier
+/*!
+A GPU based renderer for the web.
+
+It serves as an experimental render backend for [Servo](https://servo.org/),
+but it can also be used as such in a standalone application.
+
+# External dependencies
+WebRender currently depends on [FreeType](https://www.freetype.org/)
+
+# Api Structure
+The main entry point to WebRender is the `webrender::renderer::Renderer`.
+
+By calling `Renderer::new(...)` you get a `Renderer`, as well as a `RenderApiSender`.
+Your `Renderer` is responsible to render the previously processed frames onto the screen.
+
+By calling `yourRenderApiSender.create_api()`, you'll get a `RenderApi` instance,
+which is responsible for managing resources and documents. A worker thread is used internally
+to untie the workload from the application thread and therefore be able to make better use of
+multicore systems.
+
+## Frame
+
+What is referred to as a `frame`, is the current geometry on the screen.
+A new Frame is created by calling [`set_display_list()`][newframe] on the `RenderApi`.
+When the geometry is processed, the application will be informed via a `RenderNotifier`,
+a callback which you employ with [set_render_notifier][notifier] on the `Renderer`
+More information about [stacking contexts][stacking_contexts].
+
+`set_display_list()` also needs to be supplied with `BuiltDisplayList`s.
+These are obtained by finalizing a `DisplayListBuilder`. These are used to draw your geometry.
+But it doesn't only contain trivial geometry, it can also store another StackingContext, as
+they're nestable.
+
+[stacking_contexts]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+[newframe]: ../webrender_api/struct.RenderApi.html#method.set_display_list
+[notifier]: renderer/struct.Renderer.html#method.set_render_notifier
+*/
 
 #[macro_use]
 extern crate lazy_static;

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -131,6 +131,18 @@ pub struct TimeProfileCounter {
     invert: bool,
 }
 
+pub struct Timer<'a> {
+    start: u64,
+    result: &'a mut u64,
+}
+
+impl<'a> Drop for Timer<'a> {
+    fn drop(&mut self) {
+        let end = precise_time_ns();
+        *self.result += end - self.start;
+    }
+}
+
 impl TimeProfileCounter {
     pub fn new(description: &'static str, invert: bool) -> TimeProfileCounter {
         TimeProfileCounter {
@@ -156,6 +168,13 @@ impl TimeProfileCounter {
         let ns = t1 - t0;
         self.nanoseconds += ns;
         val
+    }
+
+    pub fn timer(&mut self) -> Timer {
+        Timer {
+            start: precise_time_ns(),
+            result: &mut self.nanoseconds,
+        }
     }
 
     pub fn inc(&mut self, ns: u64) {

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -68,15 +68,12 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         ApiMsg::AddNativeFont(..) |
         ApiMsg::DeleteFont(..) |
         ApiMsg::AddImage(..) |
-        ApiMsg::GenerateFrame(..) |
         ApiMsg::UpdateImage(..) |
         ApiMsg::DeleteImage(..) |
-        ApiMsg::SetDisplayList(..) |
-        ApiMsg::SetRootPipeline(..) |
-        ApiMsg::Scroll(..) |
-        ApiMsg::TickScrollingBounce |
-        ApiMsg::WebGLCommand(..) |
-        ApiMsg::SetWindowParameters(..) =>
+        ApiMsg::AddDocument{..} |
+        ApiMsg::UpdateDocument(..) |
+        ApiMsg::DeleteDocument(..) |
+        ApiMsg::WebGLCommand(..) =>
             true,
         _ => false
     }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -2,15 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use fnv::FnvHasher;
 use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
 use internal_types::{SourceTexture, ResultMsg, RendererFrame};
-use profiler::{BackendProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
+use profiler::{BackendProfileCounters, ResourceProfileCounters};
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
 use scene::Scene;
 use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 use texture_cache::TextureCache;
@@ -21,8 +23,8 @@ use webgl_types::{GLContextHandleWrapper, GLContextWrapper};
 use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
 use api::{ApiMsg, BlobImageRenderer, BuiltDisplayList, DeviceIntPoint};
-use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, IdNamespace, ImageData};
-use api::{LayerPoint, PipelineId, RenderDispatcher, RenderNotifier};
+use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentId, DocumentMsg};
+use api::{IdNamespace, ImageData, LayerPoint, RenderDispatcher, RenderNotifier};
 use api::{VRCompositorCommand, VRCompositorHandler, WebGLCommand, WebGLContextId};
 use api::{FontTemplate};
 
@@ -31,6 +33,85 @@ use offscreen_gl_context::GLContextDispatcher;
 
 #[cfg(not(feature = "webgl"))]
 use webgl_types::GLContextDispatcher;
+
+struct Document {
+    scene: Scene,
+    frame: Frame,
+    window_size: DeviceUintSize,
+    inner_rect: DeviceUintRect,
+    pan: DeviceIntPoint,
+    page_zoom_factor: f32,
+    pinch_zoom_factor: f32,
+    // A helper switch to prevent any frames rendering triggered by scrolling
+    // messages between `SetDisplayList` and `GenerateFrame`.
+    // If we allow them, then a reftest that scrolls a few layers before generating
+    // the first frame would produce inconsistent rendering results, because
+    // scroll events are not necessarily received in deterministic order.
+    render_on_scroll: Option<bool>,
+}
+
+impl Document {
+    pub fn new(
+        config: FrameBuilderConfig,
+        initial_size: DeviceUintSize,
+        enable_render_on_scroll: bool,
+    ) -> Self {
+        let render_on_scroll = if enable_render_on_scroll {
+            Some(false)
+        } else {
+            None
+        };
+        Document {
+            scene: Scene::new(),
+            frame: Frame::new(config),
+            window_size: initial_size,
+            inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), initial_size),
+            pan: DeviceIntPoint::zero(),
+            page_zoom_factor: 1.0,
+            pinch_zoom_factor: 1.0,
+            render_on_scroll,
+        }
+    }
+
+    fn accumulated_scale_factor(&self, hidpi_factor: f32) -> f32 {
+        hidpi_factor * self.page_zoom_factor * self.pinch_zoom_factor
+    }
+
+    fn build_scene(&mut self, resource_cache: &mut ResourceCache, hidpi_factor: f32) {
+        let accumulated_scale_factor = self.accumulated_scale_factor(hidpi_factor);
+        self.frame.create(&self.scene,
+                          resource_cache,
+                          self.window_size,
+                          self.inner_rect,
+                          accumulated_scale_factor);
+    }
+
+    fn render(&mut self,
+        resource_cache: &mut ResourceCache,
+        gpu_cache: &mut GpuCache,
+        resource_profile: &mut ResourceProfileCounters,
+        hidpi_factor: f32,
+    )-> RendererFrame {
+        let accumulated_scale_factor = self.accumulated_scale_factor(hidpi_factor);
+        let pan = LayerPoint::new(self.pan.x as f32 / accumulated_scale_factor,
+                                  self.pan.y as f32 / accumulated_scale_factor);
+        self.frame.build(resource_cache,
+                         gpu_cache,
+                         &self.scene.display_lists,
+                         accumulated_scale_factor,
+                         pan,
+                         &mut resource_profile.texture_cache,
+                         &mut resource_profile.gpu_cache)
+    }
+}
+
+enum DocumentOp {
+    Nop,
+    Built,
+    ScrolledNop,
+    Scrolled(RendererFrame),
+    Rendered(RendererFrame),
+}
 
 /// The render backend is responsible for transforming high level display lists into
 /// GPU-friendly work which is then submitted to the renderer in the form of a frame::Frame.
@@ -44,57 +125,45 @@ pub struct RenderBackend {
 
     // TODO(gw): Consider using strongly typed units here.
     hidpi_factor: f32,
-    page_zoom_factor: f32,
-    pinch_zoom_factor: f32,
-    pan: DeviceIntPoint,
-    window_size: DeviceUintSize,
-    inner_rect: DeviceUintRect,
     next_namespace_id: IdNamespace,
 
     gpu_cache: GpuCache,
     resource_cache: ResourceCache,
 
-    scene: Scene,
-    frame: Frame,
+    frame_config: FrameBuilderConfig,
+    documents: HashMap<DocumentId, Document, BuildHasherDefault<FnvHasher>>,
 
     notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
     webrender_context_handle: Option<GLContextHandleWrapper>,
-    webgl_contexts: HashMap<WebGLContextId, GLContextWrapper>,
-    current_bound_webgl_context_id: Option<WebGLContextId>,
     recorder: Option<Box<ApiRecordingReceiver>>,
     main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
 
     next_webgl_id: usize,
-
+    webgl_contexts: HashMap<WebGLContextId, GLContextWrapper>,
+    current_bound_webgl_context_id: Option<WebGLContextId>,
     vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
 
     enable_render_on_scroll: bool,
-
-    // A helper switch to prevent any frames rendering triggered by scrolling
-    // messages between `SetDisplayList` and `GenerateFrame`.
-    // If we allow them, then a reftest that scrolls a few layers before generating
-    // the first frame would produce inconsistent rendering results, because
-    // scroll events are not necessarily received in deterministic order.
-    render_on_scroll: bool,
 }
 
 impl RenderBackend {
-    pub fn new(api_rx: MsgReceiver<ApiMsg>,
-               payload_rx: PayloadReceiver,
-               payload_tx: PayloadSender,
-               result_tx: Sender<ResultMsg>,
-               hidpi_factor: f32,
-               texture_cache: TextureCache,
-               workers: Arc<ThreadPool>,
-               notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
-               webrender_context_handle: Option<GLContextHandleWrapper>,
-               config: FrameBuilderConfig,
-               recorder: Option<Box<ApiRecordingReceiver>>,
-               main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
-               blob_image_renderer: Option<Box<BlobImageRenderer>>,
-               vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
-               initial_window_size: DeviceUintSize,
-               enable_render_on_scroll: bool) -> RenderBackend {
+    pub fn new(
+        api_rx: MsgReceiver<ApiMsg>,
+        payload_rx: PayloadReceiver,
+        payload_tx: PayloadSender,
+        result_tx: Sender<ResultMsg>,
+        hidpi_factor: f32,
+        texture_cache: TextureCache,
+        workers: Arc<ThreadPool>,
+        notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
+        webrender_context_handle: Option<GLContextHandleWrapper>,
+        frame_config: FrameBuilderConfig,
+        recorder: Option<Box<ApiRecordingReceiver>>,
+        main_thread_dispatcher: Arc<Mutex<Option<Box<RenderDispatcher>>>>,
+        blob_image_renderer: Option<Box<BlobImageRenderer>>,
+        vr_compositor_handler: Arc<Mutex<Option<Box<VRCompositorHandler>>>>,
+        enable_render_on_scroll: bool,
+    ) -> RenderBackend {
 
         let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer);
 
@@ -106,37 +175,207 @@ impl RenderBackend {
             payload_tx,
             result_tx,
             hidpi_factor,
-            page_zoom_factor: 1.0,
-            pinch_zoom_factor: 1.0,
-            pan: DeviceIntPoint::zero(),
+
             resource_cache,
             gpu_cache: GpuCache::new(),
-            scene: Scene::new(),
-            frame: Frame::new(config),
+            frame_config,
+            documents: HashMap::with_hasher(Default::default()),
             next_namespace_id: IdNamespace(1),
             notifier,
             webrender_context_handle,
-            webgl_contexts: HashMap::new(),
-            current_bound_webgl_context_id: None,
             recorder,
             main_thread_dispatcher,
+
             next_webgl_id: 0,
+            webgl_contexts: HashMap::new(),
+            current_bound_webgl_context_id: None,
             vr_compositor_handler,
-            window_size: initial_window_size,
-            inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), initial_window_size),
+
             enable_render_on_scroll,
-            render_on_scroll: false,
         }
     }
 
-    fn scroll_frame(&mut self, frame_maybe: Option<RendererFrame>,
-                    profile_counters: &mut BackendProfileCounters) {
-        match frame_maybe {
-            Some(frame) => {
-                self.publish_frame(frame, profile_counters);
-                self.notify_compositor_of_new_scroll_frame(true)
+    fn process_document(&mut self, document_id: DocumentId, message: DocumentMsg,
+                        frame_counter: u32, mut profile_counters: &mut BackendProfileCounters)
+                        -> DocumentOp
+    {
+        let doc = self.documents.get_mut(&document_id).expect("No document?");
+
+        match message {
+            DocumentMsg::SetPageZoom(factor) => {
+                doc.page_zoom_factor = factor.get();
+                DocumentOp::Nop
             }
-            None => self.notify_compositor_of_new_scroll_frame(false),
+            DocumentMsg::SetPinchZoom(factor) => {
+                doc.pinch_zoom_factor = factor.get();
+                DocumentOp::Nop
+            }
+            DocumentMsg::SetPan(pan) => {
+                doc.pan = pan;
+                DocumentOp::Nop
+            }
+            DocumentMsg::SetWindowParameters{ window_size, inner_rect } => {
+                doc.window_size = window_size;
+                doc.inner_rect = inner_rect;
+                DocumentOp::Nop
+            }
+            DocumentMsg::SetDisplayList{
+                epoch,
+                pipeline_id,
+                background,
+                viewport_size,
+                content_size,
+                list_descriptor,
+                preserve_frame_state,
+            } => {
+                profile_scope!("SetDisplayList");
+
+                let mut data;
+                while {
+                    data = self.payload_rx.recv_payload().unwrap();
+                    data.epoch != epoch || data.pipeline_id != pipeline_id
+                }{
+                    self.payload_tx.send_payload(data).unwrap()
+                }
+                if let Some(ref mut r) = self.recorder {
+                    r.write_payload(frame_counter, &data.to_data());
+                }
+
+                let built_display_list =
+                    BuiltDisplayList::from_data(data.display_list_data,
+                                                list_descriptor);
+
+
+                if !preserve_frame_state {
+                    doc.frame.discard_frame_state_for_pipeline(pipeline_id);
+                }
+
+                let display_list_len = built_display_list.data().len();
+                let (builder_start_time, builder_finish_time, send_start_time) = built_display_list.times();
+                let display_list_received_time = precise_time_ns();
+
+                {
+                    let _timer = profile_counters.total_time.timer();
+                    doc.scene.set_display_list(pipeline_id,
+                                               epoch,
+                                               built_display_list,
+                                               background,
+                                               viewport_size,
+                                               content_size);
+                    doc.build_scene(&mut self.resource_cache, self.hidpi_factor);
+                }
+
+                if let Some(ref mut ros) = doc.render_on_scroll {
+                    *ros = false; //wait for `GenerateFrame`
+                }
+
+                // Note: this isn't quite right as auxiliary values will be
+                // pulled out somewhere in the prim_store, but aux values are
+                // really simple and cheap to access, so it's not a big deal.
+                let display_list_consumed_time = precise_time_ns();
+
+                profile_counters.ipc.set(builder_start_time,
+                                         builder_finish_time,
+                                         send_start_time,
+                                         display_list_received_time,
+                                         display_list_consumed_time,
+                                         display_list_len);
+
+                DocumentOp::Built
+            }
+            DocumentMsg::SetRootPipeline(pipeline_id) => {
+                profile_scope!("SetRootPipeline");
+
+                doc.scene.set_root_pipeline_id(pipeline_id);
+                if doc.scene.display_lists.get(&pipeline_id).is_some() {
+                    let _timer = profile_counters.total_time.timer();
+                    doc.build_scene(&mut self.resource_cache, self.hidpi_factor);
+                    DocumentOp::Built
+                } else {
+                    DocumentOp::Nop
+                }
+            }
+            DocumentMsg::Scroll(delta, cursor, move_phase) => {
+                profile_scope!("Scroll");
+                let _timer = profile_counters.total_time.timer();
+
+                if doc.frame.scroll(delta, cursor, move_phase) && doc.render_on_scroll == Some(true) {
+                    let frame = doc.render(&mut self.resource_cache,
+                                           &mut self.gpu_cache,
+                                           &mut profile_counters.resources,
+                                           self.hidpi_factor);
+                    DocumentOp::Scrolled(frame)
+                } else {
+                    DocumentOp::ScrolledNop
+                }
+            }
+            DocumentMsg::ScrollNodeWithId(origin, id, clamp) => {
+                profile_scope!("ScrollNodeWithScrollId");
+                let _timer = profile_counters.total_time.timer();
+
+                if doc.frame.scroll_node(origin, id, clamp) && doc.render_on_scroll == Some(true) {
+                    let frame = doc.render(&mut self.resource_cache,
+                                           &mut self.gpu_cache,
+                                           &mut profile_counters.resources,
+                                           self.hidpi_factor);
+                    DocumentOp::Scrolled(frame)
+                } else {
+                    DocumentOp::ScrolledNop
+                }
+            }
+            DocumentMsg::TickScrollingBounce => {
+                profile_scope!("TickScrollingBounce");
+                let _timer = profile_counters.total_time.timer();
+
+                doc.frame.tick_scrolling_bounce_animations();
+                if doc.render_on_scroll == Some(true) {
+                    let frame = doc.render(&mut self.resource_cache,
+                                           &mut self.gpu_cache,
+                                           &mut profile_counters.resources,
+                                           self.hidpi_factor);
+                    DocumentOp::Scrolled(frame)
+                } else {
+                    DocumentOp::ScrolledNop
+                }
+            }
+            DocumentMsg::GetScrollNodeState(tx) => {
+                profile_scope!("GetScrollNodeState");
+                tx.send(doc.frame.get_scroll_node_state()).unwrap();
+                DocumentOp::Nop
+            }
+            DocumentMsg::GenerateFrame(property_bindings) => {
+                profile_scope!("GenerateFrame");
+                let _timer = profile_counters.total_time.timer();
+
+                // Ideally, when there are property bindings present,
+                // we won't need to rebuild the entire frame here.
+                // However, to avoid conflicts with the ongoing work to
+                // refactor how scroll roots + transforms work, this
+                // just rebuilds the frame if there are animated property
+                // bindings present for now.
+                // TODO(gw): Once the scrolling / reference frame changes
+                //           are completed, optimize the internals of
+                //           animated properties to not require a full
+                //           rebuild of the frame!
+                if let Some(property_bindings) = property_bindings {
+                    doc.scene.properties.set_properties(property_bindings);
+                    doc.build_scene(&mut self.resource_cache, self.hidpi_factor);
+                }
+
+                if let Some(ref mut ros) = doc.render_on_scroll {
+                    *ros = true;
+                }
+
+                if doc.scene.root_pipeline_id.is_some() {
+                    let frame = doc.render(&mut self.resource_cache,
+                                           &mut self.gpu_cache,
+                                           &mut profile_counters.resources,
+                                           self.hidpi_factor);
+                    DocumentOp::Rendered(frame)
+                } else {
+                    DocumentOp::ScrolledNop
+                }
+            }
         }
     }
 
@@ -144,335 +383,14 @@ impl RenderBackend {
         let mut frame_counter: u32 = 0;
 
         loop {
-            let msg = self.api_rx.recv();
             profile_scope!("handle_msg");
-            match msg {
+
+            let msg = match self.api_rx.recv() {
                 Ok(msg) => {
                     if let Some(ref mut r) = self.recorder {
                         r.write_msg(frame_counter, &msg);
                     }
-                    match msg {
-                        ApiMsg::AddRawFont(id, bytes, index) => {
-                            profile_counters.resources.font_templates.inc(bytes.len());
-                            self.resource_cache
-                                .add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
-                        }
-                        ApiMsg::AddNativeFont(id, native_font_handle) => {
-                            self.resource_cache
-                                .add_font_template(id, FontTemplate::Native(native_font_handle));
-                        }
-                        ApiMsg::DeleteFont(id) => {
-                            self.resource_cache.delete_font_template(id);
-                        }
-                        ApiMsg::GetGlyphDimensions(font, glyph_keys, tx) => {
-                            let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
-                            for glyph_key in &glyph_keys {
-                                let glyph_dim = self.resource_cache.get_glyph_dimensions(&font, glyph_key);
-                                glyph_dimensions.push(glyph_dim);
-                            };
-                            tx.send(glyph_dimensions).unwrap();
-                        }
-                        ApiMsg::GetGlyphIndices(font_key, text, tx) => {
-                            let mut glyph_indices = Vec::new();
-                            for ch in text.chars() {
-                                let index = self.resource_cache.get_glyph_index(font_key, ch);
-                                glyph_indices.push(index);
-                            };
-                            tx.send(glyph_indices).unwrap();
-                        }
-                        ApiMsg::AddImage(id, descriptor, data, tiling) => {
-                            if let ImageData::Raw(ref bytes) = data {
-                                profile_counters.resources.image_templates.inc(bytes.len());
-                            }
-                            self.resource_cache.add_image_template(id, descriptor, data, tiling);
-                        }
-                        ApiMsg::UpdateImage(id, descriptor, bytes, dirty_rect) => {
-                            self.resource_cache.update_image_template(id, descriptor, bytes, dirty_rect);
-                        }
-                        ApiMsg::DeleteImage(id) => {
-                            self.resource_cache.delete_image_template(id);
-                        }
-                        ApiMsg::SetPageZoom(factor) => {
-                            self.page_zoom_factor = factor.get();
-                        }
-                        ApiMsg::SetPinchZoom(factor) => {
-                            self.pinch_zoom_factor = factor.get();
-                        }
-                        ApiMsg::SetPan(pan) => {
-                            self.pan = pan;
-                        }
-                        ApiMsg::SetWindowParameters(window_size, inner_rect) => {
-                            self.window_size = window_size;
-                            self.inner_rect = inner_rect;
-                        }
-                        ApiMsg::CloneApi(sender) => {
-                            let result = self.next_namespace_id;
-
-                            let IdNamespace(id_namespace) = self.next_namespace_id;
-                            self.next_namespace_id = IdNamespace(id_namespace + 1);
-
-                            sender.send(result).unwrap();
-                        }
-                        ApiMsg::SetDisplayList(background_color,
-                                               epoch,
-                                               pipeline_id,
-                                               viewport_size,
-                                               content_size,
-                                               display_list_descriptor,
-                                               preserve_frame_state) => {
-                            profile_scope!("SetDisplayList");
-                            let mut leftover_data = vec![];
-                            let mut data;
-                            loop {
-                                data = self.payload_rx.recv_payload().unwrap();
-                                {
-                                    if data.epoch == epoch &&
-                                       data.pipeline_id == pipeline_id {
-                                        break
-                                    }
-                                }
-                                leftover_data.push(data)
-                            }
-                            for leftover_data in leftover_data {
-                                self.payload_tx.send_payload(leftover_data).unwrap()
-                            }
-                            if let Some(ref mut r) = self.recorder {
-                                r.write_payload(frame_counter, &data.to_data());
-                            }
-
-                            let built_display_list =
-                                BuiltDisplayList::from_data(data.display_list_data,
-                                                            display_list_descriptor);
-
-                            if !preserve_frame_state {
-                                self.discard_frame_state_for_pipeline(pipeline_id);
-                            }
-
-                            let display_list_len = built_display_list.data().len();
-                            let (builder_start_time, builder_finish_time, send_start_time) = built_display_list.times();
-
-                            let display_list_received_time = precise_time_ns();
-
-                            profile_counters.total_time.profile(|| {
-                                self.scene.set_display_list(pipeline_id,
-                                                            epoch,
-                                                            built_display_list,
-                                                            background_color,
-                                                            viewport_size,
-                                                            content_size);
-                                self.build_scene();
-                            });
-
-                            self.render_on_scroll = false; //wait for `GenerateFrame`
-
-                            // Note: this isn't quite right as auxiliary values will be
-                            // pulled out somewhere in the prim_store, but aux values are
-                            // really simple and cheap to access, so it's not a big deal.
-                            let display_list_consumed_time = precise_time_ns();
-
-                            profile_counters.ipc.set(builder_start_time,
-                                                     builder_finish_time,
-                                                     send_start_time,
-                                                     display_list_received_time,
-                                                     display_list_consumed_time,
-                                                     display_list_len);
-                        }
-                        ApiMsg::SetRootPipeline(pipeline_id) => {
-                            profile_scope!("SetRootPipeline");
-                            self.scene.set_root_pipeline_id(pipeline_id);
-
-                            if self.scene.display_lists.get(&pipeline_id).is_none() {
-                                continue;
-                            }
-
-                            profile_counters.total_time.profile(|| {
-                                self.build_scene();
-                            })
-                        }
-                        ApiMsg::Scroll(delta, cursor, move_phase) => {
-                            profile_scope!("Scroll");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll(delta, cursor, move_phase) && self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::ScrollNodeWithId(origin, id, clamp) => {
-                            profile_scope!("ScrollNodeWithScrollId");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    if self.frame.scroll_node(origin, id, clamp) && self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::TickScrollingBounce => {
-                            profile_scope!("TickScrollingBounce");
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    self.frame.tick_scrolling_bounce_animations();
-                                    if self.render_on_scroll {
-                                        Some(self.render(counters, gpu_cache_counters))
-                                    } else {
-                                        None
-                                    }
-                                })
-                            };
-
-                            self.scroll_frame(frame, &mut profile_counters);
-                        }
-                        ApiMsg::TranslatePointToLayerSpace(..) => {
-                            panic!("unused api - remove from webrender_api");
-                        }
-                        ApiMsg::GetScrollNodeState(tx) => {
-                            profile_scope!("GetScrollNodeState");
-                            tx.send(self.frame.get_scroll_node_state()).unwrap()
-                        }
-                        ApiMsg::RequestWebGLContext(size, attributes, tx) => {
-                            if let Some(ref wrapper) = self.webrender_context_handle {
-                                let dispatcher: Option<Box<GLContextDispatcher>> = if cfg!(target_os = "windows") {
-                                    Some(Box::new(WebRenderGLDispatcher {
-                                        dispatcher: Arc::clone(&self.main_thread_dispatcher)
-                                    }))
-                                } else {
-                                    None
-                                };
-
-                                let result = wrapper.new_context(size, attributes, dispatcher);
-                                // Creating a new GLContext may make the current bound context_id dirty.
-                                // Clear it to ensure that  make_current() is called in subsequent commands.
-                                self.current_bound_webgl_context_id = None;
-
-                                match result {
-                                    Ok(ctx) => {
-                                        let id = WebGLContextId(self.next_webgl_id);
-                                        self.next_webgl_id += 1;
-
-                                        let (real_size, texture_id, limits) = ctx.get_info();
-
-                                        self.webgl_contexts.insert(id, ctx);
-
-                                        self.resource_cache
-                                            .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
-                                                               real_size);
-
-                                        tx.send(Ok((id, limits))).unwrap();
-                                    },
-                                    Err(msg) => {
-                                        tx.send(Err(msg.to_owned())).unwrap();
-                                    }
-                                }
-                            } else {
-                                tx.send(Err("Not implemented yet".to_owned())).unwrap();
-                            }
-                        }
-                        ApiMsg::ResizeWebGLContext(context_id, size) => {
-                            let ctx = self.webgl_contexts.get_mut(&context_id).unwrap();
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                ctx.make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            match ctx.resize(&size) {
-                                Ok(_) => {
-                                    // Update webgl texture size. Texture id may change too.
-                                    let (real_size, texture_id, _) = ctx.get_info();
-                                    self.resource_cache
-                                        .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
-                                                              real_size);
-                                },
-                                Err(msg) => {
-                                    error!("Error resizing WebGLContext: {}", msg);
-                                }
-                            }
-                        }
-                        ApiMsg::WebGLCommand(context_id, command) => {
-                            // TODO: Buffer the commands and only apply them here if they need to
-                            // be synchronous.
-                            let ctx = &self.webgl_contexts[&context_id];
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                ctx.make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            ctx.apply_command(command);
-                        },
-
-                        ApiMsg::VRCompositorCommand(context_id, command) => {
-                            if Some(context_id) != self.current_bound_webgl_context_id {
-                                self.webgl_contexts[&context_id].make_current();
-                                self.current_bound_webgl_context_id = Some(context_id);
-                            }
-                            self.handle_vr_compositor_command(context_id, command);
-                        }
-                        ApiMsg::GenerateFrame(property_bindings) => {
-                            profile_scope!("GenerateFrame");
-
-                            // Ideally, when there are property bindings present,
-                            // we won't need to rebuild the entire frame here.
-                            // However, to avoid conflicts with the ongoing work to
-                            // refactor how scroll roots + transforms work, this
-                            // just rebuilds the frame if there are animated property
-                            // bindings present for now.
-                            // TODO(gw): Once the scrolling / reference frame changes
-                            //           are completed, optimize the internals of
-                            //           animated properties to not require a full
-                            //           rebuild of the frame!
-                            if let Some(property_bindings) = property_bindings {
-                                self.scene.properties.set_properties(property_bindings);
-                                profile_counters.total_time.profile(|| {
-                                    self.build_scene();
-                                });
-                            }
-
-                            self.render_on_scroll = self.enable_render_on_scroll;
-
-                            let frame = {
-                                let counters = &mut profile_counters.resources.texture_cache;
-                                let gpu_cache_counters = &mut profile_counters.resources.gpu_cache;
-                                profile_counters.total_time.profile(|| {
-                                    self.render(counters, gpu_cache_counters)
-                                })
-                            };
-                            if self.scene.root_pipeline_id.is_some() {
-                                self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
-                                frame_counter += 1;
-                            }
-                        }
-                        ApiMsg::ExternalEvent(evt) => {
-                            let notifier = self.notifier.lock();
-                            notifier.unwrap()
-                                    .as_mut()
-                                    .unwrap()
-                                    .external_event(evt);
-                        }
-                        ApiMsg::ClearNamespace(namespace) => {
-                            self.resource_cache.clear_namespace(namespace);
-                        }
-                        ApiMsg::ShutDown => {
-                            let notifier = self.notifier.lock();
-                            notifier.unwrap()
-                                    .as_mut()
-                                    .unwrap()
-                                    .shut_down();
-                            break;
-                        }
-                    }
+                    msg
                 }
                 Err(..) => {
                     let notifier = self.notifier.lock();
@@ -482,25 +400,193 @@ impl RenderBackend {
                             .shut_down();
                     break;
                 }
+            };
+
+            match msg {
+                ApiMsg::AddRawFont(id, bytes, index) => {
+                    profile_counters.resources.font_templates.inc(bytes.len());
+                    self.resource_cache
+                        .add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
+                }
+                ApiMsg::AddNativeFont(id, native_font_handle) => {
+                    self.resource_cache
+                        .add_font_template(id, FontTemplate::Native(native_font_handle));
+                }
+                ApiMsg::DeleteFont(id) => {
+                    self.resource_cache.delete_font_template(id);
+                }
+                ApiMsg::GetGlyphDimensions(font, glyph_keys, tx) => {
+                    let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
+                    for glyph_key in &glyph_keys {
+                        let glyph_dim = self.resource_cache.get_glyph_dimensions(&font, glyph_key);
+                        glyph_dimensions.push(glyph_dim);
+                    };
+                    tx.send(glyph_dimensions).unwrap();
+                }
+                ApiMsg::GetGlyphIndices(font_key, text, tx) => {
+                    let mut glyph_indices = Vec::new();
+                    for ch in text.chars() {
+                        let index = self.resource_cache.get_glyph_index(font_key, ch);
+                        glyph_indices.push(index);
+                    };
+                    tx.send(glyph_indices).unwrap();
+                }
+                ApiMsg::AddImage(id, descriptor, data, tiling) => {
+                    if let ImageData::Raw(ref bytes) = data {
+                        profile_counters.resources.image_templates.inc(bytes.len());
+                    }
+                    self.resource_cache.add_image_template(id, descriptor, data, tiling);
+                }
+                ApiMsg::UpdateImage(id, descriptor, bytes, dirty_rect) => {
+                    self.resource_cache.update_image_template(id, descriptor, bytes, dirty_rect);
+                }
+                ApiMsg::DeleteImage(id) => {
+                    self.resource_cache.delete_image_template(id);
+                }
+                ApiMsg::CloneApi(sender) => {
+                    let namespace = self.next_namespace_id;
+                    self.next_namespace_id = IdNamespace(namespace.0 + 1);
+                    sender.send(namespace).unwrap();
+                }
+                ApiMsg::AddDocument(document_id, initial_size) => {
+                    let document = Document::new(self.frame_config.clone(),
+                                                 initial_size,
+                                                 self.enable_render_on_scroll);
+                    self.documents.insert(document_id, document);
+                }
+                ApiMsg::UpdateDocument(document_id, doc_msg) => {
+                    match self.process_document(document_id, doc_msg, frame_counter, &mut profile_counters) {
+                        DocumentOp::Nop => {}
+                        DocumentOp::Built => {
+                            self.flush_webgl();
+                        }
+                        DocumentOp::ScrolledNop => {
+                            self.flush_webgl();
+                            self.notify_compositor_of_new_scroll_frame(false);
+                        }
+                        DocumentOp::Scrolled(frame) => {
+                            self.publish_frame(document_id, frame, &mut profile_counters);
+                            self.notify_compositor_of_new_scroll_frame(true);
+                        }
+                        DocumentOp::Rendered(frame) => {
+                            frame_counter += 1;
+                            self.publish_frame_and_notify_compositor(document_id, frame, &mut profile_counters);
+                        }
+                    }
+                }
+                ApiMsg::DeleteDocument(document_id) => {
+                    self.documents.remove(&document_id);
+                }
+                ApiMsg::RequestWebGLContext(size, attributes, tx) => {
+                    if let Some(ref wrapper) = self.webrender_context_handle {
+                        let dispatcher: Option<Box<GLContextDispatcher>> = if cfg!(target_os = "windows") {
+                            Some(Box::new(WebRenderGLDispatcher {
+                                dispatcher: Arc::clone(&self.main_thread_dispatcher)
+                            }))
+                        } else {
+                            None
+                        };
+
+                        let result = wrapper.new_context(size, attributes, dispatcher);
+                        // Creating a new GLContext may make the current bound context_id dirty.
+                        // Clear it to ensure that  make_current() is called in subsequent commands.
+                        self.current_bound_webgl_context_id = None;
+
+                        match result {
+                            Ok(ctx) => {
+                                let id = WebGLContextId(self.next_webgl_id);
+                                self.next_webgl_id += 1;
+
+                                let (real_size, texture_id, limits) = ctx.get_info();
+
+                                self.webgl_contexts.insert(id, ctx);
+
+                                self.resource_cache
+                                    .add_webgl_texture(id, SourceTexture::WebGL(texture_id),
+                                                       real_size);
+
+                                tx.send(Ok((id, limits))).unwrap();
+                            },
+                            Err(msg) => {
+                                tx.send(Err(msg.to_owned())).unwrap();
+                            }
+                        }
+                    } else {
+                        tx.send(Err("Not implemented yet".to_owned())).unwrap();
+                    }
+                }
+                ApiMsg::ResizeWebGLContext(context_id, size) => {
+                    let ctx = self.webgl_contexts.get_mut(&context_id).unwrap();
+                    if Some(context_id) != self.current_bound_webgl_context_id {
+                        ctx.make_current();
+                        self.current_bound_webgl_context_id = Some(context_id);
+                    }
+                    match ctx.resize(&size) {
+                        Ok(_) => {
+                            // Update webgl texture size. Texture id may change too.
+                            let (real_size, texture_id, _) = ctx.get_info();
+                            self.resource_cache
+                                .update_webgl_texture(context_id, SourceTexture::WebGL(texture_id),
+                                                      real_size);
+                        },
+                        Err(msg) => {
+                            error!("Error resizing WebGLContext: {}", msg);
+                        }
+                    }
+                }
+                ApiMsg::WebGLCommand(context_id, command) => {
+                    // TODO: Buffer the commands and only apply them here if they need to
+                    // be synchronous.
+                    let ctx = &self.webgl_contexts[&context_id];
+                    if Some(context_id) != self.current_bound_webgl_context_id {
+                        ctx.make_current();
+                        self.current_bound_webgl_context_id = Some(context_id);
+                    }
+                    ctx.apply_command(command);
+                },
+
+                ApiMsg::VRCompositorCommand(context_id, command) => {
+                    if Some(context_id) != self.current_bound_webgl_context_id {
+                        self.webgl_contexts[&context_id].make_current();
+                        self.current_bound_webgl_context_id = Some(context_id);
+                    }
+                    self.handle_vr_compositor_command(context_id, command);
+                }
+                ApiMsg::ExternalEvent(evt) => {
+                    let notifier = self.notifier.lock();
+                    notifier.unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .external_event(evt);
+                }
+                ApiMsg::ClearNamespace(namespace_id) => {
+                    self.resource_cache.clear_namespace(namespace_id);
+                    let document_ids = self.documents.keys()
+                                                     .filter(|did| did.0 == namespace_id)
+                                                     .cloned()
+                                                     .collect::<Vec<_>>();
+                    for document in document_ids {
+                        self.documents.remove(&document);
+                    }
+                }
+                ApiMsg::ShutDown => {
+                    let notifier = self.notifier.lock();
+                    notifier.unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .shut_down();
+                    break;
+                }
             }
         }
-    }
 
-    fn discard_frame_state_for_pipeline(&mut self, pipeline_id: PipelineId) {
-        self.frame.discard_frame_state_for_pipeline(pipeline_id);
-    }
-
-    fn accumulated_scale_factor(&self) -> f32 {
-        self.hidpi_factor * self.page_zoom_factor * self.pinch_zoom_factor
-    }
-
-    fn build_scene(&mut self) {
-        // Flatten the stacking context hierarchy
         if let Some(id) = self.current_bound_webgl_context_id {
             self.webgl_contexts[&id].unbind();
             self.current_bound_webgl_context_id = None;
         }
+    }
 
+    fn flush_webgl(&mut self) {
         // When running in OSMesa mode with texture sharing,
         // a flush is required on any GL contexts to ensure
         // that read-back from the shared texture returns
@@ -513,45 +599,24 @@ impl RenderBackend {
             webgl_context.apply_command(WebGLCommand::Flush);
             webgl_context.unbind();
         }
-
-        let accumulated_scale_factor = self.accumulated_scale_factor();
-        self.frame.create(&self.scene,
-                          &mut self.resource_cache,
-                          self.window_size,
-                          self.inner_rect,
-                          accumulated_scale_factor);
-    }
-
-    fn render(&mut self,
-              texture_cache_profile: &mut TextureCacheProfileCounters,
-              gpu_cache_profile: &mut GpuCacheProfileCounters)
-              -> RendererFrame {
-        let accumulated_scale_factor = self.accumulated_scale_factor();
-        let pan = LayerPoint::new(self.pan.x as f32 / accumulated_scale_factor,
-                                  self.pan.y as f32 / accumulated_scale_factor);
-        let frame = self.frame.build(&mut self.resource_cache,
-                                     &mut self.gpu_cache,
-                                     &self.scene.display_lists,
-                                     accumulated_scale_factor,
-                                     pan,
-                                     texture_cache_profile,
-                                     gpu_cache_profile);
-        frame
     }
 
     fn publish_frame(&mut self,
+                     document_id: DocumentId,
                      frame: RendererFrame,
                      profile_counters: &mut BackendProfileCounters) {
+        self.flush_webgl();
         let pending_update = self.resource_cache.pending_updates();
-        let msg = ResultMsg::NewFrame(frame, pending_update, profile_counters.clone());
+        let msg = ResultMsg::NewFrame(document_id, frame, pending_update, profile_counters.clone());
         self.result_tx.send(msg).unwrap();
         profile_counters.reset();
     }
 
     fn publish_frame_and_notify_compositor(&mut self,
+                                           document_id: DocumentId,
                                            frame: RendererFrame,
                                            profile_counters: &mut BackendProfileCounters) {
-        self.publish_frame(frame, profile_counters);
+        self.publish_frame(document_id, frame, profile_counters);
 
         // TODO(gw): This is kindof bogus to have to lock the notifier
         //           each time it's used. This is due to some nastiness

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -144,7 +144,7 @@ impl<'a> BuiltDisplayListIter<'a> {
                 item: SpecificDisplayItem::PopStackingContext,
                 rect: LayoutRect::zero(),
                 local_clip: LocalClip::from(LayoutRect::zero()),
-                clip_and_scroll: ClipAndScrollInfo::simple(ClipId::new(0, PipelineId(0, 0))),
+                clip_and_scroll: ClipAndScrollInfo::simple(ClipId::new(0, PipelineId::dummy())),
             },
             cur_stops: ItemRange::default(),
             cur_glyphs: ItemRange::default(),


### PR DESCRIPTION
A namespace can now contain multiple documents. Operations on a document are done ~~via a separate object `DocumentApi`, which created from `ResourceApi` that manages resources~~ by providing `DocumentId` parameter to `RenderApi` calls.

This PR is a step towards #1357, also relates to #1370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1509)
<!-- Reviewable:end -->
