### PR TITLE
Remove LowLevelFilterOp

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use app_units::Au;
 use device::TextureFilter;
 use fnv::FnvHasher;
 use profiler::BackendProfileCounters;
@@ -47,7 +46,6 @@ pub enum SourceTexture {
 }
 
 const COLOR_FLOAT_TO_FIXED: f32 = 255.0;
-pub const ANGLE_FLOAT_TO_FIXED: f32 = 65535.0;
 
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;
 pub const ORTHO_FAR_PLANE: f32 = 1000000.0;
@@ -292,13 +290,6 @@ pub enum ResultMsg {
     NewFrame(RendererFrame, TextureUpdateList, BackendProfileCounters),
 }
 
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum AxisDirection {
-    Horizontal,
-    Vertical,
-}
-
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub struct StackingContextIndex(pub usize);
 
@@ -306,20 +297,6 @@ pub struct StackingContextIndex(pub usize);
 pub struct UvRect {
     pub uv0: DevicePoint,
     pub uv1: DevicePoint,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum LowLevelFilterOp {
-    Blur(Au, AxisDirection),
-    Brightness(Au),
-    Contrast(Au),
-    Grayscale(Au),
-    /// Fixed-point in `ANGLE_FLOAT_TO_FIXED` units.
-    HueRotate(i32),
-    Invert(Au),
-    Opacity(Au),
-    Saturate(Au),
-    Sepia(Au),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use gpu_cache::GpuCacheHandle;
-use internal_types::{HardwareCompositeOp, LowLevelFilterOp};
+use internal_types::HardwareCompositeOp;
 use mask_cache::MaskCacheInfo;
 use prim_store::{PrimitiveCacheKey, PrimitiveIndex};
 use std::{cmp, f32, i32, mem, usize};
 use tiling::{ClipScrollGroupIndex, PackedLayerIndex, RenderPass, RenderTargetIndex};
 use tiling::{RenderTargetKind, StackingContextIndex};
 use api::{ClipId, DeviceIntLength, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use api::{MixBlendMode};
+use api::{FilterOp, MixBlendMode};
 
 const FLOATS_PER_RENDER_TASK_INFO: usize = 12;
 
@@ -53,7 +53,7 @@ pub enum RenderTaskLocation {
 #[derive(Debug, Clone)]
 pub enum AlphaRenderItem {
     Primitive(Option<ClipScrollGroupIndex>, PrimitiveIndex, i32),
-    Blend(StackingContextIndex, RenderTaskId, LowLevelFilterOp, i32),
+    Blend(StackingContextIndex, RenderTaskId, FilterOp, i32),
     Composite(StackingContextIndex, RenderTaskId, RenderTaskId, MixBlendMode, i32),
     SplitComposite(StackingContextIndex, RenderTaskId, GpuCacheHandle, i32),
     HardwareComposite(StackingContextIndex, RenderTaskId, HardwareCompositeOp, i32),

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -358,9 +358,9 @@ pub enum MixBlendMode {
     Luminosity  = 15,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub enum FilterOp {
-    Blur(Au),
+    Blur(f32),
     Brightness(f32),
     Contrast(f32),
     Grayscale(f32),
@@ -374,7 +374,7 @@ pub enum FilterOp {
 impl FilterOp {
     pub fn is_noop(&self) -> bool {
         match *self {
-            FilterOp::Blur(length) if length == Au(0) => true,
+            FilterOp::Blur(length) if length == 0.0 => true,
             FilterOp::Brightness(amount) if amount == 1.0 => true,
             FilterOp::Contrast(amount) if amount == 1.0 => true,
             FilterOp::Grayscale(amount) if amount == 0.0 => true,

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -458,7 +458,7 @@ impl YamlHelper for Yaml {
         if let Some(s) = self.as_str() {
             match parse_function(s) {
                 ("blur", ref args, _) if args.len() == 1 => {
-                    Some(FilterOp::Blur(Au(args[0].parse().unwrap())))
+                    Some(FilterOp::Blur(args[0].parse().unwrap()))
                 }
                 ("brightness", ref args, _) if args.len() == 1 => {
                     Some(FilterOp::Brightness(args[0].parse().unwrap()))


### PR DESCRIPTION
LowLevelFilterOp duplicated the FilterOp from Webrender API.
All types in the low level variant used Au instead of f32 but
where always converted from floats and are converted back to
floats. So there is no advantage at all to use integers.

Also use a float for blur for consistency. See also #1244.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1511)
<!-- Reviewable:end -->
