### PR TITLE
Implement basic text layout for wrench.

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -227,6 +227,10 @@ impl GlyphRasterizer {
         self.font_contexts.lock_shared_context().get_glyph_dimensions(glyph_key)
     }
 
+    pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
+        self.font_contexts.lock_shared_context().get_glyph_index(font_key, ch)
+    }
+
     pub fn resolve_glyphs(
         &mut self,
         current_frame_id: FrameId,

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -19,6 +19,7 @@ use api::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
 use api::{GlyphKey, GlyphOptions, SubpixelPoint};
 use api::NativeFontHandle;
 use gamma_lut::{GammaLut, Color as ColorLut};
+use std::ptr;
 
 pub struct FontContext {
     cg_fonts: HashMap<FontKey, CGFont>,
@@ -56,6 +57,7 @@ struct GlyphMetrics {
     rasterized_ascent: i32,
     rasterized_width: u32,
     rasterized_height: u32,
+    advance: f32,
 }
 
 // According to the Skia source code, there's no public API to
@@ -97,6 +99,7 @@ fn get_glyph_metrics(ct_font: &CTFont,
             rasterized_height: 0,
             rasterized_ascent: 0,
             rasterized_descent: 0,
+            advance: 0.0,
         };
     }
 
@@ -125,12 +128,18 @@ fn get_glyph_metrics(ct_font: &CTFont,
     let width = right - left;
     let height = top - bottom;
 
+    let advance = ct_font.get_advances_for_glyphs(kCTFontDefaultOrientation,
+                                                  &glyph,
+                                                  ptr::null_mut(),
+                                                  1);
+
     let metrics = GlyphMetrics {
         rasterized_left: left,
         rasterized_width: width as u32,
         rasterized_height: height as u32,
         rasterized_ascent: top,
         rasterized_descent: -bottom,
+        advance: advance as f32,
     };
 
     metrics
@@ -210,6 +219,24 @@ impl FontContext {
         }
     }
 
+    pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
+        let character = ch as u16;
+        let mut glyph = 0;
+
+        self.get_ct_font(font_key, Au(16 * 60))
+            .and_then(|ref ct_font| {
+                let result = ct_font.get_glyphs_for_characters(&character,
+                                                               &mut glyph,
+                                                               1);
+
+                if result {
+                    Some(glyph as u32)
+                } else {
+                    None
+                }
+            })
+    }
+
     pub fn get_glyph_dimensions(&mut self,
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         self.get_ct_font(key.font_key, key.size).and_then(|ref ct_font| {
@@ -223,6 +250,7 @@ impl FontContext {
                     top: metrics.rasterized_ascent,
                     width: metrics.rasterized_width as u32,
                     height: metrics.rasterized_height as u32,
+                    advance: metrics.advance,
                 })
             }
         })

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -13,7 +13,7 @@ use freetype::freetype::{FT_Library, FT_Set_Char_Size};
 use freetype::freetype::{FT_Face, FT_Long, FT_UInt, FT_F26Dot6};
 use freetype::freetype::{FT_Init_FreeType, FT_Load_Glyph, FT_Render_Glyph};
 use freetype::freetype::{FT_New_Memory_Face, FT_GlyphSlot, FT_LcdFilter};
-use freetype::freetype::{FT_Done_Face, FT_Error, FT_Int32};
+use freetype::freetype::{FT_Done_Face, FT_Error, FT_Int32, FT_Get_Char_Index};
 
 use std::{cmp, mem, ptr, slice};
 use std::collections::HashMap;
@@ -155,7 +155,22 @@ impl FontContext {
                 top: top as i32,
                 width: (right - left) as u32,
                 height: (bottom - top) as u32,
+                advance: metrics.horiAdvance as f32 / 64.0,
             })
+        }
+    }
+
+    pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
+        let face = self.faces
+                       .get(&font_key)
+                       .expect("Unknown font key!");
+        unsafe {
+            let idx = FT_Get_Char_Index(face.face, ch as _);
+            if idx != 0 {
+                Some(idx)
+            } else {
+                None
+            }
         }
     }
 

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -86,28 +86,6 @@ fn dwrite_render_mode(font_face: &dwrote::FontFace,
     dwrite_render_mode
 }
 
-fn get_glyph_dimensions_with_analysis(analysis: dwrote::GlyphRunAnalysis,
-                                      texture_type: dwrote::DWRITE_TEXTURE_TYPE)
-                                      -> Option<GlyphDimensions> {
-    let bounds = analysis.get_alpha_texture_bounds(texture_type);
-
-    let width = (bounds.right - bounds.left) as u32;
-    let height = (bounds.bottom - bounds.top) as u32;
-
-    // Alpha texture bounds can sometimes return an empty rect
-    // Such as for spaces
-    if width == 0 || height == 0 {
-        return None
-    }
-
-    Some(GlyphDimensions {
-        left: bounds.left,
-        top: -bounds.top,
-        width,
-        height,
-    })
-}
-
 impl FontContext {
     pub fn new() -> FontContext {
         // These are the default values we use in Gecko.
@@ -214,6 +192,12 @@ impl FontContext {
                                          0.0, 0.0)
     }
 
+    pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
+        let face = self.fonts.get(&font_key).unwrap();
+        let indices = face.get_glyph_indices(&[ch as u32]);
+        indices.first().map(|idx| *idx as u32)
+    }
+
     // TODO: Pipe GlyphOptions into glyph_dimensions too
     pub fn get_glyph_dimensions(&self,
                                 key: &GlyphKey)
@@ -223,7 +207,35 @@ impl FontContext {
         let analysis = self.create_glyph_analysis(key, render_mode, None);
 
         let texture_type = dwrite_texture_type(render_mode);
-        get_glyph_dimensions_with_analysis(analysis, texture_type)
+
+        let bounds = analysis.get_alpha_texture_bounds(texture_type);
+
+        let width = (bounds.right - bounds.left) as u32;
+        let height = (bounds.bottom - bounds.top) as u32;
+
+        // Alpha texture bounds can sometimes return an empty rect
+        // Such as for spaces
+        if width == 0 || height == 0 {
+            return None
+        }
+
+        let face = self.fonts.get(&key.font_key).unwrap();
+        face.get_design_glyph_metrics(&[key.index as u16], false)
+            .first()
+            .map(|metrics| {
+                let em_size = key.size.to_f32_px() / 16.;
+                let design_units_per_pixel = face.metrics().designUnitsPerEm as f32 / 16. as f32;
+                let scaled_design_units_to_pixels = em_size / design_units_per_pixel;
+                let advance = metrics.advanceWidth as f32 * scaled_design_units_to_pixels;
+
+                GlyphDimensions {
+                    left: bounds.left,
+                    top: -bounds.top,
+                    width,
+                    height,
+                    advance: advance,
+                }
+            })
     }
 
     // DWRITE gives us values in RGB. WR doesn't really touch it after. Note, CG returns in BGR

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -168,6 +168,14 @@ impl RenderBackend {
                             };
                             tx.send(glyph_dimensions).unwrap();
                         }
+                        ApiMsg::GetGlyphIndices(font_key, text, tx) => {
+                            let mut glyph_indices = Vec::new();
+                            for ch in text.chars() {
+                                let index = self.resource_cache.get_glyph_index(font_key, ch);
+                                glyph_indices.push(index);
+                            };
+                            tx.send(glyph_indices).unwrap();
+                        }
                         ApiMsg::AddImage(id, descriptor, data, tiling) => {
                             if let ImageData::Raw(ref bytes) = data {
                                 profile_counters.resources.image_templates.inc(bytes.len());

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -548,6 +548,10 @@ impl ResourceCache {
         }
     }
 
+    pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
+        self.glyph_rasterizer.get_glyph_index(font_key, ch)
+    }
+
     #[inline]
     pub fn get_cached_image(&self,
                             image_key: ImageKey,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -24,6 +24,8 @@ pub enum ApiMsg {
     DeleteFont(FontKey),
     /// Gets the glyph dimensions
     GetGlyphDimensions(Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
+    /// Gets the glyph indices from a string
+    GetGlyphIndices(FontKey, String, MsgSender<Vec<Option<u32>>>),
     /// Adds an image from the resource cache.
     AddImage(ImageKey, ImageDescriptor, ImageData, Option<TileSize>),
     /// Updates the the resource cache with the new image data.
@@ -74,6 +76,7 @@ impl fmt::Debug for ApiMsg {
             ApiMsg::AddNativeFont(..) => "ApiMsg::AddNativeFont",
             ApiMsg::DeleteFont(..) => "ApiMsg::DeleteFont",
             ApiMsg::GetGlyphDimensions(..) => "ApiMsg::GetGlyphDimensions",
+            ApiMsg::GetGlyphIndices(..) => "ApiMsg::GetGlyphIndices",
             ApiMsg::AddImage(..) => "ApiMsg::AddImage",
             ApiMsg::UpdateImage(..) => "ApiMsg::UpdateImage",
             ApiMsg::DeleteImage(..) => "ApiMsg::DeleteImage",
@@ -230,6 +233,17 @@ impl RenderApi {
                                 -> Vec<Option<GlyphDimensions>> {
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::GetGlyphDimensions(glyph_keys, tx);
+        self.api_sender.send(msg).unwrap();
+        rx.recv().unwrap()
+    }
+
+    /// Gets the glyph indices for the supplied string. These
+    /// can be used to construct GlyphKeys.
+    pub fn get_glyph_indices(&self,
+                             font_key: FontKey,
+                             text: &str) -> Vec<Option<u32>> {
+        let (tx, rx) = channel::msg_channel().unwrap();
+        let msg = ApiMsg::GetGlyphIndices(font_key, text.to_string(), tx);
         self.api_sender.send(msg).unwrap();
         rx.recv().unwrap()
     }

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -52,6 +52,7 @@ pub struct GlyphDimensions {
     pub top: i32,
     pub width: u32,
     pub height: u32,
+    pub advance: f32,
 }
 
 #[repr(C)]

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -63,13 +63,7 @@ use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
 lazy_static! {
-    static ref PLATFORM_DEFAULT_FACE_NAME: String =
-        if cfg!(target_os = "windows") {
-            String::from("Arial")
-        } else {
-            String::from("Helvetica")
-        };
-
+    static ref PLATFORM_DEFAULT_FACE_NAME: String = String::from("Arial");
     static ref WHITE_COLOR: ColorF = ColorF::new(1.0, 1.0, 1.0, 1.0);
     static ref BLACK_COLOR: ColorF = ColorF::new(0.0, 0.0, 0.0, 1.0);
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use webrender::api::*;
-use wrench::{Wrench, WrenchThing, layout_simple_ascii};
+use wrench::{Wrench, WrenchThing};
 use yaml_helper::{YamlHelper, StringEnum};
 use yaml_rust::{Yaml, YamlLoader};
 use {WHITE_COLOR, BLACK_COLOR, PLATFORM_DEFAULT_FACE_NAME};
@@ -446,7 +446,7 @@ impl YamlFrameReader {
         assert!(item["blur-radius"].is_badvalue(),
             "text no longer has a blur radius, use PushTextShadow and PopTextShadow");
 
-        let (font_key, native_key) = if !item["family"].is_badvalue() {
+        let font_key = if !item["family"].is_badvalue() {
             wrench.font_key_from_yaml_table(item)
         } else if !item["font"].is_badvalue() {
             let font_file = self.rsrc_path(&item["font"]);
@@ -483,14 +483,9 @@ impl YamlFrameReader {
                                      .expect("Text items with glyphs require bounds [for now]");
             (glyphs, rect)
         } else {
-            assert!(native_key.is_some(), "Can't layout simple ascii text with raw font [for now]");
-            let native_key = native_key.unwrap();
             let text = item["text"].as_str().unwrap();
             let (glyph_indices, glyph_advances) =
-                layout_simple_ascii(native_key, text, size);
-            println!("Text layout: {}", text);
-            println!(" glyphs  -> {:?}", glyph_indices);
-            println!("    adv  -> {:?}", glyph_advances);
+                wrench.layout_simple_ascii(font_key, text, size);
             let origin = item["origin"].as_point()
                 .expect("origin required for text without glyphs");
 


### PR DESCRIPTION
Add just enough information to the WR font platforms to do basic text layout.

Tested on Linux, Mac, Windows.

This allows us to add text runs to wrench reftests and benchmarks without
having to manually specify all the glyph positions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1512)
<!-- Reviewable:end -->
