### PR TITLE
Allow ScrollFrame to be insensitive to input events

### DIFF
--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -36,7 +36,8 @@ fn body(_api: &RenderApi,
                                                      (100, 100).to(1000, 1000),
                                                      outer_scroll_frame_rect,
                                                      vec![],
-                                                     None);
+                                                     None,
+                                                     ScrollSensitivity::ScriptAndInputEvents);
     builder.push_clip_id(nested_clip_id);
 
     let mut builder2 = DisplayListBuilder::new(*pipeline_id, *layout_size);
@@ -63,11 +64,13 @@ fn body(_api: &RenderApi,
     // a unique ClipId.
     let inner_scroll_frame_rect = (330, 110).to(530, 360);
     builder3.push_rect(inner_scroll_frame_rect, None, ColorF::new(1.0, 0.0, 1.0, 0.5));
-    let inner_nested_clip_id = builder3.define_scroll_frame(None,
-                                                            (330, 110).to(2000, 2000),
-                                                            inner_scroll_frame_rect,
-                                                            vec![],
-                                                            None);
+    let inner_nested_clip_id =
+        builder3.define_scroll_frame(None,
+                                     (330, 110).to(2000, 2000),
+                                     inner_scroll_frame_rect,
+                                     vec![],
+                                     None,
+                                     ScrollSensitivity::ScriptAndInputEvents);
     builder3.push_clip_id(inner_nested_clip_id);
     let rect = (340, 120).to(440, 220);
     builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -45,7 +45,8 @@ fn body(_api: &RenderApi,
                                                   (0, 0).by(1000, 1000),
                                                   scrollbox,
                                                   vec![],
-                                                  None);
+                                                  None,
+                                                  ScrollSensitivity::ScriptAndInputEvents);
         builder.push_clip_id(clip_id);
 
         // now put some content into it.
@@ -68,7 +69,8 @@ fn body(_api: &RenderApi,
                                                          (0, 100).to(300, 400),
                                                          (0, 100).to(200, 300),
                                                          vec![],
-                                                         None);
+                                                         None,
+                                                         ScrollSensitivity::ScriptAndInputEvents);
         builder.push_clip_id(nested_clip_id);
 
         // give it a giant gray background just to distinguish it and to easily

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -93,7 +93,7 @@ impl ClipScrollTree {
             }
 
             match node.node_type {
-                NodeType::ScrollFrame(..) => {},
+                NodeType::ScrollFrame(state) if state.sensitive_to_input_events() => {},
                 _ => return None,
             }
 
@@ -303,12 +303,9 @@ impl ClipScrollTree {
         // TODO(gw): These are all independent - can be run through thread pool if it shows up
         // in the profile!
         for (clip_id, node) in &mut self.nodes {
-            let scrolling_state = match old_states.get(clip_id) {
-                Some(old_scrolling_state) => *old_scrolling_state,
-                None => ScrollingState::new(),
-            };
-
-            node.finalize(&scrolling_state);
+            if let Some(scrolling_state) = old_states.get(clip_id) {
+                node.apply_old_scrolling_state(scrolling_state);
+            }
 
             if let Some((pending_offset, clamping)) = self.pending_scroll_offsets.remove(clip_id) {
                 node.set_scroll_origin(&pending_offset, clamping);

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -5,9 +5,10 @@
 use api::{BuiltDisplayList, BuiltDisplayListIter, ClipAndScrollInfo, ClipId, ColorF};
 use api::{ComplexClipRegion, DeviceUintRect, DeviceUintSize, DisplayItemRef, Epoch, FilterOp};
 use api::{ImageDisplayItem, ItemRange, LayerPoint, LayerRect, LayerSize, LayerToScrollTransform};
-use api::{LayerVector2D, LayoutSize, LayoutTransform, LocalClip, MixBlendMode, PipelineId, PropertyBinding};
-use api::{ScrollClamping, ScrollEventPhase, ScrollLayerState, ScrollLocation, ScrollPolicy};
-use api::{SpecificDisplayItem, StackingContext, TileOffset, TransformStyle, WorldPoint};
+use api::{LayerVector2D, LayoutSize, LayoutTransform, LocalClip, MixBlendMode, PipelineId};
+use api::{PropertyBinding, ScrollClamping, ScrollEventPhase, ScrollLayerState, ScrollLocation};
+use api::{ScrollPolicy, ScrollSensitivity, SpecificDisplayItem, StackingContext, TileOffset};
+use api::{TransformStyle, WorldPoint};
 use clip_scroll_tree::{ClipScrollTree, ScrollStates};
 use euclid::rect;
 use fnv::FnvHasher;
@@ -350,7 +351,8 @@ impl Frame {
                                 new_scroll_frame_id: &ClipId,
                                 frame_rect: &LayerRect,
                                 content_rect: &LayerRect,
-                                clip_region: ClipRegion) {
+                                clip_region: ClipRegion,
+                                scroll_sensitivity: ScrollSensitivity) {
         let clip_id = self.clip_scroll_tree.generate_new_clip_id(pipeline_id);
         context.builder.add_clip_node(clip_id,
                                       *parent_id,
@@ -364,6 +366,7 @@ impl Frame {
                                          pipeline_id,
                                          &frame_rect,
                                          &content_rect.size,
+                                         scroll_sensitivity,
                                          &mut self.clip_scroll_tree);
     }
 
@@ -504,6 +507,7 @@ impl Frame {
             pipeline_id,
             &iframe_rect,
             &pipeline.content_size,
+            ScrollSensitivity::ScriptAndInputEvents,
             &mut self.clip_scroll_tree);
 
         self.flatten_root(&mut display_list.iter(), pipeline_id, context, &pipeline.content_size);
@@ -708,7 +712,8 @@ impl Frame {
                                           &info.id,
                                           &frame_rect,
                                           &content_rect,
-                                          clip_region);
+                                          clip_region,
+                                          info.scroll_sensitivity);
             }
             SpecificDisplayItem::PushNestedDisplayList => {
                 // Using the clip and scroll already processed for nesting here

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -7,8 +7,8 @@ use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect, DeviceUi
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
 use api::{LayerToScrollTransform, LayerVector2D, LayoutVector2D, LineOrientation, LineStyle};
-use api::{LocalClip, PipelineId, RepeatMode, TextShadow, TileOffset, TransformStyle};
-use api::{WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
+use api::{LocalClip, PipelineId, RepeatMode, ScrollSensitivity, TextShadow, TileOffset};
+use api::{TransformStyle, WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
 use app_units::Au;
 use fnv::FnvHasher;
 use frame::FrameId;
@@ -389,6 +389,7 @@ impl FrameBuilder {
                               pipeline_id,
                               &viewport_rect,
                               content_size,
+                              ScrollSensitivity::ScriptAndInputEvents,
                               clip_scroll_tree);
 
         topmost_scrolling_node_id
@@ -412,11 +413,13 @@ impl FrameBuilder {
                             pipeline_id: PipelineId,
                             frame_rect: &LayerRect,
                             content_size: &LayerSize,
+                            scroll_sensitivity: ScrollSensitivity,
                             clip_scroll_tree: &mut ClipScrollTree) {
         let node = ClipScrollNode::new_scroll_frame(pipeline_id,
                                                     parent_id,
                                                     frame_rect,
-                                                    content_size);
+                                                    content_size,
+                                                    scroll_sensitivity);
 
         clip_scroll_tree.add_node(node, new_node_id);
     }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -49,7 +49,7 @@ pub struct DisplayItem {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),
-    ScrollFrame(ClipDisplayItem),
+    ScrollFrame(ScrollFrameDisplayItem),
     Rectangle(RectangleDisplayItem),
     Line(LineDisplayItem),
     Text(TextDisplayItem),
@@ -75,6 +75,20 @@ pub struct ClipDisplayItem {
     pub id: ClipId,
     pub parent_id: ClipId,
     pub image_mask: Option<ImageMask>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum ScrollSensitivity {
+    ScriptAndInputEvents,
+    Script,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ScrollFrameDisplayItem {
+    pub id: ClipId,
+    pub parent_id: ClipId,
+    pub image_mask: Option<ImageMask>,
+    pub scroll_sensitivity: ScrollSensitivity,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -663,3 +677,4 @@ define_empty_heap_size_of!(ImageKey);
 define_empty_heap_size_of!(MixBlendMode);
 define_empty_heap_size_of!(TransformStyle);
 define_empty_heap_size_of!(LocalClip);
+define_empty_heap_size_of!(ScrollSensitivity);

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -12,9 +12,9 @@ use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion, Disp
 use {ExtendMode, FilterOp, FontKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem};
 use {GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering};
 use {LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D, LineDisplayItem};
-use {LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId};
-use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
-use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollPolicy};
+use {LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId, PropertyBinding};
+use {PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
+use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity};
 use {SpecificDisplayItem, StackingContext, TextDisplayItem, TextShadow, TransformStyle};
 use {WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
 use std::marker::PhantomData;
@@ -868,15 +868,17 @@ impl DisplayListBuilder {
                                   content_rect: LayoutRect,
                                   clip_rect: LayoutRect,
                                   complex_clips: I,
-                                  image_mask: Option<ImageMask>)
+                                  image_mask: Option<ImageMask>,
+                                  scroll_sensitivity: ScrollSensitivity)
                                   -> ClipId
                                   where I: IntoIterator<Item = ComplexClipRegion>,
                                         I::IntoIter: ExactSizeIterator {
         let id = self.generate_clip_id(id);
-        let item = SpecificDisplayItem::ScrollFrame(ClipDisplayItem {
+        let item = SpecificDisplayItem::ScrollFrame(ScrollFrameDisplayItem {
             id: id,
             parent_id: self.clip_stack.last().unwrap().scroll_node_id,
             image_mask: image_mask,
+            scroll_sensitivity,
         });
 
         self.push_item(item, content_rect, Some(LocalClip::from(clip_rect)));

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -610,7 +610,8 @@ impl YamlFrameReader {
                                                     content_rect,
                                                     clip_rect,
                                                     complex_clips,
-                                                    image_mask);
+                                                    image_mask,
+                                                    ScrollSensitivity::Script);
 
         if let Some(size) = yaml["scroll-offset"].as_point() {
             self.scroll_offsets.insert(id, LayerPoint::new(size.x, size.y));


### PR DESCRIPTION
overflow:hidden should be scrollable in Servo, but not by input events.
This change allows creating ScrollFrames which are only scrollable via
script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1513)
<!-- Reviewable:end -->
