### PR TITLE
Improve wrench display list "replay" and DL/IPC timing.

### DIFF
--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -329,13 +329,20 @@ pub struct IpcProfileCounters {
 }
 
 impl IpcProfileCounters {
-    pub fn set(&mut self, build_start: u64, build_end: u64, 
-                              consume_start: u64, consume_end: u64,
-                              display_len: usize) {
-        self.build_time.inc(build_end - build_start);
-        self.consume_time.inc(consume_end - consume_start);
-        self.send_time.inc(consume_start - build_end);
-        self.total_time.inc(consume_end - build_start);
+    pub fn set(&mut self,
+               build_start: u64,
+               build_end: u64,
+               send_start: u64,
+               consume_start: u64,
+               consume_end: u64,
+               display_len: usize) {
+        let build_time = build_end - build_start;
+        let consume_time = consume_end - consume_start;
+        let send_time = consume_start - send_start;
+        self.build_time.inc(build_time);
+        self.consume_time.inc(consume_time);
+        self.send_time.inc(send_time);
+        self.total_time.inc(build_time + consume_time + send_time);
         self.display_lists.inc(display_len);
     }
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -245,7 +245,7 @@ impl RenderBackend {
                             }
 
                             let display_list_len = built_display_list.data().len();
-                            let (builder_start_time, builder_finish_time) = built_display_list.times();
+                            let (builder_start_time, builder_finish_time, send_start_time) = built_display_list.times();
 
                             let display_list_received_time = precise_time_ns();
 
@@ -266,8 +266,11 @@ impl RenderBackend {
                             // really simple and cheap to access, so it's not a big deal.
                             let display_list_consumed_time = precise_time_ns();
 
-                            profile_counters.ipc.set(builder_start_time, builder_finish_time,
-                                                     display_list_received_time, display_list_consumed_time,
+                            profile_counters.ipc.set(builder_start_time,
+                                                     builder_finish_time,
+                                                     send_start_time,
+                                                     display_list_received_time,
+                                                     display_list_consumed_time,
                                                      display_list_len);
                         }
                         ApiMsg::SetRootPipeline(pipeline_id) => {

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -59,6 +59,8 @@ pub struct BuiltDisplayListDescriptor {
     builder_start_time: u64,
     /// The second IPC time stamp: after serialization
     builder_finish_time: u64,
+    /// The third IPC time stamp: just before sending
+    send_start_time: u64,
 }
 
 pub struct BuiltDisplayListIter<'a> {
@@ -101,7 +103,8 @@ impl BuiltDisplayList {
         }
     }
 
-    pub fn into_data(self) -> (Vec<u8>, BuiltDisplayListDescriptor) {
+    pub fn into_data(mut self) -> (Vec<u8>, BuiltDisplayListDescriptor) {
+        self.descriptor.send_start_time = precise_time_ns();
         (self.data, self.descriptor)
     }
 
@@ -113,8 +116,10 @@ impl BuiltDisplayList {
         &self.descriptor
     }
 
-    pub fn times(&self) -> (u64, u64) {
-      (self.descriptor.builder_start_time, self.descriptor.builder_finish_time)
+    pub fn times(&self) -> (u64, u64, u64) {
+      (self.descriptor.builder_start_time,
+       self.descriptor.builder_finish_time,
+       self.descriptor.send_start_time)
     }
 
     pub fn iter(&self) -> BuiltDisplayListIter {
@@ -961,6 +966,7 @@ impl DisplayListBuilder {
             descriptor: BuiltDisplayListDescriptor {
                 builder_start_time: self.builder_start_time,
                 builder_finish_time: end_time,
+                send_start_time: 0,
             },
             data: self.data,
          })

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -376,14 +376,17 @@ impl Wrench {
 
     pub fn send_lists(&mut self,
                       frame_number: u32,
-                      display_list: DisplayListBuilder,
+                      display_lists: Vec<(PipelineId, LayerSize, BuiltDisplayList)>,
                       scroll_offsets: &HashMap<ClipId, LayerPoint>) {
         let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
-        self.api.set_display_list(root_background_color,
-                                  Epoch(frame_number),
-                                  self.window_size_f32(),
-                                  display_list.finalize(),
-                                  false);
+
+        for display_list in display_lists {
+            self.api.set_display_list(root_background_color,
+                                      Epoch(frame_number),
+                                      self.window_size_f32(),
+                                      display_list,
+                                      false);
+        }
 
         for (id, offset) in scroll_offsets {
             self.api.scroll_node_with_id(*offset, *id, ScrollClamping::NoClamping);


### PR DESCRIPTION
Previously, wrench held on to a single DLBuilder object, and copied
this and finalize'ed it each time a DL was replayed. This has several
issues, and messes up the timings of the DL profiling.

Instead, change wrench to build the DL once, and store the built
display lists. This mostly involves plumbing the DL builder through
all the yaml reader functions.

Also, modify the DL timing code to handle the situation where a DL
is built once and sent multiple times for profiling purposes. Specifically,
record an extra timestamp just before starting the send operation and
accumulate the total time as a sum of each component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1515)
<!-- Reviewable:end -->
