### PR TITLE
add a cache of all seen glyphs to the end of the display list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "core-graphics 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -15,6 +15,7 @@ app_units = "0.5"
 bincode = "0.8"
 byteorder = "1.0"
 euclid = "0.15"
+fxhash = "0.2.1"
 gleam = "0.4.5"
 heapsize = ">= 0.3.6, < 0.5"
 ipc-channel = {version = "0.8", optional = true}

--- a/webrender_api/src/color.rs
+++ b/webrender_api/src/color.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::hash::{Hash, Hasher};
+
 /// Represents RGBA screen colors with floating point numbers.
 ///
 /// All components must be between 0.0 and 1.0.
@@ -48,6 +50,26 @@ impl ColorF {
     pub fn premultiplied(&self) -> ColorF {
         self.scale_rgb(self.a)
     }
+}
+
+// Floats don't impl Hash/Eq...
+impl Eq for ColorF { }
+impl Hash for ColorF {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Note: this is inconsistent with the Eq impl for -0.0 (don't care).
+        self.r._to_bits().hash(state);
+        self.g._to_bits().hash(state);
+        self.b._to_bits().hash(state);
+        self.a._to_bits().hash(state);
+    }
+}
+
+// FIXME: remove this when Rust 1.21 is stable (float_bits_conv)
+trait ToBits {
+    fn _to_bits(self) -> u32;
+}
+impl ToBits for f32 {
+    fn _to_bits(self) -> u32 { unsafe { ::std::mem::transmute(self) } }
 }
 
 /// Represents RGBA screen colors with one byte per channel.

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -18,6 +18,7 @@ use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivi
 use {SpecificDisplayItem, StackingContext, TextDisplayItem, TextShadow, TransformStyle};
 use {WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
 use std::marker::PhantomData;
+use std::collections::{HashMap, HashSet};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -61,6 +62,8 @@ pub struct BuiltDisplayListDescriptor {
     builder_finish_time: u64,
     /// The third IPC time stamp: just before sending
     send_start_time: u64,
+    /// The offset where DisplayItems stop and the Glyph list starts
+    glyph_offset: usize,
 }
 
 pub struct BuiltDisplayListIter<'a> {
@@ -77,6 +80,12 @@ pub struct BuiltDisplayListIter<'a> {
 pub struct DisplayItemRef<'a: 'b, 'b> {
     iter: &'b BuiltDisplayListIter<'a>,
 }
+
+pub struct GlyphsIter<'a> {
+    list: &'a BuiltDisplayList,
+    data: &'a [u8],
+}
+
 
 #[derive(PartialEq)]
 enum Peek {
@@ -126,14 +135,40 @@ impl BuiltDisplayList {
         BuiltDisplayListIter::new(self)
     }
 
+    pub fn glyphs(&self) -> GlyphsIter {
+        GlyphsIter {
+            list: self,
+            data: &self.data[self.descriptor.glyph_offset..],
+        }
+    }
+
     pub fn get<'de, T: Deserialize<'de>>(&self, range: ItemRange<T>) -> AuxIter<T> {
         AuxIter::new(&self.data[range.start .. range.start + range.length])
     }
 }
 
+/// Returns the byte-range the slice occupied, and the number of elements
+/// in the slice.
+fn skip_slice<T: for<'de> Deserialize<'de>>(list: &BuiltDisplayList, data: &mut &[u8]) -> (ItemRange<T>, usize) {
+    let base = list.data.as_ptr() as usize;
+    let start = data.as_ptr() as usize;
+
+    // Read through the values (this is a bit of a hack to reuse logic)
+    let mut iter = AuxIter::<T>::new(*data);
+    let count = iter.len();
+    for _ in &mut iter {}
+    let end = iter.data.as_ptr() as usize;
+
+    let range = ItemRange { start: start - base, length: end - start, _boo: PhantomData };
+
+    // Adjust data pointer to skip read values
+    *data = &data[range.length..];
+    (range, count)
+}
+
 impl<'a> BuiltDisplayListIter<'a> {
     pub fn new(list: &'a BuiltDisplayList) -> Self {
-        Self::new_with_list_and_data(list, &list.data)
+        Self::new_with_list_and_data(list, &list.data[..list.descriptor.glyph_offset])
     }
 
     pub fn new_with_list_and_data(list: &'a BuiltDisplayList, data: &'a [u8]) -> Self {
@@ -186,7 +221,7 @@ impl<'a> BuiltDisplayListIter<'a> {
 
             match self.cur_item.item {
                 SetGradientStops => {
-                    self.cur_stops = self.skip_slice::<GradientStop>().0;
+                    self.cur_stops = skip_slice::<GradientStop>(self.list, &mut self.data).0;
 
                     // This is a dummy item, skip over it
                     continue;
@@ -204,23 +239,8 @@ impl<'a> BuiltDisplayListIter<'a> {
         Some(self.as_ref())
     }
 
-    /// Returns the byte-range the slice occupied, and the number of elements
-    /// in the slice.
     fn skip_slice<T: for<'de> Deserialize<'de>>(&mut self) -> (ItemRange<T>, usize) {
-        let base = self.list.data.as_ptr() as usize;
-        let start = self.data.as_ptr() as usize;
-
-        // Read through the values (this is a bit of a hack to reuse logic)
-        let mut iter = AuxIter::<T>::new(self.data);
-        let count = iter.len();
-        for _ in &mut iter {}
-        let end = iter.data.as_ptr() as usize;
-
-        let range = ItemRange { start: start - base, length: end - start, _boo: PhantomData };
-
-        // Adjust data pointer to skip read values
-        self.data = &self.data[range.length..];
-        (range, count)
+        skip_slice::<T>(self.list, &mut self.data)
     }
 
     pub fn as_ref<'b>(&'b self) -> DisplayItemRef<'a, 'b> {
@@ -265,6 +285,19 @@ impl<'a> BuiltDisplayListIter<'a> {
         } else {
             Some(self.as_ref())
         }
+    }
+}
+
+impl<'a> Iterator for GlyphsIter<'a> {
+    type Item = (FontKey, ColorF, ItemRange<GlyphInstance>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.data.len() == 0 { return None; }
+
+        let (font_key, color) = bincode::deserialize_from(&mut self.data, bincode::Infinite)
+                                        .expect("MEH: malicious process?");
+        let glyphs = skip_slice::<GlyphInstance>(self.list, &mut self.data).0;
+        Some((font_key, color, glyphs))
     }
 }
 
@@ -411,6 +444,8 @@ pub struct DisplayListBuilder {
     pub data: Vec<u8>,
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ClipAndScrollInfo>,
+    // FIXME: audit whether fast hashers (FNV?) are safe here
+    glyphs: HashMap<(FontKey, ColorF), HashSet<u32>>,
     next_clip_id: u64,
     builder_start_time: u64,
 
@@ -436,6 +471,7 @@ impl DisplayListBuilder {
             data: Vec::with_capacity(capacity),
             pipeline_id,
             clip_stack: vec![ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id))],
+            glyphs: HashMap::new(),
             next_clip_id: FIRST_CLIP_ID,
             builder_start_time: start_time,
             content_size,
@@ -587,6 +623,12 @@ impl DisplayListBuilder {
 
             self.push_item(item, rect, local_clip);
             self.push_iter(glyphs);
+
+            // Remember that we've seen these glyphs
+            let mut font_glyphs = self.glyphs.entry((font_key, color))
+                                             .or_insert(HashSet::new());
+
+            font_glyphs.extend(glyphs.iter().map(|glyph| glyph.index));
         }
     }
 
@@ -957,8 +999,22 @@ impl DisplayListBuilder {
         self.push_new_empty_item(SpecificDisplayItem::PopTextShadow);
     }
 
-    pub fn finalize(self) -> (PipelineId, LayoutSize, BuiltDisplayList) {
+    pub fn finalize(mut self) -> (PipelineId, LayoutSize, BuiltDisplayList) {
+
+        let glyph_offset = self.data.len();
+
+        // Want to use self.push_iter, so can't borrow self
+        let glyphs = ::std::mem::replace(&mut self.glyphs, HashMap::new());
+
+        // Append glyph data to the end
+        for ((font_key, color), sub_glyphs) in glyphs {
+            bincode::serialize_into(&mut self.data, &font_key, bincode::Infinite).unwrap();
+            bincode::serialize_into(&mut self.data, &color, bincode::Infinite).unwrap();
+            self.push_iter(sub_glyphs);
+        }
+
         let end_time = precise_time_ns();
+
 
         (self.pipeline_id,
          self.content_size,
@@ -967,6 +1023,7 @@ impl DisplayListBuilder {
                 builder_start_time: self.builder_start_time,
                 builder_finish_time: end_time,
                 send_start_time: 0,
+                glyph_offset,
             },
             data: self.data,
          })

--- a/webrender_api/src/lib.rs
+++ b/webrender_api/src/lib.rs
@@ -11,6 +11,7 @@ extern crate byteorder;
 #[cfg(feature = "nightly")]
 extern crate core;
 extern crate euclid;
+extern crate fxhash;
 extern crate gleam;
 #[macro_use]
 extern crate heapsize;
@@ -51,3 +52,8 @@ pub use image::*;
 pub use units::*;
 #[cfg(feature = "webgl")]
 pub use webgl::*;
+
+use std::hash::BuildHasherDefault;
+use std::collections::{HashMap, HashSet};
+type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<fxhash::FxHasher>>;
+type FastHashSet<T> = HashSet<T, BuildHasherDefault<fxhash::FxHasher>>;


### PR DESCRIPTION
This lets the backend call `display_list.glyphs()` to get an iterator of every glyph seen (broken down by font/color) so that the backend can prepare glyph atlases or whatever in parallel.

This is for @glennw to build off of for #1503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1518)
<!-- Reviewable:end -->
