### PR TITLE
Move per-font-instance parameters from GlyphKey to FontInstanceKey.

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(test)]
 use app_units::Au;
 use device::TextureFilter;
 use fnv::FnvHasher;
@@ -19,11 +20,11 @@ use std::collections::HashSet;
 use std::mem;
 use texture_cache::{TextureCacheItemId, TextureCache};
 #[cfg(test)]
-use api::IdNamespace;
-use api::{ColorF, LayoutPoint};
-use api::{FontKey, FontTemplate, FontRenderMode};
+use api::{ColorF, FontRenderMode, IdNamespace};
+use api::{FontInstanceKey, LayoutPoint};
+use api::{FontKey, FontTemplate};
 use api::{ImageData, ImageDescriptor, ImageFormat};
-use api::{GlyphKey, GlyphOptions, GlyphInstance, GlyphDimensions};
+use api::{GlyphKey, GlyphInstance, GlyphDimensions};
 
 pub type GlyphCache = ResourceClassCache<GlyphRequest, Option<TextureCacheItemId>>;
 
@@ -149,29 +150,19 @@ impl GlyphRasterizer {
         &mut self,
         glyph_cache: &mut GlyphCache,
         current_frame_id: FrameId,
-        font_key: FontKey,
-        size: Au,
-        color: ColorF,
+        font: FontInstanceKey,
         glyph_instances: &[GlyphInstance],
-        render_mode: FontRenderMode,
-        glyph_options: Option<GlyphOptions>,
         requested_items: &mut HashSet<TextureCacheItemId, BuildHasherDefault<FnvHasher>>,
     ) {
-        assert!(self.font_contexts.lock_shared_context().has_font(&font_key));
+        assert!(self.font_contexts.lock_shared_context().has_font(&font.font_key));
 
         let mut glyphs = Vec::with_capacity(glyph_instances.len());
 
         // select glyphs that have not been requested yet.
         for glyph in glyph_instances {
-            let glyph_request = GlyphRequest::new(
-                font_key,
-                size,
-                color,
-                glyph.index,
-                glyph.point,
-                render_mode,
-                glyph_options,
-            );
+            let glyph_request = GlyphRequest::new(font.clone(),
+                                                  glyph.index,
+                                                  glyph.point);
 
             match glyph_cache.entry(glyph_request.clone(), current_frame_id) {
                 Entry::Occupied(entry) => {
@@ -182,7 +173,7 @@ impl GlyphRasterizer {
                 Entry::Vacant(..) => {
                     if !self.pending_glyphs.contains(&glyph_request) {
                         self.pending_glyphs.insert(glyph_request.clone());
-                        glyphs.push(glyph_request);
+                        glyphs.push(glyph_request.clone());
                     }
                 }
             }
@@ -203,11 +194,7 @@ impl GlyphRasterizer {
                 let mut context = font_contexts.lock_current_context();
                 let job = GlyphRasterJob {
                     request: request.clone(),
-                    result: context.rasterize_glyph(
-                        &request.key,
-                        request.render_mode,
-                        request.glyph_options
-                    ),
+                    result: context.rasterize_glyph(&request.font, &request.key),
                 };
 
                 // Sanity check.
@@ -223,8 +210,10 @@ impl GlyphRasterizer {
         });
     }
 
-    pub fn get_glyph_dimensions(&mut self, glyph_key: &GlyphKey) -> Option<GlyphDimensions> {
-        self.font_contexts.lock_shared_context().get_glyph_dimensions(glyph_key)
+    pub fn get_glyph_dimensions(&mut self,
+                                font: &FontInstanceKey,
+                                glyph_key: &GlyphKey) -> Option<GlyphDimensions> {
+        self.font_contexts.lock_shared_context().get_glyph_dimensions(font, glyph_key)
     }
 
     pub fn get_glyph_index(&mut self, font_key: FontKey, ch: char) -> Option<u32> {
@@ -328,24 +317,17 @@ impl FontContext {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 pub struct GlyphRequest {
     pub key: GlyphKey,
-    pub render_mode: FontRenderMode,
-    pub glyph_options: Option<GlyphOptions>,
+    pub font: FontInstanceKey,
 }
 
 impl GlyphRequest {
     pub fn new(
-        font_key: FontKey,
-        size: Au,
-        color: ColorF,
+        font: FontInstanceKey,
         index: u32,
-        point: LayoutPoint,
-        render_mode: FontRenderMode,
-        glyph_options: Option<GlyphOptions>,
-    ) -> Self {
+        point: LayoutPoint) -> Self {
         GlyphRequest {
-            key: GlyphKey::new(font_key, size, color, index, point, render_mode),
-            render_mode,
-            glyph_options,
+            key: GlyphKey::new(index, point, font.render_mode),
+            font,
         }
     }
 }
@@ -386,16 +368,20 @@ fn raterize_200_glyphs() {
         });
     }
 
+    let font = FontInstanceKey {
+        font_key,
+        color: ColorF::new(0.0, 0.0, 0.0, 1.0).into(),
+        size: Au::from_px(32),
+        render_mode: FontRenderMode::Subpixel,
+        glyph_options: None,
+    };
+
     for i in 0..4 {
         glyph_rasterizer.request_glyphs(
             &mut glyph_cache,
             frame_id,
-            font_key,
-            Au::from_px(32),
-            ColorF::new(0.0, 0.0, 0.0, 1.0),
+            font.clone(),
             &glyph_instances[(50 * i)..(50 * (i + 1))],
-            FontRenderMode::Subpixel,
-            None,
             &mut requested_items,
         );
     }

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use api::{FontKey, FontRenderMode, GlyphDimensions};
-use api::{NativeFontHandle, GlyphOptions};
+use api::{FontInstanceKey, FontKey, FontRenderMode, GlyphDimensions};
+use api::{NativeFontHandle};
 use api::{GlyphKey};
 
 use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode};
@@ -175,22 +175,26 @@ impl FontContext {
     }
 
     pub fn get_glyph_dimensions(&mut self,
+                                font: &FontInstanceKey,
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
-        self.load_glyph(key.font_key, key.size, key.index)
+        self.load_glyph(font.font_key,
+                        font.size,
+                        key.index)
             .and_then(Self::get_glyph_dimensions_impl)
     }
 
     pub fn rasterize_glyph(&mut self,
-                           key: &GlyphKey,
-                           render_mode: FontRenderMode,
-                           _glyph_options: Option<GlyphOptions>)
+                           font: &FontInstanceKey,
+                           key: &GlyphKey)
                            -> Option<RasterizedGlyph> {
 
-        let slot = match self.load_glyph(key.font_key, key.size, key.index) {
+        let slot = match self.load_glyph(font.font_key,
+                                         font.size,
+                                         key.index) {
             Some(slot) => slot,
             None => return None,
         };
-        let render_mode = match render_mode {
+        let render_mode = match font.render_mode {
             FontRenderMode::Mono => FT_Render_Mode::FT_RENDER_MODE_MONO,
             FontRenderMode::Alpha => FT_Render_Mode::FT_RENDER_MODE_NORMAL,
             FontRenderMode::Subpixel => FT_Render_Mode::FT_RENDER_MODE_LCD,

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use api::{FontKey, FontRenderMode, GlyphDimensions};
-use api::{GlyphKey, GlyphOptions};
+use api::{FontInstanceKey, GlyphKey, GlyphOptions};
 use gamma_lut::{GammaLut, Color as ColorLut};
 
 use dwrote;
@@ -153,18 +153,18 @@ impl FontContext {
         }
     }
 
-    fn create_glyph_analysis(&self, key: &GlyphKey,
-                            render_mode: FontRenderMode,
-                            options: Option<GlyphOptions>) ->
+    fn create_glyph_analysis(&self,
+                             font: &FontInstanceKey,
+                             key: &GlyphKey) ->
                             dwrote::GlyphRunAnalysis {
-        let face = self.fonts.get(&key.font_key).unwrap();
+        let face = self.fonts.get(&font.font_key).unwrap();
         let glyph = key.index as u16;
         let advance = 0.0f32;
         let offset = dwrote::GlyphOffset { advanceOffset: 0.0, ascenderOffset: 0.0 };
 
         let glyph_run = dwrote::DWRITE_GLYPH_RUN {
             fontFace: unsafe { face.as_ptr() },
-            fontEmSize: key.size.to_f32_px(), // size in DIPs (1/96", same as CSS pixels)
+            fontEmSize: font.size.to_f32_px(), // size in DIPs (1/96", same as CSS pixels)
             glyphCount: 1,
             glyphIndices: &glyph,
             glyphAdvances: &advance,
@@ -173,12 +173,13 @@ impl FontContext {
             bidiLevel: 0,
         };
 
-        let dwrite_measure_mode = dwrite_measure_mode(render_mode, options);
+        let dwrite_measure_mode = dwrite_measure_mode(font.render_mode,
+                                                      font.glyph_options);
         let dwrite_render_mode = dwrite_render_mode(face,
-                                                    render_mode,
-                                                    key.size.to_f32_px(),
+                                                    font.render_mode,
+                                                    font.size.to_f32_px(),
                                                     dwrite_measure_mode,
-                                                    options);
+                                                    font.glyph_options);
 
         let (x_offset, y_offset) = key.subpixel_point.to_f64();
         let transform = Some(
@@ -200,11 +201,12 @@ impl FontContext {
 
     // TODO: Pipe GlyphOptions into glyph_dimensions too
     pub fn get_glyph_dimensions(&self,
+                                font: &FontInstanceKey,
                                 key: &GlyphKey)
                                 -> Option<GlyphDimensions> {
         // Probably have to default to something else here.
         let render_mode = FontRenderMode::Subpixel;
-        let analysis = self.create_glyph_analysis(key, render_mode, None);
+        let analysis = self.create_glyph_analysis(font, key);
 
         let texture_type = dwrite_texture_type(render_mode);
 
@@ -219,11 +221,11 @@ impl FontContext {
             return None
         }
 
-        let face = self.fonts.get(&key.font_key).unwrap();
+        let face = self.fonts.get(&font.font_key).unwrap();
         face.get_design_glyph_metrics(&[key.index as u16], false)
             .first()
             .map(|metrics| {
-                let em_size = key.size.to_f32_px() / 16.;
+                let em_size = font.size.to_f32_px() / 16.;
                 let design_units_per_pixel = face.metrics().designUnitsPerEm as f32 / 16. as f32;
                 let scaled_design_units_to_pixels = em_size / design_units_per_pixel;
                 let advance = metrics.advanceWidth as f32 * scaled_design_units_to_pixels;
@@ -280,14 +282,11 @@ impl FontContext {
     }
 
     pub fn rasterize_glyph(&mut self,
-                           key: &GlyphKey,
-                           render_mode: FontRenderMode,
-                           glyph_options: Option<GlyphOptions>)
+                           font: &FontInstanceKey,
+                           key: &GlyphKey)
                            -> Option<RasterizedGlyph> {
-        let analysis = self.create_glyph_analysis(key,
-                                                  render_mode,
-                                                  glyph_options);
-        let texture_type = dwrite_texture_type(render_mode);
+        let analysis = self.create_glyph_analysis(font, key);
+        let texture_type = dwrite_texture_type(font.render_mode);
 
         let bounds = analysis.get_alpha_texture_bounds(texture_type);
         let width = (bounds.right - bounds.left) as usize;
@@ -301,8 +300,8 @@ impl FontContext {
 
         let mut pixels = analysis.create_alpha_texture(texture_type, bounds);
 
-        if render_mode != FontRenderMode::Mono {
-            let lut_correction = match glyph_options {
+        if font.render_mode != FontRenderMode::Mono {
+            let lut_correction = match font.glyph_options {
                 Some(option) => {
                     if option.force_gdi_rendering {
                         &self.gdi_gamma_lut
@@ -314,13 +313,13 @@ impl FontContext {
             };
 
             lut_correction.preblend_rgb(&mut pixels, width, height,
-                                        ColorLut::new(key.color.r,
-                                                      key.color.g,
-                                                      key.color.b,
-                                                      key.color.a));
+                                        ColorLut::new(font.color.r,
+                                                      font.color.g,
+                                                      font.color.b,
+                                                      font.color.a));
         }
 
-        let rgba_pixels = self.convert_to_rgba(&mut pixels, render_mode);
+        let rgba_pixels = self.convert_to_rgba(&mut pixels, font.render_mode);
 
         Some(RasterizedGlyph {
             left: bounds.left as f32,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntS
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, TextShadow};
 use api::{LayerToWorldTransform, TileOffset, WebGLContextId, YuvColorSpace, YuvFormat};
-use api::{device_length, LayerVector2D, LineOrientation, LineStyle};
+use api::{device_length, FontInstanceKey, LayerVector2D, LineOrientation, LineStyle};
 use app_units::Au;
 use border::BorderCornerInstance;
 use euclid::{Size2D};
@@ -558,12 +558,13 @@ impl TextRunPrimitiveCpu {
             TextRunMode::Shadow => self.shadow_render_mode,
         };
 
-        resource_cache.request_glyphs(self.font_key,
-                                      font_size_dp,
-                                      self.color,
-                                      &self.glyph_instances,
-                                      render_mode,
-                                      self.glyph_options);
+        let font = FontInstanceKey::new(self.font_key,
+                                        font_size_dp,
+                                        self.color,
+                                        render_mode,
+                                        self.glyph_options);
+
+        resource_cache.request_glyphs(font, &self.glyph_instances);
     }
 
     fn write_gpu_blocks(&self,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -160,10 +160,10 @@ impl RenderBackend {
                         ApiMsg::DeleteFont(id) => {
                             self.resource_cache.delete_font_template(id);
                         }
-                        ApiMsg::GetGlyphDimensions(glyph_keys, tx) => {
+                        ApiMsg::GetGlyphDimensions(font, glyph_keys, tx) => {
                             let mut glyph_dimensions = Vec::with_capacity(glyph_keys.len());
                             for glyph_key in &glyph_keys {
-                                let glyph_dim = self.resource_cache.get_glyph_dimensions(glyph_key);
+                                let glyph_dim = self.resource_cache.get_glyph_dimensions(&font, glyph_key);
                                 glyph_dimensions.push(glyph_dim);
                             };
                             tx.send(glyph_dimensions).unwrap();

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint, DeviceIntSize};
 use {DeviceUintRect, DeviceUintSize, FontKey, GlyphDimensions, GlyphKey};
 use {ImageData, ImageDescriptor, ImageKey, LayoutPoint, LayoutVector2D, LayoutSize, LayoutTransform};
-use {NativeFontHandle, WorldPoint};
+use {FontInstanceKey, NativeFontHandle, WorldPoint};
 #[cfg(feature = "webgl")]
 use {WebGLCommand, WebGLContextId};
 
@@ -23,7 +23,7 @@ pub enum ApiMsg {
     AddNativeFont(FontKey, NativeFontHandle),
     DeleteFont(FontKey),
     /// Gets the glyph dimensions
-    GetGlyphDimensions(Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
+    GetGlyphDimensions(FontInstanceKey, Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Gets the glyph indices from a string
     GetGlyphIndices(FontKey, String, MsgSender<Vec<Option<u32>>>),
     /// Adds an image from the resource cache.
@@ -229,10 +229,12 @@ impl RenderApi {
     /// Note: Internally, the internal texture cache doesn't store
     /// 'empty' textures (height or width = 0)
     /// This means that glyph dimensions e.g. for spaces (' ') will mostly be None.
-    pub fn get_glyph_dimensions(&self, glyph_keys: Vec<GlyphKey>)
+    pub fn get_glyph_dimensions(&self,
+                                font: FontInstanceKey,
+                                glyph_keys: Vec<GlyphKey>)
                                 -> Vec<Option<GlyphDimensions>> {
         let (tx, rx) = channel::msg_channel().unwrap();
-        let msg = ApiMsg::GetGlyphDimensions(glyph_keys, tx);
+        let msg = ApiMsg::GetGlyphDimensions(font, glyph_keys, tx);
         self.api_sender.send(msg).unwrap();
         rx.recv().unwrap()
     }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -5,7 +5,7 @@
 use app_units::Au;
 use euclid::SideOffsets2D;
 use {ColorF, FontKey, ImageKey, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
-use {LayoutVector2D, PipelineId, PropertyBinding, WebGLContextId};
+use {GlyphOptions, LayoutVector2D, PipelineId, PropertyBinding, WebGLContextId};
 
 // NOTE: some of these structs have an "IMPLICIT" comment.
 // This indicates that the BuiltDisplayList will have serialized
@@ -131,18 +131,10 @@ pub struct TextDisplayItem {
     pub glyph_options: Option<GlyphOptions>,
 } // IMPLICIT: glyphs: Vec<GlyphInstance>
 
-#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct GlyphOptions {
-    // These are currently only used on windows for dwrite fonts.
-    pub use_embedded_bitmap: bool,
-    pub force_gdi_rendering: bool,
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WebGLDisplayItem {
     pub context_id: WebGLContextId,
 }
-
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct NormalBorder {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -222,16 +222,18 @@ impl Wrench {
                                     .collect();
 
         // Retrieve the metrics for each glyph.
+        let font = FontInstanceKey::new(font_key,
+                                        size,
+                                        ColorF::new(0.0, 0.0, 0.0, 1.0),
+                                        FontRenderMode::Alpha,
+                                        None);
         let mut keys = Vec::new();
         for glyph_index in &indices {
-            keys.push(GlyphKey::new(font_key,
-                                    size,
-                                    ColorF::new(0.0, 0.0, 0.0, 1.0),
-                                    *glyph_index,
+            keys.push(GlyphKey::new(*glyph_index,
                                     LayerPoint::zero(),
                                     FontRenderMode::Alpha));
         }
-        let metrics = self.api.get_glyph_dimensions(keys);
+        let metrics = self.api.get_glyph_dimensions(font, keys);
 
         // Extract the advances from the metrics. The get_glyph_dimensions API
         // has a limitation that it can't currently get dimensions for non-renderable


### PR DESCRIPTION
This is prep work only. It splits fields up into a separate struct
that has values that change per-font-instance vs per-glyph.

This makes several upcoming changes feasible that will reduce the
amount and cost of hash lookups we do in the resource cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1522)
<!-- Reviewable:end -->
