### PR TITLE
Fix incorrectly deleted resources in clear_namespace function.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -810,7 +810,7 @@ impl ResourceCache {
     pub fn clear_namespace(&mut self, namespace: IdNamespace) {
         //TODO: use `retain` when we are on Rust-1.18
         let image_keys: Vec<_> = self.resources.image_templates.images.keys()
-                                                                      .filter(|&key| key.0 != namespace)
+                                                                      .filter(|&key| key.0 == namespace)
                                                                       .cloned()
                                                                       .collect();
         for key in &image_keys {
@@ -818,7 +818,7 @@ impl ResourceCache {
         }
 
         let font_keys: Vec<_> = self.resources.font_templates.keys()
-                                                             .filter(|&key| key.0 != namespace)
+                                                             .filter(|&key| key.0 == namespace)
                                                              .cloned()
                                                              .collect();
         for key in &font_keys {


### PR DESCRIPTION
clear_namespace function is removing resources from different namespaces from the IdNamespace argument. Image_keys and font_keys are filtered by `key.0 != namespace` instead of `key.0 == namespace`

Rust-1.18 is already available so I used the retain function to fix both the issue and the TODO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1524)
<!-- Reviewable:end -->
