### PR TITLE
Text rendering optimizations and bug fixes.

### DIFF
--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -7,6 +7,10 @@
 // drawn un-transformed. These are used for effects such
 // as text-shadow.
 
+#define SUBPX_DIR_NONE        0
+#define SUBPX_DIR_HORIZONTAL  1
+#define SUBPX_DIR_VERTICAL    2
+
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
@@ -25,6 +29,20 @@ void main(void) {
     TextShadow shadow = fetch_text_shadow(text_shadow_address + VECS_PER_PRIM_HEADER);
 
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
+
+    // In subpixel mode, the subpixel offset has already been
+    // accounted for while rasterizing the glyph.
+    switch (text.subpx_dir) {
+        case SUBPX_DIR_NONE:
+            break;
+        case SUBPX_DIR_HORIZONTAL:
+            glyph.offset.x = trunc(glyph.offset.x);
+            break;
+        case SUBPX_DIR_VERTICAL:
+            glyph.offset.y = trunc(glyph.offset.y);
+            break;
+    }
+
     GlyphResource res = fetch_glyph_resource(resource_address);
 
     // Glyphs size is already in device-pixels.

--- a/webrender/res/cs_text_run.vs.glsl
+++ b/webrender/res/cs_text_run.vs.glsl
@@ -7,10 +7,6 @@
 // drawn un-transformed. These are used for effects such
 // as text-shadow.
 
-#define SUBPX_DIR_NONE        0
-#define SUBPX_DIR_HORIZONTAL  1
-#define SUBPX_DIR_VERTICAL    2
-
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
@@ -28,20 +24,9 @@ void main(void) {
     PrimitiveGeometry shadow_geom = fetch_primitive_geometry(text_shadow_address);
     TextShadow shadow = fetch_text_shadow(text_shadow_address + VECS_PER_PRIM_HEADER);
 
-    Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
-
-    // In subpixel mode, the subpixel offset has already been
-    // accounted for while rasterizing the glyph.
-    switch (text.subpx_dir) {
-        case SUBPX_DIR_NONE:
-            break;
-        case SUBPX_DIR_HORIZONTAL:
-            glyph.offset.x = trunc(glyph.offset.x);
-            break;
-        case SUBPX_DIR_VERTICAL:
-            glyph.offset.y = trunc(glyph.offset.y);
-            break;
-    }
+    Glyph glyph = fetch_glyph(prim.specific_prim_address,
+                              glyph_index,
+                              text.subpx_dir);
 
     GlyphResource res = fetch_glyph_resource(resource_address);
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -802,11 +802,12 @@ Line fetch_line(int address) {
 struct TextRun {
     vec4 color;
     vec2 offset;
+    int subpx_dir;
 };
 
 TextRun fetch_text_run(int address) {
     vec4 data[2] = fetch_from_resource_cache_2(address);
-    return TextRun(data[0], data[1].xy);
+    return TextRun(data[0], data[1].xy, int(data[1].z));
 }
 
 struct Image {

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -59,6 +59,10 @@
 #define LINE_STYLE_DASHED       2
 #define LINE_STYLE_WAVY         3
 
+#define SUBPX_DIR_NONE        0
+#define SUBPX_DIR_HORIZONTAL  1
+#define SUBPX_DIR_VERTICAL    2
+
 uniform sampler2DArray sCacheA8;
 uniform sampler2DArray sCacheRGBA8;
 
@@ -419,7 +423,9 @@ struct Glyph {
     vec2 offset;
 };
 
-Glyph fetch_glyph(int specific_prim_address, int glyph_index) {
+Glyph fetch_glyph(int specific_prim_address,
+                  int glyph_index,
+                  int subpx_dir) {
     // Two glyphs are packed in each texel in the GPU cache.
     int glyph_address = specific_prim_address +
                         VECS_PER_TEXT_RUN +
@@ -427,6 +433,20 @@ Glyph fetch_glyph(int specific_prim_address, int glyph_index) {
     vec4 data = fetch_from_resource_cache_1(glyph_address);
     // Select XY or ZW based on glyph index.
     vec2 glyph = mix(data.xy, data.zw, bvec2(glyph_index % 2 == 1));
+
+    // In subpixel mode, the subpixel offset has already been
+    // accounted for while rasterizing the glyph.
+    switch (subpx_dir) {
+        case SUBPX_DIR_NONE:
+            break;
+        case SUBPX_DIR_HORIZONTAL:
+            glyph.x = trunc(glyph.x);
+            break;
+        case SUBPX_DIR_VERTICAL:
+            glyph.y = trunc(glyph.y);
+            break;
+    }
+
     return Glyph(glyph);
 }
 

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -3,30 +3,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define RENDER_MODE_MONO        0
-#define RENDER_MODE_ALPHA       1
-#define RENDER_MODE_SUBPIXEL    2
+#define SUBPX_DIR_NONE        0
+#define SUBPX_DIR_HORIZONTAL  1
+#define SUBPX_DIR_VERTICAL    2
 
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
 
     int glyph_index = prim.user_data0;
-    int render_mode = prim.user_data1;
-    int resource_address = prim.user_data2;
+    int resource_address = prim.user_data1;
 
     Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
     GlyphResource res = fetch_glyph_resource(resource_address);
 
-    switch (render_mode) {
-        case RENDER_MODE_ALPHA:
+    // In subpixel mode, the subpixel offset has already been
+    // accounted for while rasterizing the glyph.
+    switch (text.subpx_dir) {
+        case SUBPX_DIR_NONE:
             break;
-        case RENDER_MODE_MONO:
+        case SUBPX_DIR_HORIZONTAL:
+            glyph.offset.x = trunc(glyph.offset.x);
             break;
-        case RENDER_MODE_SUBPIXEL:
-            // In subpixel mode, the subpixel offset has already been
-            // accounted for while rasterizing the glyph.
-            glyph.offset = trunc(glyph.offset);
+        case SUBPX_DIR_VERTICAL:
+            glyph.offset.y = trunc(glyph.offset.y);
             break;
     }
 

--- a/webrender/res/ps_text_run.vs.glsl
+++ b/webrender/res/ps_text_run.vs.glsl
@@ -3,10 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define SUBPX_DIR_NONE        0
-#define SUBPX_DIR_HORIZONTAL  1
-#define SUBPX_DIR_VERTICAL    2
-
 void main(void) {
     Primitive prim = load_primitive();
     TextRun text = fetch_text_run(prim.specific_prim_address);
@@ -14,21 +10,10 @@ void main(void) {
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data1;
 
-    Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
+    Glyph glyph = fetch_glyph(prim.specific_prim_address,
+                              glyph_index,
+                              text.subpx_dir);
     GlyphResource res = fetch_glyph_resource(resource_address);
-
-    // In subpixel mode, the subpixel offset has already been
-    // accounted for while rasterizing the glyph.
-    switch (text.subpx_dir) {
-        case SUBPX_DIR_NONE:
-            break;
-        case SUBPX_DIR_HORIZONTAL:
-            glyph.offset.x = trunc(glyph.offset.x);
-            break;
-        case SUBPX_DIR_VERTICAL:
-            glyph.offset.y = trunc(glyph.offset.y);
-            break;
-    }
 
     vec2 local_pos = glyph.offset +
                      text.offset +

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 use std::mem;
 use texture_cache::{TextureCacheItemId, TextureCache};
 #[cfg(test)]
-use api::{ColorF, FontRenderMode, IdNamespace};
+use api::{ColorF, FontRenderMode, IdNamespace, SubpixelDirection};
 use api::{FontInstanceKey, LayoutPoint};
 use api::{FontKey, FontTemplate};
 use api::{ImageData, ImageDescriptor, ImageFormat};
@@ -321,12 +321,11 @@ pub struct GlyphRequest {
 }
 
 impl GlyphRequest {
-    pub fn new(
-        font: FontInstanceKey,
-        index: u32,
-        point: LayoutPoint) -> Self {
+    pub fn new(font: FontInstanceKey, index: u32, point: LayoutPoint) -> Self {
+        let key = GlyphKey::new(index, point, font.render_mode, font.subpx_dir);
+
         GlyphRequest {
-            key: GlyphKey::new(index, point, font.render_mode),
+            key,
             font,
         }
     }
@@ -374,6 +373,7 @@ fn raterize_200_glyphs() {
         size: Au::from_px(32),
         render_mode: FontRenderMode::Subpixel,
         glyph_options: None,
+        subpx_dir: SubpixelDirection::Horizontal,
     };
 
     for i in 0..4 {

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -16,7 +16,7 @@ use core_text;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use api::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
-use api::{GlyphKey, SubpixelPoint};
+use api::{GlyphKey, SubpixelDirection};
 use api::{FontInstanceKey, NativeFontHandle};
 use gamma_lut::{GammaLut, Color as ColorLut};
 use std::ptr;
@@ -83,7 +83,8 @@ fn supports_subpixel_aa() -> bool {
 
 fn get_glyph_metrics(ct_font: &CTFont,
                      glyph: CGGlyph,
-                     subpixel_point: &SubpixelPoint) -> GlyphMetrics {
+                     x_offset: f64,
+                     y_offset: f64) -> GlyphMetrics {
     let bounds = ct_font.get_bounding_rects_for_glyphs(kCTFontDefaultOrientation, &[glyph]);
 
     if bounds.origin.x.is_nan() || bounds.origin.y.is_nan() ||
@@ -102,8 +103,6 @@ fn get_glyph_metrics(ct_font: &CTFont,
             advance: 0.0,
         };
     }
-
-    let (x_offset, y_offset) = subpixel_point.to_f64();
 
     // First round out to pixel boundaries
     // CG Origin is bottom left
@@ -242,7 +241,8 @@ impl FontContext {
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         self.get_ct_font(font.font_key, font.size).and_then(|ref ct_font| {
             let glyph = key.index as CGGlyph;
-            let metrics = get_glyph_metrics(ct_font, glyph, &key.subpixel_point);
+            let (x_offset, y_offset) = get_subpx_offset(font, key);
+            let metrics = get_glyph_metrics(ct_font, glyph, x_offset, y_offset);
             if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
                 None
             } else {
@@ -307,7 +307,8 @@ impl FontContext {
         };
 
         let glyph = key.index as CGGlyph;
-        let metrics = get_glyph_metrics(&ct_font, glyph, &key.subpixel_point);
+        let (x_offset, y_offset) = get_subpx_offset(font, key);
+        let metrics = get_glyph_metrics(&ct_font, glyph, x_offset, y_offset);
         if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
             return Some(RasterizedGlyph::blank())
         }
@@ -364,8 +365,6 @@ impl FontContext {
         cg_context.set_should_smooth_fonts(smooth);
         cg_context.set_allows_antialiasing(antialias);
         cg_context.set_should_antialias(antialias);
-
-        let (x_offset, y_offset) = key.subpixel_point.to_f64();
 
         // CG Origin is bottom left, WR is top left. Need -y offset
         let rasterization_origin = CGPoint {
@@ -441,3 +440,10 @@ impl FontContext {
     }
 }
 
+fn get_subpx_offset(font: &FontInstanceKey, glyph: &GlyphKey) -> (f64, f64) {
+    match font.subpx_dir {
+        SubpixelDirection::None => (0.0, 0.0),
+        SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
+        SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
+    }
+}

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -241,7 +241,7 @@ impl FontContext {
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         self.get_ct_font(font.font_key, font.size).and_then(|ref ct_font| {
             let glyph = key.index as CGGlyph;
-            let (x_offset, y_offset) = get_subpx_offset(font, key);
+            let (x_offset, y_offset) = font.get_subpx_offset(key);
             let metrics = get_glyph_metrics(ct_font, glyph, x_offset, y_offset);
             if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
                 None
@@ -307,7 +307,7 @@ impl FontContext {
         };
 
         let glyph = key.index as CGGlyph;
-        let (x_offset, y_offset) = get_subpx_offset(font, key);
+        let (x_offset, y_offset) = font.get_subpx_offset(key);
         let metrics = get_glyph_metrics(&ct_font, glyph, x_offset, y_offset);
         if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
             return Some(RasterizedGlyph::blank())
@@ -437,13 +437,5 @@ impl FontContext {
             height: metrics.rasterized_height,
             bytes: rasterized_pixels,
         })
-    }
-}
-
-fn get_subpx_offset(font: &FontInstanceKey, glyph: &GlyphKey) -> (f64, f64) {
-    match font.subpx_dir {
-        SubpixelDirection::None => (0.0, 0.0),
-        SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
-        SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
     }
 }

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use api::{FontKey, FontRenderMode, GlyphDimensions};
-use api::{FontInstanceKey, GlyphKey, GlyphOptions};
+use api::{FontInstanceKey, GlyphKey, GlyphOptions, SubpixelDirection};
 use gamma_lut::{GammaLut, Color as ColorLut};
 
 use dwrote;
@@ -181,7 +181,7 @@ impl FontContext {
                                                     dwrite_measure_mode,
                                                     font.glyph_options);
 
-        let (x_offset, y_offset) = key.subpixel_point.to_f64();
+        let (x_offset, y_offset) = get_subpx_offset(font, key);
         let transform = Some(
                         dwrote::DWRITE_MATRIX { m11: 1.0, m12: 0.0, m21: 0.0, m22: 1.0,
                                                 dx: x_offset as f32, dy: y_offset as f32 }
@@ -328,5 +328,13 @@ impl FontContext {
             height: height as u32,
             bytes: rgba_pixels,
         })
+    }
+}
+
+fn get_subpx_offset(font: &FontInstanceKey, glyph: &GlyphKey) -> (f64, f64) {
+    match font.subpx_dir {
+        SubpixelDirection::None => (0.0, 0.0),
+        SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
+        SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
     }
 }

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -181,7 +181,7 @@ impl FontContext {
                                                     dwrite_measure_mode,
                                                     font.glyph_options);
 
-        let (x_offset, y_offset) = get_subpx_offset(font, key);
+        let (x_offset, y_offset) = font.get_subpx_offset(key);
         let transform = Some(
                         dwrote::DWRITE_MATRIX { m11: 1.0, m12: 0.0, m21: 0.0, m22: 1.0,
                                                 dx: x_offset as f32, dy: y_offset as f32 }
@@ -328,13 +328,5 @@ impl FontContext {
             height: height as u32,
             bytes: rgba_pixels,
         })
-    }
-}
-
-fn get_subpx_offset(font: &FontInstanceKey, glyph: &GlyphKey) -> (f64, f64) {
-    match font.subpx_dir {
-        SubpixelDirection::None => (0.0, 0.0),
-        SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
-        SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
     }
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -21,8 +21,8 @@ use api::{BlobImageResources, BlobImageData};
 use api::{DevicePoint, DeviceIntSize, DeviceUintRect, DeviceUintSize};
 use api::{Epoch, FontInstanceKey, FontKey, FontTemplate};
 use api::{GlyphDimensions, GlyphKey, GlyphInstance, IdNamespace};
-use api::{ImageData, ImageDescriptor, ImageKey, ImageRendering, LayoutPoint};
-use api::{SubpixelPoint, TileOffset, TileSize};
+use api::{ImageData, ImageDescriptor, ImageKey, ImageRendering};
+use api::{TileOffset, TileSize};
 use api::{ExternalImageData, ExternalImageType, WebGLContextId};
 use rayon::ThreadPool;
 use glyph_rasterizer::{GlyphRasterizer, GlyphCache, GlyphRequest};
@@ -494,16 +494,11 @@ impl ResourceCache {
                          glyph_instances: &[GlyphInstance],
                          mut f: F) -> SourceTexture where F: FnMut(usize, &GpuCacheHandle) {
         debug_assert_eq!(self.state, State::QueryResources);
-        let mut glyph_request = GlyphRequest::new(
-            font,
-            0,
-            LayoutPoint::zero(),
-        );
         let mut texture_id = None;
         for (loop_index, glyph_instance) in glyph_instances.iter().enumerate() {
-            glyph_request.key.index = glyph_instance.index;
-            glyph_request.key.subpixel_point = SubpixelPoint::new(glyph_instance.point,
-                                                                  glyph_request.font.render_mode);
+            let glyph_request = GlyphRequest::new(font.clone(),
+                                                  glyph_instance.index,
+                                                  glyph_instance.point);
 
             let image_id = self.cached_glyphs.get(&glyph_request, self.current_frame_id);
             let cache_item = image_id.map(|image_id| self.texture_cache.get(image_id));

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -493,15 +493,14 @@ impl AlphaRenderItem {
                                                         font_size_dp,
                                                         text_cpu.color,
                                                         text_cpu.normal_render_mode,
-                                                        text_cpu.glyph_options);
+                                                        text_cpu.glyph_options,
+                                                        text_cpu.subpx_dir);
 
                         let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                        &text_cpu.glyph_instances,
                                                                        |index, handle| {
                             let uv_address = handle.as_int(gpu_cache);
-                            instances.push(base_instance.build(index as i32,
-                                                               text_cpu.normal_render_mode as i32,
-                                                               uv_address));
+                            instances.push(base_instance.build(index as i32, uv_address, 0));
                         });
 
                         if texture_id != SourceTexture::Invalid {
@@ -1070,7 +1069,8 @@ impl RenderTarget for ColorRenderTarget {
                                                                     font_size_dp,
                                                                     text.color,
                                                                     text.shadow_render_mode,
-                                                                    text.glyph_options);
+                                                                    text.glyph_options,
+                                                                    text.subpx_dir);
 
                                     let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                                    &text.glyph_instances,

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -80,6 +80,14 @@ pub enum FontRenderMode {
     Subpixel,
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
+pub enum SubpixelDirection {
+    None = 0,
+    Horizontal,
+    Vertical,
+}
+
 const FIXED16_SHIFT: i32 = 16;
 
 // This matches the behaviour of SkScalarToFixed
@@ -92,10 +100,6 @@ impl FontRenderMode {
     // Skia quantizes subpixel offets into 1/4 increments.
     // Given the absolute position, return the quantized increment
     fn subpixel_quantize_offset(&self, pos: f32) -> SubpixelOffset {
-        if *self != FontRenderMode::Subpixel {
-            return SubpixelOffset::Zero;
-        }
-
         const SUBPIXEL_BITS: i32 = 2;
         const SUBPIXEL_FIXED16_MASK: i32 = ((1 << SUBPIXEL_BITS) - 1) << (FIXED16_SHIFT - SUBPIXEL_BITS);
 
@@ -133,26 +137,6 @@ impl Into<f64> for SubpixelOffset {
     }
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
-pub struct SubpixelPoint {
-    pub x: SubpixelOffset,
-    pub y: SubpixelOffset,
-}
-
-impl SubpixelPoint {
-    pub fn new(point: LayoutPoint,
-               render_mode: FontRenderMode) -> SubpixelPoint {
-        SubpixelPoint {
-            x: render_mode.subpixel_quantize_offset(point.x),
-            y: render_mode.subpixel_quantize_offset(point.y),
-        }
-    }
-
-    pub fn to_f64(&self) -> (f64, f64) {
-        (self.x.into(), self.y.into())
-    }
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {
     // These are currently only used on windows for dwrite fonts.
@@ -172,6 +156,7 @@ pub struct FontInstanceKey {
     pub color: ColorU,
     pub render_mode: FontRenderMode,
     pub glyph_options: Option<GlyphOptions>,
+    pub subpx_dir: SubpixelDirection,
 }
 
 impl FontInstanceKey {
@@ -179,7 +164,8 @@ impl FontInstanceKey {
                size: Au,
                mut color: ColorF,
                render_mode: FontRenderMode,
-               glyph_options: Option<GlyphOptions>) -> FontInstanceKey {
+               glyph_options: Option<GlyphOptions>,
+               subpx_dir: SubpixelDirection) -> FontInstanceKey {
         // In alpha/mono mode, the color of the font is irrelevant.
         // Forcing it to black in those cases saves rasterizing glyphs
         // of different colors when not needed.
@@ -193,6 +179,7 @@ impl FontInstanceKey {
             color: color.into(),
             render_mode,
             glyph_options,
+            subpx_dir,
         }
     }
 }
@@ -200,16 +187,23 @@ impl FontInstanceKey {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
 pub struct GlyphKey {
     pub index: u32,
-    pub subpixel_point: SubpixelPoint,
+    pub subpixel_offset: SubpixelOffset,
 }
 
 impl GlyphKey {
     pub fn new(index: u32,
                point: LayoutPoint,
-               render_mode: FontRenderMode) -> GlyphKey {
+               render_mode: FontRenderMode,
+               subpx_dir: SubpixelDirection) -> GlyphKey {
+        let pos = match subpx_dir {
+            SubpixelDirection::None => 0.0,
+            SubpixelDirection::Horizontal => point.x,
+            SubpixelDirection::Vertical => point.y,
+        };
+
         GlyphKey {
             index,
-            subpixel_point: SubpixelPoint::new(point, render_mode),
+            subpixel_offset: render_mode.subpixel_quantize_offset(pos),
         }
     }
 }

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -182,6 +182,14 @@ impl FontInstanceKey {
             subpx_dir,
         }
     }
+
+    pub fn get_subpx_offset(&self, glyph: &GlyphKey) -> (f64, f64) {
+        match self.subpx_dir {
+            SubpixelDirection::None => (0.0, 0.0),
+            SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
+            SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
+        }
+    }
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -228,12 +228,14 @@ impl Wrench {
                                         size,
                                         ColorF::new(0.0, 0.0, 0.0, 1.0),
                                         FontRenderMode::Alpha,
-                                        None);
+                                        None,
+                                        SubpixelDirection::Horizontal);
         let mut keys = Vec::new();
         for glyph_index in &indices {
             keys.push(GlyphKey::new(*glyph_index,
                                     LayerPoint::zero(),
-                                    FontRenderMode::Alpha));
+                                    FontRenderMode::Alpha,
+                                    SubpixelDirection::Horizontal));
         }
         let metrics = self.api.get_glyph_dimensions(font, keys);
 


### PR DESCRIPTION
* Switch subpixel positioning to be applied on one axis only.
  Subpixel positioning only needs to be applied on the axis of the text run direction.
  Reduces the number of glyphs rasterized significantly, saving texture memory and CPU time.
* Switch shader truncating of text run vertices to be based on the subpixel positioning direction.
* Apply subpixel positioning to alpha AA text runs (including shadows).
* Fix a bug in Linux subpixel AA mode where the dimensions didn't match the bitmap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1525)
<!-- Reviewable:end -->
