### PR TITLE
Define ClipAndScrollInfo to have empty heap size

### DIFF
--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -670,3 +670,4 @@ define_empty_heap_size_of!(MixBlendMode);
 define_empty_heap_size_of!(TransformStyle);
 define_empty_heap_size_of!(LocalClip);
 define_empty_heap_size_of!(ScrollSensitivity);
+define_empty_heap_size_of!(ClipAndScrollInfo);


### PR DESCRIPTION
This makes it easier to use in Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1526)
<!-- Reviewable:end -->
