### PR TITLE
Implement subpixel positioning for Linux / Freetype.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "freetype"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1042,7 +1042,7 @@ dependencies = [
  "core-text 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1177,7 +1177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum expat-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cef36cd1a8a02d28b91d97347c63247b9e4cb8a8e36df36f8201dc87a1c0859c"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum font-loader 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4cffa6a4953349a6dc37945f1f14228ca009e29cc7c3e9abc5fd78ac884a19a2"
-"checksum freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fde23272c687e4570aefec06cb71174ec0f5284b725deac4e77ba2665d635faf"
+"checksum freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "398b8a11884898184d55aca9806f002b3cf68f0e860e0cbb4586f834ee39b0e7"
 "checksum futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "55f0008e13fc853f79ea8fc86e931486860d4c4c156cdffb59fa5f7fa833660a"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f72af1e933f296b827361eb9e70d0267abf8ad0de9ec7fa667bbe67177b297"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -38,7 +38,7 @@ rand = "0.3"                # for the benchmarks
 servo-glutin = "0.11"     # for the example apps
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
-freetype = { version = "0.2", default-features = false }
+freetype = { version = "0.3", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.4"

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -3,19 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{FontInstanceKey, FontKey, FontRenderMode, GlyphDimensions};
-use api::{NativeFontHandle};
+use api::{NativeFontHandle, SubpixelDirection};
 use api::{GlyphKey};
 use internal_types::FastHashMap;
 
-use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode};
+use freetype::freetype::{FT_Render_Mode, FT_Pixel_Mode, FT_BBox, FT_Outline_Translate};
 use freetype::freetype::{FT_Done_FreeType, FT_Library_SetLcdFilter};
-use freetype::freetype::{FT_Library, FT_Set_Char_Size};
-use freetype::freetype::{FT_Face, FT_Long, FT_UInt, FT_F26Dot6};
+use freetype::freetype::{FT_Library, FT_Set_Char_Size, FT_Outline_Get_CBox};
+use freetype::freetype::{FT_Face, FT_Long, FT_UInt, FT_F26Dot6, FT_Glyph_Format};
 use freetype::freetype::{FT_Init_FreeType, FT_Load_Glyph, FT_Render_Glyph};
 use freetype::freetype::{FT_New_Memory_Face, FT_GlyphSlot, FT_LcdFilter};
 use freetype::freetype::{FT_Done_Face, FT_Error, FT_Int32, FT_Get_Char_Index};
 
-use std::{cmp, mem, ptr, slice};
+use std::{mem, ptr, slice};
 
 // This constant is not present in the freetype
 // bindings due to bindgen not handling the way
@@ -35,7 +35,7 @@ struct Face {
 pub struct FontContext {
     lib: FT_Library,
     faces: FastHashMap<FontKey, Face>,
-    lcd_extra_pixels: i32,
+    lcd_extra_pixels: i64,
 }
 
 // FreeType resources are safe to move between threads as long as they
@@ -130,30 +130,6 @@ impl FontContext {
             FT_Set_Char_Size(face.face, char_size as FT_F26Dot6, 0, 0, 0)
         });
 
-        // TODO(gw): Linux / Freetype doesn't actually apply subpixel
-        //           positioning. The code below doesn't quite work
-        //           because FreeType doesn't transform the the metrics
-        //           when using FT_Set_Transform, which complicates things.
-        //           Need to refactor how the metrics are calculated in
-        //           order to enable subpixel positioning.
-/*
-        let subpixel_offset: f64 = glyph.subpixel_offset.into();
-        let ft_offset = subpixel_offset * 64.0 + 0.5;
-        let mut translation = match font.subpx_dir {
-            SubpixelDirection::None => {
-                FT_Vector { x: 0, y: 0 }
-            }
-            SubpixelDirection::Horizontal => {
-                FT_Vector { x: ft_offset as FT_Long, y: 0 }
-            }
-            SubpixelDirection::Vertical => {
-                FT_Vector { x: 0, y: ft_offset as FT_Long }
-            }
-        };
-        unsafe {
-            FT_Set_Transform(face.face, ptr::null_mut(), &mut translation);
-        }*/
-
         let result = unsafe {
             FT_Load_Glyph(face.face,
                           glyph.index as FT_UInt,
@@ -163,7 +139,19 @@ impl FontContext {
         if result == SUCCESS {
             let slot = unsafe { (*face.face).glyph };
             assert!(slot != ptr::null_mut());
-            Some(slot)
+
+            // TODO(gw): We use the FT_Outline_* APIs to manage sub-pixel offsets.
+            //           We will need a custom code path for bitmap fonts (which
+            //           are very rare).
+            match unsafe { (*slot).format } {
+                FT_Glyph_Format::FT_GLYPH_FORMAT_OUTLINE => {
+                    Some(slot)
+                }
+                _ => {
+                    error!("TODO: Support bitmap fonts!");
+                    None
+                }
+            }
         } else {
             error!("Unable to load glyph for {} of size {:?} from font {:?}, {:?}",
                 glyph.index, font.size, font.font_key, result);
@@ -171,26 +159,72 @@ impl FontContext {
         }
     }
 
+    // Get the bounding box for a glyph, accounting for sub-pixel positioning.
+    fn get_bounding_box(&self,
+                        slot: FT_GlyphSlot,
+                        font: &FontInstanceKey,
+                        glyph: &GlyphKey) -> FT_BBox {
+        let mut cbox: FT_BBox = unsafe { mem::uninitialized() };
+
+        // Get the estimated bounding box from FT (control points).
+        unsafe {
+            FT_Outline_Get_CBox(&(*slot).outline, &mut cbox);
+        }
+
+        // Convert the subpixel offset to floats.
+        let (dx, dy) = font.get_subpx_offset(glyph);
+
+        // Apply extra pixel of padding for subpixel AA, due to the filter.
+        let padding = match font.render_mode {
+            FontRenderMode::Subpixel => self.lcd_extra_pixels * 64,
+            FontRenderMode::Alpha | FontRenderMode::Mono => 0,
+        };
+        cbox.xMin -= padding;
+        cbox.xMax += padding;
+
+        // Offset the bounding box by subpixel positioning.
+        // Convert to 26.6 fixed point format for FT.
+        match font.subpx_dir {
+            SubpixelDirection::None => {}
+            SubpixelDirection::Horizontal => {
+                let dx = (dx * 64.0 + 0.5) as FT_Long;
+                cbox.xMin += dx;
+                cbox.xMax += dx;
+            }
+            SubpixelDirection::Vertical => {
+                let dy = (dy * 64.0 + 0.5) as FT_Long;
+                cbox.yMin += dy;
+                cbox.yMax += dy;
+            }
+        }
+
+        // Outset the box to device pixel boundaries
+        cbox.xMin &= !63;
+        cbox.yMin &= !63;
+        cbox.xMax = (cbox.xMax + 63) & !63;
+        cbox.yMax = (cbox.yMax + 63) & !63;
+
+        cbox
+    }
+
     fn get_glyph_dimensions_impl(&self,
                                  slot: FT_GlyphSlot,
-                                 render_mode: FontRenderMode) -> Option<GlyphDimensions> {
+                                 font: &FontInstanceKey,
+                                 glyph: &GlyphKey) -> Option<GlyphDimensions> {
         let metrics = unsafe { &(*slot).metrics };
-        if metrics.width == 0 || metrics.height == 0 {
+
+        // If there's no advance, no need to consider this glyph
+        // for layout.
+        if metrics.horiAdvance == 0 {
             None
         } else {
-            let padding = match render_mode {
-                FontRenderMode::Subpixel => self.lcd_extra_pixels,
-                FontRenderMode::Alpha | FontRenderMode::Mono => 0,
-            };
-            let left = (metrics.horiBearingX >> 6) as i32 - padding;
-            let top = (metrics.horiBearingY >> 6) as i32;
-            let right = padding + ((metrics.horiBearingX + metrics.width + 0x3f) >> 6) as i32;
-            let bottom = ((metrics.horiBearingY + metrics.height + 0x3f) >> 6) as i32;
+            let cbox = self.get_bounding_box(slot, font, glyph);
+
             Some(GlyphDimensions {
-                left: left,
-                top: top,
-                width: (right - left) as u32,
-                height: (bottom - top) as u32,
+                left: (cbox.xMin >> 6) as i32,
+                top: (cbox.yMax >> 6) as i32,
+                width: ((cbox.xMax - cbox.xMin) >> 6) as u32,
+                height: ((cbox.yMax - cbox.yMin) >> 6) as u32,
                 advance: metrics.horiAdvance as f32 / 64.0,
             })
         }
@@ -215,7 +249,7 @@ impl FontContext {
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         let slot = self.load_glyph(font, key);
         slot.and_then(|slot| {
-            self.get_glyph_dimensions_impl(slot, font.render_mode)
+            self.get_glyph_dimensions_impl(slot, font, key)
         })
     }
 
@@ -228,11 +262,38 @@ impl FontContext {
             Some(slot) => slot,
             None => return None,
         };
+
         let render_mode = match font.render_mode {
             FontRenderMode::Mono => FT_Render_Mode::FT_RENDER_MODE_MONO,
             FontRenderMode::Alpha => FT_Render_Mode::FT_RENDER_MODE_NORMAL,
             FontRenderMode::Subpixel => FT_Render_Mode::FT_RENDER_MODE_LCD,
         };
+
+        // Get dimensions of the glyph, to see if we need to rasterize it.
+        let dimensions = match self.get_glyph_dimensions_impl(slot, font, key) {
+            Some(val) => val,
+            None => return None,
+        };
+
+        // For spaces and other non-printable characters, early out.
+        if dimensions.width == 0 || dimensions.height == 0 {
+            return None;
+        }
+
+        // Get the subpixel offsets in FT 26.6 format.
+        let (dx, dy) = font.get_subpx_offset(key);
+        let dx = (dx * 64.0 + 0.5) as FT_Long;
+        let dy = (dy * 64.0 + 0.5) as FT_Long;
+
+        // Move the outline curves to be at the origin, taking
+        // into account the subpixel positioning.
+        unsafe {
+            let outline = &(*slot).outline;
+            let mut cbox: FT_BBox = mem::uninitialized();
+            FT_Outline_Get_CBox(outline, &mut cbox);
+            FT_Outline_Translate(outline, dx - ((cbox.xMin + dx) & !63),
+                                          dy - ((cbox.yMin + dy) & !63));
+        }
 
         let result = unsafe { FT_Render_Glyph(slot, render_mode) };
         if result != SUCCESS {
@@ -240,88 +301,68 @@ impl FontContext {
             return None;
         }
 
-        let dimensions = match self.get_glyph_dimensions_impl(slot, font.render_mode) {
-            Some(val) => val,
-            None => return None,
-        };
-
         let bitmap = unsafe { &(*slot).bitmap };
         let pixel_mode = unsafe { mem::transmute(bitmap.pixel_mode as u32) };
         info!("Rasterizing {:?} as {:?} with dimensions {:?}", key, render_mode, dimensions);
-        // we may be filling only a part of the buffer, so initialize the whole thing with 0
-        let mut final_buffer = Vec::with_capacity(dimensions.width as usize *
-                                                  dimensions.height as usize *
-                                                  4);
 
-        let offset_x = dimensions.left - unsafe { (*slot).bitmap_left };
-        let src_pixel_width = match pixel_mode {
+        let actual_width = match pixel_mode {
             FT_Pixel_Mode::FT_PIXEL_MODE_LCD => {
                 assert!(bitmap.width % 3 == 0);
                 bitmap.width / 3
             },
-            _ => bitmap.width,
-        };
-        // determine the destination range of texels that `bitmap` provides data for
-        let dst_start = cmp::max(0, -offset_x);
-        let dst_end = cmp::min(dimensions.width as i32, src_pixel_width as i32 - offset_x);
+            FT_Pixel_Mode::FT_PIXEL_MODE_MONO |
+            FT_Pixel_Mode::FT_PIXEL_MODE_GRAY => {
+                bitmap.width
+            }
+            _ => {
+                panic!("Unexpected pixel mode!");
+            }
+        } as i32;
 
-        for y in 0 .. dimensions.height {
-            let src_y = y as i32 - dimensions.top + unsafe { (*slot).bitmap_top };
-            if src_y < 0 || src_y >= bitmap.rows as i32 {
-                for _x in 0 .. dimensions.width {
-                    final_buffer.extend_from_slice(&[0xff, 0xff, 0xff, 0]);
-                }
-                continue
-            }
-            let base = unsafe {
-                bitmap.buffer.offset((src_y * bitmap.pitch) as isize)
+        let actual_height = bitmap.rows as i32;
+        let top = unsafe { (*slot).bitmap_top };
+        let left = unsafe { (*slot).bitmap_left };
+        let mut final_buffer = vec![0; (actual_width * actual_height * 4) as usize];
+
+        // Extract the final glyph from FT format into RGBA8 format, which is
+        // what WR expects.
+        for y in 0..actual_height {
+            // Get pointer to the bytes for this row.
+            let mut src = unsafe {
+                bitmap.buffer.offset((y * bitmap.pitch) as isize)
             };
-            for _x in 0 .. dst_start {
-                final_buffer.extend_from_slice(&[0xff, 0xff, 0xff, 0]);
-            }
-            match pixel_mode {
-                FT_Pixel_Mode::FT_PIXEL_MODE_MONO => {
-                    for x in dst_start .. dst_end {
-                        let src_x = x + offset_x;
-                        let mask = 0x80 >> (src_x & 0x7);
-                        let byte = unsafe {
-                            *base.offset((src_x >> 3) as isize)
-                        };
+
+            for x in 0..actual_width {
+                let value = match pixel_mode {
+                    FT_Pixel_Mode::FT_PIXEL_MODE_MONO => {
+                        let mask = 0x80 >> (x & 0x7);
+                        let byte = unsafe { *src.offset((x >> 3) as isize) };
                         let alpha = if byte & mask != 0 { 0xff } else { 0 };
-                        final_buffer.extend_from_slice(&[0xff, 0xff, 0xff, alpha]);
+                        [0xff, 0xff, 0xff, alpha]
                     }
-                }
-                FT_Pixel_Mode::FT_PIXEL_MODE_GRAY => {
-                    for x in dst_start .. dst_end {
-                        let alpha = unsafe {
-                            *base.offset((x + offset_x) as isize)
-                        };
-                        final_buffer.extend_from_slice(&[0xff, 0xff, 0xff, alpha]);
+                    FT_Pixel_Mode::FT_PIXEL_MODE_GRAY => {
+                        let alpha = unsafe { *src };
+                        src = unsafe { src.offset(1) };
+                        [0xff, 0xff, 0xff, alpha]
                     }
-                }
-                FT_Pixel_Mode::FT_PIXEL_MODE_LCD => {
-                    for x in dst_start .. dst_end {
-                        let src_x = ((x + offset_x) * 3) as isize;
-                        assert!(src_x+2 < bitmap.pitch as isize);
-                        let t = unsafe {
-                            slice::from_raw_parts(base.offset(src_x), 3)
-                        };
-                        final_buffer.extend_from_slice(&[t[2], t[1], t[0], 0xff]);
+                    FT_Pixel_Mode::FT_PIXEL_MODE_LCD => {
+                        let t = unsafe { slice::from_raw_parts(src, 3) };
+                        src = unsafe { src.offset(3) };
+                        [t[2], t[1], t[0], 0xff]
                     }
-                }
-                _ => panic!("Unsupported {:?}", pixel_mode)
+                    _ => panic!("Unsupported {:?}", pixel_mode)
+                };
+                let i = 4 * (y * actual_width + x) as usize;
+                let dest = &mut final_buffer[i..i+4];
+                dest.clone_from_slice(&value);
             }
-            for _x in dst_end .. dimensions.width as i32 {
-                final_buffer.extend_from_slice(&[0xff, 0xff, 0xff, 0]);
-            }
-            assert_eq!(final_buffer.len(), ((y+1) * dimensions.width * 4) as usize);
         }
 
         Some(RasterizedGlyph {
-            left: dimensions.left as f32,
-            top: dimensions.top as f32,
-            width: dimensions.width as u32,
-            height: dimensions.height as u32,
+            left: (dimensions.left + left) as f32,
+            top: (dimensions.top + top - actual_height) as f32,
+            width: actual_width as u32,
+            height: actual_height as u32,
             bytes: final_buffer,
         })
     }


### PR DESCRIPTION
Refactor how the bounding box / dimensions are calculated,
correctly handling subpixel positioning offsets.

Simplify the code to extract the rasterized bitmap, now that
we can rely on the bounding box being correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1528)
<!-- Reviewable:end -->
