### PR TITLE
Implement updating external image buffers.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -816,8 +816,23 @@ impl TextureCache {
         }
 
         let op = match data {
-            ImageData::External(..) => {
-                panic!("Doesn't support Update() for external image.");
+            ImageData::External(ext_image) => {
+                match ext_image.image_type {
+                    ExternalImageType::Texture2DHandle |
+                    ExternalImageType::TextureRectHandle |
+                    ExternalImageType::TextureExternalHandle => {
+                        panic!("External texture handle should not go through texture_cache.");
+                    }
+                    ExternalImageType::ExternalBuffer => {
+                        TextureUpdateOp::UpdateForExternalBuffer {
+                            rect: existing_item.allocated_rect,
+                            id: ext_image.id,
+                            channel_index: ext_image.channel_index,
+                            stride: descriptor.stride,
+                            offset: descriptor.offset,
+                        }
+                    }
+                }
             }
             ImageData::Blob(..) => {
                 panic!("The vector image should have been rasterized into a raw image.");


### PR DESCRIPTION
Initial implementation that ignores the dirty rect, which is correct but just misses the potential optimization of uploading a sub-rectangle of the image. Right now gecko is not wired up to send the dirty rect so I don't have a good way to test the optimization handy and I want to make progress on image updates as soon as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1529)
<!-- Reviewable:end -->
