### PR TITLE
Make it possible to batch updates into transactions in the API.

### DIFF
--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -22,6 +22,7 @@ use webrender::api::*;
 fn body(_api: &RenderApi,
         _document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        _resouces: &mut ResourceUpdates,
         _pipeline_id: &PipelineId,
         _layout_size: &LayoutSize) {
     // Create a 100x100 stacking context with an animatable transform property.

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -176,6 +176,7 @@ fn main() {
 fn body(api: &RenderApi,
         _document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        resources: &mut ResourceUpdates,
         _pipeline_id: &PipelineId,
         layout_size: &LayoutSize) {
     let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);
@@ -188,10 +189,12 @@ fn body(api: &RenderApi,
                                   Vec::new());
 
     let image_mask_key = api.generate_image_key();
-    api.add_image(image_mask_key,
-                  ImageDescriptor::new(2, 2, ImageFormat::A8, true),
-                  ImageData::new(vec![0, 80, 180, 255]),
-                  None);
+    resources.add_image(
+        image_mask_key,
+        ImageDescriptor::new(2, 2, ImageFormat::A8, true),
+        ImageData::new(vec![0, 80, 180, 255]),
+        None
+    );
     let mask = ImageMask {
         image: image_mask_key,
         rect: (75, 75).by(100, 100),
@@ -231,7 +234,7 @@ fn body(api: &RenderApi,
     if false { // draw text?
         let font_key = api.generate_font_key();
         let font_bytes = load_file("res/FreeSans.ttf");
-        api.add_raw_font(font_key, font_bytes, 0);
+        resources.add_raw_font(font_key, font_bytes, 0);
 
         let text_bounds = (100, 200).by(700, 300);
         let glyphs = vec![

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -215,10 +215,11 @@ impl api::BlobImageRenderer for CheckerboardRenderer {
 fn body(api: &api::RenderApi,
         _document_id: &api::DocumentId,
         builder: &mut api::DisplayListBuilder,
+        resources: &mut api::ResourceUpdates,
         _pipeline_id: &api::PipelineId,
         layout_size: &api::LayoutSize) {
     let blob_img1 = api.generate_image_key();
-    api.add_image(
+    resources.add_image(
         blob_img1,
         api::ImageDescriptor::new(500, 500, api::ImageFormat::BGRA8, true),
         api::ImageData::new_blob_image(serialize_blob(api::ColorU::new(50, 50, 150, 255))),
@@ -226,7 +227,7 @@ fn body(api: &api::RenderApi,
     );
 
     let blob_img2 = api.generate_image_key();
-    api.add_image(
+    resources.add_image(
         blob_img2,
         api::ImageDescriptor::new(200, 200, api::ImageFormat::BGRA8, true),
         api::ImageData::new_blob_image(serialize_blob(api::ColorU::new(50, 150, 50, 255))),

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -54,6 +54,7 @@ impl HandyDandyRectBuilder for (i32, i32) {
 pub fn main_wrapper(builder_callback: fn(&RenderApi,
                                          &DocumentId,
                                          &mut DisplayListBuilder,
+                                         &mut ResourceUpdates,
                                          &PipelineId,
                                          &LayoutSize) -> (),
                     event_handler: fn(&glutin::Event,
@@ -114,8 +115,9 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
     let pipeline_id = PipelineId(0, 0);
     let layout_size = LayoutSize::new(width as f32, height as f32);
     let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
+    let mut resources = ResourceUpdates::new();
 
-    builder_callback(&api, &document_id, &mut builder, &pipeline_id, &layout_size);
+    builder_callback(&api, &document_id, &mut builder, &mut resources, &pipeline_id, &layout_size);
 
     api.set_display_list(
         document_id,
@@ -123,7 +125,9 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
         Some(root_background_color),
         LayoutSize::new(width as f32, height as f32),
         builder.finalize(),
-        true);
+        true,
+        resources
+    );
     api.set_root_pipeline(document_id, pipeline_id);
     api.generate_frame(document_id, None);
 

--- a/webrender/examples/iframe.rs
+++ b/webrender/examples/iframe.rs
@@ -19,6 +19,7 @@ use webrender::api::*;
 fn body(api: &RenderApi,
         document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        _resources: &mut ResourceUpdates,
         pipeline_id: &PipelineId,
         _layout_size: &LayoutSize) {
 
@@ -46,7 +47,9 @@ fn body(api: &RenderApi,
         None,
         sub_bounds.size,
         sub_builder.finalize(),
-        true);
+        true,
+        ResourceUpdates::new(),
+    );
 
     let bounds = sub_bounds;
     // And this is for the root pipeline

--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -19,6 +19,7 @@ use webrender::api::*;
 fn body(_api: &RenderApi,
         _document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        _resources: &mut ResourceUpdates,
         pipeline_id: &PipelineId,
         layout_size: &LayoutSize) {
     let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -19,6 +19,7 @@ use webrender::api::*;
 fn body(_api: &RenderApi,
         _document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        _resources: &mut ResourceUpdates,
         _pipeline_id: &PipelineId,
         layout_size: &LayoutSize) {
     let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -164,6 +164,7 @@ fn main() {
 fn body(api: &RenderApi,
         _document_id: &DocumentId,
         builder: &mut DisplayListBuilder,
+        resources: &mut ResourceUpdates,
         _pipeline_id: &PipelineId,
         layout_size: &LayoutSize) {
     let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);
@@ -175,30 +176,29 @@ fn body(api: &RenderApi,
                                   MixBlendMode::Normal,
                                   Vec::new());
 
-
     let yuv_chanel1 = api.generate_image_key();
     let yuv_chanel2 = api.generate_image_key();
     let yuv_chanel2_1 = api.generate_image_key();
     let yuv_chanel3 = api.generate_image_key();
-    api.add_image(
+    resources.add_image(
         yuv_chanel1,
         ImageDescriptor::new(100, 100, ImageFormat::A8, true),
         ImageData::new(vec![127; 100 * 100]),
         None,
     );
-    api.add_image(
+    resources.add_image(
         yuv_chanel2,
         ImageDescriptor::new(100, 100, ImageFormat::RG8, true),
         ImageData::new(vec![0; 100 * 100 * 2]),
         None,
     );
-    api.add_image(
+    resources.add_image(
         yuv_chanel2_1,
         ImageDescriptor::new(100, 100, ImageFormat::A8, true),
         ImageData::new(vec![127; 100 * 100]),
         None,
     );
-    api.add_image(
+    resources.add_image(
         yuv_chanel3,
         ImageDescriptor::new(100, 100, ImageFormat::A8, true),
         ImageData::new(vec![127; 100 * 100]),

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -64,12 +64,7 @@ impl ApiRecordingReceiver for BinaryRecorder {
 
 pub fn should_record_msg(msg: &ApiMsg) -> bool {
     match *msg {
-        ApiMsg::AddRawFont(..) |
-        ApiMsg::AddNativeFont(..) |
-        ApiMsg::DeleteFont(..) |
-        ApiMsg::AddImage(..) |
-        ApiMsg::UpdateImage(..) |
-        ApiMsg::DeleteImage(..) |
+        ApiMsg::UpdateResources(..) |
         ApiMsg::AddDocument{..} |
         ApiMsg::UpdateDocument(..) |
         ApiMsg::DeleteDocument(..) |

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -7,7 +7,7 @@ use frame::FrameId;
 use glyph_cache::GlyphCache;
 use gpu_cache::{GpuCache, GpuCacheHandle};
 use internal_types::{FastHashMap, FastHashSet, SourceTexture, TextureUpdateList};
-use profiler::TextureCacheProfileCounters;
+use profiler::{ResourceProfileCounters, TextureCacheProfileCounters};
 use std::cmp;
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::fmt::Debug;
@@ -16,7 +16,7 @@ use std::mem;
 use std::sync::Arc;
 use texture_cache::{TextureCache, TextureCacheItemId};
 use api::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest};
-use api::{BlobImageResources, BlobImageData};
+use api::{BlobImageResources, BlobImageData, ResourceUpdates, AddFont};
 use api::{DevicePoint, DeviceIntSize, DeviceUintRect, DeviceUintSize};
 use api::{Epoch, FontInstanceKey, FontKey, FontTemplate};
 use api::{GlyphDimensions, GlyphKey, IdNamespace};
@@ -295,6 +295,47 @@ impl ResourceCache {
                 // not make sense to tile them into smaller ones.
                 info.image_type == ExternalImageType::ExternalBuffer && size_check
             },
+        }
+    }
+
+    pub fn update_resources(
+        &mut self,
+        updates: ResourceUpdates,
+        profile_counters: &mut ResourceProfileCounters
+    ) {
+        // TODO, there is potential for optimization here, by processing updates in
+        // bulk rather than one by one (for example by sorting allocations by size or
+        // in a way that reduces fragmentation in the atlas).
+
+        for img in updates.deleted_images {
+            self.delete_image_template(img);
+        }
+
+        for img in updates.added_images {
+            if let ImageData::Raw(ref bytes) = img.data {
+                profile_counters.image_templates.inc(bytes.len());
+            }
+            self.add_image_template(img.key, img.descriptor, img.data, img.tiling);
+        }
+
+        for img in updates.updated_images {
+            self.update_image_template(img.key, img.descriptor, img.data, img.dirty_rect);
+        }
+
+        for font in updates.added_fonts {
+            match font {
+                AddFont::Raw(id, bytes, index) => {
+                    profile_counters.font_templates.inc(bytes.len());
+                    self.add_font_template(id, FontTemplate::Raw(Arc::new(bytes), index));
+                }
+                AddFont::Native(id, native_font_handle) => {
+                    self.add_font_template(id, FontTemplate::Native(native_font_handle));
+                }
+            }
+        }
+
+        for font in updates.deleted_fonts {
+            self.delete_font_template(font);
         }
     }
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -20,21 +20,22 @@ pub type TileSize = u16;
 /// The resource updates for a given transaction (they must be applied in the same frame).
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ResourceUpdates {
-    pub added_images: Vec<AddImage>,
-    pub updated_images: Vec<UpdateImage>,
-    pub deleted_images: Vec<ImageKey>,
-    pub added_fonts: Vec<AddFont>,
-    pub deleted_fonts: Vec<FontKey>,
+    pub updates: Vec<ResourceUpdate>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub enum ResourceUpdate {
+    AddImage(AddImage),
+    UpdateImage(UpdateImage),
+    DeleteImage(ImageKey),
+    AddFont(AddFont),
+    DeleteFont(FontKey),
 }
 
 impl ResourceUpdates {
     pub fn new() -> Self {
         ResourceUpdates {
-            added_images: Vec::new(),
-            updated_images: Vec::new(),
-            deleted_images: Vec::new(),
-            added_fonts: Vec::new(),
-            deleted_fonts: Vec::new(),
+            updates: Vec::new(),
         }
     }
 
@@ -45,7 +46,7 @@ impl ResourceUpdates {
         data: ImageData,
         tiling: Option<TileSize>
     ) {
-        self.added_images.push(AddImage { key, descriptor, data, tiling });
+        self.updates.push(ResourceUpdate::AddImage(AddImage { key, descriptor, data, tiling }));
     }
 
     pub fn update_image(
@@ -55,23 +56,23 @@ impl ResourceUpdates {
         data: ImageData,
         dirty_rect: Option<DeviceUintRect>
     ) {
-        self.updated_images.push(UpdateImage { key, descriptor, data, dirty_rect });
+        self.updates.push(ResourceUpdate::UpdateImage(UpdateImage { key, descriptor, data, dirty_rect }));
     }
 
     pub fn delete_image(&mut self, key: ImageKey) {
-        self.deleted_images.push(key);
+        self.updates.push(ResourceUpdate::DeleteImage(key));
     }
 
     pub fn add_raw_font(&mut self, key: FontKey, bytes: Vec<u8>, index: u32) {
-        self.added_fonts.push(AddFont::Raw(key, bytes, index));
+        self.updates.push(ResourceUpdate::AddFont(AddFont::Raw(key, bytes, index)));
     }
 
     pub fn add_native_font(&mut self, key: FontKey, native_handle: NativeFontHandle) {
-        self.added_fonts.push(AddFont::Native(key, native_handle));
+        self.updates.push(ResourceUpdate::AddFont(AddFont::Native(key, native_handle)));
     }
 
     pub fn delete_font(&mut self, key: FontKey) {
-        self.deleted_fonts.push(key);
+        self.updates.push(ResourceUpdate::DeleteFont(key));
     }
 }
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -17,19 +17,97 @@ use {WebGLCommand, WebGLContextId};
 
 pub type TileSize = u16;
 
+/// The resource updates for a given transaction (they must be applied in the same frame).
+#[derive(Clone, Deserialize, Serialize)]
+pub struct ResourceUpdates {
+    pub added_images: Vec<AddImage>,
+    pub updated_images: Vec<UpdateImage>,
+    pub deleted_images: Vec<ImageKey>,
+    pub added_fonts: Vec<AddFont>,
+    pub deleted_fonts: Vec<FontKey>,
+}
+
+impl ResourceUpdates {
+    pub fn new() -> Self {
+        ResourceUpdates {
+            added_images: Vec::new(),
+            updated_images: Vec::new(),
+            deleted_images: Vec::new(),
+            added_fonts: Vec::new(),
+            deleted_fonts: Vec::new(),
+        }
+    }
+
+    pub fn add_image(
+        &mut self,
+        key: ImageKey,
+        descriptor: ImageDescriptor,
+        data: ImageData,
+        tiling: Option<TileSize>
+    ) {
+        self.added_images.push(AddImage { key, descriptor, data, tiling });
+    }
+
+    pub fn update_image(
+        &mut self,
+        key: ImageKey,
+        descriptor: ImageDescriptor,
+        data: ImageData,
+        dirty_rect: Option<DeviceUintRect>
+    ) {
+        self.updated_images.push(UpdateImage { key, descriptor, data, dirty_rect });
+    }
+
+    pub fn delete_image(&mut self, key: ImageKey) {
+        self.deleted_images.push(key);
+    }
+
+    pub fn add_raw_font(&mut self, key: FontKey, bytes: Vec<u8>, index: u32) {
+        self.added_fonts.push(AddFont::Raw(key, bytes, index));
+    }
+
+    pub fn add_native_font(&mut self, key: FontKey, native_handle: NativeFontHandle) {
+        self.added_fonts.push(AddFont::Native(key, native_handle));
+    }
+
+    pub fn delete_font(&mut self, key: FontKey) {
+        self.deleted_fonts.push(key);
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AddImage {
+    pub key: ImageKey,
+    pub descriptor: ImageDescriptor,
+    pub data: ImageData,
+    pub tiling: Option<TileSize>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct UpdateImage {
+    pub key: ImageKey,
+    pub descriptor: ImageDescriptor,
+    pub data: ImageData,
+    pub dirty_rect: Option<DeviceUintRect>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub enum AddFont {
+    Raw(FontKey, Vec<u8>, u32),
+    Native(FontKey, NativeFontHandle),
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub enum DocumentMsg {
-    // Supplies a new frame to WebRender.
-    ///
-    /// After receiving this message, WebRender will read the display list from the payload channel.
     SetDisplayList {
+        list_descriptor: BuiltDisplayListDescriptor,
         epoch: Epoch,
         pipeline_id: PipelineId,
         background: Option<ColorF>,
         viewport_size: LayoutSize,
         content_size: LayoutSize,
-        list_descriptor: BuiltDisplayListDescriptor,
         preserve_frame_state: bool,
+        resources: ResourceUpdates,
     },
     SetPageZoom(ZoomFactor),
     SetPinchZoom(ZoomFactor),
@@ -66,19 +144,12 @@ impl fmt::Debug for DocumentMsg {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum ApiMsg {
-    AddRawFont(FontKey, Vec<u8>, u32),
-    AddNativeFont(FontKey, NativeFontHandle),
-    DeleteFont(FontKey),
+    /// Add/remove/update images and fonts.
+    UpdateResources(ResourceUpdates),
     /// Gets the glyph dimensions
     GetGlyphDimensions(FontInstanceKey, Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Gets the glyph indices from a string
     GetGlyphIndices(FontKey, String, MsgSender<Vec<Option<u32>>>),
-    /// Adds an image from the resource cache.
-    AddImage(ImageKey, ImageDescriptor, ImageData, Option<TileSize>),
-    /// Updates the the resource cache with the new image data.
-    UpdateImage(ImageKey, ImageDescriptor, ImageData, Option<DeviceUintRect>),
-    /// Drops an image from the resource cache.
-    DeleteImage(ImageKey),
     /// Adds a new document namespace.
     CloneApi(MsgSender<IdNamespace>),
     /// Adds a new document with given initial size.
@@ -104,14 +175,9 @@ pub enum ApiMsg {
 impl fmt::Debug for ApiMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
-            ApiMsg::AddRawFont(..) => "ApiMsg::AddRawFont",
-            ApiMsg::AddNativeFont(..) => "ApiMsg::AddNativeFont",
-            ApiMsg::DeleteFont(..) => "ApiMsg::DeleteFont",
+            ApiMsg::UpdateResources(..) => "ApiMsg::UpdateResources",
             ApiMsg::GetGlyphDimensions(..) => "ApiMsg::GetGlyphDimensions",
             ApiMsg::GetGlyphIndices(..) => "ApiMsg::GetGlyphIndices",
-            ApiMsg::AddImage(..) => "ApiMsg::AddImage",
-            ApiMsg::UpdateImage(..) => "ApiMsg::UpdateImage",
-            ApiMsg::DeleteImage(..) => "ApiMsg::DeleteImage",
             ApiMsg::CloneApi(..) => "ApiMsg::CloneApi",
             ApiMsg::AddDocument(..) => "ApiMsg::AddDocument",
             ApiMsg::UpdateDocument(..) => "ApiMsg::UpdateDocument",
@@ -267,24 +333,6 @@ impl RenderApi {
         FontKey::new(self.namespace_id, new_id)
     }
 
-    pub fn add_raw_font(&self, key: FontKey, bytes: Vec<u8>, index: u32) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::AddRawFont(key, bytes, index);
-        self.api_sender.send(msg).unwrap();
-    }
-
-    pub fn add_native_font(&self, key: FontKey, native_font_handle: NativeFontHandle) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::AddNativeFont(key, native_font_handle);
-        self.api_sender.send(msg).unwrap();
-    }
-
-    pub fn delete_font(&self, key: FontKey) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::DeleteFont(key);
-        self.api_sender.send(msg).unwrap();
-    }
-
     /// Gets the dimensions for the supplied glyph keys
     ///
     /// Note: Internally, the internal texture cache doesn't store
@@ -318,35 +366,8 @@ impl RenderApi {
     }
 
     /// Adds an image identified by the `ImageKey`.
-    pub fn add_image(&self,
-                     key: ImageKey,
-                     descriptor: ImageDescriptor,
-                     data: ImageData,
-                     tiling: Option<TileSize>) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::AddImage(key, descriptor, data, tiling);
-        self.api_sender.send(msg).unwrap();
-    }
-
-    /// Updates a specific image.
-    ///
-    /// Currently doesn't support changing dimensions or format by updating.
-    // TODO: Support changing dimensions (and format) during image update?
-    pub fn update_image(&self,
-                        key: ImageKey,
-                        descriptor: ImageDescriptor,
-                        data: ImageData,
-                        dirty_rect: Option<DeviceUintRect>) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::UpdateImage(key, descriptor, data, dirty_rect);
-        self.api_sender.send(msg).unwrap();
-    }
-
-    /// Deletes the specific image.
-    pub fn delete_image(&self, key: ImageKey) {
-        debug_assert_eq!(key.0, self.namespace_id);
-        let msg = ApiMsg::DeleteImage(key);
-        self.api_sender.send(msg).unwrap();
+    pub fn update_resources(&self, resources: ResourceUpdates) {
+        self.api_sender.send(ApiMsg::UpdateResources(resources)).unwrap();
     }
 
     pub fn request_webgl_context(&self, size: &DeviceIntSize, attributes: GLContextAttributes)
@@ -458,15 +479,20 @@ impl RenderApi {
     /// * `preserve_frame_state`: If a previous frame exists which matches this pipeline
     ///                           id, this setting determines if frame state (such as scrolling
     ///                           position) should be preserved for this new display list.
+    /// * `resources`: A set of resource updates that must be applied at the same time as the
+    ///                display list.
     ///
     /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
-    pub fn set_display_list(&self,
-                            document_id: DocumentId,
-                            epoch: Epoch,
-                            background: Option<ColorF>,
-                            viewport_size: LayoutSize,
-                            (pipeline_id, content_size, display_list): (PipelineId, LayoutSize, BuiltDisplayList),
-                            preserve_frame_state: bool) {
+    pub fn set_display_list(
+        &self,
+        document_id: DocumentId,
+        epoch: Epoch,
+        background: Option<ColorF>,
+        viewport_size: LayoutSize,
+        (pipeline_id, content_size, display_list): (PipelineId, LayoutSize, BuiltDisplayList),
+        preserve_frame_state: bool,
+        resources: ResourceUpdates,
+    ) {
         let (display_list_data, list_descriptor) = display_list.into_data();
         self.send(document_id, DocumentMsg::SetDisplayList {
             epoch,
@@ -475,7 +501,8 @@ impl RenderApi {
             viewport_size,
             content_size,
             list_descriptor,
-            preserve_frame_state
+            preserve_frame_state,
+            resources,
         });
 
         self.payload_sender.send_payload(Payload {

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -90,11 +90,7 @@ impl BinaryFrameReader {
         }
 
         match *msg {
-            ApiMsg::AddRawFont(..) |
-            ApiMsg::AddNativeFont(..) |
-            ApiMsg::AddImage(..) |
-            ApiMsg::UpdateImage(..) |
-            ApiMsg::DeleteImage(..) => {
+            ApiMsg::UpdateResources(..) => {
                 true
             }
             _ => {

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -106,6 +106,56 @@ impl JsonFrameWriter {
         file.write_all(b"\n").unwrap();
     }
 
+    fn update_resources(&mut self, updates: &ResourceUpdates) {
+        for img in &updates.added_images {
+            let stride = img.descriptor.stride.unwrap_or(
+                img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
+            );
+            let bytes = match img.data {
+                ImageData::Raw(ref v) => { (**v).clone() }
+                ImageData::External(_) | ImageData::Blob(_) => { return; }
+            };
+            self.images.insert(img.key, CachedImage {
+                width: img.descriptor.width,
+                height: img.descriptor.height,
+                stride,
+                format: img.descriptor.format,
+                bytes: Some(bytes),
+                path: None,
+            });
+        }
+        for img in &updates.updated_images {
+            if let Some(ref mut data) = self.images.get_mut(&img.key) {
+                assert_eq!(data.width, img.descriptor.width);
+                assert_eq!(data.height, img.descriptor.height);
+                assert_eq!(data.format, img.descriptor.format);
+
+                if let ImageData::Raw(ref bytes) = img.data {
+                    *data.path.borrow_mut() = None;
+                    *data.bytes.borrow_mut() = Some((**bytes).clone());
+                } else {
+                    // Other existing image types only make sense within the gecko integration.
+                    println!("Wrench only supports updating buffer images (ignoring update command).");
+                }
+            }
+        }
+
+        for img in &updates.deleted_images {
+            self.images.remove(img);
+        }
+
+        for font in &updates.added_fonts {
+            match font {
+                &AddFont::Raw(key, ref bytes, index) => {
+                    self.fonts.insert(key, CachedFont::Raw(Some(bytes.clone()), index, None));
+                }
+                &AddFont::Native(key, ref handle) => {
+                    self.fonts.insert(key, CachedFont::Native(handle.clone()));
+                }
+            }
+        }
+    }
+
     fn next_rsrc_paths(prefix: &str, counter: &mut u32, base_path: &Path, base: &str, ext: &str) -> (PathBuf, PathBuf) {
         let mut path_file = base_path.to_owned();
         let mut path = PathBuf::from("res");
@@ -188,50 +238,8 @@ impl fmt::Debug for JsonFrameWriter {
 impl webrender::ApiRecordingReceiver for JsonFrameWriter {
     fn write_msg(&mut self, _: u32, msg: &ApiMsg) {
         match *msg {
-            ApiMsg::AddRawFont(ref key, ref bytes, index) => {
-                self.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), index, None));
-            }
-
-            ApiMsg::AddNativeFont(ref key, ref native_font_handle) => {
-                self.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
-            }
-
-            ApiMsg::AddImage(ref key, ref descriptor, ref data, _) => {
-                let stride = descriptor.stride.unwrap_or(
-                    descriptor.width * descriptor.format.bytes_per_pixel().unwrap()
-                );
-                let bytes = match *data {
-                    ImageData::Raw(ref v) => { (**v).clone() }
-                    ImageData::External(_) | ImageData::Blob(_) => { return; }
-                };
-                self.images.insert(*key, CachedImage {
-                    width: descriptor.width,
-                    height: descriptor.height,
-                    stride,
-                    format: descriptor.format,
-                    bytes: Some(bytes),
-                    path: None,
-                });
-            }
-
-            ApiMsg::UpdateImage(ref key, descriptor, ref img_data, _dirty_rect) => {
-                if let Some(ref mut data) = self.images.get_mut(key) {
-                    assert_eq!(data.width, descriptor.width);
-                    assert_eq!(data.height, descriptor.height);
-                    assert_eq!(data.format, descriptor.format);
-
-                    if let ImageData::Raw(ref bytes) = *img_data {
-                        *data.path.borrow_mut() = None;
-                        *data.bytes.borrow_mut() = Some((**bytes).clone());
-                    } else {
-                        // Other existing image types only make sense within the gecko integration.
-                        println!("Wrench only supports updating buffer images (ignoring update command).");
-                    }
-                }
-            }
-
-            ApiMsg::DeleteImage(ref key) => {
-                self.images.remove(key);
+            ApiMsg::UpdateResources(ref updates) => {
+                self.update_resources(updates)
             }
 
             ApiMsg::UpdateDocument(_, DocumentMsg::SetDisplayList {
@@ -240,8 +248,10 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 ref background,
                 ref viewport_size,
                 ref list_descriptor,
+                ref resources,
                 ..
             }) => {
+                self.update_resources(resources);
                 self.begin_write_display_list(epoch,
                                               pipeline_id,
                                               background,

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -271,7 +271,9 @@ impl Wrench {
     #[cfg(target_os = "windows")]
     pub fn font_key_from_native_handle(&mut self, descriptor: &NativeFontHandle) -> FontKey {
         let key = self.api.generate_font_key();
-        self.api.add_native_font(key, descriptor.clone());
+        let resources = ResourceUpdates::new();
+        resources.add_native_font(key, descriptor.clone());
+        self.api.update_resources(resources);
         key
     }
 
@@ -322,7 +324,9 @@ impl Wrench {
 
     pub fn font_key_from_bytes(&mut self, bytes: Vec<u8>, index: u32) -> FontKey {
         let key = self.api.generate_font_key();
-        self.api.add_raw_font(key, bytes, index);
+        let mut update = ResourceUpdates::new();
+        update.add_raw_font(key, bytes, index);
+        self.api.update_resources(update);
         key
     }
 
@@ -380,7 +384,9 @@ impl Wrench {
         };
         let tiling = tiling.map(|tile_size|{ tile_size as u16 });
         let image_key = self.api.generate_image_key();
-        self.api.add_image(image_key, descriptor, image_data, tiling);
+        let mut resources = ResourceUpdates::new();
+        resources.add_image(image_key, descriptor, image_data, tiling);
+        self.api.update_resources(resources);
         let val = (image_key, LayoutSize::new(descriptor.width as f32, descriptor.height as f32));
         self.image_map.insert(key, val);
         val
@@ -403,12 +409,15 @@ impl Wrench {
         let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
 
         for display_list in display_lists {
-            self.api.set_display_list(self.document_id,
-                                      Epoch(frame_number),
-                                      root_background_color,
-                                      self.window_size_f32(),
-                                      display_list,
-                                      false);
+            self.api.set_display_list(
+                self.document_id,
+                Epoch(frame_number),
+                root_background_color,
+                self.window_size_f32(),
+                display_list,
+                false,
+                ResourceUpdates::new()
+            );
         }
 
         for (id, offset) in scroll_offsets {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -359,52 +359,55 @@ impl YamlFrameWriter {
     }
 
     fn update_resources(&mut self, updates: &ResourceUpdates) {
-        for img in &updates.added_images {
-            let stride = img.descriptor.stride.unwrap_or(
-                img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
-            );
-            let bytes = match img.data {
-                ImageData::Raw(ref v) => { (**v).clone() }
-                ImageData::External(_) | ImageData::Blob(_) => { return; }
-            };
-            self.images.insert(img.key, CachedImage {
-                width: img.descriptor.width,
-                height: img.descriptor.height,
-                stride,
-                format: img.descriptor.format,
-                bytes: Some(bytes),
-                path: None,
-                tiling: img.tiling,
-            });
-        }
-        for img in &updates.updated_images {
-            if let Some(ref mut data) = self.images.get_mut(&img.key) {
-                assert_eq!(data.width, img.descriptor.width);
-                assert_eq!(data.height, img.descriptor.height);
-                assert_eq!(data.format, img.descriptor.format);
-
-                if let ImageData::Raw(ref bytes) = img.data {
-                    *data.path.borrow_mut() = None;
-                    *data.bytes.borrow_mut() = Some((**bytes).clone());
-                } else {
-                    // Other existing image types only make sense within the gecko integration.
-                    println!("Wrench only supports updating buffer images (ignoring update command).");
+        for update in &updates.updates {
+            match *update {
+                ResourceUpdate::AddImage(ref img) => {
+                    let stride = img.descriptor.stride.unwrap_or(
+                        img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
+                    );
+                    let bytes = match img.data {
+                        ImageData::Raw(ref v) => { (**v).clone() }
+                        ImageData::External(_) | ImageData::Blob(_) => { return; }
+                    };
+                    self.images.insert(img.key, CachedImage {
+                        width: img.descriptor.width,
+                        height: img.descriptor.height,
+                        stride,
+                        format: img.descriptor.format,
+                        bytes: Some(bytes),
+                        tiling: img.tiling,
+                        path: None,
+                    });
                 }
-            }
-        }
+                ResourceUpdate::UpdateImage(ref img) => {
+                    if let Some(ref mut data) = self.images.get_mut(&img.key) {
+                        assert_eq!(data.width, img.descriptor.width);
+                        assert_eq!(data.height, img.descriptor.height);
+                        assert_eq!(data.format, img.descriptor.format);
 
-        for img in &updates.deleted_images {
-            self.images.remove(img);
-        }
-
-        for font in &updates.added_fonts {
-            match font {
-                &AddFont::Raw(key, ref bytes, index) => {
-                    self.fonts.insert(key, CachedFont::Raw(Some(bytes.clone()), index, None));
+                        if let ImageData::Raw(ref bytes) = img.data {
+                            *data.path.borrow_mut() = None;
+                            *data.bytes.borrow_mut() = Some((**bytes).clone());
+                        } else {
+                            // Other existing image types only make sense within the gecko integration.
+                            println!("Wrench only supports updating buffer images (ignoring update command).");
+                        }
+                    }
                 }
-                &AddFont::Native(key, ref handle) => {
-                    self.fonts.insert(key, CachedFont::Native(handle.clone()));
+                ResourceUpdate::DeleteImage(img) => {
+                    self.images.remove(&img);
                 }
+                ResourceUpdate::AddFont(ref font) => {
+                    match font {
+                        &AddFont::Raw(key, ref bytes, index) => {
+                            self.fonts.insert(key, CachedFont::Raw(Some(bytes.clone()), index, None));
+                        }
+                        &AddFont::Native(key, ref handle) => {
+                            self.fonts.insert(key, CachedFont::Native(handle.clone()));
+                        }
+                    }
+                }
+                ResourceUpdate::DeleteFont(_) => {}
             }
         }
     }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -358,6 +358,57 @@ impl YamlFrameWriter {
         scene.finish_display_list(self.pipeline_id.unwrap(), dl);
     }
 
+    fn update_resources(&mut self, updates: &ResourceUpdates) {
+        for img in &updates.added_images {
+            let stride = img.descriptor.stride.unwrap_or(
+                img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
+            );
+            let bytes = match img.data {
+                ImageData::Raw(ref v) => { (**v).clone() }
+                ImageData::External(_) | ImageData::Blob(_) => { return; }
+            };
+            self.images.insert(img.key, CachedImage {
+                width: img.descriptor.width,
+                height: img.descriptor.height,
+                stride,
+                format: img.descriptor.format,
+                bytes: Some(bytes),
+                path: None,
+                tiling: img.tiling,
+            });
+        }
+        for img in &updates.updated_images {
+            if let Some(ref mut data) = self.images.get_mut(&img.key) {
+                assert_eq!(data.width, img.descriptor.width);
+                assert_eq!(data.height, img.descriptor.height);
+                assert_eq!(data.format, img.descriptor.format);
+
+                if let ImageData::Raw(ref bytes) = img.data {
+                    *data.path.borrow_mut() = None;
+                    *data.bytes.borrow_mut() = Some((**bytes).clone());
+                } else {
+                    // Other existing image types only make sense within the gecko integration.
+                    println!("Wrench only supports updating buffer images (ignoring update command).");
+                }
+            }
+        }
+
+        for img in &updates.deleted_images {
+            self.images.remove(img);
+        }
+
+        for font in &updates.added_fonts {
+            match font {
+                &AddFont::Raw(key, ref bytes, index) => {
+                    self.fonts.insert(key, CachedFont::Raw(Some(bytes.clone()), index, None));
+                }
+                &AddFont::Native(key, ref handle) => {
+                    self.fonts.insert(key, CachedFont::Native(handle.clone()));
+                }
+            }
+        }
+    }
+
     fn next_rsrc_paths(prefix: &str, counter: &mut u32, base_path: &Path, base: &str, ext: &str) -> (PathBuf, PathBuf) {
         let mut path_file = base_path.to_owned();
         let mut path = PathBuf::from("res");
@@ -830,51 +881,8 @@ impl YamlFrameWriter {
 impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
     fn write_msg(&mut self, _: u32, msg: &ApiMsg) {
         match *msg {
-            ApiMsg::AddRawFont(ref key, ref bytes, index) => {
-                self.frame_writer.fonts.insert(*key, CachedFont::Raw(Some(bytes.clone()), index, None));
-            }
-
-            ApiMsg::AddNativeFont(ref key, ref native_font_handle) => {
-                self.frame_writer.fonts.insert(*key, CachedFont::Native(native_font_handle.clone()));
-            }
-
-            ApiMsg::AddImage(ref key, ref descriptor, ref data, ref tiling) => {
-                let stride = descriptor.stride.unwrap_or(
-                    descriptor.width * descriptor.format.bytes_per_pixel().unwrap()
-                );
-                let bytes = match *data {
-                    ImageData::Raw(ref v) => { (**v).clone() }
-                    ImageData::External(_) | ImageData::Blob(_) => { return; }
-                };
-                self.frame_writer.images.insert(*key, CachedImage {
-                    width: descriptor.width,
-                    height: descriptor.height,
-                    stride,
-                    format: descriptor.format,
-                    bytes: Some(bytes),
-                    path: None,
-                    tiling: *tiling,
-                });
-            }
-
-            ApiMsg::UpdateImage(ref key, ref descriptor, ref img_data, _dirty_rect) => {
-                if let Some(ref mut data) = self.frame_writer.images.get_mut(key) {
-                    assert_eq!(data.width, descriptor.width);
-                    assert_eq!(data.height, descriptor.height);
-                    assert_eq!(data.format, descriptor.format);
-
-                    if let ImageData::Raw(ref bytes) = *img_data {
-                        *data.path.borrow_mut() = None;
-                        *data.bytes.borrow_mut() = Some((**bytes).clone());
-                    } else {
-                        // Other existing image types only make sense within the gecko integration.
-                        println!("Wrench only supports updating buffer images (ignoring update command).");
-                    }
-                }
-            }
-
-            ApiMsg::DeleteImage(ref key) => {
-                self.frame_writer.images.remove(key);
+            ApiMsg::UpdateResources(ref updates) => {
+                self.frame_writer.update_resources(updates);
             }
 
             ApiMsg::UpdateDocument(_, DocumentMsg::SetRootPipeline(ref pipeline_id)) => {
@@ -886,8 +894,10 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 ref background,
                 ref viewport_size,
                 ref list_descriptor,
+                ref resources,
                 ..
             }) => {
+                self.frame_writer.update_resources(resources);
                 self.frame_writer.begin_write_display_list(&mut self.scene,
                                                            epoch,
                                                            pipeline_id,


### PR DESCRIPTION
Add a `ResourceUpdates` struct which groups addition/updates/deletions of images and can be sent as transaction:
 -  with a display list using `api.set_display_list`
 -  or without display list using `api.update_resources` (replacing `add_image`, `update_image` and `delete_image`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1532)
<!-- Reviewable:end -->
