### PR TITLE
Pass the dirty rect down into the blob image

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -350,7 +350,8 @@ impl ResourceCache {
             if let ImageData::Blob(ref mut blob) = data {
                 self.blob_image_renderer.as_mut().unwrap().update(
                     image_key,
-                    mem::replace(blob, BlobImageData::new())
+                    mem::replace(blob, BlobImageData::new()),
+                    dirty_rect
                 );
             }
 

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -150,7 +150,7 @@ pub trait BlobImageResources {
 pub trait BlobImageRenderer: Send {
     fn add(&mut self, key: ImageKey, data: BlobImageData, tiling: Option<TileSize>);
 
-    fn update(&mut self, key: ImageKey, data: BlobImageData);
+    fn update(&mut self, key: ImageKey, data: BlobImageData, dirty_rect: Option<DeviceUintRect>);
 
     fn delete(&mut self, key: ImageKey);
 


### PR DESCRIPTION
This lets us know which area of the image has changed and is useful
for merging the old blob data and the new blob data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1535)
<!-- Reviewable:end -->
