### PR TITLE
Add a benchmark / stress test that has 8192 image templates.

### DIFF
--- a/wrench/benchmarks/benchmarks.list
+++ b/wrench/benchmarks/benchmarks.list
@@ -4,3 +4,5 @@ simple-batching.yaml
 large-clip-rect.yaml
 transforms-simple.yaml
 text-rendering.yaml
+many-images.yaml
+

--- a/wrench/benchmarks/many-images.yaml
+++ b/wrench/benchmarks/many-images.yaml
@@ -1,0 +1,16386 @@
+root:
+  items:
+    - image: solid-color(0, 0, 0, 255, 8, 8)
+      bounds: 0 0 8 8
+    - image: solid-color(1, 0, 0, 255, 8, 8)
+      bounds: 8 0 8 8
+    - image: solid-color(2, 0, 0, 255, 8, 8)
+      bounds: 16 0 8 8
+    - image: solid-color(3, 0, 0, 255, 8, 8)
+      bounds: 24 0 8 8
+    - image: solid-color(4, 0, 0, 255, 8, 8)
+      bounds: 32 0 8 8
+    - image: solid-color(5, 0, 0, 255, 8, 8)
+      bounds: 40 0 8 8
+    - image: solid-color(6, 0, 0, 255, 8, 8)
+      bounds: 48 0 8 8
+    - image: solid-color(7, 0, 0, 255, 8, 8)
+      bounds: 56 0 8 8
+    - image: solid-color(8, 0, 0, 255, 8, 8)
+      bounds: 64 0 8 8
+    - image: solid-color(9, 0, 0, 255, 8, 8)
+      bounds: 72 0 8 8
+    - image: solid-color(10, 0, 0, 255, 8, 8)
+      bounds: 80 0 8 8
+    - image: solid-color(11, 0, 0, 255, 8, 8)
+      bounds: 88 0 8 8
+    - image: solid-color(12, 0, 0, 255, 8, 8)
+      bounds: 96 0 8 8
+    - image: solid-color(13, 0, 0, 255, 8, 8)
+      bounds: 104 0 8 8
+    - image: solid-color(14, 0, 0, 255, 8, 8)
+      bounds: 112 0 8 8
+    - image: solid-color(15, 0, 0, 255, 8, 8)
+      bounds: 120 0 8 8
+    - image: solid-color(16, 0, 0, 255, 8, 8)
+      bounds: 128 0 8 8
+    - image: solid-color(17, 0, 0, 255, 8, 8)
+      bounds: 136 0 8 8
+    - image: solid-color(18, 0, 0, 255, 8, 8)
+      bounds: 144 0 8 8
+    - image: solid-color(19, 0, 0, 255, 8, 8)
+      bounds: 152 0 8 8
+    - image: solid-color(20, 0, 0, 255, 8, 8)
+      bounds: 160 0 8 8
+    - image: solid-color(21, 0, 0, 255, 8, 8)
+      bounds: 168 0 8 8
+    - image: solid-color(22, 0, 0, 255, 8, 8)
+      bounds: 176 0 8 8
+    - image: solid-color(23, 0, 0, 255, 8, 8)
+      bounds: 184 0 8 8
+    - image: solid-color(24, 0, 0, 255, 8, 8)
+      bounds: 192 0 8 8
+    - image: solid-color(25, 0, 0, 255, 8, 8)
+      bounds: 200 0 8 8
+    - image: solid-color(26, 0, 0, 255, 8, 8)
+      bounds: 208 0 8 8
+    - image: solid-color(27, 0, 0, 255, 8, 8)
+      bounds: 216 0 8 8
+    - image: solid-color(28, 0, 0, 255, 8, 8)
+      bounds: 224 0 8 8
+    - image: solid-color(29, 0, 0, 255, 8, 8)
+      bounds: 232 0 8 8
+    - image: solid-color(30, 0, 0, 255, 8, 8)
+      bounds: 240 0 8 8
+    - image: solid-color(31, 0, 0, 255, 8, 8)
+      bounds: 248 0 8 8
+    - image: solid-color(32, 0, 0, 255, 8, 8)
+      bounds: 256 0 8 8
+    - image: solid-color(33, 0, 0, 255, 8, 8)
+      bounds: 264 0 8 8
+    - image: solid-color(34, 0, 0, 255, 8, 8)
+      bounds: 272 0 8 8
+    - image: solid-color(35, 0, 0, 255, 8, 8)
+      bounds: 280 0 8 8
+    - image: solid-color(36, 0, 0, 255, 8, 8)
+      bounds: 288 0 8 8
+    - image: solid-color(37, 0, 0, 255, 8, 8)
+      bounds: 296 0 8 8
+    - image: solid-color(38, 0, 0, 255, 8, 8)
+      bounds: 304 0 8 8
+    - image: solid-color(39, 0, 0, 255, 8, 8)
+      bounds: 312 0 8 8
+    - image: solid-color(40, 0, 0, 255, 8, 8)
+      bounds: 320 0 8 8
+    - image: solid-color(41, 0, 0, 255, 8, 8)
+      bounds: 328 0 8 8
+    - image: solid-color(42, 0, 0, 255, 8, 8)
+      bounds: 336 0 8 8
+    - image: solid-color(43, 0, 0, 255, 8, 8)
+      bounds: 344 0 8 8
+    - image: solid-color(44, 0, 0, 255, 8, 8)
+      bounds: 352 0 8 8
+    - image: solid-color(45, 0, 0, 255, 8, 8)
+      bounds: 360 0 8 8
+    - image: solid-color(46, 0, 0, 255, 8, 8)
+      bounds: 368 0 8 8
+    - image: solid-color(47, 0, 0, 255, 8, 8)
+      bounds: 376 0 8 8
+    - image: solid-color(48, 0, 0, 255, 8, 8)
+      bounds: 384 0 8 8
+    - image: solid-color(49, 0, 0, 255, 8, 8)
+      bounds: 392 0 8 8
+    - image: solid-color(50, 0, 0, 255, 8, 8)
+      bounds: 400 0 8 8
+    - image: solid-color(51, 0, 0, 255, 8, 8)
+      bounds: 408 0 8 8
+    - image: solid-color(52, 0, 0, 255, 8, 8)
+      bounds: 416 0 8 8
+    - image: solid-color(53, 0, 0, 255, 8, 8)
+      bounds: 424 0 8 8
+    - image: solid-color(54, 0, 0, 255, 8, 8)
+      bounds: 432 0 8 8
+    - image: solid-color(55, 0, 0, 255, 8, 8)
+      bounds: 440 0 8 8
+    - image: solid-color(56, 0, 0, 255, 8, 8)
+      bounds: 448 0 8 8
+    - image: solid-color(57, 0, 0, 255, 8, 8)
+      bounds: 456 0 8 8
+    - image: solid-color(58, 0, 0, 255, 8, 8)
+      bounds: 464 0 8 8
+    - image: solid-color(59, 0, 0, 255, 8, 8)
+      bounds: 472 0 8 8
+    - image: solid-color(60, 0, 0, 255, 8, 8)
+      bounds: 480 0 8 8
+    - image: solid-color(61, 0, 0, 255, 8, 8)
+      bounds: 488 0 8 8
+    - image: solid-color(62, 0, 0, 255, 8, 8)
+      bounds: 496 0 8 8
+    - image: solid-color(63, 0, 0, 255, 8, 8)
+      bounds: 504 0 8 8
+    - image: solid-color(64, 0, 0, 255, 8, 8)
+      bounds: 512 0 8 8
+    - image: solid-color(65, 0, 0, 255, 8, 8)
+      bounds: 520 0 8 8
+    - image: solid-color(66, 0, 0, 255, 8, 8)
+      bounds: 528 0 8 8
+    - image: solid-color(67, 0, 0, 255, 8, 8)
+      bounds: 536 0 8 8
+    - image: solid-color(68, 0, 0, 255, 8, 8)
+      bounds: 544 0 8 8
+    - image: solid-color(69, 0, 0, 255, 8, 8)
+      bounds: 552 0 8 8
+    - image: solid-color(70, 0, 0, 255, 8, 8)
+      bounds: 560 0 8 8
+    - image: solid-color(71, 0, 0, 255, 8, 8)
+      bounds: 568 0 8 8
+    - image: solid-color(72, 0, 0, 255, 8, 8)
+      bounds: 576 0 8 8
+    - image: solid-color(73, 0, 0, 255, 8, 8)
+      bounds: 584 0 8 8
+    - image: solid-color(74, 0, 0, 255, 8, 8)
+      bounds: 592 0 8 8
+    - image: solid-color(75, 0, 0, 255, 8, 8)
+      bounds: 600 0 8 8
+    - image: solid-color(76, 0, 0, 255, 8, 8)
+      bounds: 608 0 8 8
+    - image: solid-color(77, 0, 0, 255, 8, 8)
+      bounds: 616 0 8 8
+    - image: solid-color(78, 0, 0, 255, 8, 8)
+      bounds: 624 0 8 8
+    - image: solid-color(79, 0, 0, 255, 8, 8)
+      bounds: 632 0 8 8
+    - image: solid-color(80, 0, 0, 255, 8, 8)
+      bounds: 640 0 8 8
+    - image: solid-color(81, 0, 0, 255, 8, 8)
+      bounds: 648 0 8 8
+    - image: solid-color(82, 0, 0, 255, 8, 8)
+      bounds: 656 0 8 8
+    - image: solid-color(83, 0, 0, 255, 8, 8)
+      bounds: 664 0 8 8
+    - image: solid-color(84, 0, 0, 255, 8, 8)
+      bounds: 672 0 8 8
+    - image: solid-color(85, 0, 0, 255, 8, 8)
+      bounds: 680 0 8 8
+    - image: solid-color(86, 0, 0, 255, 8, 8)
+      bounds: 688 0 8 8
+    - image: solid-color(87, 0, 0, 255, 8, 8)
+      bounds: 696 0 8 8
+    - image: solid-color(88, 0, 0, 255, 8, 8)
+      bounds: 704 0 8 8
+    - image: solid-color(89, 0, 0, 255, 8, 8)
+      bounds: 712 0 8 8
+    - image: solid-color(90, 0, 0, 255, 8, 8)
+      bounds: 720 0 8 8
+    - image: solid-color(91, 0, 0, 255, 8, 8)
+      bounds: 728 0 8 8
+    - image: solid-color(92, 0, 0, 255, 8, 8)
+      bounds: 736 0 8 8
+    - image: solid-color(93, 0, 0, 255, 8, 8)
+      bounds: 744 0 8 8
+    - image: solid-color(94, 0, 0, 255, 8, 8)
+      bounds: 752 0 8 8
+    - image: solid-color(95, 0, 0, 255, 8, 8)
+      bounds: 760 0 8 8
+    - image: solid-color(96, 0, 0, 255, 8, 8)
+      bounds: 768 0 8 8
+    - image: solid-color(97, 0, 0, 255, 8, 8)
+      bounds: 776 0 8 8
+    - image: solid-color(98, 0, 0, 255, 8, 8)
+      bounds: 784 0 8 8
+    - image: solid-color(99, 0, 0, 255, 8, 8)
+      bounds: 792 0 8 8
+    - image: solid-color(100, 0, 0, 255, 8, 8)
+      bounds: 800 0 8 8
+    - image: solid-color(101, 0, 0, 255, 8, 8)
+      bounds: 808 0 8 8
+    - image: solid-color(102, 0, 0, 255, 8, 8)
+      bounds: 816 0 8 8
+    - image: solid-color(103, 0, 0, 255, 8, 8)
+      bounds: 824 0 8 8
+    - image: solid-color(104, 0, 0, 255, 8, 8)
+      bounds: 832 0 8 8
+    - image: solid-color(105, 0, 0, 255, 8, 8)
+      bounds: 840 0 8 8
+    - image: solid-color(106, 0, 0, 255, 8, 8)
+      bounds: 848 0 8 8
+    - image: solid-color(107, 0, 0, 255, 8, 8)
+      bounds: 856 0 8 8
+    - image: solid-color(108, 0, 0, 255, 8, 8)
+      bounds: 864 0 8 8
+    - image: solid-color(109, 0, 0, 255, 8, 8)
+      bounds: 872 0 8 8
+    - image: solid-color(110, 0, 0, 255, 8, 8)
+      bounds: 880 0 8 8
+    - image: solid-color(111, 0, 0, 255, 8, 8)
+      bounds: 888 0 8 8
+    - image: solid-color(112, 0, 0, 255, 8, 8)
+      bounds: 896 0 8 8
+    - image: solid-color(113, 0, 0, 255, 8, 8)
+      bounds: 904 0 8 8
+    - image: solid-color(114, 0, 0, 255, 8, 8)
+      bounds: 912 0 8 8
+    - image: solid-color(115, 0, 0, 255, 8, 8)
+      bounds: 920 0 8 8
+    - image: solid-color(116, 0, 0, 255, 8, 8)
+      bounds: 928 0 8 8
+    - image: solid-color(117, 0, 0, 255, 8, 8)
+      bounds: 936 0 8 8
+    - image: solid-color(118, 0, 0, 255, 8, 8)
+      bounds: 944 0 8 8
+    - image: solid-color(119, 0, 0, 255, 8, 8)
+      bounds: 952 0 8 8
+    - image: solid-color(120, 0, 0, 255, 8, 8)
+      bounds: 960 0 8 8
+    - image: solid-color(121, 0, 0, 255, 8, 8)
+      bounds: 968 0 8 8
+    - image: solid-color(122, 0, 0, 255, 8, 8)
+      bounds: 976 0 8 8
+    - image: solid-color(123, 0, 0, 255, 8, 8)
+      bounds: 984 0 8 8
+    - image: solid-color(124, 0, 0, 255, 8, 8)
+      bounds: 992 0 8 8
+    - image: solid-color(125, 0, 0, 255, 8, 8)
+      bounds: 1000 0 8 8
+    - image: solid-color(126, 0, 0, 255, 8, 8)
+      bounds: 1008 0 8 8
+    - image: solid-color(127, 0, 0, 255, 8, 8)
+      bounds: 1016 0 8 8
+    - image: solid-color(0, 1, 0, 255, 8, 8)
+      bounds: 0 8 8 8
+    - image: solid-color(1, 1, 0, 255, 8, 8)
+      bounds: 8 8 8 8
+    - image: solid-color(2, 1, 0, 255, 8, 8)
+      bounds: 16 8 8 8
+    - image: solid-color(3, 1, 0, 255, 8, 8)
+      bounds: 24 8 8 8
+    - image: solid-color(4, 1, 0, 255, 8, 8)
+      bounds: 32 8 8 8
+    - image: solid-color(5, 1, 0, 255, 8, 8)
+      bounds: 40 8 8 8
+    - image: solid-color(6, 1, 0, 255, 8, 8)
+      bounds: 48 8 8 8
+    - image: solid-color(7, 1, 0, 255, 8, 8)
+      bounds: 56 8 8 8
+    - image: solid-color(8, 1, 0, 255, 8, 8)
+      bounds: 64 8 8 8
+    - image: solid-color(9, 1, 0, 255, 8, 8)
+      bounds: 72 8 8 8
+    - image: solid-color(10, 1, 0, 255, 8, 8)
+      bounds: 80 8 8 8
+    - image: solid-color(11, 1, 0, 255, 8, 8)
+      bounds: 88 8 8 8
+    - image: solid-color(12, 1, 0, 255, 8, 8)
+      bounds: 96 8 8 8
+    - image: solid-color(13, 1, 0, 255, 8, 8)
+      bounds: 104 8 8 8
+    - image: solid-color(14, 1, 0, 255, 8, 8)
+      bounds: 112 8 8 8
+    - image: solid-color(15, 1, 0, 255, 8, 8)
+      bounds: 120 8 8 8
+    - image: solid-color(16, 1, 0, 255, 8, 8)
+      bounds: 128 8 8 8
+    - image: solid-color(17, 1, 0, 255, 8, 8)
+      bounds: 136 8 8 8
+    - image: solid-color(18, 1, 0, 255, 8, 8)
+      bounds: 144 8 8 8
+    - image: solid-color(19, 1, 0, 255, 8, 8)
+      bounds: 152 8 8 8
+    - image: solid-color(20, 1, 0, 255, 8, 8)
+      bounds: 160 8 8 8
+    - image: solid-color(21, 1, 0, 255, 8, 8)
+      bounds: 168 8 8 8
+    - image: solid-color(22, 1, 0, 255, 8, 8)
+      bounds: 176 8 8 8
+    - image: solid-color(23, 1, 0, 255, 8, 8)
+      bounds: 184 8 8 8
+    - image: solid-color(24, 1, 0, 255, 8, 8)
+      bounds: 192 8 8 8
+    - image: solid-color(25, 1, 0, 255, 8, 8)
+      bounds: 200 8 8 8
+    - image: solid-color(26, 1, 0, 255, 8, 8)
+      bounds: 208 8 8 8
+    - image: solid-color(27, 1, 0, 255, 8, 8)
+      bounds: 216 8 8 8
+    - image: solid-color(28, 1, 0, 255, 8, 8)
+      bounds: 224 8 8 8
+    - image: solid-color(29, 1, 0, 255, 8, 8)
+      bounds: 232 8 8 8
+    - image: solid-color(30, 1, 0, 255, 8, 8)
+      bounds: 240 8 8 8
+    - image: solid-color(31, 1, 0, 255, 8, 8)
+      bounds: 248 8 8 8
+    - image: solid-color(32, 1, 0, 255, 8, 8)
+      bounds: 256 8 8 8
+    - image: solid-color(33, 1, 0, 255, 8, 8)
+      bounds: 264 8 8 8
+    - image: solid-color(34, 1, 0, 255, 8, 8)
+      bounds: 272 8 8 8
+    - image: solid-color(35, 1, 0, 255, 8, 8)
+      bounds: 280 8 8 8
+    - image: solid-color(36, 1, 0, 255, 8, 8)
+      bounds: 288 8 8 8
+    - image: solid-color(37, 1, 0, 255, 8, 8)
+      bounds: 296 8 8 8
+    - image: solid-color(38, 1, 0, 255, 8, 8)
+      bounds: 304 8 8 8
+    - image: solid-color(39, 1, 0, 255, 8, 8)
+      bounds: 312 8 8 8
+    - image: solid-color(40, 1, 0, 255, 8, 8)
+      bounds: 320 8 8 8
+    - image: solid-color(41, 1, 0, 255, 8, 8)
+      bounds: 328 8 8 8
+    - image: solid-color(42, 1, 0, 255, 8, 8)
+      bounds: 336 8 8 8
+    - image: solid-color(43, 1, 0, 255, 8, 8)
+      bounds: 344 8 8 8
+    - image: solid-color(44, 1, 0, 255, 8, 8)
+      bounds: 352 8 8 8
+    - image: solid-color(45, 1, 0, 255, 8, 8)
+      bounds: 360 8 8 8
+    - image: solid-color(46, 1, 0, 255, 8, 8)
+      bounds: 368 8 8 8
+    - image: solid-color(47, 1, 0, 255, 8, 8)
+      bounds: 376 8 8 8
+    - image: solid-color(48, 1, 0, 255, 8, 8)
+      bounds: 384 8 8 8
+    - image: solid-color(49, 1, 0, 255, 8, 8)
+      bounds: 392 8 8 8
+    - image: solid-color(50, 1, 0, 255, 8, 8)
+      bounds: 400 8 8 8
+    - image: solid-color(51, 1, 0, 255, 8, 8)
+      bounds: 408 8 8 8
+    - image: solid-color(52, 1, 0, 255, 8, 8)
+      bounds: 416 8 8 8
+    - image: solid-color(53, 1, 0, 255, 8, 8)
+      bounds: 424 8 8 8
+    - image: solid-color(54, 1, 0, 255, 8, 8)
+      bounds: 432 8 8 8
+    - image: solid-color(55, 1, 0, 255, 8, 8)
+      bounds: 440 8 8 8
+    - image: solid-color(56, 1, 0, 255, 8, 8)
+      bounds: 448 8 8 8
+    - image: solid-color(57, 1, 0, 255, 8, 8)
+      bounds: 456 8 8 8
+    - image: solid-color(58, 1, 0, 255, 8, 8)
+      bounds: 464 8 8 8
+    - image: solid-color(59, 1, 0, 255, 8, 8)
+      bounds: 472 8 8 8
+    - image: solid-color(60, 1, 0, 255, 8, 8)
+      bounds: 480 8 8 8
+    - image: solid-color(61, 1, 0, 255, 8, 8)
+      bounds: 488 8 8 8
+    - image: solid-color(62, 1, 0, 255, 8, 8)
+      bounds: 496 8 8 8
+    - image: solid-color(63, 1, 0, 255, 8, 8)
+      bounds: 504 8 8 8
+    - image: solid-color(64, 1, 0, 255, 8, 8)
+      bounds: 512 8 8 8
+    - image: solid-color(65, 1, 0, 255, 8, 8)
+      bounds: 520 8 8 8
+    - image: solid-color(66, 1, 0, 255, 8, 8)
+      bounds: 528 8 8 8
+    - image: solid-color(67, 1, 0, 255, 8, 8)
+      bounds: 536 8 8 8
+    - image: solid-color(68, 1, 0, 255, 8, 8)
+      bounds: 544 8 8 8
+    - image: solid-color(69, 1, 0, 255, 8, 8)
+      bounds: 552 8 8 8
+    - image: solid-color(70, 1, 0, 255, 8, 8)
+      bounds: 560 8 8 8
+    - image: solid-color(71, 1, 0, 255, 8, 8)
+      bounds: 568 8 8 8
+    - image: solid-color(72, 1, 0, 255, 8, 8)
+      bounds: 576 8 8 8
+    - image: solid-color(73, 1, 0, 255, 8, 8)
+      bounds: 584 8 8 8
+    - image: solid-color(74, 1, 0, 255, 8, 8)
+      bounds: 592 8 8 8
+    - image: solid-color(75, 1, 0, 255, 8, 8)
+      bounds: 600 8 8 8
+    - image: solid-color(76, 1, 0, 255, 8, 8)
+      bounds: 608 8 8 8
+    - image: solid-color(77, 1, 0, 255, 8, 8)
+      bounds: 616 8 8 8
+    - image: solid-color(78, 1, 0, 255, 8, 8)
+      bounds: 624 8 8 8
+    - image: solid-color(79, 1, 0, 255, 8, 8)
+      bounds: 632 8 8 8
+    - image: solid-color(80, 1, 0, 255, 8, 8)
+      bounds: 640 8 8 8
+    - image: solid-color(81, 1, 0, 255, 8, 8)
+      bounds: 648 8 8 8
+    - image: solid-color(82, 1, 0, 255, 8, 8)
+      bounds: 656 8 8 8
+    - image: solid-color(83, 1, 0, 255, 8, 8)
+      bounds: 664 8 8 8
+    - image: solid-color(84, 1, 0, 255, 8, 8)
+      bounds: 672 8 8 8
+    - image: solid-color(85, 1, 0, 255, 8, 8)
+      bounds: 680 8 8 8
+    - image: solid-color(86, 1, 0, 255, 8, 8)
+      bounds: 688 8 8 8
+    - image: solid-color(87, 1, 0, 255, 8, 8)
+      bounds: 696 8 8 8
+    - image: solid-color(88, 1, 0, 255, 8, 8)
+      bounds: 704 8 8 8
+    - image: solid-color(89, 1, 0, 255, 8, 8)
+      bounds: 712 8 8 8
+    - image: solid-color(90, 1, 0, 255, 8, 8)
+      bounds: 720 8 8 8
+    - image: solid-color(91, 1, 0, 255, 8, 8)
+      bounds: 728 8 8 8
+    - image: solid-color(92, 1, 0, 255, 8, 8)
+      bounds: 736 8 8 8
+    - image: solid-color(93, 1, 0, 255, 8, 8)
+      bounds: 744 8 8 8
+    - image: solid-color(94, 1, 0, 255, 8, 8)
+      bounds: 752 8 8 8
+    - image: solid-color(95, 1, 0, 255, 8, 8)
+      bounds: 760 8 8 8
+    - image: solid-color(96, 1, 0, 255, 8, 8)
+      bounds: 768 8 8 8
+    - image: solid-color(97, 1, 0, 255, 8, 8)
+      bounds: 776 8 8 8
+    - image: solid-color(98, 1, 0, 255, 8, 8)
+      bounds: 784 8 8 8
+    - image: solid-color(99, 1, 0, 255, 8, 8)
+      bounds: 792 8 8 8
+    - image: solid-color(100, 1, 0, 255, 8, 8)
+      bounds: 800 8 8 8
+    - image: solid-color(101, 1, 0, 255, 8, 8)
+      bounds: 808 8 8 8
+    - image: solid-color(102, 1, 0, 255, 8, 8)
+      bounds: 816 8 8 8
+    - image: solid-color(103, 1, 0, 255, 8, 8)
+      bounds: 824 8 8 8
+    - image: solid-color(104, 1, 0, 255, 8, 8)
+      bounds: 832 8 8 8
+    - image: solid-color(105, 1, 0, 255, 8, 8)
+      bounds: 840 8 8 8
+    - image: solid-color(106, 1, 0, 255, 8, 8)
+      bounds: 848 8 8 8
+    - image: solid-color(107, 1, 0, 255, 8, 8)
+      bounds: 856 8 8 8
+    - image: solid-color(108, 1, 0, 255, 8, 8)
+      bounds: 864 8 8 8
+    - image: solid-color(109, 1, 0, 255, 8, 8)
+      bounds: 872 8 8 8
+    - image: solid-color(110, 1, 0, 255, 8, 8)
+      bounds: 880 8 8 8
+    - image: solid-color(111, 1, 0, 255, 8, 8)
+      bounds: 888 8 8 8
+    - image: solid-color(112, 1, 0, 255, 8, 8)
+      bounds: 896 8 8 8
+    - image: solid-color(113, 1, 0, 255, 8, 8)
+      bounds: 904 8 8 8
+    - image: solid-color(114, 1, 0, 255, 8, 8)
+      bounds: 912 8 8 8
+    - image: solid-color(115, 1, 0, 255, 8, 8)
+      bounds: 920 8 8 8
+    - image: solid-color(116, 1, 0, 255, 8, 8)
+      bounds: 928 8 8 8
+    - image: solid-color(117, 1, 0, 255, 8, 8)
+      bounds: 936 8 8 8
+    - image: solid-color(118, 1, 0, 255, 8, 8)
+      bounds: 944 8 8 8
+    - image: solid-color(119, 1, 0, 255, 8, 8)
+      bounds: 952 8 8 8
+    - image: solid-color(120, 1, 0, 255, 8, 8)
+      bounds: 960 8 8 8
+    - image: solid-color(121, 1, 0, 255, 8, 8)
+      bounds: 968 8 8 8
+    - image: solid-color(122, 1, 0, 255, 8, 8)
+      bounds: 976 8 8 8
+    - image: solid-color(123, 1, 0, 255, 8, 8)
+      bounds: 984 8 8 8
+    - image: solid-color(124, 1, 0, 255, 8, 8)
+      bounds: 992 8 8 8
+    - image: solid-color(125, 1, 0, 255, 8, 8)
+      bounds: 1000 8 8 8
+    - image: solid-color(126, 1, 0, 255, 8, 8)
+      bounds: 1008 8 8 8
+    - image: solid-color(127, 1, 0, 255, 8, 8)
+      bounds: 1016 8 8 8
+    - image: solid-color(0, 2, 0, 255, 8, 8)
+      bounds: 0 16 8 8
+    - image: solid-color(1, 2, 0, 255, 8, 8)
+      bounds: 8 16 8 8
+    - image: solid-color(2, 2, 0, 255, 8, 8)
+      bounds: 16 16 8 8
+    - image: solid-color(3, 2, 0, 255, 8, 8)
+      bounds: 24 16 8 8
+    - image: solid-color(4, 2, 0, 255, 8, 8)
+      bounds: 32 16 8 8
+    - image: solid-color(5, 2, 0, 255, 8, 8)
+      bounds: 40 16 8 8
+    - image: solid-color(6, 2, 0, 255, 8, 8)
+      bounds: 48 16 8 8
+    - image: solid-color(7, 2, 0, 255, 8, 8)
+      bounds: 56 16 8 8
+    - image: solid-color(8, 2, 0, 255, 8, 8)
+      bounds: 64 16 8 8
+    - image: solid-color(9, 2, 0, 255, 8, 8)
+      bounds: 72 16 8 8
+    - image: solid-color(10, 2, 0, 255, 8, 8)
+      bounds: 80 16 8 8
+    - image: solid-color(11, 2, 0, 255, 8, 8)
+      bounds: 88 16 8 8
+    - image: solid-color(12, 2, 0, 255, 8, 8)
+      bounds: 96 16 8 8
+    - image: solid-color(13, 2, 0, 255, 8, 8)
+      bounds: 104 16 8 8
+    - image: solid-color(14, 2, 0, 255, 8, 8)
+      bounds: 112 16 8 8
+    - image: solid-color(15, 2, 0, 255, 8, 8)
+      bounds: 120 16 8 8
+    - image: solid-color(16, 2, 0, 255, 8, 8)
+      bounds: 128 16 8 8
+    - image: solid-color(17, 2, 0, 255, 8, 8)
+      bounds: 136 16 8 8
+    - image: solid-color(18, 2, 0, 255, 8, 8)
+      bounds: 144 16 8 8
+    - image: solid-color(19, 2, 0, 255, 8, 8)
+      bounds: 152 16 8 8
+    - image: solid-color(20, 2, 0, 255, 8, 8)
+      bounds: 160 16 8 8
+    - image: solid-color(21, 2, 0, 255, 8, 8)
+      bounds: 168 16 8 8
+    - image: solid-color(22, 2, 0, 255, 8, 8)
+      bounds: 176 16 8 8
+    - image: solid-color(23, 2, 0, 255, 8, 8)
+      bounds: 184 16 8 8
+    - image: solid-color(24, 2, 0, 255, 8, 8)
+      bounds: 192 16 8 8
+    - image: solid-color(25, 2, 0, 255, 8, 8)
+      bounds: 200 16 8 8
+    - image: solid-color(26, 2, 0, 255, 8, 8)
+      bounds: 208 16 8 8
+    - image: solid-color(27, 2, 0, 255, 8, 8)
+      bounds: 216 16 8 8
+    - image: solid-color(28, 2, 0, 255, 8, 8)
+      bounds: 224 16 8 8
+    - image: solid-color(29, 2, 0, 255, 8, 8)
+      bounds: 232 16 8 8
+    - image: solid-color(30, 2, 0, 255, 8, 8)
+      bounds: 240 16 8 8
+    - image: solid-color(31, 2, 0, 255, 8, 8)
+      bounds: 248 16 8 8
+    - image: solid-color(32, 2, 0, 255, 8, 8)
+      bounds: 256 16 8 8
+    - image: solid-color(33, 2, 0, 255, 8, 8)
+      bounds: 264 16 8 8
+    - image: solid-color(34, 2, 0, 255, 8, 8)
+      bounds: 272 16 8 8
+    - image: solid-color(35, 2, 0, 255, 8, 8)
+      bounds: 280 16 8 8
+    - image: solid-color(36, 2, 0, 255, 8, 8)
+      bounds: 288 16 8 8
+    - image: solid-color(37, 2, 0, 255, 8, 8)
+      bounds: 296 16 8 8
+    - image: solid-color(38, 2, 0, 255, 8, 8)
+      bounds: 304 16 8 8
+    - image: solid-color(39, 2, 0, 255, 8, 8)
+      bounds: 312 16 8 8
+    - image: solid-color(40, 2, 0, 255, 8, 8)
+      bounds: 320 16 8 8
+    - image: solid-color(41, 2, 0, 255, 8, 8)
+      bounds: 328 16 8 8
+    - image: solid-color(42, 2, 0, 255, 8, 8)
+      bounds: 336 16 8 8
+    - image: solid-color(43, 2, 0, 255, 8, 8)
+      bounds: 344 16 8 8
+    - image: solid-color(44, 2, 0, 255, 8, 8)
+      bounds: 352 16 8 8
+    - image: solid-color(45, 2, 0, 255, 8, 8)
+      bounds: 360 16 8 8
+    - image: solid-color(46, 2, 0, 255, 8, 8)
+      bounds: 368 16 8 8
+    - image: solid-color(47, 2, 0, 255, 8, 8)
+      bounds: 376 16 8 8
+    - image: solid-color(48, 2, 0, 255, 8, 8)
+      bounds: 384 16 8 8
+    - image: solid-color(49, 2, 0, 255, 8, 8)
+      bounds: 392 16 8 8
+    - image: solid-color(50, 2, 0, 255, 8, 8)
+      bounds: 400 16 8 8
+    - image: solid-color(51, 2, 0, 255, 8, 8)
+      bounds: 408 16 8 8
+    - image: solid-color(52, 2, 0, 255, 8, 8)
+      bounds: 416 16 8 8
+    - image: solid-color(53, 2, 0, 255, 8, 8)
+      bounds: 424 16 8 8
+    - image: solid-color(54, 2, 0, 255, 8, 8)
+      bounds: 432 16 8 8
+    - image: solid-color(55, 2, 0, 255, 8, 8)
+      bounds: 440 16 8 8
+    - image: solid-color(56, 2, 0, 255, 8, 8)
+      bounds: 448 16 8 8
+    - image: solid-color(57, 2, 0, 255, 8, 8)
+      bounds: 456 16 8 8
+    - image: solid-color(58, 2, 0, 255, 8, 8)
+      bounds: 464 16 8 8
+    - image: solid-color(59, 2, 0, 255, 8, 8)
+      bounds: 472 16 8 8
+    - image: solid-color(60, 2, 0, 255, 8, 8)
+      bounds: 480 16 8 8
+    - image: solid-color(61, 2, 0, 255, 8, 8)
+      bounds: 488 16 8 8
+    - image: solid-color(62, 2, 0, 255, 8, 8)
+      bounds: 496 16 8 8
+    - image: solid-color(63, 2, 0, 255, 8, 8)
+      bounds: 504 16 8 8
+    - image: solid-color(64, 2, 0, 255, 8, 8)
+      bounds: 512 16 8 8
+    - image: solid-color(65, 2, 0, 255, 8, 8)
+      bounds: 520 16 8 8
+    - image: solid-color(66, 2, 0, 255, 8, 8)
+      bounds: 528 16 8 8
+    - image: solid-color(67, 2, 0, 255, 8, 8)
+      bounds: 536 16 8 8
+    - image: solid-color(68, 2, 0, 255, 8, 8)
+      bounds: 544 16 8 8
+    - image: solid-color(69, 2, 0, 255, 8, 8)
+      bounds: 552 16 8 8
+    - image: solid-color(70, 2, 0, 255, 8, 8)
+      bounds: 560 16 8 8
+    - image: solid-color(71, 2, 0, 255, 8, 8)
+      bounds: 568 16 8 8
+    - image: solid-color(72, 2, 0, 255, 8, 8)
+      bounds: 576 16 8 8
+    - image: solid-color(73, 2, 0, 255, 8, 8)
+      bounds: 584 16 8 8
+    - image: solid-color(74, 2, 0, 255, 8, 8)
+      bounds: 592 16 8 8
+    - image: solid-color(75, 2, 0, 255, 8, 8)
+      bounds: 600 16 8 8
+    - image: solid-color(76, 2, 0, 255, 8, 8)
+      bounds: 608 16 8 8
+    - image: solid-color(77, 2, 0, 255, 8, 8)
+      bounds: 616 16 8 8
+    - image: solid-color(78, 2, 0, 255, 8, 8)
+      bounds: 624 16 8 8
+    - image: solid-color(79, 2, 0, 255, 8, 8)
+      bounds: 632 16 8 8
+    - image: solid-color(80, 2, 0, 255, 8, 8)
+      bounds: 640 16 8 8
+    - image: solid-color(81, 2, 0, 255, 8, 8)
+      bounds: 648 16 8 8
+    - image: solid-color(82, 2, 0, 255, 8, 8)
+      bounds: 656 16 8 8
+    - image: solid-color(83, 2, 0, 255, 8, 8)
+      bounds: 664 16 8 8
+    - image: solid-color(84, 2, 0, 255, 8, 8)
+      bounds: 672 16 8 8
+    - image: solid-color(85, 2, 0, 255, 8, 8)
+      bounds: 680 16 8 8
+    - image: solid-color(86, 2, 0, 255, 8, 8)
+      bounds: 688 16 8 8
+    - image: solid-color(87, 2, 0, 255, 8, 8)
+      bounds: 696 16 8 8
+    - image: solid-color(88, 2, 0, 255, 8, 8)
+      bounds: 704 16 8 8
+    - image: solid-color(89, 2, 0, 255, 8, 8)
+      bounds: 712 16 8 8
+    - image: solid-color(90, 2, 0, 255, 8, 8)
+      bounds: 720 16 8 8
+    - image: solid-color(91, 2, 0, 255, 8, 8)
+      bounds: 728 16 8 8
+    - image: solid-color(92, 2, 0, 255, 8, 8)
+      bounds: 736 16 8 8
+    - image: solid-color(93, 2, 0, 255, 8, 8)
+      bounds: 744 16 8 8
+    - image: solid-color(94, 2, 0, 255, 8, 8)
+      bounds: 752 16 8 8
+    - image: solid-color(95, 2, 0, 255, 8, 8)
+      bounds: 760 16 8 8
+    - image: solid-color(96, 2, 0, 255, 8, 8)
+      bounds: 768 16 8 8
+    - image: solid-color(97, 2, 0, 255, 8, 8)
+      bounds: 776 16 8 8
+    - image: solid-color(98, 2, 0, 255, 8, 8)
+      bounds: 784 16 8 8
+    - image: solid-color(99, 2, 0, 255, 8, 8)
+      bounds: 792 16 8 8
+    - image: solid-color(100, 2, 0, 255, 8, 8)
+      bounds: 800 16 8 8
+    - image: solid-color(101, 2, 0, 255, 8, 8)
+      bounds: 808 16 8 8
+    - image: solid-color(102, 2, 0, 255, 8, 8)
+      bounds: 816 16 8 8
+    - image: solid-color(103, 2, 0, 255, 8, 8)
+      bounds: 824 16 8 8
+    - image: solid-color(104, 2, 0, 255, 8, 8)
+      bounds: 832 16 8 8
+    - image: solid-color(105, 2, 0, 255, 8, 8)
+      bounds: 840 16 8 8
+    - image: solid-color(106, 2, 0, 255, 8, 8)
+      bounds: 848 16 8 8
+    - image: solid-color(107, 2, 0, 255, 8, 8)
+      bounds: 856 16 8 8
+    - image: solid-color(108, 2, 0, 255, 8, 8)
+      bounds: 864 16 8 8
+    - image: solid-color(109, 2, 0, 255, 8, 8)
+      bounds: 872 16 8 8
+    - image: solid-color(110, 2, 0, 255, 8, 8)
+      bounds: 880 16 8 8
+    - image: solid-color(111, 2, 0, 255, 8, 8)
+      bounds: 888 16 8 8
+    - image: solid-color(112, 2, 0, 255, 8, 8)
+      bounds: 896 16 8 8
+    - image: solid-color(113, 2, 0, 255, 8, 8)
+      bounds: 904 16 8 8
+    - image: solid-color(114, 2, 0, 255, 8, 8)
+      bounds: 912 16 8 8
+    - image: solid-color(115, 2, 0, 255, 8, 8)
+      bounds: 920 16 8 8
+    - image: solid-color(116, 2, 0, 255, 8, 8)
+      bounds: 928 16 8 8
+    - image: solid-color(117, 2, 0, 255, 8, 8)
+      bounds: 936 16 8 8
+    - image: solid-color(118, 2, 0, 255, 8, 8)
+      bounds: 944 16 8 8
+    - image: solid-color(119, 2, 0, 255, 8, 8)
+      bounds: 952 16 8 8
+    - image: solid-color(120, 2, 0, 255, 8, 8)
+      bounds: 960 16 8 8
+    - image: solid-color(121, 2, 0, 255, 8, 8)
+      bounds: 968 16 8 8
+    - image: solid-color(122, 2, 0, 255, 8, 8)
+      bounds: 976 16 8 8
+    - image: solid-color(123, 2, 0, 255, 8, 8)
+      bounds: 984 16 8 8
+    - image: solid-color(124, 2, 0, 255, 8, 8)
+      bounds: 992 16 8 8
+    - image: solid-color(125, 2, 0, 255, 8, 8)
+      bounds: 1000 16 8 8
+    - image: solid-color(126, 2, 0, 255, 8, 8)
+      bounds: 1008 16 8 8
+    - image: solid-color(127, 2, 0, 255, 8, 8)
+      bounds: 1016 16 8 8
+    - image: solid-color(0, 3, 0, 255, 8, 8)
+      bounds: 0 24 8 8
+    - image: solid-color(1, 3, 0, 255, 8, 8)
+      bounds: 8 24 8 8
+    - image: solid-color(2, 3, 0, 255, 8, 8)
+      bounds: 16 24 8 8
+    - image: solid-color(3, 3, 0, 255, 8, 8)
+      bounds: 24 24 8 8
+    - image: solid-color(4, 3, 0, 255, 8, 8)
+      bounds: 32 24 8 8
+    - image: solid-color(5, 3, 0, 255, 8, 8)
+      bounds: 40 24 8 8
+    - image: solid-color(6, 3, 0, 255, 8, 8)
+      bounds: 48 24 8 8
+    - image: solid-color(7, 3, 0, 255, 8, 8)
+      bounds: 56 24 8 8
+    - image: solid-color(8, 3, 0, 255, 8, 8)
+      bounds: 64 24 8 8
+    - image: solid-color(9, 3, 0, 255, 8, 8)
+      bounds: 72 24 8 8
+    - image: solid-color(10, 3, 0, 255, 8, 8)
+      bounds: 80 24 8 8
+    - image: solid-color(11, 3, 0, 255, 8, 8)
+      bounds: 88 24 8 8
+    - image: solid-color(12, 3, 0, 255, 8, 8)
+      bounds: 96 24 8 8
+    - image: solid-color(13, 3, 0, 255, 8, 8)
+      bounds: 104 24 8 8
+    - image: solid-color(14, 3, 0, 255, 8, 8)
+      bounds: 112 24 8 8
+    - image: solid-color(15, 3, 0, 255, 8, 8)
+      bounds: 120 24 8 8
+    - image: solid-color(16, 3, 0, 255, 8, 8)
+      bounds: 128 24 8 8
+    - image: solid-color(17, 3, 0, 255, 8, 8)
+      bounds: 136 24 8 8
+    - image: solid-color(18, 3, 0, 255, 8, 8)
+      bounds: 144 24 8 8
+    - image: solid-color(19, 3, 0, 255, 8, 8)
+      bounds: 152 24 8 8
+    - image: solid-color(20, 3, 0, 255, 8, 8)
+      bounds: 160 24 8 8
+    - image: solid-color(21, 3, 0, 255, 8, 8)
+      bounds: 168 24 8 8
+    - image: solid-color(22, 3, 0, 255, 8, 8)
+      bounds: 176 24 8 8
+    - image: solid-color(23, 3, 0, 255, 8, 8)
+      bounds: 184 24 8 8
+    - image: solid-color(24, 3, 0, 255, 8, 8)
+      bounds: 192 24 8 8
+    - image: solid-color(25, 3, 0, 255, 8, 8)
+      bounds: 200 24 8 8
+    - image: solid-color(26, 3, 0, 255, 8, 8)
+      bounds: 208 24 8 8
+    - image: solid-color(27, 3, 0, 255, 8, 8)
+      bounds: 216 24 8 8
+    - image: solid-color(28, 3, 0, 255, 8, 8)
+      bounds: 224 24 8 8
+    - image: solid-color(29, 3, 0, 255, 8, 8)
+      bounds: 232 24 8 8
+    - image: solid-color(30, 3, 0, 255, 8, 8)
+      bounds: 240 24 8 8
+    - image: solid-color(31, 3, 0, 255, 8, 8)
+      bounds: 248 24 8 8
+    - image: solid-color(32, 3, 0, 255, 8, 8)
+      bounds: 256 24 8 8
+    - image: solid-color(33, 3, 0, 255, 8, 8)
+      bounds: 264 24 8 8
+    - image: solid-color(34, 3, 0, 255, 8, 8)
+      bounds: 272 24 8 8
+    - image: solid-color(35, 3, 0, 255, 8, 8)
+      bounds: 280 24 8 8
+    - image: solid-color(36, 3, 0, 255, 8, 8)
+      bounds: 288 24 8 8
+    - image: solid-color(37, 3, 0, 255, 8, 8)
+      bounds: 296 24 8 8
+    - image: solid-color(38, 3, 0, 255, 8, 8)
+      bounds: 304 24 8 8
+    - image: solid-color(39, 3, 0, 255, 8, 8)
+      bounds: 312 24 8 8
+    - image: solid-color(40, 3, 0, 255, 8, 8)
+      bounds: 320 24 8 8
+    - image: solid-color(41, 3, 0, 255, 8, 8)
+      bounds: 328 24 8 8
+    - image: solid-color(42, 3, 0, 255, 8, 8)
+      bounds: 336 24 8 8
+    - image: solid-color(43, 3, 0, 255, 8, 8)
+      bounds: 344 24 8 8
+    - image: solid-color(44, 3, 0, 255, 8, 8)
+      bounds: 352 24 8 8
+    - image: solid-color(45, 3, 0, 255, 8, 8)
+      bounds: 360 24 8 8
+    - image: solid-color(46, 3, 0, 255, 8, 8)
+      bounds: 368 24 8 8
+    - image: solid-color(47, 3, 0, 255, 8, 8)
+      bounds: 376 24 8 8
+    - image: solid-color(48, 3, 0, 255, 8, 8)
+      bounds: 384 24 8 8
+    - image: solid-color(49, 3, 0, 255, 8, 8)
+      bounds: 392 24 8 8
+    - image: solid-color(50, 3, 0, 255, 8, 8)
+      bounds: 400 24 8 8
+    - image: solid-color(51, 3, 0, 255, 8, 8)
+      bounds: 408 24 8 8
+    - image: solid-color(52, 3, 0, 255, 8, 8)
+      bounds: 416 24 8 8
+    - image: solid-color(53, 3, 0, 255, 8, 8)
+      bounds: 424 24 8 8
+    - image: solid-color(54, 3, 0, 255, 8, 8)
+      bounds: 432 24 8 8
+    - image: solid-color(55, 3, 0, 255, 8, 8)
+      bounds: 440 24 8 8
+    - image: solid-color(56, 3, 0, 255, 8, 8)
+      bounds: 448 24 8 8
+    - image: solid-color(57, 3, 0, 255, 8, 8)
+      bounds: 456 24 8 8
+    - image: solid-color(58, 3, 0, 255, 8, 8)
+      bounds: 464 24 8 8
+    - image: solid-color(59, 3, 0, 255, 8, 8)
+      bounds: 472 24 8 8
+    - image: solid-color(60, 3, 0, 255, 8, 8)
+      bounds: 480 24 8 8
+    - image: solid-color(61, 3, 0, 255, 8, 8)
+      bounds: 488 24 8 8
+    - image: solid-color(62, 3, 0, 255, 8, 8)
+      bounds: 496 24 8 8
+    - image: solid-color(63, 3, 0, 255, 8, 8)
+      bounds: 504 24 8 8
+    - image: solid-color(64, 3, 0, 255, 8, 8)
+      bounds: 512 24 8 8
+    - image: solid-color(65, 3, 0, 255, 8, 8)
+      bounds: 520 24 8 8
+    - image: solid-color(66, 3, 0, 255, 8, 8)
+      bounds: 528 24 8 8
+    - image: solid-color(67, 3, 0, 255, 8, 8)
+      bounds: 536 24 8 8
+    - image: solid-color(68, 3, 0, 255, 8, 8)
+      bounds: 544 24 8 8
+    - image: solid-color(69, 3, 0, 255, 8, 8)
+      bounds: 552 24 8 8
+    - image: solid-color(70, 3, 0, 255, 8, 8)
+      bounds: 560 24 8 8
+    - image: solid-color(71, 3, 0, 255, 8, 8)
+      bounds: 568 24 8 8
+    - image: solid-color(72, 3, 0, 255, 8, 8)
+      bounds: 576 24 8 8
+    - image: solid-color(73, 3, 0, 255, 8, 8)
+      bounds: 584 24 8 8
+    - image: solid-color(74, 3, 0, 255, 8, 8)
+      bounds: 592 24 8 8
+    - image: solid-color(75, 3, 0, 255, 8, 8)
+      bounds: 600 24 8 8
+    - image: solid-color(76, 3, 0, 255, 8, 8)
+      bounds: 608 24 8 8
+    - image: solid-color(77, 3, 0, 255, 8, 8)
+      bounds: 616 24 8 8
+    - image: solid-color(78, 3, 0, 255, 8, 8)
+      bounds: 624 24 8 8
+    - image: solid-color(79, 3, 0, 255, 8, 8)
+      bounds: 632 24 8 8
+    - image: solid-color(80, 3, 0, 255, 8, 8)
+      bounds: 640 24 8 8
+    - image: solid-color(81, 3, 0, 255, 8, 8)
+      bounds: 648 24 8 8
+    - image: solid-color(82, 3, 0, 255, 8, 8)
+      bounds: 656 24 8 8
+    - image: solid-color(83, 3, 0, 255, 8, 8)
+      bounds: 664 24 8 8
+    - image: solid-color(84, 3, 0, 255, 8, 8)
+      bounds: 672 24 8 8
+    - image: solid-color(85, 3, 0, 255, 8, 8)
+      bounds: 680 24 8 8
+    - image: solid-color(86, 3, 0, 255, 8, 8)
+      bounds: 688 24 8 8
+    - image: solid-color(87, 3, 0, 255, 8, 8)
+      bounds: 696 24 8 8
+    - image: solid-color(88, 3, 0, 255, 8, 8)
+      bounds: 704 24 8 8
+    - image: solid-color(89, 3, 0, 255, 8, 8)
+      bounds: 712 24 8 8
+    - image: solid-color(90, 3, 0, 255, 8, 8)
+      bounds: 720 24 8 8
+    - image: solid-color(91, 3, 0, 255, 8, 8)
+      bounds: 728 24 8 8
+    - image: solid-color(92, 3, 0, 255, 8, 8)
+      bounds: 736 24 8 8
+    - image: solid-color(93, 3, 0, 255, 8, 8)
+      bounds: 744 24 8 8
+    - image: solid-color(94, 3, 0, 255, 8, 8)
+      bounds: 752 24 8 8
+    - image: solid-color(95, 3, 0, 255, 8, 8)
+      bounds: 760 24 8 8
+    - image: solid-color(96, 3, 0, 255, 8, 8)
+      bounds: 768 24 8 8
+    - image: solid-color(97, 3, 0, 255, 8, 8)
+      bounds: 776 24 8 8
+    - image: solid-color(98, 3, 0, 255, 8, 8)
+      bounds: 784 24 8 8
+    - image: solid-color(99, 3, 0, 255, 8, 8)
+      bounds: 792 24 8 8
+    - image: solid-color(100, 3, 0, 255, 8, 8)
+      bounds: 800 24 8 8
+    - image: solid-color(101, 3, 0, 255, 8, 8)
+      bounds: 808 24 8 8
+    - image: solid-color(102, 3, 0, 255, 8, 8)
+      bounds: 816 24 8 8
+    - image: solid-color(103, 3, 0, 255, 8, 8)
+      bounds: 824 24 8 8
+    - image: solid-color(104, 3, 0, 255, 8, 8)
+      bounds: 832 24 8 8
+    - image: solid-color(105, 3, 0, 255, 8, 8)
+      bounds: 840 24 8 8
+    - image: solid-color(106, 3, 0, 255, 8, 8)
+      bounds: 848 24 8 8
+    - image: solid-color(107, 3, 0, 255, 8, 8)
+      bounds: 856 24 8 8
+    - image: solid-color(108, 3, 0, 255, 8, 8)
+      bounds: 864 24 8 8
+    - image: solid-color(109, 3, 0, 255, 8, 8)
+      bounds: 872 24 8 8
+    - image: solid-color(110, 3, 0, 255, 8, 8)
+      bounds: 880 24 8 8
+    - image: solid-color(111, 3, 0, 255, 8, 8)
+      bounds: 888 24 8 8
+    - image: solid-color(112, 3, 0, 255, 8, 8)
+      bounds: 896 24 8 8
+    - image: solid-color(113, 3, 0, 255, 8, 8)
+      bounds: 904 24 8 8
+    - image: solid-color(114, 3, 0, 255, 8, 8)
+      bounds: 912 24 8 8
+    - image: solid-color(115, 3, 0, 255, 8, 8)
+      bounds: 920 24 8 8
+    - image: solid-color(116, 3, 0, 255, 8, 8)
+      bounds: 928 24 8 8
+    - image: solid-color(117, 3, 0, 255, 8, 8)
+      bounds: 936 24 8 8
+    - image: solid-color(118, 3, 0, 255, 8, 8)
+      bounds: 944 24 8 8
+    - image: solid-color(119, 3, 0, 255, 8, 8)
+      bounds: 952 24 8 8
+    - image: solid-color(120, 3, 0, 255, 8, 8)
+      bounds: 960 24 8 8
+    - image: solid-color(121, 3, 0, 255, 8, 8)
+      bounds: 968 24 8 8
+    - image: solid-color(122, 3, 0, 255, 8, 8)
+      bounds: 976 24 8 8
+    - image: solid-color(123, 3, 0, 255, 8, 8)
+      bounds: 984 24 8 8
+    - image: solid-color(124, 3, 0, 255, 8, 8)
+      bounds: 992 24 8 8
+    - image: solid-color(125, 3, 0, 255, 8, 8)
+      bounds: 1000 24 8 8
+    - image: solid-color(126, 3, 0, 255, 8, 8)
+      bounds: 1008 24 8 8
+    - image: solid-color(127, 3, 0, 255, 8, 8)
+      bounds: 1016 24 8 8
+    - image: solid-color(0, 4, 0, 255, 8, 8)
+      bounds: 0 32 8 8
+    - image: solid-color(1, 4, 0, 255, 8, 8)
+      bounds: 8 32 8 8
+    - image: solid-color(2, 4, 0, 255, 8, 8)
+      bounds: 16 32 8 8
+    - image: solid-color(3, 4, 0, 255, 8, 8)
+      bounds: 24 32 8 8
+    - image: solid-color(4, 4, 0, 255, 8, 8)
+      bounds: 32 32 8 8
+    - image: solid-color(5, 4, 0, 255, 8, 8)
+      bounds: 40 32 8 8
+    - image: solid-color(6, 4, 0, 255, 8, 8)
+      bounds: 48 32 8 8
+    - image: solid-color(7, 4, 0, 255, 8, 8)
+      bounds: 56 32 8 8
+    - image: solid-color(8, 4, 0, 255, 8, 8)
+      bounds: 64 32 8 8
+    - image: solid-color(9, 4, 0, 255, 8, 8)
+      bounds: 72 32 8 8
+    - image: solid-color(10, 4, 0, 255, 8, 8)
+      bounds: 80 32 8 8
+    - image: solid-color(11, 4, 0, 255, 8, 8)
+      bounds: 88 32 8 8
+    - image: solid-color(12, 4, 0, 255, 8, 8)
+      bounds: 96 32 8 8
+    - image: solid-color(13, 4, 0, 255, 8, 8)
+      bounds: 104 32 8 8
+    - image: solid-color(14, 4, 0, 255, 8, 8)
+      bounds: 112 32 8 8
+    - image: solid-color(15, 4, 0, 255, 8, 8)
+      bounds: 120 32 8 8
+    - image: solid-color(16, 4, 0, 255, 8, 8)
+      bounds: 128 32 8 8
+    - image: solid-color(17, 4, 0, 255, 8, 8)
+      bounds: 136 32 8 8
+    - image: solid-color(18, 4, 0, 255, 8, 8)
+      bounds: 144 32 8 8
+    - image: solid-color(19, 4, 0, 255, 8, 8)
+      bounds: 152 32 8 8
+    - image: solid-color(20, 4, 0, 255, 8, 8)
+      bounds: 160 32 8 8
+    - image: solid-color(21, 4, 0, 255, 8, 8)
+      bounds: 168 32 8 8
+    - image: solid-color(22, 4, 0, 255, 8, 8)
+      bounds: 176 32 8 8
+    - image: solid-color(23, 4, 0, 255, 8, 8)
+      bounds: 184 32 8 8
+    - image: solid-color(24, 4, 0, 255, 8, 8)
+      bounds: 192 32 8 8
+    - image: solid-color(25, 4, 0, 255, 8, 8)
+      bounds: 200 32 8 8
+    - image: solid-color(26, 4, 0, 255, 8, 8)
+      bounds: 208 32 8 8
+    - image: solid-color(27, 4, 0, 255, 8, 8)
+      bounds: 216 32 8 8
+    - image: solid-color(28, 4, 0, 255, 8, 8)
+      bounds: 224 32 8 8
+    - image: solid-color(29, 4, 0, 255, 8, 8)
+      bounds: 232 32 8 8
+    - image: solid-color(30, 4, 0, 255, 8, 8)
+      bounds: 240 32 8 8
+    - image: solid-color(31, 4, 0, 255, 8, 8)
+      bounds: 248 32 8 8
+    - image: solid-color(32, 4, 0, 255, 8, 8)
+      bounds: 256 32 8 8
+    - image: solid-color(33, 4, 0, 255, 8, 8)
+      bounds: 264 32 8 8
+    - image: solid-color(34, 4, 0, 255, 8, 8)
+      bounds: 272 32 8 8
+    - image: solid-color(35, 4, 0, 255, 8, 8)
+      bounds: 280 32 8 8
+    - image: solid-color(36, 4, 0, 255, 8, 8)
+      bounds: 288 32 8 8
+    - image: solid-color(37, 4, 0, 255, 8, 8)
+      bounds: 296 32 8 8
+    - image: solid-color(38, 4, 0, 255, 8, 8)
+      bounds: 304 32 8 8
+    - image: solid-color(39, 4, 0, 255, 8, 8)
+      bounds: 312 32 8 8
+    - image: solid-color(40, 4, 0, 255, 8, 8)
+      bounds: 320 32 8 8
+    - image: solid-color(41, 4, 0, 255, 8, 8)
+      bounds: 328 32 8 8
+    - image: solid-color(42, 4, 0, 255, 8, 8)
+      bounds: 336 32 8 8
+    - image: solid-color(43, 4, 0, 255, 8, 8)
+      bounds: 344 32 8 8
+    - image: solid-color(44, 4, 0, 255, 8, 8)
+      bounds: 352 32 8 8
+    - image: solid-color(45, 4, 0, 255, 8, 8)
+      bounds: 360 32 8 8
+    - image: solid-color(46, 4, 0, 255, 8, 8)
+      bounds: 368 32 8 8
+    - image: solid-color(47, 4, 0, 255, 8, 8)
+      bounds: 376 32 8 8
+    - image: solid-color(48, 4, 0, 255, 8, 8)
+      bounds: 384 32 8 8
+    - image: solid-color(49, 4, 0, 255, 8, 8)
+      bounds: 392 32 8 8
+    - image: solid-color(50, 4, 0, 255, 8, 8)
+      bounds: 400 32 8 8
+    - image: solid-color(51, 4, 0, 255, 8, 8)
+      bounds: 408 32 8 8
+    - image: solid-color(52, 4, 0, 255, 8, 8)
+      bounds: 416 32 8 8
+    - image: solid-color(53, 4, 0, 255, 8, 8)
+      bounds: 424 32 8 8
+    - image: solid-color(54, 4, 0, 255, 8, 8)
+      bounds: 432 32 8 8
+    - image: solid-color(55, 4, 0, 255, 8, 8)
+      bounds: 440 32 8 8
+    - image: solid-color(56, 4, 0, 255, 8, 8)
+      bounds: 448 32 8 8
+    - image: solid-color(57, 4, 0, 255, 8, 8)
+      bounds: 456 32 8 8
+    - image: solid-color(58, 4, 0, 255, 8, 8)
+      bounds: 464 32 8 8
+    - image: solid-color(59, 4, 0, 255, 8, 8)
+      bounds: 472 32 8 8
+    - image: solid-color(60, 4, 0, 255, 8, 8)
+      bounds: 480 32 8 8
+    - image: solid-color(61, 4, 0, 255, 8, 8)
+      bounds: 488 32 8 8
+    - image: solid-color(62, 4, 0, 255, 8, 8)
+      bounds: 496 32 8 8
+    - image: solid-color(63, 4, 0, 255, 8, 8)
+      bounds: 504 32 8 8
+    - image: solid-color(64, 4, 0, 255, 8, 8)
+      bounds: 512 32 8 8
+    - image: solid-color(65, 4, 0, 255, 8, 8)
+      bounds: 520 32 8 8
+    - image: solid-color(66, 4, 0, 255, 8, 8)
+      bounds: 528 32 8 8
+    - image: solid-color(67, 4, 0, 255, 8, 8)
+      bounds: 536 32 8 8
+    - image: solid-color(68, 4, 0, 255, 8, 8)
+      bounds: 544 32 8 8
+    - image: solid-color(69, 4, 0, 255, 8, 8)
+      bounds: 552 32 8 8
+    - image: solid-color(70, 4, 0, 255, 8, 8)
+      bounds: 560 32 8 8
+    - image: solid-color(71, 4, 0, 255, 8, 8)
+      bounds: 568 32 8 8
+    - image: solid-color(72, 4, 0, 255, 8, 8)
+      bounds: 576 32 8 8
+    - image: solid-color(73, 4, 0, 255, 8, 8)
+      bounds: 584 32 8 8
+    - image: solid-color(74, 4, 0, 255, 8, 8)
+      bounds: 592 32 8 8
+    - image: solid-color(75, 4, 0, 255, 8, 8)
+      bounds: 600 32 8 8
+    - image: solid-color(76, 4, 0, 255, 8, 8)
+      bounds: 608 32 8 8
+    - image: solid-color(77, 4, 0, 255, 8, 8)
+      bounds: 616 32 8 8
+    - image: solid-color(78, 4, 0, 255, 8, 8)
+      bounds: 624 32 8 8
+    - image: solid-color(79, 4, 0, 255, 8, 8)
+      bounds: 632 32 8 8
+    - image: solid-color(80, 4, 0, 255, 8, 8)
+      bounds: 640 32 8 8
+    - image: solid-color(81, 4, 0, 255, 8, 8)
+      bounds: 648 32 8 8
+    - image: solid-color(82, 4, 0, 255, 8, 8)
+      bounds: 656 32 8 8
+    - image: solid-color(83, 4, 0, 255, 8, 8)
+      bounds: 664 32 8 8
+    - image: solid-color(84, 4, 0, 255, 8, 8)
+      bounds: 672 32 8 8
+    - image: solid-color(85, 4, 0, 255, 8, 8)
+      bounds: 680 32 8 8
+    - image: solid-color(86, 4, 0, 255, 8, 8)
+      bounds: 688 32 8 8
+    - image: solid-color(87, 4, 0, 255, 8, 8)
+      bounds: 696 32 8 8
+    - image: solid-color(88, 4, 0, 255, 8, 8)
+      bounds: 704 32 8 8
+    - image: solid-color(89, 4, 0, 255, 8, 8)
+      bounds: 712 32 8 8
+    - image: solid-color(90, 4, 0, 255, 8, 8)
+      bounds: 720 32 8 8
+    - image: solid-color(91, 4, 0, 255, 8, 8)
+      bounds: 728 32 8 8
+    - image: solid-color(92, 4, 0, 255, 8, 8)
+      bounds: 736 32 8 8
+    - image: solid-color(93, 4, 0, 255, 8, 8)
+      bounds: 744 32 8 8
+    - image: solid-color(94, 4, 0, 255, 8, 8)
+      bounds: 752 32 8 8
+    - image: solid-color(95, 4, 0, 255, 8, 8)
+      bounds: 760 32 8 8
+    - image: solid-color(96, 4, 0, 255, 8, 8)
+      bounds: 768 32 8 8
+    - image: solid-color(97, 4, 0, 255, 8, 8)
+      bounds: 776 32 8 8
+    - image: solid-color(98, 4, 0, 255, 8, 8)
+      bounds: 784 32 8 8
+    - image: solid-color(99, 4, 0, 255, 8, 8)
+      bounds: 792 32 8 8
+    - image: solid-color(100, 4, 0, 255, 8, 8)
+      bounds: 800 32 8 8
+    - image: solid-color(101, 4, 0, 255, 8, 8)
+      bounds: 808 32 8 8
+    - image: solid-color(102, 4, 0, 255, 8, 8)
+      bounds: 816 32 8 8
+    - image: solid-color(103, 4, 0, 255, 8, 8)
+      bounds: 824 32 8 8
+    - image: solid-color(104, 4, 0, 255, 8, 8)
+      bounds: 832 32 8 8
+    - image: solid-color(105, 4, 0, 255, 8, 8)
+      bounds: 840 32 8 8
+    - image: solid-color(106, 4, 0, 255, 8, 8)
+      bounds: 848 32 8 8
+    - image: solid-color(107, 4, 0, 255, 8, 8)
+      bounds: 856 32 8 8
+    - image: solid-color(108, 4, 0, 255, 8, 8)
+      bounds: 864 32 8 8
+    - image: solid-color(109, 4, 0, 255, 8, 8)
+      bounds: 872 32 8 8
+    - image: solid-color(110, 4, 0, 255, 8, 8)
+      bounds: 880 32 8 8
+    - image: solid-color(111, 4, 0, 255, 8, 8)
+      bounds: 888 32 8 8
+    - image: solid-color(112, 4, 0, 255, 8, 8)
+      bounds: 896 32 8 8
+    - image: solid-color(113, 4, 0, 255, 8, 8)
+      bounds: 904 32 8 8
+    - image: solid-color(114, 4, 0, 255, 8, 8)
+      bounds: 912 32 8 8
+    - image: solid-color(115, 4, 0, 255, 8, 8)
+      bounds: 920 32 8 8
+    - image: solid-color(116, 4, 0, 255, 8, 8)
+      bounds: 928 32 8 8
+    - image: solid-color(117, 4, 0, 255, 8, 8)
+      bounds: 936 32 8 8
+    - image: solid-color(118, 4, 0, 255, 8, 8)
+      bounds: 944 32 8 8
+    - image: solid-color(119, 4, 0, 255, 8, 8)
+      bounds: 952 32 8 8
+    - image: solid-color(120, 4, 0, 255, 8, 8)
+      bounds: 960 32 8 8
+    - image: solid-color(121, 4, 0, 255, 8, 8)
+      bounds: 968 32 8 8
+    - image: solid-color(122, 4, 0, 255, 8, 8)
+      bounds: 976 32 8 8
+    - image: solid-color(123, 4, 0, 255, 8, 8)
+      bounds: 984 32 8 8
+    - image: solid-color(124, 4, 0, 255, 8, 8)
+      bounds: 992 32 8 8
+    - image: solid-color(125, 4, 0, 255, 8, 8)
+      bounds: 1000 32 8 8
+    - image: solid-color(126, 4, 0, 255, 8, 8)
+      bounds: 1008 32 8 8
+    - image: solid-color(127, 4, 0, 255, 8, 8)
+      bounds: 1016 32 8 8
+    - image: solid-color(0, 5, 0, 255, 8, 8)
+      bounds: 0 40 8 8
+    - image: solid-color(1, 5, 0, 255, 8, 8)
+      bounds: 8 40 8 8
+    - image: solid-color(2, 5, 0, 255, 8, 8)
+      bounds: 16 40 8 8
+    - image: solid-color(3, 5, 0, 255, 8, 8)
+      bounds: 24 40 8 8
+    - image: solid-color(4, 5, 0, 255, 8, 8)
+      bounds: 32 40 8 8
+    - image: solid-color(5, 5, 0, 255, 8, 8)
+      bounds: 40 40 8 8
+    - image: solid-color(6, 5, 0, 255, 8, 8)
+      bounds: 48 40 8 8
+    - image: solid-color(7, 5, 0, 255, 8, 8)
+      bounds: 56 40 8 8
+    - image: solid-color(8, 5, 0, 255, 8, 8)
+      bounds: 64 40 8 8
+    - image: solid-color(9, 5, 0, 255, 8, 8)
+      bounds: 72 40 8 8
+    - image: solid-color(10, 5, 0, 255, 8, 8)
+      bounds: 80 40 8 8
+    - image: solid-color(11, 5, 0, 255, 8, 8)
+      bounds: 88 40 8 8
+    - image: solid-color(12, 5, 0, 255, 8, 8)
+      bounds: 96 40 8 8
+    - image: solid-color(13, 5, 0, 255, 8, 8)
+      bounds: 104 40 8 8
+    - image: solid-color(14, 5, 0, 255, 8, 8)
+      bounds: 112 40 8 8
+    - image: solid-color(15, 5, 0, 255, 8, 8)
+      bounds: 120 40 8 8
+    - image: solid-color(16, 5, 0, 255, 8, 8)
+      bounds: 128 40 8 8
+    - image: solid-color(17, 5, 0, 255, 8, 8)
+      bounds: 136 40 8 8
+    - image: solid-color(18, 5, 0, 255, 8, 8)
+      bounds: 144 40 8 8
+    - image: solid-color(19, 5, 0, 255, 8, 8)
+      bounds: 152 40 8 8
+    - image: solid-color(20, 5, 0, 255, 8, 8)
+      bounds: 160 40 8 8
+    - image: solid-color(21, 5, 0, 255, 8, 8)
+      bounds: 168 40 8 8
+    - image: solid-color(22, 5, 0, 255, 8, 8)
+      bounds: 176 40 8 8
+    - image: solid-color(23, 5, 0, 255, 8, 8)
+      bounds: 184 40 8 8
+    - image: solid-color(24, 5, 0, 255, 8, 8)
+      bounds: 192 40 8 8
+    - image: solid-color(25, 5, 0, 255, 8, 8)
+      bounds: 200 40 8 8
+    - image: solid-color(26, 5, 0, 255, 8, 8)
+      bounds: 208 40 8 8
+    - image: solid-color(27, 5, 0, 255, 8, 8)
+      bounds: 216 40 8 8
+    - image: solid-color(28, 5, 0, 255, 8, 8)
+      bounds: 224 40 8 8
+    - image: solid-color(29, 5, 0, 255, 8, 8)
+      bounds: 232 40 8 8
+    - image: solid-color(30, 5, 0, 255, 8, 8)
+      bounds: 240 40 8 8
+    - image: solid-color(31, 5, 0, 255, 8, 8)
+      bounds: 248 40 8 8
+    - image: solid-color(32, 5, 0, 255, 8, 8)
+      bounds: 256 40 8 8
+    - image: solid-color(33, 5, 0, 255, 8, 8)
+      bounds: 264 40 8 8
+    - image: solid-color(34, 5, 0, 255, 8, 8)
+      bounds: 272 40 8 8
+    - image: solid-color(35, 5, 0, 255, 8, 8)
+      bounds: 280 40 8 8
+    - image: solid-color(36, 5, 0, 255, 8, 8)
+      bounds: 288 40 8 8
+    - image: solid-color(37, 5, 0, 255, 8, 8)
+      bounds: 296 40 8 8
+    - image: solid-color(38, 5, 0, 255, 8, 8)
+      bounds: 304 40 8 8
+    - image: solid-color(39, 5, 0, 255, 8, 8)
+      bounds: 312 40 8 8
+    - image: solid-color(40, 5, 0, 255, 8, 8)
+      bounds: 320 40 8 8
+    - image: solid-color(41, 5, 0, 255, 8, 8)
+      bounds: 328 40 8 8
+    - image: solid-color(42, 5, 0, 255, 8, 8)
+      bounds: 336 40 8 8
+    - image: solid-color(43, 5, 0, 255, 8, 8)
+      bounds: 344 40 8 8
+    - image: solid-color(44, 5, 0, 255, 8, 8)
+      bounds: 352 40 8 8
+    - image: solid-color(45, 5, 0, 255, 8, 8)
+      bounds: 360 40 8 8
+    - image: solid-color(46, 5, 0, 255, 8, 8)
+      bounds: 368 40 8 8
+    - image: solid-color(47, 5, 0, 255, 8, 8)
+      bounds: 376 40 8 8
+    - image: solid-color(48, 5, 0, 255, 8, 8)
+      bounds: 384 40 8 8
+    - image: solid-color(49, 5, 0, 255, 8, 8)
+      bounds: 392 40 8 8
+    - image: solid-color(50, 5, 0, 255, 8, 8)
+      bounds: 400 40 8 8
+    - image: solid-color(51, 5, 0, 255, 8, 8)
+      bounds: 408 40 8 8
+    - image: solid-color(52, 5, 0, 255, 8, 8)
+      bounds: 416 40 8 8
+    - image: solid-color(53, 5, 0, 255, 8, 8)
+      bounds: 424 40 8 8
+    - image: solid-color(54, 5, 0, 255, 8, 8)
+      bounds: 432 40 8 8
+    - image: solid-color(55, 5, 0, 255, 8, 8)
+      bounds: 440 40 8 8
+    - image: solid-color(56, 5, 0, 255, 8, 8)
+      bounds: 448 40 8 8
+    - image: solid-color(57, 5, 0, 255, 8, 8)
+      bounds: 456 40 8 8
+    - image: solid-color(58, 5, 0, 255, 8, 8)
+      bounds: 464 40 8 8
+    - image: solid-color(59, 5, 0, 255, 8, 8)
+      bounds: 472 40 8 8
+    - image: solid-color(60, 5, 0, 255, 8, 8)
+      bounds: 480 40 8 8
+    - image: solid-color(61, 5, 0, 255, 8, 8)
+      bounds: 488 40 8 8
+    - image: solid-color(62, 5, 0, 255, 8, 8)
+      bounds: 496 40 8 8
+    - image: solid-color(63, 5, 0, 255, 8, 8)
+      bounds: 504 40 8 8
+    - image: solid-color(64, 5, 0, 255, 8, 8)
+      bounds: 512 40 8 8
+    - image: solid-color(65, 5, 0, 255, 8, 8)
+      bounds: 520 40 8 8
+    - image: solid-color(66, 5, 0, 255, 8, 8)
+      bounds: 528 40 8 8
+    - image: solid-color(67, 5, 0, 255, 8, 8)
+      bounds: 536 40 8 8
+    - image: solid-color(68, 5, 0, 255, 8, 8)
+      bounds: 544 40 8 8
+    - image: solid-color(69, 5, 0, 255, 8, 8)
+      bounds: 552 40 8 8
+    - image: solid-color(70, 5, 0, 255, 8, 8)
+      bounds: 560 40 8 8
+    - image: solid-color(71, 5, 0, 255, 8, 8)
+      bounds: 568 40 8 8
+    - image: solid-color(72, 5, 0, 255, 8, 8)
+      bounds: 576 40 8 8
+    - image: solid-color(73, 5, 0, 255, 8, 8)
+      bounds: 584 40 8 8
+    - image: solid-color(74, 5, 0, 255, 8, 8)
+      bounds: 592 40 8 8
+    - image: solid-color(75, 5, 0, 255, 8, 8)
+      bounds: 600 40 8 8
+    - image: solid-color(76, 5, 0, 255, 8, 8)
+      bounds: 608 40 8 8
+    - image: solid-color(77, 5, 0, 255, 8, 8)
+      bounds: 616 40 8 8
+    - image: solid-color(78, 5, 0, 255, 8, 8)
+      bounds: 624 40 8 8
+    - image: solid-color(79, 5, 0, 255, 8, 8)
+      bounds: 632 40 8 8
+    - image: solid-color(80, 5, 0, 255, 8, 8)
+      bounds: 640 40 8 8
+    - image: solid-color(81, 5, 0, 255, 8, 8)
+      bounds: 648 40 8 8
+    - image: solid-color(82, 5, 0, 255, 8, 8)
+      bounds: 656 40 8 8
+    - image: solid-color(83, 5, 0, 255, 8, 8)
+      bounds: 664 40 8 8
+    - image: solid-color(84, 5, 0, 255, 8, 8)
+      bounds: 672 40 8 8
+    - image: solid-color(85, 5, 0, 255, 8, 8)
+      bounds: 680 40 8 8
+    - image: solid-color(86, 5, 0, 255, 8, 8)
+      bounds: 688 40 8 8
+    - image: solid-color(87, 5, 0, 255, 8, 8)
+      bounds: 696 40 8 8
+    - image: solid-color(88, 5, 0, 255, 8, 8)
+      bounds: 704 40 8 8
+    - image: solid-color(89, 5, 0, 255, 8, 8)
+      bounds: 712 40 8 8
+    - image: solid-color(90, 5, 0, 255, 8, 8)
+      bounds: 720 40 8 8
+    - image: solid-color(91, 5, 0, 255, 8, 8)
+      bounds: 728 40 8 8
+    - image: solid-color(92, 5, 0, 255, 8, 8)
+      bounds: 736 40 8 8
+    - image: solid-color(93, 5, 0, 255, 8, 8)
+      bounds: 744 40 8 8
+    - image: solid-color(94, 5, 0, 255, 8, 8)
+      bounds: 752 40 8 8
+    - image: solid-color(95, 5, 0, 255, 8, 8)
+      bounds: 760 40 8 8
+    - image: solid-color(96, 5, 0, 255, 8, 8)
+      bounds: 768 40 8 8
+    - image: solid-color(97, 5, 0, 255, 8, 8)
+      bounds: 776 40 8 8
+    - image: solid-color(98, 5, 0, 255, 8, 8)
+      bounds: 784 40 8 8
+    - image: solid-color(99, 5, 0, 255, 8, 8)
+      bounds: 792 40 8 8
+    - image: solid-color(100, 5, 0, 255, 8, 8)
+      bounds: 800 40 8 8
+    - image: solid-color(101, 5, 0, 255, 8, 8)
+      bounds: 808 40 8 8
+    - image: solid-color(102, 5, 0, 255, 8, 8)
+      bounds: 816 40 8 8
+    - image: solid-color(103, 5, 0, 255, 8, 8)
+      bounds: 824 40 8 8
+    - image: solid-color(104, 5, 0, 255, 8, 8)
+      bounds: 832 40 8 8
+    - image: solid-color(105, 5, 0, 255, 8, 8)
+      bounds: 840 40 8 8
+    - image: solid-color(106, 5, 0, 255, 8, 8)
+      bounds: 848 40 8 8
+    - image: solid-color(107, 5, 0, 255, 8, 8)
+      bounds: 856 40 8 8
+    - image: solid-color(108, 5, 0, 255, 8, 8)
+      bounds: 864 40 8 8
+    - image: solid-color(109, 5, 0, 255, 8, 8)
+      bounds: 872 40 8 8
+    - image: solid-color(110, 5, 0, 255, 8, 8)
+      bounds: 880 40 8 8
+    - image: solid-color(111, 5, 0, 255, 8, 8)
+      bounds: 888 40 8 8
+    - image: solid-color(112, 5, 0, 255, 8, 8)
+      bounds: 896 40 8 8
+    - image: solid-color(113, 5, 0, 255, 8, 8)
+      bounds: 904 40 8 8
+    - image: solid-color(114, 5, 0, 255, 8, 8)
+      bounds: 912 40 8 8
+    - image: solid-color(115, 5, 0, 255, 8, 8)
+      bounds: 920 40 8 8
+    - image: solid-color(116, 5, 0, 255, 8, 8)
+      bounds: 928 40 8 8
+    - image: solid-color(117, 5, 0, 255, 8, 8)
+      bounds: 936 40 8 8
+    - image: solid-color(118, 5, 0, 255, 8, 8)
+      bounds: 944 40 8 8
+    - image: solid-color(119, 5, 0, 255, 8, 8)
+      bounds: 952 40 8 8
+    - image: solid-color(120, 5, 0, 255, 8, 8)
+      bounds: 960 40 8 8
+    - image: solid-color(121, 5, 0, 255, 8, 8)
+      bounds: 968 40 8 8
+    - image: solid-color(122, 5, 0, 255, 8, 8)
+      bounds: 976 40 8 8
+    - image: solid-color(123, 5, 0, 255, 8, 8)
+      bounds: 984 40 8 8
+    - image: solid-color(124, 5, 0, 255, 8, 8)
+      bounds: 992 40 8 8
+    - image: solid-color(125, 5, 0, 255, 8, 8)
+      bounds: 1000 40 8 8
+    - image: solid-color(126, 5, 0, 255, 8, 8)
+      bounds: 1008 40 8 8
+    - image: solid-color(127, 5, 0, 255, 8, 8)
+      bounds: 1016 40 8 8
+    - image: solid-color(0, 6, 0, 255, 8, 8)
+      bounds: 0 48 8 8
+    - image: solid-color(1, 6, 0, 255, 8, 8)
+      bounds: 8 48 8 8
+    - image: solid-color(2, 6, 0, 255, 8, 8)
+      bounds: 16 48 8 8
+    - image: solid-color(3, 6, 0, 255, 8, 8)
+      bounds: 24 48 8 8
+    - image: solid-color(4, 6, 0, 255, 8, 8)
+      bounds: 32 48 8 8
+    - image: solid-color(5, 6, 0, 255, 8, 8)
+      bounds: 40 48 8 8
+    - image: solid-color(6, 6, 0, 255, 8, 8)
+      bounds: 48 48 8 8
+    - image: solid-color(7, 6, 0, 255, 8, 8)
+      bounds: 56 48 8 8
+    - image: solid-color(8, 6, 0, 255, 8, 8)
+      bounds: 64 48 8 8
+    - image: solid-color(9, 6, 0, 255, 8, 8)
+      bounds: 72 48 8 8
+    - image: solid-color(10, 6, 0, 255, 8, 8)
+      bounds: 80 48 8 8
+    - image: solid-color(11, 6, 0, 255, 8, 8)
+      bounds: 88 48 8 8
+    - image: solid-color(12, 6, 0, 255, 8, 8)
+      bounds: 96 48 8 8
+    - image: solid-color(13, 6, 0, 255, 8, 8)
+      bounds: 104 48 8 8
+    - image: solid-color(14, 6, 0, 255, 8, 8)
+      bounds: 112 48 8 8
+    - image: solid-color(15, 6, 0, 255, 8, 8)
+      bounds: 120 48 8 8
+    - image: solid-color(16, 6, 0, 255, 8, 8)
+      bounds: 128 48 8 8
+    - image: solid-color(17, 6, 0, 255, 8, 8)
+      bounds: 136 48 8 8
+    - image: solid-color(18, 6, 0, 255, 8, 8)
+      bounds: 144 48 8 8
+    - image: solid-color(19, 6, 0, 255, 8, 8)
+      bounds: 152 48 8 8
+    - image: solid-color(20, 6, 0, 255, 8, 8)
+      bounds: 160 48 8 8
+    - image: solid-color(21, 6, 0, 255, 8, 8)
+      bounds: 168 48 8 8
+    - image: solid-color(22, 6, 0, 255, 8, 8)
+      bounds: 176 48 8 8
+    - image: solid-color(23, 6, 0, 255, 8, 8)
+      bounds: 184 48 8 8
+    - image: solid-color(24, 6, 0, 255, 8, 8)
+      bounds: 192 48 8 8
+    - image: solid-color(25, 6, 0, 255, 8, 8)
+      bounds: 200 48 8 8
+    - image: solid-color(26, 6, 0, 255, 8, 8)
+      bounds: 208 48 8 8
+    - image: solid-color(27, 6, 0, 255, 8, 8)
+      bounds: 216 48 8 8
+    - image: solid-color(28, 6, 0, 255, 8, 8)
+      bounds: 224 48 8 8
+    - image: solid-color(29, 6, 0, 255, 8, 8)
+      bounds: 232 48 8 8
+    - image: solid-color(30, 6, 0, 255, 8, 8)
+      bounds: 240 48 8 8
+    - image: solid-color(31, 6, 0, 255, 8, 8)
+      bounds: 248 48 8 8
+    - image: solid-color(32, 6, 0, 255, 8, 8)
+      bounds: 256 48 8 8
+    - image: solid-color(33, 6, 0, 255, 8, 8)
+      bounds: 264 48 8 8
+    - image: solid-color(34, 6, 0, 255, 8, 8)
+      bounds: 272 48 8 8
+    - image: solid-color(35, 6, 0, 255, 8, 8)
+      bounds: 280 48 8 8
+    - image: solid-color(36, 6, 0, 255, 8, 8)
+      bounds: 288 48 8 8
+    - image: solid-color(37, 6, 0, 255, 8, 8)
+      bounds: 296 48 8 8
+    - image: solid-color(38, 6, 0, 255, 8, 8)
+      bounds: 304 48 8 8
+    - image: solid-color(39, 6, 0, 255, 8, 8)
+      bounds: 312 48 8 8
+    - image: solid-color(40, 6, 0, 255, 8, 8)
+      bounds: 320 48 8 8
+    - image: solid-color(41, 6, 0, 255, 8, 8)
+      bounds: 328 48 8 8
+    - image: solid-color(42, 6, 0, 255, 8, 8)
+      bounds: 336 48 8 8
+    - image: solid-color(43, 6, 0, 255, 8, 8)
+      bounds: 344 48 8 8
+    - image: solid-color(44, 6, 0, 255, 8, 8)
+      bounds: 352 48 8 8
+    - image: solid-color(45, 6, 0, 255, 8, 8)
+      bounds: 360 48 8 8
+    - image: solid-color(46, 6, 0, 255, 8, 8)
+      bounds: 368 48 8 8
+    - image: solid-color(47, 6, 0, 255, 8, 8)
+      bounds: 376 48 8 8
+    - image: solid-color(48, 6, 0, 255, 8, 8)
+      bounds: 384 48 8 8
+    - image: solid-color(49, 6, 0, 255, 8, 8)
+      bounds: 392 48 8 8
+    - image: solid-color(50, 6, 0, 255, 8, 8)
+      bounds: 400 48 8 8
+    - image: solid-color(51, 6, 0, 255, 8, 8)
+      bounds: 408 48 8 8
+    - image: solid-color(52, 6, 0, 255, 8, 8)
+      bounds: 416 48 8 8
+    - image: solid-color(53, 6, 0, 255, 8, 8)
+      bounds: 424 48 8 8
+    - image: solid-color(54, 6, 0, 255, 8, 8)
+      bounds: 432 48 8 8
+    - image: solid-color(55, 6, 0, 255, 8, 8)
+      bounds: 440 48 8 8
+    - image: solid-color(56, 6, 0, 255, 8, 8)
+      bounds: 448 48 8 8
+    - image: solid-color(57, 6, 0, 255, 8, 8)
+      bounds: 456 48 8 8
+    - image: solid-color(58, 6, 0, 255, 8, 8)
+      bounds: 464 48 8 8
+    - image: solid-color(59, 6, 0, 255, 8, 8)
+      bounds: 472 48 8 8
+    - image: solid-color(60, 6, 0, 255, 8, 8)
+      bounds: 480 48 8 8
+    - image: solid-color(61, 6, 0, 255, 8, 8)
+      bounds: 488 48 8 8
+    - image: solid-color(62, 6, 0, 255, 8, 8)
+      bounds: 496 48 8 8
+    - image: solid-color(63, 6, 0, 255, 8, 8)
+      bounds: 504 48 8 8
+    - image: solid-color(64, 6, 0, 255, 8, 8)
+      bounds: 512 48 8 8
+    - image: solid-color(65, 6, 0, 255, 8, 8)
+      bounds: 520 48 8 8
+    - image: solid-color(66, 6, 0, 255, 8, 8)
+      bounds: 528 48 8 8
+    - image: solid-color(67, 6, 0, 255, 8, 8)
+      bounds: 536 48 8 8
+    - image: solid-color(68, 6, 0, 255, 8, 8)
+      bounds: 544 48 8 8
+    - image: solid-color(69, 6, 0, 255, 8, 8)
+      bounds: 552 48 8 8
+    - image: solid-color(70, 6, 0, 255, 8, 8)
+      bounds: 560 48 8 8
+    - image: solid-color(71, 6, 0, 255, 8, 8)
+      bounds: 568 48 8 8
+    - image: solid-color(72, 6, 0, 255, 8, 8)
+      bounds: 576 48 8 8
+    - image: solid-color(73, 6, 0, 255, 8, 8)
+      bounds: 584 48 8 8
+    - image: solid-color(74, 6, 0, 255, 8, 8)
+      bounds: 592 48 8 8
+    - image: solid-color(75, 6, 0, 255, 8, 8)
+      bounds: 600 48 8 8
+    - image: solid-color(76, 6, 0, 255, 8, 8)
+      bounds: 608 48 8 8
+    - image: solid-color(77, 6, 0, 255, 8, 8)
+      bounds: 616 48 8 8
+    - image: solid-color(78, 6, 0, 255, 8, 8)
+      bounds: 624 48 8 8
+    - image: solid-color(79, 6, 0, 255, 8, 8)
+      bounds: 632 48 8 8
+    - image: solid-color(80, 6, 0, 255, 8, 8)
+      bounds: 640 48 8 8
+    - image: solid-color(81, 6, 0, 255, 8, 8)
+      bounds: 648 48 8 8
+    - image: solid-color(82, 6, 0, 255, 8, 8)
+      bounds: 656 48 8 8
+    - image: solid-color(83, 6, 0, 255, 8, 8)
+      bounds: 664 48 8 8
+    - image: solid-color(84, 6, 0, 255, 8, 8)
+      bounds: 672 48 8 8
+    - image: solid-color(85, 6, 0, 255, 8, 8)
+      bounds: 680 48 8 8
+    - image: solid-color(86, 6, 0, 255, 8, 8)
+      bounds: 688 48 8 8
+    - image: solid-color(87, 6, 0, 255, 8, 8)
+      bounds: 696 48 8 8
+    - image: solid-color(88, 6, 0, 255, 8, 8)
+      bounds: 704 48 8 8
+    - image: solid-color(89, 6, 0, 255, 8, 8)
+      bounds: 712 48 8 8
+    - image: solid-color(90, 6, 0, 255, 8, 8)
+      bounds: 720 48 8 8
+    - image: solid-color(91, 6, 0, 255, 8, 8)
+      bounds: 728 48 8 8
+    - image: solid-color(92, 6, 0, 255, 8, 8)
+      bounds: 736 48 8 8
+    - image: solid-color(93, 6, 0, 255, 8, 8)
+      bounds: 744 48 8 8
+    - image: solid-color(94, 6, 0, 255, 8, 8)
+      bounds: 752 48 8 8
+    - image: solid-color(95, 6, 0, 255, 8, 8)
+      bounds: 760 48 8 8
+    - image: solid-color(96, 6, 0, 255, 8, 8)
+      bounds: 768 48 8 8
+    - image: solid-color(97, 6, 0, 255, 8, 8)
+      bounds: 776 48 8 8
+    - image: solid-color(98, 6, 0, 255, 8, 8)
+      bounds: 784 48 8 8
+    - image: solid-color(99, 6, 0, 255, 8, 8)
+      bounds: 792 48 8 8
+    - image: solid-color(100, 6, 0, 255, 8, 8)
+      bounds: 800 48 8 8
+    - image: solid-color(101, 6, 0, 255, 8, 8)
+      bounds: 808 48 8 8
+    - image: solid-color(102, 6, 0, 255, 8, 8)
+      bounds: 816 48 8 8
+    - image: solid-color(103, 6, 0, 255, 8, 8)
+      bounds: 824 48 8 8
+    - image: solid-color(104, 6, 0, 255, 8, 8)
+      bounds: 832 48 8 8
+    - image: solid-color(105, 6, 0, 255, 8, 8)
+      bounds: 840 48 8 8
+    - image: solid-color(106, 6, 0, 255, 8, 8)
+      bounds: 848 48 8 8
+    - image: solid-color(107, 6, 0, 255, 8, 8)
+      bounds: 856 48 8 8
+    - image: solid-color(108, 6, 0, 255, 8, 8)
+      bounds: 864 48 8 8
+    - image: solid-color(109, 6, 0, 255, 8, 8)
+      bounds: 872 48 8 8
+    - image: solid-color(110, 6, 0, 255, 8, 8)
+      bounds: 880 48 8 8
+    - image: solid-color(111, 6, 0, 255, 8, 8)
+      bounds: 888 48 8 8
+    - image: solid-color(112, 6, 0, 255, 8, 8)
+      bounds: 896 48 8 8
+    - image: solid-color(113, 6, 0, 255, 8, 8)
+      bounds: 904 48 8 8
+    - image: solid-color(114, 6, 0, 255, 8, 8)
+      bounds: 912 48 8 8
+    - image: solid-color(115, 6, 0, 255, 8, 8)
+      bounds: 920 48 8 8
+    - image: solid-color(116, 6, 0, 255, 8, 8)
+      bounds: 928 48 8 8
+    - image: solid-color(117, 6, 0, 255, 8, 8)
+      bounds: 936 48 8 8
+    - image: solid-color(118, 6, 0, 255, 8, 8)
+      bounds: 944 48 8 8
+    - image: solid-color(119, 6, 0, 255, 8, 8)
+      bounds: 952 48 8 8
+    - image: solid-color(120, 6, 0, 255, 8, 8)
+      bounds: 960 48 8 8
+    - image: solid-color(121, 6, 0, 255, 8, 8)
+      bounds: 968 48 8 8
+    - image: solid-color(122, 6, 0, 255, 8, 8)
+      bounds: 976 48 8 8
+    - image: solid-color(123, 6, 0, 255, 8, 8)
+      bounds: 984 48 8 8
+    - image: solid-color(124, 6, 0, 255, 8, 8)
+      bounds: 992 48 8 8
+    - image: solid-color(125, 6, 0, 255, 8, 8)
+      bounds: 1000 48 8 8
+    - image: solid-color(126, 6, 0, 255, 8, 8)
+      bounds: 1008 48 8 8
+    - image: solid-color(127, 6, 0, 255, 8, 8)
+      bounds: 1016 48 8 8
+    - image: solid-color(0, 7, 0, 255, 8, 8)
+      bounds: 0 56 8 8
+    - image: solid-color(1, 7, 0, 255, 8, 8)
+      bounds: 8 56 8 8
+    - image: solid-color(2, 7, 0, 255, 8, 8)
+      bounds: 16 56 8 8
+    - image: solid-color(3, 7, 0, 255, 8, 8)
+      bounds: 24 56 8 8
+    - image: solid-color(4, 7, 0, 255, 8, 8)
+      bounds: 32 56 8 8
+    - image: solid-color(5, 7, 0, 255, 8, 8)
+      bounds: 40 56 8 8
+    - image: solid-color(6, 7, 0, 255, 8, 8)
+      bounds: 48 56 8 8
+    - image: solid-color(7, 7, 0, 255, 8, 8)
+      bounds: 56 56 8 8
+    - image: solid-color(8, 7, 0, 255, 8, 8)
+      bounds: 64 56 8 8
+    - image: solid-color(9, 7, 0, 255, 8, 8)
+      bounds: 72 56 8 8
+    - image: solid-color(10, 7, 0, 255, 8, 8)
+      bounds: 80 56 8 8
+    - image: solid-color(11, 7, 0, 255, 8, 8)
+      bounds: 88 56 8 8
+    - image: solid-color(12, 7, 0, 255, 8, 8)
+      bounds: 96 56 8 8
+    - image: solid-color(13, 7, 0, 255, 8, 8)
+      bounds: 104 56 8 8
+    - image: solid-color(14, 7, 0, 255, 8, 8)
+      bounds: 112 56 8 8
+    - image: solid-color(15, 7, 0, 255, 8, 8)
+      bounds: 120 56 8 8
+    - image: solid-color(16, 7, 0, 255, 8, 8)
+      bounds: 128 56 8 8
+    - image: solid-color(17, 7, 0, 255, 8, 8)
+      bounds: 136 56 8 8
+    - image: solid-color(18, 7, 0, 255, 8, 8)
+      bounds: 144 56 8 8
+    - image: solid-color(19, 7, 0, 255, 8, 8)
+      bounds: 152 56 8 8
+    - image: solid-color(20, 7, 0, 255, 8, 8)
+      bounds: 160 56 8 8
+    - image: solid-color(21, 7, 0, 255, 8, 8)
+      bounds: 168 56 8 8
+    - image: solid-color(22, 7, 0, 255, 8, 8)
+      bounds: 176 56 8 8
+    - image: solid-color(23, 7, 0, 255, 8, 8)
+      bounds: 184 56 8 8
+    - image: solid-color(24, 7, 0, 255, 8, 8)
+      bounds: 192 56 8 8
+    - image: solid-color(25, 7, 0, 255, 8, 8)
+      bounds: 200 56 8 8
+    - image: solid-color(26, 7, 0, 255, 8, 8)
+      bounds: 208 56 8 8
+    - image: solid-color(27, 7, 0, 255, 8, 8)
+      bounds: 216 56 8 8
+    - image: solid-color(28, 7, 0, 255, 8, 8)
+      bounds: 224 56 8 8
+    - image: solid-color(29, 7, 0, 255, 8, 8)
+      bounds: 232 56 8 8
+    - image: solid-color(30, 7, 0, 255, 8, 8)
+      bounds: 240 56 8 8
+    - image: solid-color(31, 7, 0, 255, 8, 8)
+      bounds: 248 56 8 8
+    - image: solid-color(32, 7, 0, 255, 8, 8)
+      bounds: 256 56 8 8
+    - image: solid-color(33, 7, 0, 255, 8, 8)
+      bounds: 264 56 8 8
+    - image: solid-color(34, 7, 0, 255, 8, 8)
+      bounds: 272 56 8 8
+    - image: solid-color(35, 7, 0, 255, 8, 8)
+      bounds: 280 56 8 8
+    - image: solid-color(36, 7, 0, 255, 8, 8)
+      bounds: 288 56 8 8
+    - image: solid-color(37, 7, 0, 255, 8, 8)
+      bounds: 296 56 8 8
+    - image: solid-color(38, 7, 0, 255, 8, 8)
+      bounds: 304 56 8 8
+    - image: solid-color(39, 7, 0, 255, 8, 8)
+      bounds: 312 56 8 8
+    - image: solid-color(40, 7, 0, 255, 8, 8)
+      bounds: 320 56 8 8
+    - image: solid-color(41, 7, 0, 255, 8, 8)
+      bounds: 328 56 8 8
+    - image: solid-color(42, 7, 0, 255, 8, 8)
+      bounds: 336 56 8 8
+    - image: solid-color(43, 7, 0, 255, 8, 8)
+      bounds: 344 56 8 8
+    - image: solid-color(44, 7, 0, 255, 8, 8)
+      bounds: 352 56 8 8
+    - image: solid-color(45, 7, 0, 255, 8, 8)
+      bounds: 360 56 8 8
+    - image: solid-color(46, 7, 0, 255, 8, 8)
+      bounds: 368 56 8 8
+    - image: solid-color(47, 7, 0, 255, 8, 8)
+      bounds: 376 56 8 8
+    - image: solid-color(48, 7, 0, 255, 8, 8)
+      bounds: 384 56 8 8
+    - image: solid-color(49, 7, 0, 255, 8, 8)
+      bounds: 392 56 8 8
+    - image: solid-color(50, 7, 0, 255, 8, 8)
+      bounds: 400 56 8 8
+    - image: solid-color(51, 7, 0, 255, 8, 8)
+      bounds: 408 56 8 8
+    - image: solid-color(52, 7, 0, 255, 8, 8)
+      bounds: 416 56 8 8
+    - image: solid-color(53, 7, 0, 255, 8, 8)
+      bounds: 424 56 8 8
+    - image: solid-color(54, 7, 0, 255, 8, 8)
+      bounds: 432 56 8 8
+    - image: solid-color(55, 7, 0, 255, 8, 8)
+      bounds: 440 56 8 8
+    - image: solid-color(56, 7, 0, 255, 8, 8)
+      bounds: 448 56 8 8
+    - image: solid-color(57, 7, 0, 255, 8, 8)
+      bounds: 456 56 8 8
+    - image: solid-color(58, 7, 0, 255, 8, 8)
+      bounds: 464 56 8 8
+    - image: solid-color(59, 7, 0, 255, 8, 8)
+      bounds: 472 56 8 8
+    - image: solid-color(60, 7, 0, 255, 8, 8)
+      bounds: 480 56 8 8
+    - image: solid-color(61, 7, 0, 255, 8, 8)
+      bounds: 488 56 8 8
+    - image: solid-color(62, 7, 0, 255, 8, 8)
+      bounds: 496 56 8 8
+    - image: solid-color(63, 7, 0, 255, 8, 8)
+      bounds: 504 56 8 8
+    - image: solid-color(64, 7, 0, 255, 8, 8)
+      bounds: 512 56 8 8
+    - image: solid-color(65, 7, 0, 255, 8, 8)
+      bounds: 520 56 8 8
+    - image: solid-color(66, 7, 0, 255, 8, 8)
+      bounds: 528 56 8 8
+    - image: solid-color(67, 7, 0, 255, 8, 8)
+      bounds: 536 56 8 8
+    - image: solid-color(68, 7, 0, 255, 8, 8)
+      bounds: 544 56 8 8
+    - image: solid-color(69, 7, 0, 255, 8, 8)
+      bounds: 552 56 8 8
+    - image: solid-color(70, 7, 0, 255, 8, 8)
+      bounds: 560 56 8 8
+    - image: solid-color(71, 7, 0, 255, 8, 8)
+      bounds: 568 56 8 8
+    - image: solid-color(72, 7, 0, 255, 8, 8)
+      bounds: 576 56 8 8
+    - image: solid-color(73, 7, 0, 255, 8, 8)
+      bounds: 584 56 8 8
+    - image: solid-color(74, 7, 0, 255, 8, 8)
+      bounds: 592 56 8 8
+    - image: solid-color(75, 7, 0, 255, 8, 8)
+      bounds: 600 56 8 8
+    - image: solid-color(76, 7, 0, 255, 8, 8)
+      bounds: 608 56 8 8
+    - image: solid-color(77, 7, 0, 255, 8, 8)
+      bounds: 616 56 8 8
+    - image: solid-color(78, 7, 0, 255, 8, 8)
+      bounds: 624 56 8 8
+    - image: solid-color(79, 7, 0, 255, 8, 8)
+      bounds: 632 56 8 8
+    - image: solid-color(80, 7, 0, 255, 8, 8)
+      bounds: 640 56 8 8
+    - image: solid-color(81, 7, 0, 255, 8, 8)
+      bounds: 648 56 8 8
+    - image: solid-color(82, 7, 0, 255, 8, 8)
+      bounds: 656 56 8 8
+    - image: solid-color(83, 7, 0, 255, 8, 8)
+      bounds: 664 56 8 8
+    - image: solid-color(84, 7, 0, 255, 8, 8)
+      bounds: 672 56 8 8
+    - image: solid-color(85, 7, 0, 255, 8, 8)
+      bounds: 680 56 8 8
+    - image: solid-color(86, 7, 0, 255, 8, 8)
+      bounds: 688 56 8 8
+    - image: solid-color(87, 7, 0, 255, 8, 8)
+      bounds: 696 56 8 8
+    - image: solid-color(88, 7, 0, 255, 8, 8)
+      bounds: 704 56 8 8
+    - image: solid-color(89, 7, 0, 255, 8, 8)
+      bounds: 712 56 8 8
+    - image: solid-color(90, 7, 0, 255, 8, 8)
+      bounds: 720 56 8 8
+    - image: solid-color(91, 7, 0, 255, 8, 8)
+      bounds: 728 56 8 8
+    - image: solid-color(92, 7, 0, 255, 8, 8)
+      bounds: 736 56 8 8
+    - image: solid-color(93, 7, 0, 255, 8, 8)
+      bounds: 744 56 8 8
+    - image: solid-color(94, 7, 0, 255, 8, 8)
+      bounds: 752 56 8 8
+    - image: solid-color(95, 7, 0, 255, 8, 8)
+      bounds: 760 56 8 8
+    - image: solid-color(96, 7, 0, 255, 8, 8)
+      bounds: 768 56 8 8
+    - image: solid-color(97, 7, 0, 255, 8, 8)
+      bounds: 776 56 8 8
+    - image: solid-color(98, 7, 0, 255, 8, 8)
+      bounds: 784 56 8 8
+    - image: solid-color(99, 7, 0, 255, 8, 8)
+      bounds: 792 56 8 8
+    - image: solid-color(100, 7, 0, 255, 8, 8)
+      bounds: 800 56 8 8
+    - image: solid-color(101, 7, 0, 255, 8, 8)
+      bounds: 808 56 8 8
+    - image: solid-color(102, 7, 0, 255, 8, 8)
+      bounds: 816 56 8 8
+    - image: solid-color(103, 7, 0, 255, 8, 8)
+      bounds: 824 56 8 8
+    - image: solid-color(104, 7, 0, 255, 8, 8)
+      bounds: 832 56 8 8
+    - image: solid-color(105, 7, 0, 255, 8, 8)
+      bounds: 840 56 8 8
+    - image: solid-color(106, 7, 0, 255, 8, 8)
+      bounds: 848 56 8 8
+    - image: solid-color(107, 7, 0, 255, 8, 8)
+      bounds: 856 56 8 8
+    - image: solid-color(108, 7, 0, 255, 8, 8)
+      bounds: 864 56 8 8
+    - image: solid-color(109, 7, 0, 255, 8, 8)
+      bounds: 872 56 8 8
+    - image: solid-color(110, 7, 0, 255, 8, 8)
+      bounds: 880 56 8 8
+    - image: solid-color(111, 7, 0, 255, 8, 8)
+      bounds: 888 56 8 8
+    - image: solid-color(112, 7, 0, 255, 8, 8)
+      bounds: 896 56 8 8
+    - image: solid-color(113, 7, 0, 255, 8, 8)
+      bounds: 904 56 8 8
+    - image: solid-color(114, 7, 0, 255, 8, 8)
+      bounds: 912 56 8 8
+    - image: solid-color(115, 7, 0, 255, 8, 8)
+      bounds: 920 56 8 8
+    - image: solid-color(116, 7, 0, 255, 8, 8)
+      bounds: 928 56 8 8
+    - image: solid-color(117, 7, 0, 255, 8, 8)
+      bounds: 936 56 8 8
+    - image: solid-color(118, 7, 0, 255, 8, 8)
+      bounds: 944 56 8 8
+    - image: solid-color(119, 7, 0, 255, 8, 8)
+      bounds: 952 56 8 8
+    - image: solid-color(120, 7, 0, 255, 8, 8)
+      bounds: 960 56 8 8
+    - image: solid-color(121, 7, 0, 255, 8, 8)
+      bounds: 968 56 8 8
+    - image: solid-color(122, 7, 0, 255, 8, 8)
+      bounds: 976 56 8 8
+    - image: solid-color(123, 7, 0, 255, 8, 8)
+      bounds: 984 56 8 8
+    - image: solid-color(124, 7, 0, 255, 8, 8)
+      bounds: 992 56 8 8
+    - image: solid-color(125, 7, 0, 255, 8, 8)
+      bounds: 1000 56 8 8
+    - image: solid-color(126, 7, 0, 255, 8, 8)
+      bounds: 1008 56 8 8
+    - image: solid-color(127, 7, 0, 255, 8, 8)
+      bounds: 1016 56 8 8
+    - image: solid-color(0, 8, 0, 255, 8, 8)
+      bounds: 0 64 8 8
+    - image: solid-color(1, 8, 0, 255, 8, 8)
+      bounds: 8 64 8 8
+    - image: solid-color(2, 8, 0, 255, 8, 8)
+      bounds: 16 64 8 8
+    - image: solid-color(3, 8, 0, 255, 8, 8)
+      bounds: 24 64 8 8
+    - image: solid-color(4, 8, 0, 255, 8, 8)
+      bounds: 32 64 8 8
+    - image: solid-color(5, 8, 0, 255, 8, 8)
+      bounds: 40 64 8 8
+    - image: solid-color(6, 8, 0, 255, 8, 8)
+      bounds: 48 64 8 8
+    - image: solid-color(7, 8, 0, 255, 8, 8)
+      bounds: 56 64 8 8
+    - image: solid-color(8, 8, 0, 255, 8, 8)
+      bounds: 64 64 8 8
+    - image: solid-color(9, 8, 0, 255, 8, 8)
+      bounds: 72 64 8 8
+    - image: solid-color(10, 8, 0, 255, 8, 8)
+      bounds: 80 64 8 8
+    - image: solid-color(11, 8, 0, 255, 8, 8)
+      bounds: 88 64 8 8
+    - image: solid-color(12, 8, 0, 255, 8, 8)
+      bounds: 96 64 8 8
+    - image: solid-color(13, 8, 0, 255, 8, 8)
+      bounds: 104 64 8 8
+    - image: solid-color(14, 8, 0, 255, 8, 8)
+      bounds: 112 64 8 8
+    - image: solid-color(15, 8, 0, 255, 8, 8)
+      bounds: 120 64 8 8
+    - image: solid-color(16, 8, 0, 255, 8, 8)
+      bounds: 128 64 8 8
+    - image: solid-color(17, 8, 0, 255, 8, 8)
+      bounds: 136 64 8 8
+    - image: solid-color(18, 8, 0, 255, 8, 8)
+      bounds: 144 64 8 8
+    - image: solid-color(19, 8, 0, 255, 8, 8)
+      bounds: 152 64 8 8
+    - image: solid-color(20, 8, 0, 255, 8, 8)
+      bounds: 160 64 8 8
+    - image: solid-color(21, 8, 0, 255, 8, 8)
+      bounds: 168 64 8 8
+    - image: solid-color(22, 8, 0, 255, 8, 8)
+      bounds: 176 64 8 8
+    - image: solid-color(23, 8, 0, 255, 8, 8)
+      bounds: 184 64 8 8
+    - image: solid-color(24, 8, 0, 255, 8, 8)
+      bounds: 192 64 8 8
+    - image: solid-color(25, 8, 0, 255, 8, 8)
+      bounds: 200 64 8 8
+    - image: solid-color(26, 8, 0, 255, 8, 8)
+      bounds: 208 64 8 8
+    - image: solid-color(27, 8, 0, 255, 8, 8)
+      bounds: 216 64 8 8
+    - image: solid-color(28, 8, 0, 255, 8, 8)
+      bounds: 224 64 8 8
+    - image: solid-color(29, 8, 0, 255, 8, 8)
+      bounds: 232 64 8 8
+    - image: solid-color(30, 8, 0, 255, 8, 8)
+      bounds: 240 64 8 8
+    - image: solid-color(31, 8, 0, 255, 8, 8)
+      bounds: 248 64 8 8
+    - image: solid-color(32, 8, 0, 255, 8, 8)
+      bounds: 256 64 8 8
+    - image: solid-color(33, 8, 0, 255, 8, 8)
+      bounds: 264 64 8 8
+    - image: solid-color(34, 8, 0, 255, 8, 8)
+      bounds: 272 64 8 8
+    - image: solid-color(35, 8, 0, 255, 8, 8)
+      bounds: 280 64 8 8
+    - image: solid-color(36, 8, 0, 255, 8, 8)
+      bounds: 288 64 8 8
+    - image: solid-color(37, 8, 0, 255, 8, 8)
+      bounds: 296 64 8 8
+    - image: solid-color(38, 8, 0, 255, 8, 8)
+      bounds: 304 64 8 8
+    - image: solid-color(39, 8, 0, 255, 8, 8)
+      bounds: 312 64 8 8
+    - image: solid-color(40, 8, 0, 255, 8, 8)
+      bounds: 320 64 8 8
+    - image: solid-color(41, 8, 0, 255, 8, 8)
+      bounds: 328 64 8 8
+    - image: solid-color(42, 8, 0, 255, 8, 8)
+      bounds: 336 64 8 8
+    - image: solid-color(43, 8, 0, 255, 8, 8)
+      bounds: 344 64 8 8
+    - image: solid-color(44, 8, 0, 255, 8, 8)
+      bounds: 352 64 8 8
+    - image: solid-color(45, 8, 0, 255, 8, 8)
+      bounds: 360 64 8 8
+    - image: solid-color(46, 8, 0, 255, 8, 8)
+      bounds: 368 64 8 8
+    - image: solid-color(47, 8, 0, 255, 8, 8)
+      bounds: 376 64 8 8
+    - image: solid-color(48, 8, 0, 255, 8, 8)
+      bounds: 384 64 8 8
+    - image: solid-color(49, 8, 0, 255, 8, 8)
+      bounds: 392 64 8 8
+    - image: solid-color(50, 8, 0, 255, 8, 8)
+      bounds: 400 64 8 8
+    - image: solid-color(51, 8, 0, 255, 8, 8)
+      bounds: 408 64 8 8
+    - image: solid-color(52, 8, 0, 255, 8, 8)
+      bounds: 416 64 8 8
+    - image: solid-color(53, 8, 0, 255, 8, 8)
+      bounds: 424 64 8 8
+    - image: solid-color(54, 8, 0, 255, 8, 8)
+      bounds: 432 64 8 8
+    - image: solid-color(55, 8, 0, 255, 8, 8)
+      bounds: 440 64 8 8
+    - image: solid-color(56, 8, 0, 255, 8, 8)
+      bounds: 448 64 8 8
+    - image: solid-color(57, 8, 0, 255, 8, 8)
+      bounds: 456 64 8 8
+    - image: solid-color(58, 8, 0, 255, 8, 8)
+      bounds: 464 64 8 8
+    - image: solid-color(59, 8, 0, 255, 8, 8)
+      bounds: 472 64 8 8
+    - image: solid-color(60, 8, 0, 255, 8, 8)
+      bounds: 480 64 8 8
+    - image: solid-color(61, 8, 0, 255, 8, 8)
+      bounds: 488 64 8 8
+    - image: solid-color(62, 8, 0, 255, 8, 8)
+      bounds: 496 64 8 8
+    - image: solid-color(63, 8, 0, 255, 8, 8)
+      bounds: 504 64 8 8
+    - image: solid-color(64, 8, 0, 255, 8, 8)
+      bounds: 512 64 8 8
+    - image: solid-color(65, 8, 0, 255, 8, 8)
+      bounds: 520 64 8 8
+    - image: solid-color(66, 8, 0, 255, 8, 8)
+      bounds: 528 64 8 8
+    - image: solid-color(67, 8, 0, 255, 8, 8)
+      bounds: 536 64 8 8
+    - image: solid-color(68, 8, 0, 255, 8, 8)
+      bounds: 544 64 8 8
+    - image: solid-color(69, 8, 0, 255, 8, 8)
+      bounds: 552 64 8 8
+    - image: solid-color(70, 8, 0, 255, 8, 8)
+      bounds: 560 64 8 8
+    - image: solid-color(71, 8, 0, 255, 8, 8)
+      bounds: 568 64 8 8
+    - image: solid-color(72, 8, 0, 255, 8, 8)
+      bounds: 576 64 8 8
+    - image: solid-color(73, 8, 0, 255, 8, 8)
+      bounds: 584 64 8 8
+    - image: solid-color(74, 8, 0, 255, 8, 8)
+      bounds: 592 64 8 8
+    - image: solid-color(75, 8, 0, 255, 8, 8)
+      bounds: 600 64 8 8
+    - image: solid-color(76, 8, 0, 255, 8, 8)
+      bounds: 608 64 8 8
+    - image: solid-color(77, 8, 0, 255, 8, 8)
+      bounds: 616 64 8 8
+    - image: solid-color(78, 8, 0, 255, 8, 8)
+      bounds: 624 64 8 8
+    - image: solid-color(79, 8, 0, 255, 8, 8)
+      bounds: 632 64 8 8
+    - image: solid-color(80, 8, 0, 255, 8, 8)
+      bounds: 640 64 8 8
+    - image: solid-color(81, 8, 0, 255, 8, 8)
+      bounds: 648 64 8 8
+    - image: solid-color(82, 8, 0, 255, 8, 8)
+      bounds: 656 64 8 8
+    - image: solid-color(83, 8, 0, 255, 8, 8)
+      bounds: 664 64 8 8
+    - image: solid-color(84, 8, 0, 255, 8, 8)
+      bounds: 672 64 8 8
+    - image: solid-color(85, 8, 0, 255, 8, 8)
+      bounds: 680 64 8 8
+    - image: solid-color(86, 8, 0, 255, 8, 8)
+      bounds: 688 64 8 8
+    - image: solid-color(87, 8, 0, 255, 8, 8)
+      bounds: 696 64 8 8
+    - image: solid-color(88, 8, 0, 255, 8, 8)
+      bounds: 704 64 8 8
+    - image: solid-color(89, 8, 0, 255, 8, 8)
+      bounds: 712 64 8 8
+    - image: solid-color(90, 8, 0, 255, 8, 8)
+      bounds: 720 64 8 8
+    - image: solid-color(91, 8, 0, 255, 8, 8)
+      bounds: 728 64 8 8
+    - image: solid-color(92, 8, 0, 255, 8, 8)
+      bounds: 736 64 8 8
+    - image: solid-color(93, 8, 0, 255, 8, 8)
+      bounds: 744 64 8 8
+    - image: solid-color(94, 8, 0, 255, 8, 8)
+      bounds: 752 64 8 8
+    - image: solid-color(95, 8, 0, 255, 8, 8)
+      bounds: 760 64 8 8
+    - image: solid-color(96, 8, 0, 255, 8, 8)
+      bounds: 768 64 8 8
+    - image: solid-color(97, 8, 0, 255, 8, 8)
+      bounds: 776 64 8 8
+    - image: solid-color(98, 8, 0, 255, 8, 8)
+      bounds: 784 64 8 8
+    - image: solid-color(99, 8, 0, 255, 8, 8)
+      bounds: 792 64 8 8
+    - image: solid-color(100, 8, 0, 255, 8, 8)
+      bounds: 800 64 8 8
+    - image: solid-color(101, 8, 0, 255, 8, 8)
+      bounds: 808 64 8 8
+    - image: solid-color(102, 8, 0, 255, 8, 8)
+      bounds: 816 64 8 8
+    - image: solid-color(103, 8, 0, 255, 8, 8)
+      bounds: 824 64 8 8
+    - image: solid-color(104, 8, 0, 255, 8, 8)
+      bounds: 832 64 8 8
+    - image: solid-color(105, 8, 0, 255, 8, 8)
+      bounds: 840 64 8 8
+    - image: solid-color(106, 8, 0, 255, 8, 8)
+      bounds: 848 64 8 8
+    - image: solid-color(107, 8, 0, 255, 8, 8)
+      bounds: 856 64 8 8
+    - image: solid-color(108, 8, 0, 255, 8, 8)
+      bounds: 864 64 8 8
+    - image: solid-color(109, 8, 0, 255, 8, 8)
+      bounds: 872 64 8 8
+    - image: solid-color(110, 8, 0, 255, 8, 8)
+      bounds: 880 64 8 8
+    - image: solid-color(111, 8, 0, 255, 8, 8)
+      bounds: 888 64 8 8
+    - image: solid-color(112, 8, 0, 255, 8, 8)
+      bounds: 896 64 8 8
+    - image: solid-color(113, 8, 0, 255, 8, 8)
+      bounds: 904 64 8 8
+    - image: solid-color(114, 8, 0, 255, 8, 8)
+      bounds: 912 64 8 8
+    - image: solid-color(115, 8, 0, 255, 8, 8)
+      bounds: 920 64 8 8
+    - image: solid-color(116, 8, 0, 255, 8, 8)
+      bounds: 928 64 8 8
+    - image: solid-color(117, 8, 0, 255, 8, 8)
+      bounds: 936 64 8 8
+    - image: solid-color(118, 8, 0, 255, 8, 8)
+      bounds: 944 64 8 8
+    - image: solid-color(119, 8, 0, 255, 8, 8)
+      bounds: 952 64 8 8
+    - image: solid-color(120, 8, 0, 255, 8, 8)
+      bounds: 960 64 8 8
+    - image: solid-color(121, 8, 0, 255, 8, 8)
+      bounds: 968 64 8 8
+    - image: solid-color(122, 8, 0, 255, 8, 8)
+      bounds: 976 64 8 8
+    - image: solid-color(123, 8, 0, 255, 8, 8)
+      bounds: 984 64 8 8
+    - image: solid-color(124, 8, 0, 255, 8, 8)
+      bounds: 992 64 8 8
+    - image: solid-color(125, 8, 0, 255, 8, 8)
+      bounds: 1000 64 8 8
+    - image: solid-color(126, 8, 0, 255, 8, 8)
+      bounds: 1008 64 8 8
+    - image: solid-color(127, 8, 0, 255, 8, 8)
+      bounds: 1016 64 8 8
+    - image: solid-color(0, 9, 0, 255, 8, 8)
+      bounds: 0 72 8 8
+    - image: solid-color(1, 9, 0, 255, 8, 8)
+      bounds: 8 72 8 8
+    - image: solid-color(2, 9, 0, 255, 8, 8)
+      bounds: 16 72 8 8
+    - image: solid-color(3, 9, 0, 255, 8, 8)
+      bounds: 24 72 8 8
+    - image: solid-color(4, 9, 0, 255, 8, 8)
+      bounds: 32 72 8 8
+    - image: solid-color(5, 9, 0, 255, 8, 8)
+      bounds: 40 72 8 8
+    - image: solid-color(6, 9, 0, 255, 8, 8)
+      bounds: 48 72 8 8
+    - image: solid-color(7, 9, 0, 255, 8, 8)
+      bounds: 56 72 8 8
+    - image: solid-color(8, 9, 0, 255, 8, 8)
+      bounds: 64 72 8 8
+    - image: solid-color(9, 9, 0, 255, 8, 8)
+      bounds: 72 72 8 8
+    - image: solid-color(10, 9, 0, 255, 8, 8)
+      bounds: 80 72 8 8
+    - image: solid-color(11, 9, 0, 255, 8, 8)
+      bounds: 88 72 8 8
+    - image: solid-color(12, 9, 0, 255, 8, 8)
+      bounds: 96 72 8 8
+    - image: solid-color(13, 9, 0, 255, 8, 8)
+      bounds: 104 72 8 8
+    - image: solid-color(14, 9, 0, 255, 8, 8)
+      bounds: 112 72 8 8
+    - image: solid-color(15, 9, 0, 255, 8, 8)
+      bounds: 120 72 8 8
+    - image: solid-color(16, 9, 0, 255, 8, 8)
+      bounds: 128 72 8 8
+    - image: solid-color(17, 9, 0, 255, 8, 8)
+      bounds: 136 72 8 8
+    - image: solid-color(18, 9, 0, 255, 8, 8)
+      bounds: 144 72 8 8
+    - image: solid-color(19, 9, 0, 255, 8, 8)
+      bounds: 152 72 8 8
+    - image: solid-color(20, 9, 0, 255, 8, 8)
+      bounds: 160 72 8 8
+    - image: solid-color(21, 9, 0, 255, 8, 8)
+      bounds: 168 72 8 8
+    - image: solid-color(22, 9, 0, 255, 8, 8)
+      bounds: 176 72 8 8
+    - image: solid-color(23, 9, 0, 255, 8, 8)
+      bounds: 184 72 8 8
+    - image: solid-color(24, 9, 0, 255, 8, 8)
+      bounds: 192 72 8 8
+    - image: solid-color(25, 9, 0, 255, 8, 8)
+      bounds: 200 72 8 8
+    - image: solid-color(26, 9, 0, 255, 8, 8)
+      bounds: 208 72 8 8
+    - image: solid-color(27, 9, 0, 255, 8, 8)
+      bounds: 216 72 8 8
+    - image: solid-color(28, 9, 0, 255, 8, 8)
+      bounds: 224 72 8 8
+    - image: solid-color(29, 9, 0, 255, 8, 8)
+      bounds: 232 72 8 8
+    - image: solid-color(30, 9, 0, 255, 8, 8)
+      bounds: 240 72 8 8
+    - image: solid-color(31, 9, 0, 255, 8, 8)
+      bounds: 248 72 8 8
+    - image: solid-color(32, 9, 0, 255, 8, 8)
+      bounds: 256 72 8 8
+    - image: solid-color(33, 9, 0, 255, 8, 8)
+      bounds: 264 72 8 8
+    - image: solid-color(34, 9, 0, 255, 8, 8)
+      bounds: 272 72 8 8
+    - image: solid-color(35, 9, 0, 255, 8, 8)
+      bounds: 280 72 8 8
+    - image: solid-color(36, 9, 0, 255, 8, 8)
+      bounds: 288 72 8 8
+    - image: solid-color(37, 9, 0, 255, 8, 8)
+      bounds: 296 72 8 8
+    - image: solid-color(38, 9, 0, 255, 8, 8)
+      bounds: 304 72 8 8
+    - image: solid-color(39, 9, 0, 255, 8, 8)
+      bounds: 312 72 8 8
+    - image: solid-color(40, 9, 0, 255, 8, 8)
+      bounds: 320 72 8 8
+    - image: solid-color(41, 9, 0, 255, 8, 8)
+      bounds: 328 72 8 8
+    - image: solid-color(42, 9, 0, 255, 8, 8)
+      bounds: 336 72 8 8
+    - image: solid-color(43, 9, 0, 255, 8, 8)
+      bounds: 344 72 8 8
+    - image: solid-color(44, 9, 0, 255, 8, 8)
+      bounds: 352 72 8 8
+    - image: solid-color(45, 9, 0, 255, 8, 8)
+      bounds: 360 72 8 8
+    - image: solid-color(46, 9, 0, 255, 8, 8)
+      bounds: 368 72 8 8
+    - image: solid-color(47, 9, 0, 255, 8, 8)
+      bounds: 376 72 8 8
+    - image: solid-color(48, 9, 0, 255, 8, 8)
+      bounds: 384 72 8 8
+    - image: solid-color(49, 9, 0, 255, 8, 8)
+      bounds: 392 72 8 8
+    - image: solid-color(50, 9, 0, 255, 8, 8)
+      bounds: 400 72 8 8
+    - image: solid-color(51, 9, 0, 255, 8, 8)
+      bounds: 408 72 8 8
+    - image: solid-color(52, 9, 0, 255, 8, 8)
+      bounds: 416 72 8 8
+    - image: solid-color(53, 9, 0, 255, 8, 8)
+      bounds: 424 72 8 8
+    - image: solid-color(54, 9, 0, 255, 8, 8)
+      bounds: 432 72 8 8
+    - image: solid-color(55, 9, 0, 255, 8, 8)
+      bounds: 440 72 8 8
+    - image: solid-color(56, 9, 0, 255, 8, 8)
+      bounds: 448 72 8 8
+    - image: solid-color(57, 9, 0, 255, 8, 8)
+      bounds: 456 72 8 8
+    - image: solid-color(58, 9, 0, 255, 8, 8)
+      bounds: 464 72 8 8
+    - image: solid-color(59, 9, 0, 255, 8, 8)
+      bounds: 472 72 8 8
+    - image: solid-color(60, 9, 0, 255, 8, 8)
+      bounds: 480 72 8 8
+    - image: solid-color(61, 9, 0, 255, 8, 8)
+      bounds: 488 72 8 8
+    - image: solid-color(62, 9, 0, 255, 8, 8)
+      bounds: 496 72 8 8
+    - image: solid-color(63, 9, 0, 255, 8, 8)
+      bounds: 504 72 8 8
+    - image: solid-color(64, 9, 0, 255, 8, 8)
+      bounds: 512 72 8 8
+    - image: solid-color(65, 9, 0, 255, 8, 8)
+      bounds: 520 72 8 8
+    - image: solid-color(66, 9, 0, 255, 8, 8)
+      bounds: 528 72 8 8
+    - image: solid-color(67, 9, 0, 255, 8, 8)
+      bounds: 536 72 8 8
+    - image: solid-color(68, 9, 0, 255, 8, 8)
+      bounds: 544 72 8 8
+    - image: solid-color(69, 9, 0, 255, 8, 8)
+      bounds: 552 72 8 8
+    - image: solid-color(70, 9, 0, 255, 8, 8)
+      bounds: 560 72 8 8
+    - image: solid-color(71, 9, 0, 255, 8, 8)
+      bounds: 568 72 8 8
+    - image: solid-color(72, 9, 0, 255, 8, 8)
+      bounds: 576 72 8 8
+    - image: solid-color(73, 9, 0, 255, 8, 8)
+      bounds: 584 72 8 8
+    - image: solid-color(74, 9, 0, 255, 8, 8)
+      bounds: 592 72 8 8
+    - image: solid-color(75, 9, 0, 255, 8, 8)
+      bounds: 600 72 8 8
+    - image: solid-color(76, 9, 0, 255, 8, 8)
+      bounds: 608 72 8 8
+    - image: solid-color(77, 9, 0, 255, 8, 8)
+      bounds: 616 72 8 8
+    - image: solid-color(78, 9, 0, 255, 8, 8)
+      bounds: 624 72 8 8
+    - image: solid-color(79, 9, 0, 255, 8, 8)
+      bounds: 632 72 8 8
+    - image: solid-color(80, 9, 0, 255, 8, 8)
+      bounds: 640 72 8 8
+    - image: solid-color(81, 9, 0, 255, 8, 8)
+      bounds: 648 72 8 8
+    - image: solid-color(82, 9, 0, 255, 8, 8)
+      bounds: 656 72 8 8
+    - image: solid-color(83, 9, 0, 255, 8, 8)
+      bounds: 664 72 8 8
+    - image: solid-color(84, 9, 0, 255, 8, 8)
+      bounds: 672 72 8 8
+    - image: solid-color(85, 9, 0, 255, 8, 8)
+      bounds: 680 72 8 8
+    - image: solid-color(86, 9, 0, 255, 8, 8)
+      bounds: 688 72 8 8
+    - image: solid-color(87, 9, 0, 255, 8, 8)
+      bounds: 696 72 8 8
+    - image: solid-color(88, 9, 0, 255, 8, 8)
+      bounds: 704 72 8 8
+    - image: solid-color(89, 9, 0, 255, 8, 8)
+      bounds: 712 72 8 8
+    - image: solid-color(90, 9, 0, 255, 8, 8)
+      bounds: 720 72 8 8
+    - image: solid-color(91, 9, 0, 255, 8, 8)
+      bounds: 728 72 8 8
+    - image: solid-color(92, 9, 0, 255, 8, 8)
+      bounds: 736 72 8 8
+    - image: solid-color(93, 9, 0, 255, 8, 8)
+      bounds: 744 72 8 8
+    - image: solid-color(94, 9, 0, 255, 8, 8)
+      bounds: 752 72 8 8
+    - image: solid-color(95, 9, 0, 255, 8, 8)
+      bounds: 760 72 8 8
+    - image: solid-color(96, 9, 0, 255, 8, 8)
+      bounds: 768 72 8 8
+    - image: solid-color(97, 9, 0, 255, 8, 8)
+      bounds: 776 72 8 8
+    - image: solid-color(98, 9, 0, 255, 8, 8)
+      bounds: 784 72 8 8
+    - image: solid-color(99, 9, 0, 255, 8, 8)
+      bounds: 792 72 8 8
+    - image: solid-color(100, 9, 0, 255, 8, 8)
+      bounds: 800 72 8 8
+    - image: solid-color(101, 9, 0, 255, 8, 8)
+      bounds: 808 72 8 8
+    - image: solid-color(102, 9, 0, 255, 8, 8)
+      bounds: 816 72 8 8
+    - image: solid-color(103, 9, 0, 255, 8, 8)
+      bounds: 824 72 8 8
+    - image: solid-color(104, 9, 0, 255, 8, 8)
+      bounds: 832 72 8 8
+    - image: solid-color(105, 9, 0, 255, 8, 8)
+      bounds: 840 72 8 8
+    - image: solid-color(106, 9, 0, 255, 8, 8)
+      bounds: 848 72 8 8
+    - image: solid-color(107, 9, 0, 255, 8, 8)
+      bounds: 856 72 8 8
+    - image: solid-color(108, 9, 0, 255, 8, 8)
+      bounds: 864 72 8 8
+    - image: solid-color(109, 9, 0, 255, 8, 8)
+      bounds: 872 72 8 8
+    - image: solid-color(110, 9, 0, 255, 8, 8)
+      bounds: 880 72 8 8
+    - image: solid-color(111, 9, 0, 255, 8, 8)
+      bounds: 888 72 8 8
+    - image: solid-color(112, 9, 0, 255, 8, 8)
+      bounds: 896 72 8 8
+    - image: solid-color(113, 9, 0, 255, 8, 8)
+      bounds: 904 72 8 8
+    - image: solid-color(114, 9, 0, 255, 8, 8)
+      bounds: 912 72 8 8
+    - image: solid-color(115, 9, 0, 255, 8, 8)
+      bounds: 920 72 8 8
+    - image: solid-color(116, 9, 0, 255, 8, 8)
+      bounds: 928 72 8 8
+    - image: solid-color(117, 9, 0, 255, 8, 8)
+      bounds: 936 72 8 8
+    - image: solid-color(118, 9, 0, 255, 8, 8)
+      bounds: 944 72 8 8
+    - image: solid-color(119, 9, 0, 255, 8, 8)
+      bounds: 952 72 8 8
+    - image: solid-color(120, 9, 0, 255, 8, 8)
+      bounds: 960 72 8 8
+    - image: solid-color(121, 9, 0, 255, 8, 8)
+      bounds: 968 72 8 8
+    - image: solid-color(122, 9, 0, 255, 8, 8)
+      bounds: 976 72 8 8
+    - image: solid-color(123, 9, 0, 255, 8, 8)
+      bounds: 984 72 8 8
+    - image: solid-color(124, 9, 0, 255, 8, 8)
+      bounds: 992 72 8 8
+    - image: solid-color(125, 9, 0, 255, 8, 8)
+      bounds: 1000 72 8 8
+    - image: solid-color(126, 9, 0, 255, 8, 8)
+      bounds: 1008 72 8 8
+    - image: solid-color(127, 9, 0, 255, 8, 8)
+      bounds: 1016 72 8 8
+    - image: solid-color(0, 10, 0, 255, 8, 8)
+      bounds: 0 80 8 8
+    - image: solid-color(1, 10, 0, 255, 8, 8)
+      bounds: 8 80 8 8
+    - image: solid-color(2, 10, 0, 255, 8, 8)
+      bounds: 16 80 8 8
+    - image: solid-color(3, 10, 0, 255, 8, 8)
+      bounds: 24 80 8 8
+    - image: solid-color(4, 10, 0, 255, 8, 8)
+      bounds: 32 80 8 8
+    - image: solid-color(5, 10, 0, 255, 8, 8)
+      bounds: 40 80 8 8
+    - image: solid-color(6, 10, 0, 255, 8, 8)
+      bounds: 48 80 8 8
+    - image: solid-color(7, 10, 0, 255, 8, 8)
+      bounds: 56 80 8 8
+    - image: solid-color(8, 10, 0, 255, 8, 8)
+      bounds: 64 80 8 8
+    - image: solid-color(9, 10, 0, 255, 8, 8)
+      bounds: 72 80 8 8
+    - image: solid-color(10, 10, 0, 255, 8, 8)
+      bounds: 80 80 8 8
+    - image: solid-color(11, 10, 0, 255, 8, 8)
+      bounds: 88 80 8 8
+    - image: solid-color(12, 10, 0, 255, 8, 8)
+      bounds: 96 80 8 8
+    - image: solid-color(13, 10, 0, 255, 8, 8)
+      bounds: 104 80 8 8
+    - image: solid-color(14, 10, 0, 255, 8, 8)
+      bounds: 112 80 8 8
+    - image: solid-color(15, 10, 0, 255, 8, 8)
+      bounds: 120 80 8 8
+    - image: solid-color(16, 10, 0, 255, 8, 8)
+      bounds: 128 80 8 8
+    - image: solid-color(17, 10, 0, 255, 8, 8)
+      bounds: 136 80 8 8
+    - image: solid-color(18, 10, 0, 255, 8, 8)
+      bounds: 144 80 8 8
+    - image: solid-color(19, 10, 0, 255, 8, 8)
+      bounds: 152 80 8 8
+    - image: solid-color(20, 10, 0, 255, 8, 8)
+      bounds: 160 80 8 8
+    - image: solid-color(21, 10, 0, 255, 8, 8)
+      bounds: 168 80 8 8
+    - image: solid-color(22, 10, 0, 255, 8, 8)
+      bounds: 176 80 8 8
+    - image: solid-color(23, 10, 0, 255, 8, 8)
+      bounds: 184 80 8 8
+    - image: solid-color(24, 10, 0, 255, 8, 8)
+      bounds: 192 80 8 8
+    - image: solid-color(25, 10, 0, 255, 8, 8)
+      bounds: 200 80 8 8
+    - image: solid-color(26, 10, 0, 255, 8, 8)
+      bounds: 208 80 8 8
+    - image: solid-color(27, 10, 0, 255, 8, 8)
+      bounds: 216 80 8 8
+    - image: solid-color(28, 10, 0, 255, 8, 8)
+      bounds: 224 80 8 8
+    - image: solid-color(29, 10, 0, 255, 8, 8)
+      bounds: 232 80 8 8
+    - image: solid-color(30, 10, 0, 255, 8, 8)
+      bounds: 240 80 8 8
+    - image: solid-color(31, 10, 0, 255, 8, 8)
+      bounds: 248 80 8 8
+    - image: solid-color(32, 10, 0, 255, 8, 8)
+      bounds: 256 80 8 8
+    - image: solid-color(33, 10, 0, 255, 8, 8)
+      bounds: 264 80 8 8
+    - image: solid-color(34, 10, 0, 255, 8, 8)
+      bounds: 272 80 8 8
+    - image: solid-color(35, 10, 0, 255, 8, 8)
+      bounds: 280 80 8 8
+    - image: solid-color(36, 10, 0, 255, 8, 8)
+      bounds: 288 80 8 8
+    - image: solid-color(37, 10, 0, 255, 8, 8)
+      bounds: 296 80 8 8
+    - image: solid-color(38, 10, 0, 255, 8, 8)
+      bounds: 304 80 8 8
+    - image: solid-color(39, 10, 0, 255, 8, 8)
+      bounds: 312 80 8 8
+    - image: solid-color(40, 10, 0, 255, 8, 8)
+      bounds: 320 80 8 8
+    - image: solid-color(41, 10, 0, 255, 8, 8)
+      bounds: 328 80 8 8
+    - image: solid-color(42, 10, 0, 255, 8, 8)
+      bounds: 336 80 8 8
+    - image: solid-color(43, 10, 0, 255, 8, 8)
+      bounds: 344 80 8 8
+    - image: solid-color(44, 10, 0, 255, 8, 8)
+      bounds: 352 80 8 8
+    - image: solid-color(45, 10, 0, 255, 8, 8)
+      bounds: 360 80 8 8
+    - image: solid-color(46, 10, 0, 255, 8, 8)
+      bounds: 368 80 8 8
+    - image: solid-color(47, 10, 0, 255, 8, 8)
+      bounds: 376 80 8 8
+    - image: solid-color(48, 10, 0, 255, 8, 8)
+      bounds: 384 80 8 8
+    - image: solid-color(49, 10, 0, 255, 8, 8)
+      bounds: 392 80 8 8
+    - image: solid-color(50, 10, 0, 255, 8, 8)
+      bounds: 400 80 8 8
+    - image: solid-color(51, 10, 0, 255, 8, 8)
+      bounds: 408 80 8 8
+    - image: solid-color(52, 10, 0, 255, 8, 8)
+      bounds: 416 80 8 8
+    - image: solid-color(53, 10, 0, 255, 8, 8)
+      bounds: 424 80 8 8
+    - image: solid-color(54, 10, 0, 255, 8, 8)
+      bounds: 432 80 8 8
+    - image: solid-color(55, 10, 0, 255, 8, 8)
+      bounds: 440 80 8 8
+    - image: solid-color(56, 10, 0, 255, 8, 8)
+      bounds: 448 80 8 8
+    - image: solid-color(57, 10, 0, 255, 8, 8)
+      bounds: 456 80 8 8
+    - image: solid-color(58, 10, 0, 255, 8, 8)
+      bounds: 464 80 8 8
+    - image: solid-color(59, 10, 0, 255, 8, 8)
+      bounds: 472 80 8 8
+    - image: solid-color(60, 10, 0, 255, 8, 8)
+      bounds: 480 80 8 8
+    - image: solid-color(61, 10, 0, 255, 8, 8)
+      bounds: 488 80 8 8
+    - image: solid-color(62, 10, 0, 255, 8, 8)
+      bounds: 496 80 8 8
+    - image: solid-color(63, 10, 0, 255, 8, 8)
+      bounds: 504 80 8 8
+    - image: solid-color(64, 10, 0, 255, 8, 8)
+      bounds: 512 80 8 8
+    - image: solid-color(65, 10, 0, 255, 8, 8)
+      bounds: 520 80 8 8
+    - image: solid-color(66, 10, 0, 255, 8, 8)
+      bounds: 528 80 8 8
+    - image: solid-color(67, 10, 0, 255, 8, 8)
+      bounds: 536 80 8 8
+    - image: solid-color(68, 10, 0, 255, 8, 8)
+      bounds: 544 80 8 8
+    - image: solid-color(69, 10, 0, 255, 8, 8)
+      bounds: 552 80 8 8
+    - image: solid-color(70, 10, 0, 255, 8, 8)
+      bounds: 560 80 8 8
+    - image: solid-color(71, 10, 0, 255, 8, 8)
+      bounds: 568 80 8 8
+    - image: solid-color(72, 10, 0, 255, 8, 8)
+      bounds: 576 80 8 8
+    - image: solid-color(73, 10, 0, 255, 8, 8)
+      bounds: 584 80 8 8
+    - image: solid-color(74, 10, 0, 255, 8, 8)
+      bounds: 592 80 8 8
+    - image: solid-color(75, 10, 0, 255, 8, 8)
+      bounds: 600 80 8 8
+    - image: solid-color(76, 10, 0, 255, 8, 8)
+      bounds: 608 80 8 8
+    - image: solid-color(77, 10, 0, 255, 8, 8)
+      bounds: 616 80 8 8
+    - image: solid-color(78, 10, 0, 255, 8, 8)
+      bounds: 624 80 8 8
+    - image: solid-color(79, 10, 0, 255, 8, 8)
+      bounds: 632 80 8 8
+    - image: solid-color(80, 10, 0, 255, 8, 8)
+      bounds: 640 80 8 8
+    - image: solid-color(81, 10, 0, 255, 8, 8)
+      bounds: 648 80 8 8
+    - image: solid-color(82, 10, 0, 255, 8, 8)
+      bounds: 656 80 8 8
+    - image: solid-color(83, 10, 0, 255, 8, 8)
+      bounds: 664 80 8 8
+    - image: solid-color(84, 10, 0, 255, 8, 8)
+      bounds: 672 80 8 8
+    - image: solid-color(85, 10, 0, 255, 8, 8)
+      bounds: 680 80 8 8
+    - image: solid-color(86, 10, 0, 255, 8, 8)
+      bounds: 688 80 8 8
+    - image: solid-color(87, 10, 0, 255, 8, 8)
+      bounds: 696 80 8 8
+    - image: solid-color(88, 10, 0, 255, 8, 8)
+      bounds: 704 80 8 8
+    - image: solid-color(89, 10, 0, 255, 8, 8)
+      bounds: 712 80 8 8
+    - image: solid-color(90, 10, 0, 255, 8, 8)
+      bounds: 720 80 8 8
+    - image: solid-color(91, 10, 0, 255, 8, 8)
+      bounds: 728 80 8 8
+    - image: solid-color(92, 10, 0, 255, 8, 8)
+      bounds: 736 80 8 8
+    - image: solid-color(93, 10, 0, 255, 8, 8)
+      bounds: 744 80 8 8
+    - image: solid-color(94, 10, 0, 255, 8, 8)
+      bounds: 752 80 8 8
+    - image: solid-color(95, 10, 0, 255, 8, 8)
+      bounds: 760 80 8 8
+    - image: solid-color(96, 10, 0, 255, 8, 8)
+      bounds: 768 80 8 8
+    - image: solid-color(97, 10, 0, 255, 8, 8)
+      bounds: 776 80 8 8
+    - image: solid-color(98, 10, 0, 255, 8, 8)
+      bounds: 784 80 8 8
+    - image: solid-color(99, 10, 0, 255, 8, 8)
+      bounds: 792 80 8 8
+    - image: solid-color(100, 10, 0, 255, 8, 8)
+      bounds: 800 80 8 8
+    - image: solid-color(101, 10, 0, 255, 8, 8)
+      bounds: 808 80 8 8
+    - image: solid-color(102, 10, 0, 255, 8, 8)
+      bounds: 816 80 8 8
+    - image: solid-color(103, 10, 0, 255, 8, 8)
+      bounds: 824 80 8 8
+    - image: solid-color(104, 10, 0, 255, 8, 8)
+      bounds: 832 80 8 8
+    - image: solid-color(105, 10, 0, 255, 8, 8)
+      bounds: 840 80 8 8
+    - image: solid-color(106, 10, 0, 255, 8, 8)
+      bounds: 848 80 8 8
+    - image: solid-color(107, 10, 0, 255, 8, 8)
+      bounds: 856 80 8 8
+    - image: solid-color(108, 10, 0, 255, 8, 8)
+      bounds: 864 80 8 8
+    - image: solid-color(109, 10, 0, 255, 8, 8)
+      bounds: 872 80 8 8
+    - image: solid-color(110, 10, 0, 255, 8, 8)
+      bounds: 880 80 8 8
+    - image: solid-color(111, 10, 0, 255, 8, 8)
+      bounds: 888 80 8 8
+    - image: solid-color(112, 10, 0, 255, 8, 8)
+      bounds: 896 80 8 8
+    - image: solid-color(113, 10, 0, 255, 8, 8)
+      bounds: 904 80 8 8
+    - image: solid-color(114, 10, 0, 255, 8, 8)
+      bounds: 912 80 8 8
+    - image: solid-color(115, 10, 0, 255, 8, 8)
+      bounds: 920 80 8 8
+    - image: solid-color(116, 10, 0, 255, 8, 8)
+      bounds: 928 80 8 8
+    - image: solid-color(117, 10, 0, 255, 8, 8)
+      bounds: 936 80 8 8
+    - image: solid-color(118, 10, 0, 255, 8, 8)
+      bounds: 944 80 8 8
+    - image: solid-color(119, 10, 0, 255, 8, 8)
+      bounds: 952 80 8 8
+    - image: solid-color(120, 10, 0, 255, 8, 8)
+      bounds: 960 80 8 8
+    - image: solid-color(121, 10, 0, 255, 8, 8)
+      bounds: 968 80 8 8
+    - image: solid-color(122, 10, 0, 255, 8, 8)
+      bounds: 976 80 8 8
+    - image: solid-color(123, 10, 0, 255, 8, 8)
+      bounds: 984 80 8 8
+    - image: solid-color(124, 10, 0, 255, 8, 8)
+      bounds: 992 80 8 8
+    - image: solid-color(125, 10, 0, 255, 8, 8)
+      bounds: 1000 80 8 8
+    - image: solid-color(126, 10, 0, 255, 8, 8)
+      bounds: 1008 80 8 8
+    - image: solid-color(127, 10, 0, 255, 8, 8)
+      bounds: 1016 80 8 8
+    - image: solid-color(0, 11, 0, 255, 8, 8)
+      bounds: 0 88 8 8
+    - image: solid-color(1, 11, 0, 255, 8, 8)
+      bounds: 8 88 8 8
+    - image: solid-color(2, 11, 0, 255, 8, 8)
+      bounds: 16 88 8 8
+    - image: solid-color(3, 11, 0, 255, 8, 8)
+      bounds: 24 88 8 8
+    - image: solid-color(4, 11, 0, 255, 8, 8)
+      bounds: 32 88 8 8
+    - image: solid-color(5, 11, 0, 255, 8, 8)
+      bounds: 40 88 8 8
+    - image: solid-color(6, 11, 0, 255, 8, 8)
+      bounds: 48 88 8 8
+    - image: solid-color(7, 11, 0, 255, 8, 8)
+      bounds: 56 88 8 8
+    - image: solid-color(8, 11, 0, 255, 8, 8)
+      bounds: 64 88 8 8
+    - image: solid-color(9, 11, 0, 255, 8, 8)
+      bounds: 72 88 8 8
+    - image: solid-color(10, 11, 0, 255, 8, 8)
+      bounds: 80 88 8 8
+    - image: solid-color(11, 11, 0, 255, 8, 8)
+      bounds: 88 88 8 8
+    - image: solid-color(12, 11, 0, 255, 8, 8)
+      bounds: 96 88 8 8
+    - image: solid-color(13, 11, 0, 255, 8, 8)
+      bounds: 104 88 8 8
+    - image: solid-color(14, 11, 0, 255, 8, 8)
+      bounds: 112 88 8 8
+    - image: solid-color(15, 11, 0, 255, 8, 8)
+      bounds: 120 88 8 8
+    - image: solid-color(16, 11, 0, 255, 8, 8)
+      bounds: 128 88 8 8
+    - image: solid-color(17, 11, 0, 255, 8, 8)
+      bounds: 136 88 8 8
+    - image: solid-color(18, 11, 0, 255, 8, 8)
+      bounds: 144 88 8 8
+    - image: solid-color(19, 11, 0, 255, 8, 8)
+      bounds: 152 88 8 8
+    - image: solid-color(20, 11, 0, 255, 8, 8)
+      bounds: 160 88 8 8
+    - image: solid-color(21, 11, 0, 255, 8, 8)
+      bounds: 168 88 8 8
+    - image: solid-color(22, 11, 0, 255, 8, 8)
+      bounds: 176 88 8 8
+    - image: solid-color(23, 11, 0, 255, 8, 8)
+      bounds: 184 88 8 8
+    - image: solid-color(24, 11, 0, 255, 8, 8)
+      bounds: 192 88 8 8
+    - image: solid-color(25, 11, 0, 255, 8, 8)
+      bounds: 200 88 8 8
+    - image: solid-color(26, 11, 0, 255, 8, 8)
+      bounds: 208 88 8 8
+    - image: solid-color(27, 11, 0, 255, 8, 8)
+      bounds: 216 88 8 8
+    - image: solid-color(28, 11, 0, 255, 8, 8)
+      bounds: 224 88 8 8
+    - image: solid-color(29, 11, 0, 255, 8, 8)
+      bounds: 232 88 8 8
+    - image: solid-color(30, 11, 0, 255, 8, 8)
+      bounds: 240 88 8 8
+    - image: solid-color(31, 11, 0, 255, 8, 8)
+      bounds: 248 88 8 8
+    - image: solid-color(32, 11, 0, 255, 8, 8)
+      bounds: 256 88 8 8
+    - image: solid-color(33, 11, 0, 255, 8, 8)
+      bounds: 264 88 8 8
+    - image: solid-color(34, 11, 0, 255, 8, 8)
+      bounds: 272 88 8 8
+    - image: solid-color(35, 11, 0, 255, 8, 8)
+      bounds: 280 88 8 8
+    - image: solid-color(36, 11, 0, 255, 8, 8)
+      bounds: 288 88 8 8
+    - image: solid-color(37, 11, 0, 255, 8, 8)
+      bounds: 296 88 8 8
+    - image: solid-color(38, 11, 0, 255, 8, 8)
+      bounds: 304 88 8 8
+    - image: solid-color(39, 11, 0, 255, 8, 8)
+      bounds: 312 88 8 8
+    - image: solid-color(40, 11, 0, 255, 8, 8)
+      bounds: 320 88 8 8
+    - image: solid-color(41, 11, 0, 255, 8, 8)
+      bounds: 328 88 8 8
+    - image: solid-color(42, 11, 0, 255, 8, 8)
+      bounds: 336 88 8 8
+    - image: solid-color(43, 11, 0, 255, 8, 8)
+      bounds: 344 88 8 8
+    - image: solid-color(44, 11, 0, 255, 8, 8)
+      bounds: 352 88 8 8
+    - image: solid-color(45, 11, 0, 255, 8, 8)
+      bounds: 360 88 8 8
+    - image: solid-color(46, 11, 0, 255, 8, 8)
+      bounds: 368 88 8 8
+    - image: solid-color(47, 11, 0, 255, 8, 8)
+      bounds: 376 88 8 8
+    - image: solid-color(48, 11, 0, 255, 8, 8)
+      bounds: 384 88 8 8
+    - image: solid-color(49, 11, 0, 255, 8, 8)
+      bounds: 392 88 8 8
+    - image: solid-color(50, 11, 0, 255, 8, 8)
+      bounds: 400 88 8 8
+    - image: solid-color(51, 11, 0, 255, 8, 8)
+      bounds: 408 88 8 8
+    - image: solid-color(52, 11, 0, 255, 8, 8)
+      bounds: 416 88 8 8
+    - image: solid-color(53, 11, 0, 255, 8, 8)
+      bounds: 424 88 8 8
+    - image: solid-color(54, 11, 0, 255, 8, 8)
+      bounds: 432 88 8 8
+    - image: solid-color(55, 11, 0, 255, 8, 8)
+      bounds: 440 88 8 8
+    - image: solid-color(56, 11, 0, 255, 8, 8)
+      bounds: 448 88 8 8
+    - image: solid-color(57, 11, 0, 255, 8, 8)
+      bounds: 456 88 8 8
+    - image: solid-color(58, 11, 0, 255, 8, 8)
+      bounds: 464 88 8 8
+    - image: solid-color(59, 11, 0, 255, 8, 8)
+      bounds: 472 88 8 8
+    - image: solid-color(60, 11, 0, 255, 8, 8)
+      bounds: 480 88 8 8
+    - image: solid-color(61, 11, 0, 255, 8, 8)
+      bounds: 488 88 8 8
+    - image: solid-color(62, 11, 0, 255, 8, 8)
+      bounds: 496 88 8 8
+    - image: solid-color(63, 11, 0, 255, 8, 8)
+      bounds: 504 88 8 8
+    - image: solid-color(64, 11, 0, 255, 8, 8)
+      bounds: 512 88 8 8
+    - image: solid-color(65, 11, 0, 255, 8, 8)
+      bounds: 520 88 8 8
+    - image: solid-color(66, 11, 0, 255, 8, 8)
+      bounds: 528 88 8 8
+    - image: solid-color(67, 11, 0, 255, 8, 8)
+      bounds: 536 88 8 8
+    - image: solid-color(68, 11, 0, 255, 8, 8)
+      bounds: 544 88 8 8
+    - image: solid-color(69, 11, 0, 255, 8, 8)
+      bounds: 552 88 8 8
+    - image: solid-color(70, 11, 0, 255, 8, 8)
+      bounds: 560 88 8 8
+    - image: solid-color(71, 11, 0, 255, 8, 8)
+      bounds: 568 88 8 8
+    - image: solid-color(72, 11, 0, 255, 8, 8)
+      bounds: 576 88 8 8
+    - image: solid-color(73, 11, 0, 255, 8, 8)
+      bounds: 584 88 8 8
+    - image: solid-color(74, 11, 0, 255, 8, 8)
+      bounds: 592 88 8 8
+    - image: solid-color(75, 11, 0, 255, 8, 8)
+      bounds: 600 88 8 8
+    - image: solid-color(76, 11, 0, 255, 8, 8)
+      bounds: 608 88 8 8
+    - image: solid-color(77, 11, 0, 255, 8, 8)
+      bounds: 616 88 8 8
+    - image: solid-color(78, 11, 0, 255, 8, 8)
+      bounds: 624 88 8 8
+    - image: solid-color(79, 11, 0, 255, 8, 8)
+      bounds: 632 88 8 8
+    - image: solid-color(80, 11, 0, 255, 8, 8)
+      bounds: 640 88 8 8
+    - image: solid-color(81, 11, 0, 255, 8, 8)
+      bounds: 648 88 8 8
+    - image: solid-color(82, 11, 0, 255, 8, 8)
+      bounds: 656 88 8 8
+    - image: solid-color(83, 11, 0, 255, 8, 8)
+      bounds: 664 88 8 8
+    - image: solid-color(84, 11, 0, 255, 8, 8)
+      bounds: 672 88 8 8
+    - image: solid-color(85, 11, 0, 255, 8, 8)
+      bounds: 680 88 8 8
+    - image: solid-color(86, 11, 0, 255, 8, 8)
+      bounds: 688 88 8 8
+    - image: solid-color(87, 11, 0, 255, 8, 8)
+      bounds: 696 88 8 8
+    - image: solid-color(88, 11, 0, 255, 8, 8)
+      bounds: 704 88 8 8
+    - image: solid-color(89, 11, 0, 255, 8, 8)
+      bounds: 712 88 8 8
+    - image: solid-color(90, 11, 0, 255, 8, 8)
+      bounds: 720 88 8 8
+    - image: solid-color(91, 11, 0, 255, 8, 8)
+      bounds: 728 88 8 8
+    - image: solid-color(92, 11, 0, 255, 8, 8)
+      bounds: 736 88 8 8
+    - image: solid-color(93, 11, 0, 255, 8, 8)
+      bounds: 744 88 8 8
+    - image: solid-color(94, 11, 0, 255, 8, 8)
+      bounds: 752 88 8 8
+    - image: solid-color(95, 11, 0, 255, 8, 8)
+      bounds: 760 88 8 8
+    - image: solid-color(96, 11, 0, 255, 8, 8)
+      bounds: 768 88 8 8
+    - image: solid-color(97, 11, 0, 255, 8, 8)
+      bounds: 776 88 8 8
+    - image: solid-color(98, 11, 0, 255, 8, 8)
+      bounds: 784 88 8 8
+    - image: solid-color(99, 11, 0, 255, 8, 8)
+      bounds: 792 88 8 8
+    - image: solid-color(100, 11, 0, 255, 8, 8)
+      bounds: 800 88 8 8
+    - image: solid-color(101, 11, 0, 255, 8, 8)
+      bounds: 808 88 8 8
+    - image: solid-color(102, 11, 0, 255, 8, 8)
+      bounds: 816 88 8 8
+    - image: solid-color(103, 11, 0, 255, 8, 8)
+      bounds: 824 88 8 8
+    - image: solid-color(104, 11, 0, 255, 8, 8)
+      bounds: 832 88 8 8
+    - image: solid-color(105, 11, 0, 255, 8, 8)
+      bounds: 840 88 8 8
+    - image: solid-color(106, 11, 0, 255, 8, 8)
+      bounds: 848 88 8 8
+    - image: solid-color(107, 11, 0, 255, 8, 8)
+      bounds: 856 88 8 8
+    - image: solid-color(108, 11, 0, 255, 8, 8)
+      bounds: 864 88 8 8
+    - image: solid-color(109, 11, 0, 255, 8, 8)
+      bounds: 872 88 8 8
+    - image: solid-color(110, 11, 0, 255, 8, 8)
+      bounds: 880 88 8 8
+    - image: solid-color(111, 11, 0, 255, 8, 8)
+      bounds: 888 88 8 8
+    - image: solid-color(112, 11, 0, 255, 8, 8)
+      bounds: 896 88 8 8
+    - image: solid-color(113, 11, 0, 255, 8, 8)
+      bounds: 904 88 8 8
+    - image: solid-color(114, 11, 0, 255, 8, 8)
+      bounds: 912 88 8 8
+    - image: solid-color(115, 11, 0, 255, 8, 8)
+      bounds: 920 88 8 8
+    - image: solid-color(116, 11, 0, 255, 8, 8)
+      bounds: 928 88 8 8
+    - image: solid-color(117, 11, 0, 255, 8, 8)
+      bounds: 936 88 8 8
+    - image: solid-color(118, 11, 0, 255, 8, 8)
+      bounds: 944 88 8 8
+    - image: solid-color(119, 11, 0, 255, 8, 8)
+      bounds: 952 88 8 8
+    - image: solid-color(120, 11, 0, 255, 8, 8)
+      bounds: 960 88 8 8
+    - image: solid-color(121, 11, 0, 255, 8, 8)
+      bounds: 968 88 8 8
+    - image: solid-color(122, 11, 0, 255, 8, 8)
+      bounds: 976 88 8 8
+    - image: solid-color(123, 11, 0, 255, 8, 8)
+      bounds: 984 88 8 8
+    - image: solid-color(124, 11, 0, 255, 8, 8)
+      bounds: 992 88 8 8
+    - image: solid-color(125, 11, 0, 255, 8, 8)
+      bounds: 1000 88 8 8
+    - image: solid-color(126, 11, 0, 255, 8, 8)
+      bounds: 1008 88 8 8
+    - image: solid-color(127, 11, 0, 255, 8, 8)
+      bounds: 1016 88 8 8
+    - image: solid-color(0, 12, 0, 255, 8, 8)
+      bounds: 0 96 8 8
+    - image: solid-color(1, 12, 0, 255, 8, 8)
+      bounds: 8 96 8 8
+    - image: solid-color(2, 12, 0, 255, 8, 8)
+      bounds: 16 96 8 8
+    - image: solid-color(3, 12, 0, 255, 8, 8)
+      bounds: 24 96 8 8
+    - image: solid-color(4, 12, 0, 255, 8, 8)
+      bounds: 32 96 8 8
+    - image: solid-color(5, 12, 0, 255, 8, 8)
+      bounds: 40 96 8 8
+    - image: solid-color(6, 12, 0, 255, 8, 8)
+      bounds: 48 96 8 8
+    - image: solid-color(7, 12, 0, 255, 8, 8)
+      bounds: 56 96 8 8
+    - image: solid-color(8, 12, 0, 255, 8, 8)
+      bounds: 64 96 8 8
+    - image: solid-color(9, 12, 0, 255, 8, 8)
+      bounds: 72 96 8 8
+    - image: solid-color(10, 12, 0, 255, 8, 8)
+      bounds: 80 96 8 8
+    - image: solid-color(11, 12, 0, 255, 8, 8)
+      bounds: 88 96 8 8
+    - image: solid-color(12, 12, 0, 255, 8, 8)
+      bounds: 96 96 8 8
+    - image: solid-color(13, 12, 0, 255, 8, 8)
+      bounds: 104 96 8 8
+    - image: solid-color(14, 12, 0, 255, 8, 8)
+      bounds: 112 96 8 8
+    - image: solid-color(15, 12, 0, 255, 8, 8)
+      bounds: 120 96 8 8
+    - image: solid-color(16, 12, 0, 255, 8, 8)
+      bounds: 128 96 8 8
+    - image: solid-color(17, 12, 0, 255, 8, 8)
+      bounds: 136 96 8 8
+    - image: solid-color(18, 12, 0, 255, 8, 8)
+      bounds: 144 96 8 8
+    - image: solid-color(19, 12, 0, 255, 8, 8)
+      bounds: 152 96 8 8
+    - image: solid-color(20, 12, 0, 255, 8, 8)
+      bounds: 160 96 8 8
+    - image: solid-color(21, 12, 0, 255, 8, 8)
+      bounds: 168 96 8 8
+    - image: solid-color(22, 12, 0, 255, 8, 8)
+      bounds: 176 96 8 8
+    - image: solid-color(23, 12, 0, 255, 8, 8)
+      bounds: 184 96 8 8
+    - image: solid-color(24, 12, 0, 255, 8, 8)
+      bounds: 192 96 8 8
+    - image: solid-color(25, 12, 0, 255, 8, 8)
+      bounds: 200 96 8 8
+    - image: solid-color(26, 12, 0, 255, 8, 8)
+      bounds: 208 96 8 8
+    - image: solid-color(27, 12, 0, 255, 8, 8)
+      bounds: 216 96 8 8
+    - image: solid-color(28, 12, 0, 255, 8, 8)
+      bounds: 224 96 8 8
+    - image: solid-color(29, 12, 0, 255, 8, 8)
+      bounds: 232 96 8 8
+    - image: solid-color(30, 12, 0, 255, 8, 8)
+      bounds: 240 96 8 8
+    - image: solid-color(31, 12, 0, 255, 8, 8)
+      bounds: 248 96 8 8
+    - image: solid-color(32, 12, 0, 255, 8, 8)
+      bounds: 256 96 8 8
+    - image: solid-color(33, 12, 0, 255, 8, 8)
+      bounds: 264 96 8 8
+    - image: solid-color(34, 12, 0, 255, 8, 8)
+      bounds: 272 96 8 8
+    - image: solid-color(35, 12, 0, 255, 8, 8)
+      bounds: 280 96 8 8
+    - image: solid-color(36, 12, 0, 255, 8, 8)
+      bounds: 288 96 8 8
+    - image: solid-color(37, 12, 0, 255, 8, 8)
+      bounds: 296 96 8 8
+    - image: solid-color(38, 12, 0, 255, 8, 8)
+      bounds: 304 96 8 8
+    - image: solid-color(39, 12, 0, 255, 8, 8)
+      bounds: 312 96 8 8
+    - image: solid-color(40, 12, 0, 255, 8, 8)
+      bounds: 320 96 8 8
+    - image: solid-color(41, 12, 0, 255, 8, 8)
+      bounds: 328 96 8 8
+    - image: solid-color(42, 12, 0, 255, 8, 8)
+      bounds: 336 96 8 8
+    - image: solid-color(43, 12, 0, 255, 8, 8)
+      bounds: 344 96 8 8
+    - image: solid-color(44, 12, 0, 255, 8, 8)
+      bounds: 352 96 8 8
+    - image: solid-color(45, 12, 0, 255, 8, 8)
+      bounds: 360 96 8 8
+    - image: solid-color(46, 12, 0, 255, 8, 8)
+      bounds: 368 96 8 8
+    - image: solid-color(47, 12, 0, 255, 8, 8)
+      bounds: 376 96 8 8
+    - image: solid-color(48, 12, 0, 255, 8, 8)
+      bounds: 384 96 8 8
+    - image: solid-color(49, 12, 0, 255, 8, 8)
+      bounds: 392 96 8 8
+    - image: solid-color(50, 12, 0, 255, 8, 8)
+      bounds: 400 96 8 8
+    - image: solid-color(51, 12, 0, 255, 8, 8)
+      bounds: 408 96 8 8
+    - image: solid-color(52, 12, 0, 255, 8, 8)
+      bounds: 416 96 8 8
+    - image: solid-color(53, 12, 0, 255, 8, 8)
+      bounds: 424 96 8 8
+    - image: solid-color(54, 12, 0, 255, 8, 8)
+      bounds: 432 96 8 8
+    - image: solid-color(55, 12, 0, 255, 8, 8)
+      bounds: 440 96 8 8
+    - image: solid-color(56, 12, 0, 255, 8, 8)
+      bounds: 448 96 8 8
+    - image: solid-color(57, 12, 0, 255, 8, 8)
+      bounds: 456 96 8 8
+    - image: solid-color(58, 12, 0, 255, 8, 8)
+      bounds: 464 96 8 8
+    - image: solid-color(59, 12, 0, 255, 8, 8)
+      bounds: 472 96 8 8
+    - image: solid-color(60, 12, 0, 255, 8, 8)
+      bounds: 480 96 8 8
+    - image: solid-color(61, 12, 0, 255, 8, 8)
+      bounds: 488 96 8 8
+    - image: solid-color(62, 12, 0, 255, 8, 8)
+      bounds: 496 96 8 8
+    - image: solid-color(63, 12, 0, 255, 8, 8)
+      bounds: 504 96 8 8
+    - image: solid-color(64, 12, 0, 255, 8, 8)
+      bounds: 512 96 8 8
+    - image: solid-color(65, 12, 0, 255, 8, 8)
+      bounds: 520 96 8 8
+    - image: solid-color(66, 12, 0, 255, 8, 8)
+      bounds: 528 96 8 8
+    - image: solid-color(67, 12, 0, 255, 8, 8)
+      bounds: 536 96 8 8
+    - image: solid-color(68, 12, 0, 255, 8, 8)
+      bounds: 544 96 8 8
+    - image: solid-color(69, 12, 0, 255, 8, 8)
+      bounds: 552 96 8 8
+    - image: solid-color(70, 12, 0, 255, 8, 8)
+      bounds: 560 96 8 8
+    - image: solid-color(71, 12, 0, 255, 8, 8)
+      bounds: 568 96 8 8
+    - image: solid-color(72, 12, 0, 255, 8, 8)
+      bounds: 576 96 8 8
+    - image: solid-color(73, 12, 0, 255, 8, 8)
+      bounds: 584 96 8 8
+    - image: solid-color(74, 12, 0, 255, 8, 8)
+      bounds: 592 96 8 8
+    - image: solid-color(75, 12, 0, 255, 8, 8)
+      bounds: 600 96 8 8
+    - image: solid-color(76, 12, 0, 255, 8, 8)
+      bounds: 608 96 8 8
+    - image: solid-color(77, 12, 0, 255, 8, 8)
+      bounds: 616 96 8 8
+    - image: solid-color(78, 12, 0, 255, 8, 8)
+      bounds: 624 96 8 8
+    - image: solid-color(79, 12, 0, 255, 8, 8)
+      bounds: 632 96 8 8
+    - image: solid-color(80, 12, 0, 255, 8, 8)
+      bounds: 640 96 8 8
+    - image: solid-color(81, 12, 0, 255, 8, 8)
+      bounds: 648 96 8 8
+    - image: solid-color(82, 12, 0, 255, 8, 8)
+      bounds: 656 96 8 8
+    - image: solid-color(83, 12, 0, 255, 8, 8)
+      bounds: 664 96 8 8
+    - image: solid-color(84, 12, 0, 255, 8, 8)
+      bounds: 672 96 8 8
+    - image: solid-color(85, 12, 0, 255, 8, 8)
+      bounds: 680 96 8 8
+    - image: solid-color(86, 12, 0, 255, 8, 8)
+      bounds: 688 96 8 8
+    - image: solid-color(87, 12, 0, 255, 8, 8)
+      bounds: 696 96 8 8
+    - image: solid-color(88, 12, 0, 255, 8, 8)
+      bounds: 704 96 8 8
+    - image: solid-color(89, 12, 0, 255, 8, 8)
+      bounds: 712 96 8 8
+    - image: solid-color(90, 12, 0, 255, 8, 8)
+      bounds: 720 96 8 8
+    - image: solid-color(91, 12, 0, 255, 8, 8)
+      bounds: 728 96 8 8
+    - image: solid-color(92, 12, 0, 255, 8, 8)
+      bounds: 736 96 8 8
+    - image: solid-color(93, 12, 0, 255, 8, 8)
+      bounds: 744 96 8 8
+    - image: solid-color(94, 12, 0, 255, 8, 8)
+      bounds: 752 96 8 8
+    - image: solid-color(95, 12, 0, 255, 8, 8)
+      bounds: 760 96 8 8
+    - image: solid-color(96, 12, 0, 255, 8, 8)
+      bounds: 768 96 8 8
+    - image: solid-color(97, 12, 0, 255, 8, 8)
+      bounds: 776 96 8 8
+    - image: solid-color(98, 12, 0, 255, 8, 8)
+      bounds: 784 96 8 8
+    - image: solid-color(99, 12, 0, 255, 8, 8)
+      bounds: 792 96 8 8
+    - image: solid-color(100, 12, 0, 255, 8, 8)
+      bounds: 800 96 8 8
+    - image: solid-color(101, 12, 0, 255, 8, 8)
+      bounds: 808 96 8 8
+    - image: solid-color(102, 12, 0, 255, 8, 8)
+      bounds: 816 96 8 8
+    - image: solid-color(103, 12, 0, 255, 8, 8)
+      bounds: 824 96 8 8
+    - image: solid-color(104, 12, 0, 255, 8, 8)
+      bounds: 832 96 8 8
+    - image: solid-color(105, 12, 0, 255, 8, 8)
+      bounds: 840 96 8 8
+    - image: solid-color(106, 12, 0, 255, 8, 8)
+      bounds: 848 96 8 8
+    - image: solid-color(107, 12, 0, 255, 8, 8)
+      bounds: 856 96 8 8
+    - image: solid-color(108, 12, 0, 255, 8, 8)
+      bounds: 864 96 8 8
+    - image: solid-color(109, 12, 0, 255, 8, 8)
+      bounds: 872 96 8 8
+    - image: solid-color(110, 12, 0, 255, 8, 8)
+      bounds: 880 96 8 8
+    - image: solid-color(111, 12, 0, 255, 8, 8)
+      bounds: 888 96 8 8
+    - image: solid-color(112, 12, 0, 255, 8, 8)
+      bounds: 896 96 8 8
+    - image: solid-color(113, 12, 0, 255, 8, 8)
+      bounds: 904 96 8 8
+    - image: solid-color(114, 12, 0, 255, 8, 8)
+      bounds: 912 96 8 8
+    - image: solid-color(115, 12, 0, 255, 8, 8)
+      bounds: 920 96 8 8
+    - image: solid-color(116, 12, 0, 255, 8, 8)
+      bounds: 928 96 8 8
+    - image: solid-color(117, 12, 0, 255, 8, 8)
+      bounds: 936 96 8 8
+    - image: solid-color(118, 12, 0, 255, 8, 8)
+      bounds: 944 96 8 8
+    - image: solid-color(119, 12, 0, 255, 8, 8)
+      bounds: 952 96 8 8
+    - image: solid-color(120, 12, 0, 255, 8, 8)
+      bounds: 960 96 8 8
+    - image: solid-color(121, 12, 0, 255, 8, 8)
+      bounds: 968 96 8 8
+    - image: solid-color(122, 12, 0, 255, 8, 8)
+      bounds: 976 96 8 8
+    - image: solid-color(123, 12, 0, 255, 8, 8)
+      bounds: 984 96 8 8
+    - image: solid-color(124, 12, 0, 255, 8, 8)
+      bounds: 992 96 8 8
+    - image: solid-color(125, 12, 0, 255, 8, 8)
+      bounds: 1000 96 8 8
+    - image: solid-color(126, 12, 0, 255, 8, 8)
+      bounds: 1008 96 8 8
+    - image: solid-color(127, 12, 0, 255, 8, 8)
+      bounds: 1016 96 8 8
+    - image: solid-color(0, 13, 0, 255, 8, 8)
+      bounds: 0 104 8 8
+    - image: solid-color(1, 13, 0, 255, 8, 8)
+      bounds: 8 104 8 8
+    - image: solid-color(2, 13, 0, 255, 8, 8)
+      bounds: 16 104 8 8
+    - image: solid-color(3, 13, 0, 255, 8, 8)
+      bounds: 24 104 8 8
+    - image: solid-color(4, 13, 0, 255, 8, 8)
+      bounds: 32 104 8 8
+    - image: solid-color(5, 13, 0, 255, 8, 8)
+      bounds: 40 104 8 8
+    - image: solid-color(6, 13, 0, 255, 8, 8)
+      bounds: 48 104 8 8
+    - image: solid-color(7, 13, 0, 255, 8, 8)
+      bounds: 56 104 8 8
+    - image: solid-color(8, 13, 0, 255, 8, 8)
+      bounds: 64 104 8 8
+    - image: solid-color(9, 13, 0, 255, 8, 8)
+      bounds: 72 104 8 8
+    - image: solid-color(10, 13, 0, 255, 8, 8)
+      bounds: 80 104 8 8
+    - image: solid-color(11, 13, 0, 255, 8, 8)
+      bounds: 88 104 8 8
+    - image: solid-color(12, 13, 0, 255, 8, 8)
+      bounds: 96 104 8 8
+    - image: solid-color(13, 13, 0, 255, 8, 8)
+      bounds: 104 104 8 8
+    - image: solid-color(14, 13, 0, 255, 8, 8)
+      bounds: 112 104 8 8
+    - image: solid-color(15, 13, 0, 255, 8, 8)
+      bounds: 120 104 8 8
+    - image: solid-color(16, 13, 0, 255, 8, 8)
+      bounds: 128 104 8 8
+    - image: solid-color(17, 13, 0, 255, 8, 8)
+      bounds: 136 104 8 8
+    - image: solid-color(18, 13, 0, 255, 8, 8)
+      bounds: 144 104 8 8
+    - image: solid-color(19, 13, 0, 255, 8, 8)
+      bounds: 152 104 8 8
+    - image: solid-color(20, 13, 0, 255, 8, 8)
+      bounds: 160 104 8 8
+    - image: solid-color(21, 13, 0, 255, 8, 8)
+      bounds: 168 104 8 8
+    - image: solid-color(22, 13, 0, 255, 8, 8)
+      bounds: 176 104 8 8
+    - image: solid-color(23, 13, 0, 255, 8, 8)
+      bounds: 184 104 8 8
+    - image: solid-color(24, 13, 0, 255, 8, 8)
+      bounds: 192 104 8 8
+    - image: solid-color(25, 13, 0, 255, 8, 8)
+      bounds: 200 104 8 8
+    - image: solid-color(26, 13, 0, 255, 8, 8)
+      bounds: 208 104 8 8
+    - image: solid-color(27, 13, 0, 255, 8, 8)
+      bounds: 216 104 8 8
+    - image: solid-color(28, 13, 0, 255, 8, 8)
+      bounds: 224 104 8 8
+    - image: solid-color(29, 13, 0, 255, 8, 8)
+      bounds: 232 104 8 8
+    - image: solid-color(30, 13, 0, 255, 8, 8)
+      bounds: 240 104 8 8
+    - image: solid-color(31, 13, 0, 255, 8, 8)
+      bounds: 248 104 8 8
+    - image: solid-color(32, 13, 0, 255, 8, 8)
+      bounds: 256 104 8 8
+    - image: solid-color(33, 13, 0, 255, 8, 8)
+      bounds: 264 104 8 8
+    - image: solid-color(34, 13, 0, 255, 8, 8)
+      bounds: 272 104 8 8
+    - image: solid-color(35, 13, 0, 255, 8, 8)
+      bounds: 280 104 8 8
+    - image: solid-color(36, 13, 0, 255, 8, 8)
+      bounds: 288 104 8 8
+    - image: solid-color(37, 13, 0, 255, 8, 8)
+      bounds: 296 104 8 8
+    - image: solid-color(38, 13, 0, 255, 8, 8)
+      bounds: 304 104 8 8
+    - image: solid-color(39, 13, 0, 255, 8, 8)
+      bounds: 312 104 8 8
+    - image: solid-color(40, 13, 0, 255, 8, 8)
+      bounds: 320 104 8 8
+    - image: solid-color(41, 13, 0, 255, 8, 8)
+      bounds: 328 104 8 8
+    - image: solid-color(42, 13, 0, 255, 8, 8)
+      bounds: 336 104 8 8
+    - image: solid-color(43, 13, 0, 255, 8, 8)
+      bounds: 344 104 8 8
+    - image: solid-color(44, 13, 0, 255, 8, 8)
+      bounds: 352 104 8 8
+    - image: solid-color(45, 13, 0, 255, 8, 8)
+      bounds: 360 104 8 8
+    - image: solid-color(46, 13, 0, 255, 8, 8)
+      bounds: 368 104 8 8
+    - image: solid-color(47, 13, 0, 255, 8, 8)
+      bounds: 376 104 8 8
+    - image: solid-color(48, 13, 0, 255, 8, 8)
+      bounds: 384 104 8 8
+    - image: solid-color(49, 13, 0, 255, 8, 8)
+      bounds: 392 104 8 8
+    - image: solid-color(50, 13, 0, 255, 8, 8)
+      bounds: 400 104 8 8
+    - image: solid-color(51, 13, 0, 255, 8, 8)
+      bounds: 408 104 8 8
+    - image: solid-color(52, 13, 0, 255, 8, 8)
+      bounds: 416 104 8 8
+    - image: solid-color(53, 13, 0, 255, 8, 8)
+      bounds: 424 104 8 8
+    - image: solid-color(54, 13, 0, 255, 8, 8)
+      bounds: 432 104 8 8
+    - image: solid-color(55, 13, 0, 255, 8, 8)
+      bounds: 440 104 8 8
+    - image: solid-color(56, 13, 0, 255, 8, 8)
+      bounds: 448 104 8 8
+    - image: solid-color(57, 13, 0, 255, 8, 8)
+      bounds: 456 104 8 8
+    - image: solid-color(58, 13, 0, 255, 8, 8)
+      bounds: 464 104 8 8
+    - image: solid-color(59, 13, 0, 255, 8, 8)
+      bounds: 472 104 8 8
+    - image: solid-color(60, 13, 0, 255, 8, 8)
+      bounds: 480 104 8 8
+    - image: solid-color(61, 13, 0, 255, 8, 8)
+      bounds: 488 104 8 8
+    - image: solid-color(62, 13, 0, 255, 8, 8)
+      bounds: 496 104 8 8
+    - image: solid-color(63, 13, 0, 255, 8, 8)
+      bounds: 504 104 8 8
+    - image: solid-color(64, 13, 0, 255, 8, 8)
+      bounds: 512 104 8 8
+    - image: solid-color(65, 13, 0, 255, 8, 8)
+      bounds: 520 104 8 8
+    - image: solid-color(66, 13, 0, 255, 8, 8)
+      bounds: 528 104 8 8
+    - image: solid-color(67, 13, 0, 255, 8, 8)
+      bounds: 536 104 8 8
+    - image: solid-color(68, 13, 0, 255, 8, 8)
+      bounds: 544 104 8 8
+    - image: solid-color(69, 13, 0, 255, 8, 8)
+      bounds: 552 104 8 8
+    - image: solid-color(70, 13, 0, 255, 8, 8)
+      bounds: 560 104 8 8
+    - image: solid-color(71, 13, 0, 255, 8, 8)
+      bounds: 568 104 8 8
+    - image: solid-color(72, 13, 0, 255, 8, 8)
+      bounds: 576 104 8 8
+    - image: solid-color(73, 13, 0, 255, 8, 8)
+      bounds: 584 104 8 8
+    - image: solid-color(74, 13, 0, 255, 8, 8)
+      bounds: 592 104 8 8
+    - image: solid-color(75, 13, 0, 255, 8, 8)
+      bounds: 600 104 8 8
+    - image: solid-color(76, 13, 0, 255, 8, 8)
+      bounds: 608 104 8 8
+    - image: solid-color(77, 13, 0, 255, 8, 8)
+      bounds: 616 104 8 8
+    - image: solid-color(78, 13, 0, 255, 8, 8)
+      bounds: 624 104 8 8
+    - image: solid-color(79, 13, 0, 255, 8, 8)
+      bounds: 632 104 8 8
+    - image: solid-color(80, 13, 0, 255, 8, 8)
+      bounds: 640 104 8 8
+    - image: solid-color(81, 13, 0, 255, 8, 8)
+      bounds: 648 104 8 8
+    - image: solid-color(82, 13, 0, 255, 8, 8)
+      bounds: 656 104 8 8
+    - image: solid-color(83, 13, 0, 255, 8, 8)
+      bounds: 664 104 8 8
+    - image: solid-color(84, 13, 0, 255, 8, 8)
+      bounds: 672 104 8 8
+    - image: solid-color(85, 13, 0, 255, 8, 8)
+      bounds: 680 104 8 8
+    - image: solid-color(86, 13, 0, 255, 8, 8)
+      bounds: 688 104 8 8
+    - image: solid-color(87, 13, 0, 255, 8, 8)
+      bounds: 696 104 8 8
+    - image: solid-color(88, 13, 0, 255, 8, 8)
+      bounds: 704 104 8 8
+    - image: solid-color(89, 13, 0, 255, 8, 8)
+      bounds: 712 104 8 8
+    - image: solid-color(90, 13, 0, 255, 8, 8)
+      bounds: 720 104 8 8
+    - image: solid-color(91, 13, 0, 255, 8, 8)
+      bounds: 728 104 8 8
+    - image: solid-color(92, 13, 0, 255, 8, 8)
+      bounds: 736 104 8 8
+    - image: solid-color(93, 13, 0, 255, 8, 8)
+      bounds: 744 104 8 8
+    - image: solid-color(94, 13, 0, 255, 8, 8)
+      bounds: 752 104 8 8
+    - image: solid-color(95, 13, 0, 255, 8, 8)
+      bounds: 760 104 8 8
+    - image: solid-color(96, 13, 0, 255, 8, 8)
+      bounds: 768 104 8 8
+    - image: solid-color(97, 13, 0, 255, 8, 8)
+      bounds: 776 104 8 8
+    - image: solid-color(98, 13, 0, 255, 8, 8)
+      bounds: 784 104 8 8
+    - image: solid-color(99, 13, 0, 255, 8, 8)
+      bounds: 792 104 8 8
+    - image: solid-color(100, 13, 0, 255, 8, 8)
+      bounds: 800 104 8 8
+    - image: solid-color(101, 13, 0, 255, 8, 8)
+      bounds: 808 104 8 8
+    - image: solid-color(102, 13, 0, 255, 8, 8)
+      bounds: 816 104 8 8
+    - image: solid-color(103, 13, 0, 255, 8, 8)
+      bounds: 824 104 8 8
+    - image: solid-color(104, 13, 0, 255, 8, 8)
+      bounds: 832 104 8 8
+    - image: solid-color(105, 13, 0, 255, 8, 8)
+      bounds: 840 104 8 8
+    - image: solid-color(106, 13, 0, 255, 8, 8)
+      bounds: 848 104 8 8
+    - image: solid-color(107, 13, 0, 255, 8, 8)
+      bounds: 856 104 8 8
+    - image: solid-color(108, 13, 0, 255, 8, 8)
+      bounds: 864 104 8 8
+    - image: solid-color(109, 13, 0, 255, 8, 8)
+      bounds: 872 104 8 8
+    - image: solid-color(110, 13, 0, 255, 8, 8)
+      bounds: 880 104 8 8
+    - image: solid-color(111, 13, 0, 255, 8, 8)
+      bounds: 888 104 8 8
+    - image: solid-color(112, 13, 0, 255, 8, 8)
+      bounds: 896 104 8 8
+    - image: solid-color(113, 13, 0, 255, 8, 8)
+      bounds: 904 104 8 8
+    - image: solid-color(114, 13, 0, 255, 8, 8)
+      bounds: 912 104 8 8
+    - image: solid-color(115, 13, 0, 255, 8, 8)
+      bounds: 920 104 8 8
+    - image: solid-color(116, 13, 0, 255, 8, 8)
+      bounds: 928 104 8 8
+    - image: solid-color(117, 13, 0, 255, 8, 8)
+      bounds: 936 104 8 8
+    - image: solid-color(118, 13, 0, 255, 8, 8)
+      bounds: 944 104 8 8
+    - image: solid-color(119, 13, 0, 255, 8, 8)
+      bounds: 952 104 8 8
+    - image: solid-color(120, 13, 0, 255, 8, 8)
+      bounds: 960 104 8 8
+    - image: solid-color(121, 13, 0, 255, 8, 8)
+      bounds: 968 104 8 8
+    - image: solid-color(122, 13, 0, 255, 8, 8)
+      bounds: 976 104 8 8
+    - image: solid-color(123, 13, 0, 255, 8, 8)
+      bounds: 984 104 8 8
+    - image: solid-color(124, 13, 0, 255, 8, 8)
+      bounds: 992 104 8 8
+    - image: solid-color(125, 13, 0, 255, 8, 8)
+      bounds: 1000 104 8 8
+    - image: solid-color(126, 13, 0, 255, 8, 8)
+      bounds: 1008 104 8 8
+    - image: solid-color(127, 13, 0, 255, 8, 8)
+      bounds: 1016 104 8 8
+    - image: solid-color(0, 14, 0, 255, 8, 8)
+      bounds: 0 112 8 8
+    - image: solid-color(1, 14, 0, 255, 8, 8)
+      bounds: 8 112 8 8
+    - image: solid-color(2, 14, 0, 255, 8, 8)
+      bounds: 16 112 8 8
+    - image: solid-color(3, 14, 0, 255, 8, 8)
+      bounds: 24 112 8 8
+    - image: solid-color(4, 14, 0, 255, 8, 8)
+      bounds: 32 112 8 8
+    - image: solid-color(5, 14, 0, 255, 8, 8)
+      bounds: 40 112 8 8
+    - image: solid-color(6, 14, 0, 255, 8, 8)
+      bounds: 48 112 8 8
+    - image: solid-color(7, 14, 0, 255, 8, 8)
+      bounds: 56 112 8 8
+    - image: solid-color(8, 14, 0, 255, 8, 8)
+      bounds: 64 112 8 8
+    - image: solid-color(9, 14, 0, 255, 8, 8)
+      bounds: 72 112 8 8
+    - image: solid-color(10, 14, 0, 255, 8, 8)
+      bounds: 80 112 8 8
+    - image: solid-color(11, 14, 0, 255, 8, 8)
+      bounds: 88 112 8 8
+    - image: solid-color(12, 14, 0, 255, 8, 8)
+      bounds: 96 112 8 8
+    - image: solid-color(13, 14, 0, 255, 8, 8)
+      bounds: 104 112 8 8
+    - image: solid-color(14, 14, 0, 255, 8, 8)
+      bounds: 112 112 8 8
+    - image: solid-color(15, 14, 0, 255, 8, 8)
+      bounds: 120 112 8 8
+    - image: solid-color(16, 14, 0, 255, 8, 8)
+      bounds: 128 112 8 8
+    - image: solid-color(17, 14, 0, 255, 8, 8)
+      bounds: 136 112 8 8
+    - image: solid-color(18, 14, 0, 255, 8, 8)
+      bounds: 144 112 8 8
+    - image: solid-color(19, 14, 0, 255, 8, 8)
+      bounds: 152 112 8 8
+    - image: solid-color(20, 14, 0, 255, 8, 8)
+      bounds: 160 112 8 8
+    - image: solid-color(21, 14, 0, 255, 8, 8)
+      bounds: 168 112 8 8
+    - image: solid-color(22, 14, 0, 255, 8, 8)
+      bounds: 176 112 8 8
+    - image: solid-color(23, 14, 0, 255, 8, 8)
+      bounds: 184 112 8 8
+    - image: solid-color(24, 14, 0, 255, 8, 8)
+      bounds: 192 112 8 8
+    - image: solid-color(25, 14, 0, 255, 8, 8)
+      bounds: 200 112 8 8
+    - image: solid-color(26, 14, 0, 255, 8, 8)
+      bounds: 208 112 8 8
+    - image: solid-color(27, 14, 0, 255, 8, 8)
+      bounds: 216 112 8 8
+    - image: solid-color(28, 14, 0, 255, 8, 8)
+      bounds: 224 112 8 8
+    - image: solid-color(29, 14, 0, 255, 8, 8)
+      bounds: 232 112 8 8
+    - image: solid-color(30, 14, 0, 255, 8, 8)
+      bounds: 240 112 8 8
+    - image: solid-color(31, 14, 0, 255, 8, 8)
+      bounds: 248 112 8 8
+    - image: solid-color(32, 14, 0, 255, 8, 8)
+      bounds: 256 112 8 8
+    - image: solid-color(33, 14, 0, 255, 8, 8)
+      bounds: 264 112 8 8
+    - image: solid-color(34, 14, 0, 255, 8, 8)
+      bounds: 272 112 8 8
+    - image: solid-color(35, 14, 0, 255, 8, 8)
+      bounds: 280 112 8 8
+    - image: solid-color(36, 14, 0, 255, 8, 8)
+      bounds: 288 112 8 8
+    - image: solid-color(37, 14, 0, 255, 8, 8)
+      bounds: 296 112 8 8
+    - image: solid-color(38, 14, 0, 255, 8, 8)
+      bounds: 304 112 8 8
+    - image: solid-color(39, 14, 0, 255, 8, 8)
+      bounds: 312 112 8 8
+    - image: solid-color(40, 14, 0, 255, 8, 8)
+      bounds: 320 112 8 8
+    - image: solid-color(41, 14, 0, 255, 8, 8)
+      bounds: 328 112 8 8
+    - image: solid-color(42, 14, 0, 255, 8, 8)
+      bounds: 336 112 8 8
+    - image: solid-color(43, 14, 0, 255, 8, 8)
+      bounds: 344 112 8 8
+    - image: solid-color(44, 14, 0, 255, 8, 8)
+      bounds: 352 112 8 8
+    - image: solid-color(45, 14, 0, 255, 8, 8)
+      bounds: 360 112 8 8
+    - image: solid-color(46, 14, 0, 255, 8, 8)
+      bounds: 368 112 8 8
+    - image: solid-color(47, 14, 0, 255, 8, 8)
+      bounds: 376 112 8 8
+    - image: solid-color(48, 14, 0, 255, 8, 8)
+      bounds: 384 112 8 8
+    - image: solid-color(49, 14, 0, 255, 8, 8)
+      bounds: 392 112 8 8
+    - image: solid-color(50, 14, 0, 255, 8, 8)
+      bounds: 400 112 8 8
+    - image: solid-color(51, 14, 0, 255, 8, 8)
+      bounds: 408 112 8 8
+    - image: solid-color(52, 14, 0, 255, 8, 8)
+      bounds: 416 112 8 8
+    - image: solid-color(53, 14, 0, 255, 8, 8)
+      bounds: 424 112 8 8
+    - image: solid-color(54, 14, 0, 255, 8, 8)
+      bounds: 432 112 8 8
+    - image: solid-color(55, 14, 0, 255, 8, 8)
+      bounds: 440 112 8 8
+    - image: solid-color(56, 14, 0, 255, 8, 8)
+      bounds: 448 112 8 8
+    - image: solid-color(57, 14, 0, 255, 8, 8)
+      bounds: 456 112 8 8
+    - image: solid-color(58, 14, 0, 255, 8, 8)
+      bounds: 464 112 8 8
+    - image: solid-color(59, 14, 0, 255, 8, 8)
+      bounds: 472 112 8 8
+    - image: solid-color(60, 14, 0, 255, 8, 8)
+      bounds: 480 112 8 8
+    - image: solid-color(61, 14, 0, 255, 8, 8)
+      bounds: 488 112 8 8
+    - image: solid-color(62, 14, 0, 255, 8, 8)
+      bounds: 496 112 8 8
+    - image: solid-color(63, 14, 0, 255, 8, 8)
+      bounds: 504 112 8 8
+    - image: solid-color(64, 14, 0, 255, 8, 8)
+      bounds: 512 112 8 8
+    - image: solid-color(65, 14, 0, 255, 8, 8)
+      bounds: 520 112 8 8
+    - image: solid-color(66, 14, 0, 255, 8, 8)
+      bounds: 528 112 8 8
+    - image: solid-color(67, 14, 0, 255, 8, 8)
+      bounds: 536 112 8 8
+    - image: solid-color(68, 14, 0, 255, 8, 8)
+      bounds: 544 112 8 8
+    - image: solid-color(69, 14, 0, 255, 8, 8)
+      bounds: 552 112 8 8
+    - image: solid-color(70, 14, 0, 255, 8, 8)
+      bounds: 560 112 8 8
+    - image: solid-color(71, 14, 0, 255, 8, 8)
+      bounds: 568 112 8 8
+    - image: solid-color(72, 14, 0, 255, 8, 8)
+      bounds: 576 112 8 8
+    - image: solid-color(73, 14, 0, 255, 8, 8)
+      bounds: 584 112 8 8
+    - image: solid-color(74, 14, 0, 255, 8, 8)
+      bounds: 592 112 8 8
+    - image: solid-color(75, 14, 0, 255, 8, 8)
+      bounds: 600 112 8 8
+    - image: solid-color(76, 14, 0, 255, 8, 8)
+      bounds: 608 112 8 8
+    - image: solid-color(77, 14, 0, 255, 8, 8)
+      bounds: 616 112 8 8
+    - image: solid-color(78, 14, 0, 255, 8, 8)
+      bounds: 624 112 8 8
+    - image: solid-color(79, 14, 0, 255, 8, 8)
+      bounds: 632 112 8 8
+    - image: solid-color(80, 14, 0, 255, 8, 8)
+      bounds: 640 112 8 8
+    - image: solid-color(81, 14, 0, 255, 8, 8)
+      bounds: 648 112 8 8
+    - image: solid-color(82, 14, 0, 255, 8, 8)
+      bounds: 656 112 8 8
+    - image: solid-color(83, 14, 0, 255, 8, 8)
+      bounds: 664 112 8 8
+    - image: solid-color(84, 14, 0, 255, 8, 8)
+      bounds: 672 112 8 8
+    - image: solid-color(85, 14, 0, 255, 8, 8)
+      bounds: 680 112 8 8
+    - image: solid-color(86, 14, 0, 255, 8, 8)
+      bounds: 688 112 8 8
+    - image: solid-color(87, 14, 0, 255, 8, 8)
+      bounds: 696 112 8 8
+    - image: solid-color(88, 14, 0, 255, 8, 8)
+      bounds: 704 112 8 8
+    - image: solid-color(89, 14, 0, 255, 8, 8)
+      bounds: 712 112 8 8
+    - image: solid-color(90, 14, 0, 255, 8, 8)
+      bounds: 720 112 8 8
+    - image: solid-color(91, 14, 0, 255, 8, 8)
+      bounds: 728 112 8 8
+    - image: solid-color(92, 14, 0, 255, 8, 8)
+      bounds: 736 112 8 8
+    - image: solid-color(93, 14, 0, 255, 8, 8)
+      bounds: 744 112 8 8
+    - image: solid-color(94, 14, 0, 255, 8, 8)
+      bounds: 752 112 8 8
+    - image: solid-color(95, 14, 0, 255, 8, 8)
+      bounds: 760 112 8 8
+    - image: solid-color(96, 14, 0, 255, 8, 8)
+      bounds: 768 112 8 8
+    - image: solid-color(97, 14, 0, 255, 8, 8)
+      bounds: 776 112 8 8
+    - image: solid-color(98, 14, 0, 255, 8, 8)
+      bounds: 784 112 8 8
+    - image: solid-color(99, 14, 0, 255, 8, 8)
+      bounds: 792 112 8 8
+    - image: solid-color(100, 14, 0, 255, 8, 8)
+      bounds: 800 112 8 8
+    - image: solid-color(101, 14, 0, 255, 8, 8)
+      bounds: 808 112 8 8
+    - image: solid-color(102, 14, 0, 255, 8, 8)
+      bounds: 816 112 8 8
+    - image: solid-color(103, 14, 0, 255, 8, 8)
+      bounds: 824 112 8 8
+    - image: solid-color(104, 14, 0, 255, 8, 8)
+      bounds: 832 112 8 8
+    - image: solid-color(105, 14, 0, 255, 8, 8)
+      bounds: 840 112 8 8
+    - image: solid-color(106, 14, 0, 255, 8, 8)
+      bounds: 848 112 8 8
+    - image: solid-color(107, 14, 0, 255, 8, 8)
+      bounds: 856 112 8 8
+    - image: solid-color(108, 14, 0, 255, 8, 8)
+      bounds: 864 112 8 8
+    - image: solid-color(109, 14, 0, 255, 8, 8)
+      bounds: 872 112 8 8
+    - image: solid-color(110, 14, 0, 255, 8, 8)
+      bounds: 880 112 8 8
+    - image: solid-color(111, 14, 0, 255, 8, 8)
+      bounds: 888 112 8 8
+    - image: solid-color(112, 14, 0, 255, 8, 8)
+      bounds: 896 112 8 8
+    - image: solid-color(113, 14, 0, 255, 8, 8)
+      bounds: 904 112 8 8
+    - image: solid-color(114, 14, 0, 255, 8, 8)
+      bounds: 912 112 8 8
+    - image: solid-color(115, 14, 0, 255, 8, 8)
+      bounds: 920 112 8 8
+    - image: solid-color(116, 14, 0, 255, 8, 8)
+      bounds: 928 112 8 8
+    - image: solid-color(117, 14, 0, 255, 8, 8)
+      bounds: 936 112 8 8
+    - image: solid-color(118, 14, 0, 255, 8, 8)
+      bounds: 944 112 8 8
+    - image: solid-color(119, 14, 0, 255, 8, 8)
+      bounds: 952 112 8 8
+    - image: solid-color(120, 14, 0, 255, 8, 8)
+      bounds: 960 112 8 8
+    - image: solid-color(121, 14, 0, 255, 8, 8)
+      bounds: 968 112 8 8
+    - image: solid-color(122, 14, 0, 255, 8, 8)
+      bounds: 976 112 8 8
+    - image: solid-color(123, 14, 0, 255, 8, 8)
+      bounds: 984 112 8 8
+    - image: solid-color(124, 14, 0, 255, 8, 8)
+      bounds: 992 112 8 8
+    - image: solid-color(125, 14, 0, 255, 8, 8)
+      bounds: 1000 112 8 8
+    - image: solid-color(126, 14, 0, 255, 8, 8)
+      bounds: 1008 112 8 8
+    - image: solid-color(127, 14, 0, 255, 8, 8)
+      bounds: 1016 112 8 8
+    - image: solid-color(0, 15, 0, 255, 8, 8)
+      bounds: 0 120 8 8
+    - image: solid-color(1, 15, 0, 255, 8, 8)
+      bounds: 8 120 8 8
+    - image: solid-color(2, 15, 0, 255, 8, 8)
+      bounds: 16 120 8 8
+    - image: solid-color(3, 15, 0, 255, 8, 8)
+      bounds: 24 120 8 8
+    - image: solid-color(4, 15, 0, 255, 8, 8)
+      bounds: 32 120 8 8
+    - image: solid-color(5, 15, 0, 255, 8, 8)
+      bounds: 40 120 8 8
+    - image: solid-color(6, 15, 0, 255, 8, 8)
+      bounds: 48 120 8 8
+    - image: solid-color(7, 15, 0, 255, 8, 8)
+      bounds: 56 120 8 8
+    - image: solid-color(8, 15, 0, 255, 8, 8)
+      bounds: 64 120 8 8
+    - image: solid-color(9, 15, 0, 255, 8, 8)
+      bounds: 72 120 8 8
+    - image: solid-color(10, 15, 0, 255, 8, 8)
+      bounds: 80 120 8 8
+    - image: solid-color(11, 15, 0, 255, 8, 8)
+      bounds: 88 120 8 8
+    - image: solid-color(12, 15, 0, 255, 8, 8)
+      bounds: 96 120 8 8
+    - image: solid-color(13, 15, 0, 255, 8, 8)
+      bounds: 104 120 8 8
+    - image: solid-color(14, 15, 0, 255, 8, 8)
+      bounds: 112 120 8 8
+    - image: solid-color(15, 15, 0, 255, 8, 8)
+      bounds: 120 120 8 8
+    - image: solid-color(16, 15, 0, 255, 8, 8)
+      bounds: 128 120 8 8
+    - image: solid-color(17, 15, 0, 255, 8, 8)
+      bounds: 136 120 8 8
+    - image: solid-color(18, 15, 0, 255, 8, 8)
+      bounds: 144 120 8 8
+    - image: solid-color(19, 15, 0, 255, 8, 8)
+      bounds: 152 120 8 8
+    - image: solid-color(20, 15, 0, 255, 8, 8)
+      bounds: 160 120 8 8
+    - image: solid-color(21, 15, 0, 255, 8, 8)
+      bounds: 168 120 8 8
+    - image: solid-color(22, 15, 0, 255, 8, 8)
+      bounds: 176 120 8 8
+    - image: solid-color(23, 15, 0, 255, 8, 8)
+      bounds: 184 120 8 8
+    - image: solid-color(24, 15, 0, 255, 8, 8)
+      bounds: 192 120 8 8
+    - image: solid-color(25, 15, 0, 255, 8, 8)
+      bounds: 200 120 8 8
+    - image: solid-color(26, 15, 0, 255, 8, 8)
+      bounds: 208 120 8 8
+    - image: solid-color(27, 15, 0, 255, 8, 8)
+      bounds: 216 120 8 8
+    - image: solid-color(28, 15, 0, 255, 8, 8)
+      bounds: 224 120 8 8
+    - image: solid-color(29, 15, 0, 255, 8, 8)
+      bounds: 232 120 8 8
+    - image: solid-color(30, 15, 0, 255, 8, 8)
+      bounds: 240 120 8 8
+    - image: solid-color(31, 15, 0, 255, 8, 8)
+      bounds: 248 120 8 8
+    - image: solid-color(32, 15, 0, 255, 8, 8)
+      bounds: 256 120 8 8
+    - image: solid-color(33, 15, 0, 255, 8, 8)
+      bounds: 264 120 8 8
+    - image: solid-color(34, 15, 0, 255, 8, 8)
+      bounds: 272 120 8 8
+    - image: solid-color(35, 15, 0, 255, 8, 8)
+      bounds: 280 120 8 8
+    - image: solid-color(36, 15, 0, 255, 8, 8)
+      bounds: 288 120 8 8
+    - image: solid-color(37, 15, 0, 255, 8, 8)
+      bounds: 296 120 8 8
+    - image: solid-color(38, 15, 0, 255, 8, 8)
+      bounds: 304 120 8 8
+    - image: solid-color(39, 15, 0, 255, 8, 8)
+      bounds: 312 120 8 8
+    - image: solid-color(40, 15, 0, 255, 8, 8)
+      bounds: 320 120 8 8
+    - image: solid-color(41, 15, 0, 255, 8, 8)
+      bounds: 328 120 8 8
+    - image: solid-color(42, 15, 0, 255, 8, 8)
+      bounds: 336 120 8 8
+    - image: solid-color(43, 15, 0, 255, 8, 8)
+      bounds: 344 120 8 8
+    - image: solid-color(44, 15, 0, 255, 8, 8)
+      bounds: 352 120 8 8
+    - image: solid-color(45, 15, 0, 255, 8, 8)
+      bounds: 360 120 8 8
+    - image: solid-color(46, 15, 0, 255, 8, 8)
+      bounds: 368 120 8 8
+    - image: solid-color(47, 15, 0, 255, 8, 8)
+      bounds: 376 120 8 8
+    - image: solid-color(48, 15, 0, 255, 8, 8)
+      bounds: 384 120 8 8
+    - image: solid-color(49, 15, 0, 255, 8, 8)
+      bounds: 392 120 8 8
+    - image: solid-color(50, 15, 0, 255, 8, 8)
+      bounds: 400 120 8 8
+    - image: solid-color(51, 15, 0, 255, 8, 8)
+      bounds: 408 120 8 8
+    - image: solid-color(52, 15, 0, 255, 8, 8)
+      bounds: 416 120 8 8
+    - image: solid-color(53, 15, 0, 255, 8, 8)
+      bounds: 424 120 8 8
+    - image: solid-color(54, 15, 0, 255, 8, 8)
+      bounds: 432 120 8 8
+    - image: solid-color(55, 15, 0, 255, 8, 8)
+      bounds: 440 120 8 8
+    - image: solid-color(56, 15, 0, 255, 8, 8)
+      bounds: 448 120 8 8
+    - image: solid-color(57, 15, 0, 255, 8, 8)
+      bounds: 456 120 8 8
+    - image: solid-color(58, 15, 0, 255, 8, 8)
+      bounds: 464 120 8 8
+    - image: solid-color(59, 15, 0, 255, 8, 8)
+      bounds: 472 120 8 8
+    - image: solid-color(60, 15, 0, 255, 8, 8)
+      bounds: 480 120 8 8
+    - image: solid-color(61, 15, 0, 255, 8, 8)
+      bounds: 488 120 8 8
+    - image: solid-color(62, 15, 0, 255, 8, 8)
+      bounds: 496 120 8 8
+    - image: solid-color(63, 15, 0, 255, 8, 8)
+      bounds: 504 120 8 8
+    - image: solid-color(64, 15, 0, 255, 8, 8)
+      bounds: 512 120 8 8
+    - image: solid-color(65, 15, 0, 255, 8, 8)
+      bounds: 520 120 8 8
+    - image: solid-color(66, 15, 0, 255, 8, 8)
+      bounds: 528 120 8 8
+    - image: solid-color(67, 15, 0, 255, 8, 8)
+      bounds: 536 120 8 8
+    - image: solid-color(68, 15, 0, 255, 8, 8)
+      bounds: 544 120 8 8
+    - image: solid-color(69, 15, 0, 255, 8, 8)
+      bounds: 552 120 8 8
+    - image: solid-color(70, 15, 0, 255, 8, 8)
+      bounds: 560 120 8 8
+    - image: solid-color(71, 15, 0, 255, 8, 8)
+      bounds: 568 120 8 8
+    - image: solid-color(72, 15, 0, 255, 8, 8)
+      bounds: 576 120 8 8
+    - image: solid-color(73, 15, 0, 255, 8, 8)
+      bounds: 584 120 8 8
+    - image: solid-color(74, 15, 0, 255, 8, 8)
+      bounds: 592 120 8 8
+    - image: solid-color(75, 15, 0, 255, 8, 8)
+      bounds: 600 120 8 8
+    - image: solid-color(76, 15, 0, 255, 8, 8)
+      bounds: 608 120 8 8
+    - image: solid-color(77, 15, 0, 255, 8, 8)
+      bounds: 616 120 8 8
+    - image: solid-color(78, 15, 0, 255, 8, 8)
+      bounds: 624 120 8 8
+    - image: solid-color(79, 15, 0, 255, 8, 8)
+      bounds: 632 120 8 8
+    - image: solid-color(80, 15, 0, 255, 8, 8)
+      bounds: 640 120 8 8
+    - image: solid-color(81, 15, 0, 255, 8, 8)
+      bounds: 648 120 8 8
+    - image: solid-color(82, 15, 0, 255, 8, 8)
+      bounds: 656 120 8 8
+    - image: solid-color(83, 15, 0, 255, 8, 8)
+      bounds: 664 120 8 8
+    - image: solid-color(84, 15, 0, 255, 8, 8)
+      bounds: 672 120 8 8
+    - image: solid-color(85, 15, 0, 255, 8, 8)
+      bounds: 680 120 8 8
+    - image: solid-color(86, 15, 0, 255, 8, 8)
+      bounds: 688 120 8 8
+    - image: solid-color(87, 15, 0, 255, 8, 8)
+      bounds: 696 120 8 8
+    - image: solid-color(88, 15, 0, 255, 8, 8)
+      bounds: 704 120 8 8
+    - image: solid-color(89, 15, 0, 255, 8, 8)
+      bounds: 712 120 8 8
+    - image: solid-color(90, 15, 0, 255, 8, 8)
+      bounds: 720 120 8 8
+    - image: solid-color(91, 15, 0, 255, 8, 8)
+      bounds: 728 120 8 8
+    - image: solid-color(92, 15, 0, 255, 8, 8)
+      bounds: 736 120 8 8
+    - image: solid-color(93, 15, 0, 255, 8, 8)
+      bounds: 744 120 8 8
+    - image: solid-color(94, 15, 0, 255, 8, 8)
+      bounds: 752 120 8 8
+    - image: solid-color(95, 15, 0, 255, 8, 8)
+      bounds: 760 120 8 8
+    - image: solid-color(96, 15, 0, 255, 8, 8)
+      bounds: 768 120 8 8
+    - image: solid-color(97, 15, 0, 255, 8, 8)
+      bounds: 776 120 8 8
+    - image: solid-color(98, 15, 0, 255, 8, 8)
+      bounds: 784 120 8 8
+    - image: solid-color(99, 15, 0, 255, 8, 8)
+      bounds: 792 120 8 8
+    - image: solid-color(100, 15, 0, 255, 8, 8)
+      bounds: 800 120 8 8
+    - image: solid-color(101, 15, 0, 255, 8, 8)
+      bounds: 808 120 8 8
+    - image: solid-color(102, 15, 0, 255, 8, 8)
+      bounds: 816 120 8 8
+    - image: solid-color(103, 15, 0, 255, 8, 8)
+      bounds: 824 120 8 8
+    - image: solid-color(104, 15, 0, 255, 8, 8)
+      bounds: 832 120 8 8
+    - image: solid-color(105, 15, 0, 255, 8, 8)
+      bounds: 840 120 8 8
+    - image: solid-color(106, 15, 0, 255, 8, 8)
+      bounds: 848 120 8 8
+    - image: solid-color(107, 15, 0, 255, 8, 8)
+      bounds: 856 120 8 8
+    - image: solid-color(108, 15, 0, 255, 8, 8)
+      bounds: 864 120 8 8
+    - image: solid-color(109, 15, 0, 255, 8, 8)
+      bounds: 872 120 8 8
+    - image: solid-color(110, 15, 0, 255, 8, 8)
+      bounds: 880 120 8 8
+    - image: solid-color(111, 15, 0, 255, 8, 8)
+      bounds: 888 120 8 8
+    - image: solid-color(112, 15, 0, 255, 8, 8)
+      bounds: 896 120 8 8
+    - image: solid-color(113, 15, 0, 255, 8, 8)
+      bounds: 904 120 8 8
+    - image: solid-color(114, 15, 0, 255, 8, 8)
+      bounds: 912 120 8 8
+    - image: solid-color(115, 15, 0, 255, 8, 8)
+      bounds: 920 120 8 8
+    - image: solid-color(116, 15, 0, 255, 8, 8)
+      bounds: 928 120 8 8
+    - image: solid-color(117, 15, 0, 255, 8, 8)
+      bounds: 936 120 8 8
+    - image: solid-color(118, 15, 0, 255, 8, 8)
+      bounds: 944 120 8 8
+    - image: solid-color(119, 15, 0, 255, 8, 8)
+      bounds: 952 120 8 8
+    - image: solid-color(120, 15, 0, 255, 8, 8)
+      bounds: 960 120 8 8
+    - image: solid-color(121, 15, 0, 255, 8, 8)
+      bounds: 968 120 8 8
+    - image: solid-color(122, 15, 0, 255, 8, 8)
+      bounds: 976 120 8 8
+    - image: solid-color(123, 15, 0, 255, 8, 8)
+      bounds: 984 120 8 8
+    - image: solid-color(124, 15, 0, 255, 8, 8)
+      bounds: 992 120 8 8
+    - image: solid-color(125, 15, 0, 255, 8, 8)
+      bounds: 1000 120 8 8
+    - image: solid-color(126, 15, 0, 255, 8, 8)
+      bounds: 1008 120 8 8
+    - image: solid-color(127, 15, 0, 255, 8, 8)
+      bounds: 1016 120 8 8
+    - image: solid-color(0, 16, 0, 255, 8, 8)
+      bounds: 0 128 8 8
+    - image: solid-color(1, 16, 0, 255, 8, 8)
+      bounds: 8 128 8 8
+    - image: solid-color(2, 16, 0, 255, 8, 8)
+      bounds: 16 128 8 8
+    - image: solid-color(3, 16, 0, 255, 8, 8)
+      bounds: 24 128 8 8
+    - image: solid-color(4, 16, 0, 255, 8, 8)
+      bounds: 32 128 8 8
+    - image: solid-color(5, 16, 0, 255, 8, 8)
+      bounds: 40 128 8 8
+    - image: solid-color(6, 16, 0, 255, 8, 8)
+      bounds: 48 128 8 8
+    - image: solid-color(7, 16, 0, 255, 8, 8)
+      bounds: 56 128 8 8
+    - image: solid-color(8, 16, 0, 255, 8, 8)
+      bounds: 64 128 8 8
+    - image: solid-color(9, 16, 0, 255, 8, 8)
+      bounds: 72 128 8 8
+    - image: solid-color(10, 16, 0, 255, 8, 8)
+      bounds: 80 128 8 8
+    - image: solid-color(11, 16, 0, 255, 8, 8)
+      bounds: 88 128 8 8
+    - image: solid-color(12, 16, 0, 255, 8, 8)
+      bounds: 96 128 8 8
+    - image: solid-color(13, 16, 0, 255, 8, 8)
+      bounds: 104 128 8 8
+    - image: solid-color(14, 16, 0, 255, 8, 8)
+      bounds: 112 128 8 8
+    - image: solid-color(15, 16, 0, 255, 8, 8)
+      bounds: 120 128 8 8
+    - image: solid-color(16, 16, 0, 255, 8, 8)
+      bounds: 128 128 8 8
+    - image: solid-color(17, 16, 0, 255, 8, 8)
+      bounds: 136 128 8 8
+    - image: solid-color(18, 16, 0, 255, 8, 8)
+      bounds: 144 128 8 8
+    - image: solid-color(19, 16, 0, 255, 8, 8)
+      bounds: 152 128 8 8
+    - image: solid-color(20, 16, 0, 255, 8, 8)
+      bounds: 160 128 8 8
+    - image: solid-color(21, 16, 0, 255, 8, 8)
+      bounds: 168 128 8 8
+    - image: solid-color(22, 16, 0, 255, 8, 8)
+      bounds: 176 128 8 8
+    - image: solid-color(23, 16, 0, 255, 8, 8)
+      bounds: 184 128 8 8
+    - image: solid-color(24, 16, 0, 255, 8, 8)
+      bounds: 192 128 8 8
+    - image: solid-color(25, 16, 0, 255, 8, 8)
+      bounds: 200 128 8 8
+    - image: solid-color(26, 16, 0, 255, 8, 8)
+      bounds: 208 128 8 8
+    - image: solid-color(27, 16, 0, 255, 8, 8)
+      bounds: 216 128 8 8
+    - image: solid-color(28, 16, 0, 255, 8, 8)
+      bounds: 224 128 8 8
+    - image: solid-color(29, 16, 0, 255, 8, 8)
+      bounds: 232 128 8 8
+    - image: solid-color(30, 16, 0, 255, 8, 8)
+      bounds: 240 128 8 8
+    - image: solid-color(31, 16, 0, 255, 8, 8)
+      bounds: 248 128 8 8
+    - image: solid-color(32, 16, 0, 255, 8, 8)
+      bounds: 256 128 8 8
+    - image: solid-color(33, 16, 0, 255, 8, 8)
+      bounds: 264 128 8 8
+    - image: solid-color(34, 16, 0, 255, 8, 8)
+      bounds: 272 128 8 8
+    - image: solid-color(35, 16, 0, 255, 8, 8)
+      bounds: 280 128 8 8
+    - image: solid-color(36, 16, 0, 255, 8, 8)
+      bounds: 288 128 8 8
+    - image: solid-color(37, 16, 0, 255, 8, 8)
+      bounds: 296 128 8 8
+    - image: solid-color(38, 16, 0, 255, 8, 8)
+      bounds: 304 128 8 8
+    - image: solid-color(39, 16, 0, 255, 8, 8)
+      bounds: 312 128 8 8
+    - image: solid-color(40, 16, 0, 255, 8, 8)
+      bounds: 320 128 8 8
+    - image: solid-color(41, 16, 0, 255, 8, 8)
+      bounds: 328 128 8 8
+    - image: solid-color(42, 16, 0, 255, 8, 8)
+      bounds: 336 128 8 8
+    - image: solid-color(43, 16, 0, 255, 8, 8)
+      bounds: 344 128 8 8
+    - image: solid-color(44, 16, 0, 255, 8, 8)
+      bounds: 352 128 8 8
+    - image: solid-color(45, 16, 0, 255, 8, 8)
+      bounds: 360 128 8 8
+    - image: solid-color(46, 16, 0, 255, 8, 8)
+      bounds: 368 128 8 8
+    - image: solid-color(47, 16, 0, 255, 8, 8)
+      bounds: 376 128 8 8
+    - image: solid-color(48, 16, 0, 255, 8, 8)
+      bounds: 384 128 8 8
+    - image: solid-color(49, 16, 0, 255, 8, 8)
+      bounds: 392 128 8 8
+    - image: solid-color(50, 16, 0, 255, 8, 8)
+      bounds: 400 128 8 8
+    - image: solid-color(51, 16, 0, 255, 8, 8)
+      bounds: 408 128 8 8
+    - image: solid-color(52, 16, 0, 255, 8, 8)
+      bounds: 416 128 8 8
+    - image: solid-color(53, 16, 0, 255, 8, 8)
+      bounds: 424 128 8 8
+    - image: solid-color(54, 16, 0, 255, 8, 8)
+      bounds: 432 128 8 8
+    - image: solid-color(55, 16, 0, 255, 8, 8)
+      bounds: 440 128 8 8
+    - image: solid-color(56, 16, 0, 255, 8, 8)
+      bounds: 448 128 8 8
+    - image: solid-color(57, 16, 0, 255, 8, 8)
+      bounds: 456 128 8 8
+    - image: solid-color(58, 16, 0, 255, 8, 8)
+      bounds: 464 128 8 8
+    - image: solid-color(59, 16, 0, 255, 8, 8)
+      bounds: 472 128 8 8
+    - image: solid-color(60, 16, 0, 255, 8, 8)
+      bounds: 480 128 8 8
+    - image: solid-color(61, 16, 0, 255, 8, 8)
+      bounds: 488 128 8 8
+    - image: solid-color(62, 16, 0, 255, 8, 8)
+      bounds: 496 128 8 8
+    - image: solid-color(63, 16, 0, 255, 8, 8)
+      bounds: 504 128 8 8
+    - image: solid-color(64, 16, 0, 255, 8, 8)
+      bounds: 512 128 8 8
+    - image: solid-color(65, 16, 0, 255, 8, 8)
+      bounds: 520 128 8 8
+    - image: solid-color(66, 16, 0, 255, 8, 8)
+      bounds: 528 128 8 8
+    - image: solid-color(67, 16, 0, 255, 8, 8)
+      bounds: 536 128 8 8
+    - image: solid-color(68, 16, 0, 255, 8, 8)
+      bounds: 544 128 8 8
+    - image: solid-color(69, 16, 0, 255, 8, 8)
+      bounds: 552 128 8 8
+    - image: solid-color(70, 16, 0, 255, 8, 8)
+      bounds: 560 128 8 8
+    - image: solid-color(71, 16, 0, 255, 8, 8)
+      bounds: 568 128 8 8
+    - image: solid-color(72, 16, 0, 255, 8, 8)
+      bounds: 576 128 8 8
+    - image: solid-color(73, 16, 0, 255, 8, 8)
+      bounds: 584 128 8 8
+    - image: solid-color(74, 16, 0, 255, 8, 8)
+      bounds: 592 128 8 8
+    - image: solid-color(75, 16, 0, 255, 8, 8)
+      bounds: 600 128 8 8
+    - image: solid-color(76, 16, 0, 255, 8, 8)
+      bounds: 608 128 8 8
+    - image: solid-color(77, 16, 0, 255, 8, 8)
+      bounds: 616 128 8 8
+    - image: solid-color(78, 16, 0, 255, 8, 8)
+      bounds: 624 128 8 8
+    - image: solid-color(79, 16, 0, 255, 8, 8)
+      bounds: 632 128 8 8
+    - image: solid-color(80, 16, 0, 255, 8, 8)
+      bounds: 640 128 8 8
+    - image: solid-color(81, 16, 0, 255, 8, 8)
+      bounds: 648 128 8 8
+    - image: solid-color(82, 16, 0, 255, 8, 8)
+      bounds: 656 128 8 8
+    - image: solid-color(83, 16, 0, 255, 8, 8)
+      bounds: 664 128 8 8
+    - image: solid-color(84, 16, 0, 255, 8, 8)
+      bounds: 672 128 8 8
+    - image: solid-color(85, 16, 0, 255, 8, 8)
+      bounds: 680 128 8 8
+    - image: solid-color(86, 16, 0, 255, 8, 8)
+      bounds: 688 128 8 8
+    - image: solid-color(87, 16, 0, 255, 8, 8)
+      bounds: 696 128 8 8
+    - image: solid-color(88, 16, 0, 255, 8, 8)
+      bounds: 704 128 8 8
+    - image: solid-color(89, 16, 0, 255, 8, 8)
+      bounds: 712 128 8 8
+    - image: solid-color(90, 16, 0, 255, 8, 8)
+      bounds: 720 128 8 8
+    - image: solid-color(91, 16, 0, 255, 8, 8)
+      bounds: 728 128 8 8
+    - image: solid-color(92, 16, 0, 255, 8, 8)
+      bounds: 736 128 8 8
+    - image: solid-color(93, 16, 0, 255, 8, 8)
+      bounds: 744 128 8 8
+    - image: solid-color(94, 16, 0, 255, 8, 8)
+      bounds: 752 128 8 8
+    - image: solid-color(95, 16, 0, 255, 8, 8)
+      bounds: 760 128 8 8
+    - image: solid-color(96, 16, 0, 255, 8, 8)
+      bounds: 768 128 8 8
+    - image: solid-color(97, 16, 0, 255, 8, 8)
+      bounds: 776 128 8 8
+    - image: solid-color(98, 16, 0, 255, 8, 8)
+      bounds: 784 128 8 8
+    - image: solid-color(99, 16, 0, 255, 8, 8)
+      bounds: 792 128 8 8
+    - image: solid-color(100, 16, 0, 255, 8, 8)
+      bounds: 800 128 8 8
+    - image: solid-color(101, 16, 0, 255, 8, 8)
+      bounds: 808 128 8 8
+    - image: solid-color(102, 16, 0, 255, 8, 8)
+      bounds: 816 128 8 8
+    - image: solid-color(103, 16, 0, 255, 8, 8)
+      bounds: 824 128 8 8
+    - image: solid-color(104, 16, 0, 255, 8, 8)
+      bounds: 832 128 8 8
+    - image: solid-color(105, 16, 0, 255, 8, 8)
+      bounds: 840 128 8 8
+    - image: solid-color(106, 16, 0, 255, 8, 8)
+      bounds: 848 128 8 8
+    - image: solid-color(107, 16, 0, 255, 8, 8)
+      bounds: 856 128 8 8
+    - image: solid-color(108, 16, 0, 255, 8, 8)
+      bounds: 864 128 8 8
+    - image: solid-color(109, 16, 0, 255, 8, 8)
+      bounds: 872 128 8 8
+    - image: solid-color(110, 16, 0, 255, 8, 8)
+      bounds: 880 128 8 8
+    - image: solid-color(111, 16, 0, 255, 8, 8)
+      bounds: 888 128 8 8
+    - image: solid-color(112, 16, 0, 255, 8, 8)
+      bounds: 896 128 8 8
+    - image: solid-color(113, 16, 0, 255, 8, 8)
+      bounds: 904 128 8 8
+    - image: solid-color(114, 16, 0, 255, 8, 8)
+      bounds: 912 128 8 8
+    - image: solid-color(115, 16, 0, 255, 8, 8)
+      bounds: 920 128 8 8
+    - image: solid-color(116, 16, 0, 255, 8, 8)
+      bounds: 928 128 8 8
+    - image: solid-color(117, 16, 0, 255, 8, 8)
+      bounds: 936 128 8 8
+    - image: solid-color(118, 16, 0, 255, 8, 8)
+      bounds: 944 128 8 8
+    - image: solid-color(119, 16, 0, 255, 8, 8)
+      bounds: 952 128 8 8
+    - image: solid-color(120, 16, 0, 255, 8, 8)
+      bounds: 960 128 8 8
+    - image: solid-color(121, 16, 0, 255, 8, 8)
+      bounds: 968 128 8 8
+    - image: solid-color(122, 16, 0, 255, 8, 8)
+      bounds: 976 128 8 8
+    - image: solid-color(123, 16, 0, 255, 8, 8)
+      bounds: 984 128 8 8
+    - image: solid-color(124, 16, 0, 255, 8, 8)
+      bounds: 992 128 8 8
+    - image: solid-color(125, 16, 0, 255, 8, 8)
+      bounds: 1000 128 8 8
+    - image: solid-color(126, 16, 0, 255, 8, 8)
+      bounds: 1008 128 8 8
+    - image: solid-color(127, 16, 0, 255, 8, 8)
+      bounds: 1016 128 8 8
+    - image: solid-color(0, 17, 0, 255, 8, 8)
+      bounds: 0 136 8 8
+    - image: solid-color(1, 17, 0, 255, 8, 8)
+      bounds: 8 136 8 8
+    - image: solid-color(2, 17, 0, 255, 8, 8)
+      bounds: 16 136 8 8
+    - image: solid-color(3, 17, 0, 255, 8, 8)
+      bounds: 24 136 8 8
+    - image: solid-color(4, 17, 0, 255, 8, 8)
+      bounds: 32 136 8 8
+    - image: solid-color(5, 17, 0, 255, 8, 8)
+      bounds: 40 136 8 8
+    - image: solid-color(6, 17, 0, 255, 8, 8)
+      bounds: 48 136 8 8
+    - image: solid-color(7, 17, 0, 255, 8, 8)
+      bounds: 56 136 8 8
+    - image: solid-color(8, 17, 0, 255, 8, 8)
+      bounds: 64 136 8 8
+    - image: solid-color(9, 17, 0, 255, 8, 8)
+      bounds: 72 136 8 8
+    - image: solid-color(10, 17, 0, 255, 8, 8)
+      bounds: 80 136 8 8
+    - image: solid-color(11, 17, 0, 255, 8, 8)
+      bounds: 88 136 8 8
+    - image: solid-color(12, 17, 0, 255, 8, 8)
+      bounds: 96 136 8 8
+    - image: solid-color(13, 17, 0, 255, 8, 8)
+      bounds: 104 136 8 8
+    - image: solid-color(14, 17, 0, 255, 8, 8)
+      bounds: 112 136 8 8
+    - image: solid-color(15, 17, 0, 255, 8, 8)
+      bounds: 120 136 8 8
+    - image: solid-color(16, 17, 0, 255, 8, 8)
+      bounds: 128 136 8 8
+    - image: solid-color(17, 17, 0, 255, 8, 8)
+      bounds: 136 136 8 8
+    - image: solid-color(18, 17, 0, 255, 8, 8)
+      bounds: 144 136 8 8
+    - image: solid-color(19, 17, 0, 255, 8, 8)
+      bounds: 152 136 8 8
+    - image: solid-color(20, 17, 0, 255, 8, 8)
+      bounds: 160 136 8 8
+    - image: solid-color(21, 17, 0, 255, 8, 8)
+      bounds: 168 136 8 8
+    - image: solid-color(22, 17, 0, 255, 8, 8)
+      bounds: 176 136 8 8
+    - image: solid-color(23, 17, 0, 255, 8, 8)
+      bounds: 184 136 8 8
+    - image: solid-color(24, 17, 0, 255, 8, 8)
+      bounds: 192 136 8 8
+    - image: solid-color(25, 17, 0, 255, 8, 8)
+      bounds: 200 136 8 8
+    - image: solid-color(26, 17, 0, 255, 8, 8)
+      bounds: 208 136 8 8
+    - image: solid-color(27, 17, 0, 255, 8, 8)
+      bounds: 216 136 8 8
+    - image: solid-color(28, 17, 0, 255, 8, 8)
+      bounds: 224 136 8 8
+    - image: solid-color(29, 17, 0, 255, 8, 8)
+      bounds: 232 136 8 8
+    - image: solid-color(30, 17, 0, 255, 8, 8)
+      bounds: 240 136 8 8
+    - image: solid-color(31, 17, 0, 255, 8, 8)
+      bounds: 248 136 8 8
+    - image: solid-color(32, 17, 0, 255, 8, 8)
+      bounds: 256 136 8 8
+    - image: solid-color(33, 17, 0, 255, 8, 8)
+      bounds: 264 136 8 8
+    - image: solid-color(34, 17, 0, 255, 8, 8)
+      bounds: 272 136 8 8
+    - image: solid-color(35, 17, 0, 255, 8, 8)
+      bounds: 280 136 8 8
+    - image: solid-color(36, 17, 0, 255, 8, 8)
+      bounds: 288 136 8 8
+    - image: solid-color(37, 17, 0, 255, 8, 8)
+      bounds: 296 136 8 8
+    - image: solid-color(38, 17, 0, 255, 8, 8)
+      bounds: 304 136 8 8
+    - image: solid-color(39, 17, 0, 255, 8, 8)
+      bounds: 312 136 8 8
+    - image: solid-color(40, 17, 0, 255, 8, 8)
+      bounds: 320 136 8 8
+    - image: solid-color(41, 17, 0, 255, 8, 8)
+      bounds: 328 136 8 8
+    - image: solid-color(42, 17, 0, 255, 8, 8)
+      bounds: 336 136 8 8
+    - image: solid-color(43, 17, 0, 255, 8, 8)
+      bounds: 344 136 8 8
+    - image: solid-color(44, 17, 0, 255, 8, 8)
+      bounds: 352 136 8 8
+    - image: solid-color(45, 17, 0, 255, 8, 8)
+      bounds: 360 136 8 8
+    - image: solid-color(46, 17, 0, 255, 8, 8)
+      bounds: 368 136 8 8
+    - image: solid-color(47, 17, 0, 255, 8, 8)
+      bounds: 376 136 8 8
+    - image: solid-color(48, 17, 0, 255, 8, 8)
+      bounds: 384 136 8 8
+    - image: solid-color(49, 17, 0, 255, 8, 8)
+      bounds: 392 136 8 8
+    - image: solid-color(50, 17, 0, 255, 8, 8)
+      bounds: 400 136 8 8
+    - image: solid-color(51, 17, 0, 255, 8, 8)
+      bounds: 408 136 8 8
+    - image: solid-color(52, 17, 0, 255, 8, 8)
+      bounds: 416 136 8 8
+    - image: solid-color(53, 17, 0, 255, 8, 8)
+      bounds: 424 136 8 8
+    - image: solid-color(54, 17, 0, 255, 8, 8)
+      bounds: 432 136 8 8
+    - image: solid-color(55, 17, 0, 255, 8, 8)
+      bounds: 440 136 8 8
+    - image: solid-color(56, 17, 0, 255, 8, 8)
+      bounds: 448 136 8 8
+    - image: solid-color(57, 17, 0, 255, 8, 8)
+      bounds: 456 136 8 8
+    - image: solid-color(58, 17, 0, 255, 8, 8)
+      bounds: 464 136 8 8
+    - image: solid-color(59, 17, 0, 255, 8, 8)
+      bounds: 472 136 8 8
+    - image: solid-color(60, 17, 0, 255, 8, 8)
+      bounds: 480 136 8 8
+    - image: solid-color(61, 17, 0, 255, 8, 8)
+      bounds: 488 136 8 8
+    - image: solid-color(62, 17, 0, 255, 8, 8)
+      bounds: 496 136 8 8
+    - image: solid-color(63, 17, 0, 255, 8, 8)
+      bounds: 504 136 8 8
+    - image: solid-color(64, 17, 0, 255, 8, 8)
+      bounds: 512 136 8 8
+    - image: solid-color(65, 17, 0, 255, 8, 8)
+      bounds: 520 136 8 8
+    - image: solid-color(66, 17, 0, 255, 8, 8)
+      bounds: 528 136 8 8
+    - image: solid-color(67, 17, 0, 255, 8, 8)
+      bounds: 536 136 8 8
+    - image: solid-color(68, 17, 0, 255, 8, 8)
+      bounds: 544 136 8 8
+    - image: solid-color(69, 17, 0, 255, 8, 8)
+      bounds: 552 136 8 8
+    - image: solid-color(70, 17, 0, 255, 8, 8)
+      bounds: 560 136 8 8
+    - image: solid-color(71, 17, 0, 255, 8, 8)
+      bounds: 568 136 8 8
+    - image: solid-color(72, 17, 0, 255, 8, 8)
+      bounds: 576 136 8 8
+    - image: solid-color(73, 17, 0, 255, 8, 8)
+      bounds: 584 136 8 8
+    - image: solid-color(74, 17, 0, 255, 8, 8)
+      bounds: 592 136 8 8
+    - image: solid-color(75, 17, 0, 255, 8, 8)
+      bounds: 600 136 8 8
+    - image: solid-color(76, 17, 0, 255, 8, 8)
+      bounds: 608 136 8 8
+    - image: solid-color(77, 17, 0, 255, 8, 8)
+      bounds: 616 136 8 8
+    - image: solid-color(78, 17, 0, 255, 8, 8)
+      bounds: 624 136 8 8
+    - image: solid-color(79, 17, 0, 255, 8, 8)
+      bounds: 632 136 8 8
+    - image: solid-color(80, 17, 0, 255, 8, 8)
+      bounds: 640 136 8 8
+    - image: solid-color(81, 17, 0, 255, 8, 8)
+      bounds: 648 136 8 8
+    - image: solid-color(82, 17, 0, 255, 8, 8)
+      bounds: 656 136 8 8
+    - image: solid-color(83, 17, 0, 255, 8, 8)
+      bounds: 664 136 8 8
+    - image: solid-color(84, 17, 0, 255, 8, 8)
+      bounds: 672 136 8 8
+    - image: solid-color(85, 17, 0, 255, 8, 8)
+      bounds: 680 136 8 8
+    - image: solid-color(86, 17, 0, 255, 8, 8)
+      bounds: 688 136 8 8
+    - image: solid-color(87, 17, 0, 255, 8, 8)
+      bounds: 696 136 8 8
+    - image: solid-color(88, 17, 0, 255, 8, 8)
+      bounds: 704 136 8 8
+    - image: solid-color(89, 17, 0, 255, 8, 8)
+      bounds: 712 136 8 8
+    - image: solid-color(90, 17, 0, 255, 8, 8)
+      bounds: 720 136 8 8
+    - image: solid-color(91, 17, 0, 255, 8, 8)
+      bounds: 728 136 8 8
+    - image: solid-color(92, 17, 0, 255, 8, 8)
+      bounds: 736 136 8 8
+    - image: solid-color(93, 17, 0, 255, 8, 8)
+      bounds: 744 136 8 8
+    - image: solid-color(94, 17, 0, 255, 8, 8)
+      bounds: 752 136 8 8
+    - image: solid-color(95, 17, 0, 255, 8, 8)
+      bounds: 760 136 8 8
+    - image: solid-color(96, 17, 0, 255, 8, 8)
+      bounds: 768 136 8 8
+    - image: solid-color(97, 17, 0, 255, 8, 8)
+      bounds: 776 136 8 8
+    - image: solid-color(98, 17, 0, 255, 8, 8)
+      bounds: 784 136 8 8
+    - image: solid-color(99, 17, 0, 255, 8, 8)
+      bounds: 792 136 8 8
+    - image: solid-color(100, 17, 0, 255, 8, 8)
+      bounds: 800 136 8 8
+    - image: solid-color(101, 17, 0, 255, 8, 8)
+      bounds: 808 136 8 8
+    - image: solid-color(102, 17, 0, 255, 8, 8)
+      bounds: 816 136 8 8
+    - image: solid-color(103, 17, 0, 255, 8, 8)
+      bounds: 824 136 8 8
+    - image: solid-color(104, 17, 0, 255, 8, 8)
+      bounds: 832 136 8 8
+    - image: solid-color(105, 17, 0, 255, 8, 8)
+      bounds: 840 136 8 8
+    - image: solid-color(106, 17, 0, 255, 8, 8)
+      bounds: 848 136 8 8
+    - image: solid-color(107, 17, 0, 255, 8, 8)
+      bounds: 856 136 8 8
+    - image: solid-color(108, 17, 0, 255, 8, 8)
+      bounds: 864 136 8 8
+    - image: solid-color(109, 17, 0, 255, 8, 8)
+      bounds: 872 136 8 8
+    - image: solid-color(110, 17, 0, 255, 8, 8)
+      bounds: 880 136 8 8
+    - image: solid-color(111, 17, 0, 255, 8, 8)
+      bounds: 888 136 8 8
+    - image: solid-color(112, 17, 0, 255, 8, 8)
+      bounds: 896 136 8 8
+    - image: solid-color(113, 17, 0, 255, 8, 8)
+      bounds: 904 136 8 8
+    - image: solid-color(114, 17, 0, 255, 8, 8)
+      bounds: 912 136 8 8
+    - image: solid-color(115, 17, 0, 255, 8, 8)
+      bounds: 920 136 8 8
+    - image: solid-color(116, 17, 0, 255, 8, 8)
+      bounds: 928 136 8 8
+    - image: solid-color(117, 17, 0, 255, 8, 8)
+      bounds: 936 136 8 8
+    - image: solid-color(118, 17, 0, 255, 8, 8)
+      bounds: 944 136 8 8
+    - image: solid-color(119, 17, 0, 255, 8, 8)
+      bounds: 952 136 8 8
+    - image: solid-color(120, 17, 0, 255, 8, 8)
+      bounds: 960 136 8 8
+    - image: solid-color(121, 17, 0, 255, 8, 8)
+      bounds: 968 136 8 8
+    - image: solid-color(122, 17, 0, 255, 8, 8)
+      bounds: 976 136 8 8
+    - image: solid-color(123, 17, 0, 255, 8, 8)
+      bounds: 984 136 8 8
+    - image: solid-color(124, 17, 0, 255, 8, 8)
+      bounds: 992 136 8 8
+    - image: solid-color(125, 17, 0, 255, 8, 8)
+      bounds: 1000 136 8 8
+    - image: solid-color(126, 17, 0, 255, 8, 8)
+      bounds: 1008 136 8 8
+    - image: solid-color(127, 17, 0, 255, 8, 8)
+      bounds: 1016 136 8 8
+    - image: solid-color(0, 18, 0, 255, 8, 8)
+      bounds: 0 144 8 8
+    - image: solid-color(1, 18, 0, 255, 8, 8)
+      bounds: 8 144 8 8
+    - image: solid-color(2, 18, 0, 255, 8, 8)
+      bounds: 16 144 8 8
+    - image: solid-color(3, 18, 0, 255, 8, 8)
+      bounds: 24 144 8 8
+    - image: solid-color(4, 18, 0, 255, 8, 8)
+      bounds: 32 144 8 8
+    - image: solid-color(5, 18, 0, 255, 8, 8)
+      bounds: 40 144 8 8
+    - image: solid-color(6, 18, 0, 255, 8, 8)
+      bounds: 48 144 8 8
+    - image: solid-color(7, 18, 0, 255, 8, 8)
+      bounds: 56 144 8 8
+    - image: solid-color(8, 18, 0, 255, 8, 8)
+      bounds: 64 144 8 8
+    - image: solid-color(9, 18, 0, 255, 8, 8)
+      bounds: 72 144 8 8
+    - image: solid-color(10, 18, 0, 255, 8, 8)
+      bounds: 80 144 8 8
+    - image: solid-color(11, 18, 0, 255, 8, 8)
+      bounds: 88 144 8 8
+    - image: solid-color(12, 18, 0, 255, 8, 8)
+      bounds: 96 144 8 8
+    - image: solid-color(13, 18, 0, 255, 8, 8)
+      bounds: 104 144 8 8
+    - image: solid-color(14, 18, 0, 255, 8, 8)
+      bounds: 112 144 8 8
+    - image: solid-color(15, 18, 0, 255, 8, 8)
+      bounds: 120 144 8 8
+    - image: solid-color(16, 18, 0, 255, 8, 8)
+      bounds: 128 144 8 8
+    - image: solid-color(17, 18, 0, 255, 8, 8)
+      bounds: 136 144 8 8
+    - image: solid-color(18, 18, 0, 255, 8, 8)
+      bounds: 144 144 8 8
+    - image: solid-color(19, 18, 0, 255, 8, 8)
+      bounds: 152 144 8 8
+    - image: solid-color(20, 18, 0, 255, 8, 8)
+      bounds: 160 144 8 8
+    - image: solid-color(21, 18, 0, 255, 8, 8)
+      bounds: 168 144 8 8
+    - image: solid-color(22, 18, 0, 255, 8, 8)
+      bounds: 176 144 8 8
+    - image: solid-color(23, 18, 0, 255, 8, 8)
+      bounds: 184 144 8 8
+    - image: solid-color(24, 18, 0, 255, 8, 8)
+      bounds: 192 144 8 8
+    - image: solid-color(25, 18, 0, 255, 8, 8)
+      bounds: 200 144 8 8
+    - image: solid-color(26, 18, 0, 255, 8, 8)
+      bounds: 208 144 8 8
+    - image: solid-color(27, 18, 0, 255, 8, 8)
+      bounds: 216 144 8 8
+    - image: solid-color(28, 18, 0, 255, 8, 8)
+      bounds: 224 144 8 8
+    - image: solid-color(29, 18, 0, 255, 8, 8)
+      bounds: 232 144 8 8
+    - image: solid-color(30, 18, 0, 255, 8, 8)
+      bounds: 240 144 8 8
+    - image: solid-color(31, 18, 0, 255, 8, 8)
+      bounds: 248 144 8 8
+    - image: solid-color(32, 18, 0, 255, 8, 8)
+      bounds: 256 144 8 8
+    - image: solid-color(33, 18, 0, 255, 8, 8)
+      bounds: 264 144 8 8
+    - image: solid-color(34, 18, 0, 255, 8, 8)
+      bounds: 272 144 8 8
+    - image: solid-color(35, 18, 0, 255, 8, 8)
+      bounds: 280 144 8 8
+    - image: solid-color(36, 18, 0, 255, 8, 8)
+      bounds: 288 144 8 8
+    - image: solid-color(37, 18, 0, 255, 8, 8)
+      bounds: 296 144 8 8
+    - image: solid-color(38, 18, 0, 255, 8, 8)
+      bounds: 304 144 8 8
+    - image: solid-color(39, 18, 0, 255, 8, 8)
+      bounds: 312 144 8 8
+    - image: solid-color(40, 18, 0, 255, 8, 8)
+      bounds: 320 144 8 8
+    - image: solid-color(41, 18, 0, 255, 8, 8)
+      bounds: 328 144 8 8
+    - image: solid-color(42, 18, 0, 255, 8, 8)
+      bounds: 336 144 8 8
+    - image: solid-color(43, 18, 0, 255, 8, 8)
+      bounds: 344 144 8 8
+    - image: solid-color(44, 18, 0, 255, 8, 8)
+      bounds: 352 144 8 8
+    - image: solid-color(45, 18, 0, 255, 8, 8)
+      bounds: 360 144 8 8
+    - image: solid-color(46, 18, 0, 255, 8, 8)
+      bounds: 368 144 8 8
+    - image: solid-color(47, 18, 0, 255, 8, 8)
+      bounds: 376 144 8 8
+    - image: solid-color(48, 18, 0, 255, 8, 8)
+      bounds: 384 144 8 8
+    - image: solid-color(49, 18, 0, 255, 8, 8)
+      bounds: 392 144 8 8
+    - image: solid-color(50, 18, 0, 255, 8, 8)
+      bounds: 400 144 8 8
+    - image: solid-color(51, 18, 0, 255, 8, 8)
+      bounds: 408 144 8 8
+    - image: solid-color(52, 18, 0, 255, 8, 8)
+      bounds: 416 144 8 8
+    - image: solid-color(53, 18, 0, 255, 8, 8)
+      bounds: 424 144 8 8
+    - image: solid-color(54, 18, 0, 255, 8, 8)
+      bounds: 432 144 8 8
+    - image: solid-color(55, 18, 0, 255, 8, 8)
+      bounds: 440 144 8 8
+    - image: solid-color(56, 18, 0, 255, 8, 8)
+      bounds: 448 144 8 8
+    - image: solid-color(57, 18, 0, 255, 8, 8)
+      bounds: 456 144 8 8
+    - image: solid-color(58, 18, 0, 255, 8, 8)
+      bounds: 464 144 8 8
+    - image: solid-color(59, 18, 0, 255, 8, 8)
+      bounds: 472 144 8 8
+    - image: solid-color(60, 18, 0, 255, 8, 8)
+      bounds: 480 144 8 8
+    - image: solid-color(61, 18, 0, 255, 8, 8)
+      bounds: 488 144 8 8
+    - image: solid-color(62, 18, 0, 255, 8, 8)
+      bounds: 496 144 8 8
+    - image: solid-color(63, 18, 0, 255, 8, 8)
+      bounds: 504 144 8 8
+    - image: solid-color(64, 18, 0, 255, 8, 8)
+      bounds: 512 144 8 8
+    - image: solid-color(65, 18, 0, 255, 8, 8)
+      bounds: 520 144 8 8
+    - image: solid-color(66, 18, 0, 255, 8, 8)
+      bounds: 528 144 8 8
+    - image: solid-color(67, 18, 0, 255, 8, 8)
+      bounds: 536 144 8 8
+    - image: solid-color(68, 18, 0, 255, 8, 8)
+      bounds: 544 144 8 8
+    - image: solid-color(69, 18, 0, 255, 8, 8)
+      bounds: 552 144 8 8
+    - image: solid-color(70, 18, 0, 255, 8, 8)
+      bounds: 560 144 8 8
+    - image: solid-color(71, 18, 0, 255, 8, 8)
+      bounds: 568 144 8 8
+    - image: solid-color(72, 18, 0, 255, 8, 8)
+      bounds: 576 144 8 8
+    - image: solid-color(73, 18, 0, 255, 8, 8)
+      bounds: 584 144 8 8
+    - image: solid-color(74, 18, 0, 255, 8, 8)
+      bounds: 592 144 8 8
+    - image: solid-color(75, 18, 0, 255, 8, 8)
+      bounds: 600 144 8 8
+    - image: solid-color(76, 18, 0, 255, 8, 8)
+      bounds: 608 144 8 8
+    - image: solid-color(77, 18, 0, 255, 8, 8)
+      bounds: 616 144 8 8
+    - image: solid-color(78, 18, 0, 255, 8, 8)
+      bounds: 624 144 8 8
+    - image: solid-color(79, 18, 0, 255, 8, 8)
+      bounds: 632 144 8 8
+    - image: solid-color(80, 18, 0, 255, 8, 8)
+      bounds: 640 144 8 8
+    - image: solid-color(81, 18, 0, 255, 8, 8)
+      bounds: 648 144 8 8
+    - image: solid-color(82, 18, 0, 255, 8, 8)
+      bounds: 656 144 8 8
+    - image: solid-color(83, 18, 0, 255, 8, 8)
+      bounds: 664 144 8 8
+    - image: solid-color(84, 18, 0, 255, 8, 8)
+      bounds: 672 144 8 8
+    - image: solid-color(85, 18, 0, 255, 8, 8)
+      bounds: 680 144 8 8
+    - image: solid-color(86, 18, 0, 255, 8, 8)
+      bounds: 688 144 8 8
+    - image: solid-color(87, 18, 0, 255, 8, 8)
+      bounds: 696 144 8 8
+    - image: solid-color(88, 18, 0, 255, 8, 8)
+      bounds: 704 144 8 8
+    - image: solid-color(89, 18, 0, 255, 8, 8)
+      bounds: 712 144 8 8
+    - image: solid-color(90, 18, 0, 255, 8, 8)
+      bounds: 720 144 8 8
+    - image: solid-color(91, 18, 0, 255, 8, 8)
+      bounds: 728 144 8 8
+    - image: solid-color(92, 18, 0, 255, 8, 8)
+      bounds: 736 144 8 8
+    - image: solid-color(93, 18, 0, 255, 8, 8)
+      bounds: 744 144 8 8
+    - image: solid-color(94, 18, 0, 255, 8, 8)
+      bounds: 752 144 8 8
+    - image: solid-color(95, 18, 0, 255, 8, 8)
+      bounds: 760 144 8 8
+    - image: solid-color(96, 18, 0, 255, 8, 8)
+      bounds: 768 144 8 8
+    - image: solid-color(97, 18, 0, 255, 8, 8)
+      bounds: 776 144 8 8
+    - image: solid-color(98, 18, 0, 255, 8, 8)
+      bounds: 784 144 8 8
+    - image: solid-color(99, 18, 0, 255, 8, 8)
+      bounds: 792 144 8 8
+    - image: solid-color(100, 18, 0, 255, 8, 8)
+      bounds: 800 144 8 8
+    - image: solid-color(101, 18, 0, 255, 8, 8)
+      bounds: 808 144 8 8
+    - image: solid-color(102, 18, 0, 255, 8, 8)
+      bounds: 816 144 8 8
+    - image: solid-color(103, 18, 0, 255, 8, 8)
+      bounds: 824 144 8 8
+    - image: solid-color(104, 18, 0, 255, 8, 8)
+      bounds: 832 144 8 8
+    - image: solid-color(105, 18, 0, 255, 8, 8)
+      bounds: 840 144 8 8
+    - image: solid-color(106, 18, 0, 255, 8, 8)
+      bounds: 848 144 8 8
+    - image: solid-color(107, 18, 0, 255, 8, 8)
+      bounds: 856 144 8 8
+    - image: solid-color(108, 18, 0, 255, 8, 8)
+      bounds: 864 144 8 8
+    - image: solid-color(109, 18, 0, 255, 8, 8)
+      bounds: 872 144 8 8
+    - image: solid-color(110, 18, 0, 255, 8, 8)
+      bounds: 880 144 8 8
+    - image: solid-color(111, 18, 0, 255, 8, 8)
+      bounds: 888 144 8 8
+    - image: solid-color(112, 18, 0, 255, 8, 8)
+      bounds: 896 144 8 8
+    - image: solid-color(113, 18, 0, 255, 8, 8)
+      bounds: 904 144 8 8
+    - image: solid-color(114, 18, 0, 255, 8, 8)
+      bounds: 912 144 8 8
+    - image: solid-color(115, 18, 0, 255, 8, 8)
+      bounds: 920 144 8 8
+    - image: solid-color(116, 18, 0, 255, 8, 8)
+      bounds: 928 144 8 8
+    - image: solid-color(117, 18, 0, 255, 8, 8)
+      bounds: 936 144 8 8
+    - image: solid-color(118, 18, 0, 255, 8, 8)
+      bounds: 944 144 8 8
+    - image: solid-color(119, 18, 0, 255, 8, 8)
+      bounds: 952 144 8 8
+    - image: solid-color(120, 18, 0, 255, 8, 8)
+      bounds: 960 144 8 8
+    - image: solid-color(121, 18, 0, 255, 8, 8)
+      bounds: 968 144 8 8
+    - image: solid-color(122, 18, 0, 255, 8, 8)
+      bounds: 976 144 8 8
+    - image: solid-color(123, 18, 0, 255, 8, 8)
+      bounds: 984 144 8 8
+    - image: solid-color(124, 18, 0, 255, 8, 8)
+      bounds: 992 144 8 8
+    - image: solid-color(125, 18, 0, 255, 8, 8)
+      bounds: 1000 144 8 8
+    - image: solid-color(126, 18, 0, 255, 8, 8)
+      bounds: 1008 144 8 8
+    - image: solid-color(127, 18, 0, 255, 8, 8)
+      bounds: 1016 144 8 8
+    - image: solid-color(0, 19, 0, 255, 8, 8)
+      bounds: 0 152 8 8
+    - image: solid-color(1, 19, 0, 255, 8, 8)
+      bounds: 8 152 8 8
+    - image: solid-color(2, 19, 0, 255, 8, 8)
+      bounds: 16 152 8 8
+    - image: solid-color(3, 19, 0, 255, 8, 8)
+      bounds: 24 152 8 8
+    - image: solid-color(4, 19, 0, 255, 8, 8)
+      bounds: 32 152 8 8
+    - image: solid-color(5, 19, 0, 255, 8, 8)
+      bounds: 40 152 8 8
+    - image: solid-color(6, 19, 0, 255, 8, 8)
+      bounds: 48 152 8 8
+    - image: solid-color(7, 19, 0, 255, 8, 8)
+      bounds: 56 152 8 8
+    - image: solid-color(8, 19, 0, 255, 8, 8)
+      bounds: 64 152 8 8
+    - image: solid-color(9, 19, 0, 255, 8, 8)
+      bounds: 72 152 8 8
+    - image: solid-color(10, 19, 0, 255, 8, 8)
+      bounds: 80 152 8 8
+    - image: solid-color(11, 19, 0, 255, 8, 8)
+      bounds: 88 152 8 8
+    - image: solid-color(12, 19, 0, 255, 8, 8)
+      bounds: 96 152 8 8
+    - image: solid-color(13, 19, 0, 255, 8, 8)
+      bounds: 104 152 8 8
+    - image: solid-color(14, 19, 0, 255, 8, 8)
+      bounds: 112 152 8 8
+    - image: solid-color(15, 19, 0, 255, 8, 8)
+      bounds: 120 152 8 8
+    - image: solid-color(16, 19, 0, 255, 8, 8)
+      bounds: 128 152 8 8
+    - image: solid-color(17, 19, 0, 255, 8, 8)
+      bounds: 136 152 8 8
+    - image: solid-color(18, 19, 0, 255, 8, 8)
+      bounds: 144 152 8 8
+    - image: solid-color(19, 19, 0, 255, 8, 8)
+      bounds: 152 152 8 8
+    - image: solid-color(20, 19, 0, 255, 8, 8)
+      bounds: 160 152 8 8
+    - image: solid-color(21, 19, 0, 255, 8, 8)
+      bounds: 168 152 8 8
+    - image: solid-color(22, 19, 0, 255, 8, 8)
+      bounds: 176 152 8 8
+    - image: solid-color(23, 19, 0, 255, 8, 8)
+      bounds: 184 152 8 8
+    - image: solid-color(24, 19, 0, 255, 8, 8)
+      bounds: 192 152 8 8
+    - image: solid-color(25, 19, 0, 255, 8, 8)
+      bounds: 200 152 8 8
+    - image: solid-color(26, 19, 0, 255, 8, 8)
+      bounds: 208 152 8 8
+    - image: solid-color(27, 19, 0, 255, 8, 8)
+      bounds: 216 152 8 8
+    - image: solid-color(28, 19, 0, 255, 8, 8)
+      bounds: 224 152 8 8
+    - image: solid-color(29, 19, 0, 255, 8, 8)
+      bounds: 232 152 8 8
+    - image: solid-color(30, 19, 0, 255, 8, 8)
+      bounds: 240 152 8 8
+    - image: solid-color(31, 19, 0, 255, 8, 8)
+      bounds: 248 152 8 8
+    - image: solid-color(32, 19, 0, 255, 8, 8)
+      bounds: 256 152 8 8
+    - image: solid-color(33, 19, 0, 255, 8, 8)
+      bounds: 264 152 8 8
+    - image: solid-color(34, 19, 0, 255, 8, 8)
+      bounds: 272 152 8 8
+    - image: solid-color(35, 19, 0, 255, 8, 8)
+      bounds: 280 152 8 8
+    - image: solid-color(36, 19, 0, 255, 8, 8)
+      bounds: 288 152 8 8
+    - image: solid-color(37, 19, 0, 255, 8, 8)
+      bounds: 296 152 8 8
+    - image: solid-color(38, 19, 0, 255, 8, 8)
+      bounds: 304 152 8 8
+    - image: solid-color(39, 19, 0, 255, 8, 8)
+      bounds: 312 152 8 8
+    - image: solid-color(40, 19, 0, 255, 8, 8)
+      bounds: 320 152 8 8
+    - image: solid-color(41, 19, 0, 255, 8, 8)
+      bounds: 328 152 8 8
+    - image: solid-color(42, 19, 0, 255, 8, 8)
+      bounds: 336 152 8 8
+    - image: solid-color(43, 19, 0, 255, 8, 8)
+      bounds: 344 152 8 8
+    - image: solid-color(44, 19, 0, 255, 8, 8)
+      bounds: 352 152 8 8
+    - image: solid-color(45, 19, 0, 255, 8, 8)
+      bounds: 360 152 8 8
+    - image: solid-color(46, 19, 0, 255, 8, 8)
+      bounds: 368 152 8 8
+    - image: solid-color(47, 19, 0, 255, 8, 8)
+      bounds: 376 152 8 8
+    - image: solid-color(48, 19, 0, 255, 8, 8)
+      bounds: 384 152 8 8
+    - image: solid-color(49, 19, 0, 255, 8, 8)
+      bounds: 392 152 8 8
+    - image: solid-color(50, 19, 0, 255, 8, 8)
+      bounds: 400 152 8 8
+    - image: solid-color(51, 19, 0, 255, 8, 8)
+      bounds: 408 152 8 8
+    - image: solid-color(52, 19, 0, 255, 8, 8)
+      bounds: 416 152 8 8
+    - image: solid-color(53, 19, 0, 255, 8, 8)
+      bounds: 424 152 8 8
+    - image: solid-color(54, 19, 0, 255, 8, 8)
+      bounds: 432 152 8 8
+    - image: solid-color(55, 19, 0, 255, 8, 8)
+      bounds: 440 152 8 8
+    - image: solid-color(56, 19, 0, 255, 8, 8)
+      bounds: 448 152 8 8
+    - image: solid-color(57, 19, 0, 255, 8, 8)
+      bounds: 456 152 8 8
+    - image: solid-color(58, 19, 0, 255, 8, 8)
+      bounds: 464 152 8 8
+    - image: solid-color(59, 19, 0, 255, 8, 8)
+      bounds: 472 152 8 8
+    - image: solid-color(60, 19, 0, 255, 8, 8)
+      bounds: 480 152 8 8
+    - image: solid-color(61, 19, 0, 255, 8, 8)
+      bounds: 488 152 8 8
+    - image: solid-color(62, 19, 0, 255, 8, 8)
+      bounds: 496 152 8 8
+    - image: solid-color(63, 19, 0, 255, 8, 8)
+      bounds: 504 152 8 8
+    - image: solid-color(64, 19, 0, 255, 8, 8)
+      bounds: 512 152 8 8
+    - image: solid-color(65, 19, 0, 255, 8, 8)
+      bounds: 520 152 8 8
+    - image: solid-color(66, 19, 0, 255, 8, 8)
+      bounds: 528 152 8 8
+    - image: solid-color(67, 19, 0, 255, 8, 8)
+      bounds: 536 152 8 8
+    - image: solid-color(68, 19, 0, 255, 8, 8)
+      bounds: 544 152 8 8
+    - image: solid-color(69, 19, 0, 255, 8, 8)
+      bounds: 552 152 8 8
+    - image: solid-color(70, 19, 0, 255, 8, 8)
+      bounds: 560 152 8 8
+    - image: solid-color(71, 19, 0, 255, 8, 8)
+      bounds: 568 152 8 8
+    - image: solid-color(72, 19, 0, 255, 8, 8)
+      bounds: 576 152 8 8
+    - image: solid-color(73, 19, 0, 255, 8, 8)
+      bounds: 584 152 8 8
+    - image: solid-color(74, 19, 0, 255, 8, 8)
+      bounds: 592 152 8 8
+    - image: solid-color(75, 19, 0, 255, 8, 8)
+      bounds: 600 152 8 8
+    - image: solid-color(76, 19, 0, 255, 8, 8)
+      bounds: 608 152 8 8
+    - image: solid-color(77, 19, 0, 255, 8, 8)
+      bounds: 616 152 8 8
+    - image: solid-color(78, 19, 0, 255, 8, 8)
+      bounds: 624 152 8 8
+    - image: solid-color(79, 19, 0, 255, 8, 8)
+      bounds: 632 152 8 8
+    - image: solid-color(80, 19, 0, 255, 8, 8)
+      bounds: 640 152 8 8
+    - image: solid-color(81, 19, 0, 255, 8, 8)
+      bounds: 648 152 8 8
+    - image: solid-color(82, 19, 0, 255, 8, 8)
+      bounds: 656 152 8 8
+    - image: solid-color(83, 19, 0, 255, 8, 8)
+      bounds: 664 152 8 8
+    - image: solid-color(84, 19, 0, 255, 8, 8)
+      bounds: 672 152 8 8
+    - image: solid-color(85, 19, 0, 255, 8, 8)
+      bounds: 680 152 8 8
+    - image: solid-color(86, 19, 0, 255, 8, 8)
+      bounds: 688 152 8 8
+    - image: solid-color(87, 19, 0, 255, 8, 8)
+      bounds: 696 152 8 8
+    - image: solid-color(88, 19, 0, 255, 8, 8)
+      bounds: 704 152 8 8
+    - image: solid-color(89, 19, 0, 255, 8, 8)
+      bounds: 712 152 8 8
+    - image: solid-color(90, 19, 0, 255, 8, 8)
+      bounds: 720 152 8 8
+    - image: solid-color(91, 19, 0, 255, 8, 8)
+      bounds: 728 152 8 8
+    - image: solid-color(92, 19, 0, 255, 8, 8)
+      bounds: 736 152 8 8
+    - image: solid-color(93, 19, 0, 255, 8, 8)
+      bounds: 744 152 8 8
+    - image: solid-color(94, 19, 0, 255, 8, 8)
+      bounds: 752 152 8 8
+    - image: solid-color(95, 19, 0, 255, 8, 8)
+      bounds: 760 152 8 8
+    - image: solid-color(96, 19, 0, 255, 8, 8)
+      bounds: 768 152 8 8
+    - image: solid-color(97, 19, 0, 255, 8, 8)
+      bounds: 776 152 8 8
+    - image: solid-color(98, 19, 0, 255, 8, 8)
+      bounds: 784 152 8 8
+    - image: solid-color(99, 19, 0, 255, 8, 8)
+      bounds: 792 152 8 8
+    - image: solid-color(100, 19, 0, 255, 8, 8)
+      bounds: 800 152 8 8
+    - image: solid-color(101, 19, 0, 255, 8, 8)
+      bounds: 808 152 8 8
+    - image: solid-color(102, 19, 0, 255, 8, 8)
+      bounds: 816 152 8 8
+    - image: solid-color(103, 19, 0, 255, 8, 8)
+      bounds: 824 152 8 8
+    - image: solid-color(104, 19, 0, 255, 8, 8)
+      bounds: 832 152 8 8
+    - image: solid-color(105, 19, 0, 255, 8, 8)
+      bounds: 840 152 8 8
+    - image: solid-color(106, 19, 0, 255, 8, 8)
+      bounds: 848 152 8 8
+    - image: solid-color(107, 19, 0, 255, 8, 8)
+      bounds: 856 152 8 8
+    - image: solid-color(108, 19, 0, 255, 8, 8)
+      bounds: 864 152 8 8
+    - image: solid-color(109, 19, 0, 255, 8, 8)
+      bounds: 872 152 8 8
+    - image: solid-color(110, 19, 0, 255, 8, 8)
+      bounds: 880 152 8 8
+    - image: solid-color(111, 19, 0, 255, 8, 8)
+      bounds: 888 152 8 8
+    - image: solid-color(112, 19, 0, 255, 8, 8)
+      bounds: 896 152 8 8
+    - image: solid-color(113, 19, 0, 255, 8, 8)
+      bounds: 904 152 8 8
+    - image: solid-color(114, 19, 0, 255, 8, 8)
+      bounds: 912 152 8 8
+    - image: solid-color(115, 19, 0, 255, 8, 8)
+      bounds: 920 152 8 8
+    - image: solid-color(116, 19, 0, 255, 8, 8)
+      bounds: 928 152 8 8
+    - image: solid-color(117, 19, 0, 255, 8, 8)
+      bounds: 936 152 8 8
+    - image: solid-color(118, 19, 0, 255, 8, 8)
+      bounds: 944 152 8 8
+    - image: solid-color(119, 19, 0, 255, 8, 8)
+      bounds: 952 152 8 8
+    - image: solid-color(120, 19, 0, 255, 8, 8)
+      bounds: 960 152 8 8
+    - image: solid-color(121, 19, 0, 255, 8, 8)
+      bounds: 968 152 8 8
+    - image: solid-color(122, 19, 0, 255, 8, 8)
+      bounds: 976 152 8 8
+    - image: solid-color(123, 19, 0, 255, 8, 8)
+      bounds: 984 152 8 8
+    - image: solid-color(124, 19, 0, 255, 8, 8)
+      bounds: 992 152 8 8
+    - image: solid-color(125, 19, 0, 255, 8, 8)
+      bounds: 1000 152 8 8
+    - image: solid-color(126, 19, 0, 255, 8, 8)
+      bounds: 1008 152 8 8
+    - image: solid-color(127, 19, 0, 255, 8, 8)
+      bounds: 1016 152 8 8
+    - image: solid-color(0, 20, 0, 255, 8, 8)
+      bounds: 0 160 8 8
+    - image: solid-color(1, 20, 0, 255, 8, 8)
+      bounds: 8 160 8 8
+    - image: solid-color(2, 20, 0, 255, 8, 8)
+      bounds: 16 160 8 8
+    - image: solid-color(3, 20, 0, 255, 8, 8)
+      bounds: 24 160 8 8
+    - image: solid-color(4, 20, 0, 255, 8, 8)
+      bounds: 32 160 8 8
+    - image: solid-color(5, 20, 0, 255, 8, 8)
+      bounds: 40 160 8 8
+    - image: solid-color(6, 20, 0, 255, 8, 8)
+      bounds: 48 160 8 8
+    - image: solid-color(7, 20, 0, 255, 8, 8)
+      bounds: 56 160 8 8
+    - image: solid-color(8, 20, 0, 255, 8, 8)
+      bounds: 64 160 8 8
+    - image: solid-color(9, 20, 0, 255, 8, 8)
+      bounds: 72 160 8 8
+    - image: solid-color(10, 20, 0, 255, 8, 8)
+      bounds: 80 160 8 8
+    - image: solid-color(11, 20, 0, 255, 8, 8)
+      bounds: 88 160 8 8
+    - image: solid-color(12, 20, 0, 255, 8, 8)
+      bounds: 96 160 8 8
+    - image: solid-color(13, 20, 0, 255, 8, 8)
+      bounds: 104 160 8 8
+    - image: solid-color(14, 20, 0, 255, 8, 8)
+      bounds: 112 160 8 8
+    - image: solid-color(15, 20, 0, 255, 8, 8)
+      bounds: 120 160 8 8
+    - image: solid-color(16, 20, 0, 255, 8, 8)
+      bounds: 128 160 8 8
+    - image: solid-color(17, 20, 0, 255, 8, 8)
+      bounds: 136 160 8 8
+    - image: solid-color(18, 20, 0, 255, 8, 8)
+      bounds: 144 160 8 8
+    - image: solid-color(19, 20, 0, 255, 8, 8)
+      bounds: 152 160 8 8
+    - image: solid-color(20, 20, 0, 255, 8, 8)
+      bounds: 160 160 8 8
+    - image: solid-color(21, 20, 0, 255, 8, 8)
+      bounds: 168 160 8 8
+    - image: solid-color(22, 20, 0, 255, 8, 8)
+      bounds: 176 160 8 8
+    - image: solid-color(23, 20, 0, 255, 8, 8)
+      bounds: 184 160 8 8
+    - image: solid-color(24, 20, 0, 255, 8, 8)
+      bounds: 192 160 8 8
+    - image: solid-color(25, 20, 0, 255, 8, 8)
+      bounds: 200 160 8 8
+    - image: solid-color(26, 20, 0, 255, 8, 8)
+      bounds: 208 160 8 8
+    - image: solid-color(27, 20, 0, 255, 8, 8)
+      bounds: 216 160 8 8
+    - image: solid-color(28, 20, 0, 255, 8, 8)
+      bounds: 224 160 8 8
+    - image: solid-color(29, 20, 0, 255, 8, 8)
+      bounds: 232 160 8 8
+    - image: solid-color(30, 20, 0, 255, 8, 8)
+      bounds: 240 160 8 8
+    - image: solid-color(31, 20, 0, 255, 8, 8)
+      bounds: 248 160 8 8
+    - image: solid-color(32, 20, 0, 255, 8, 8)
+      bounds: 256 160 8 8
+    - image: solid-color(33, 20, 0, 255, 8, 8)
+      bounds: 264 160 8 8
+    - image: solid-color(34, 20, 0, 255, 8, 8)
+      bounds: 272 160 8 8
+    - image: solid-color(35, 20, 0, 255, 8, 8)
+      bounds: 280 160 8 8
+    - image: solid-color(36, 20, 0, 255, 8, 8)
+      bounds: 288 160 8 8
+    - image: solid-color(37, 20, 0, 255, 8, 8)
+      bounds: 296 160 8 8
+    - image: solid-color(38, 20, 0, 255, 8, 8)
+      bounds: 304 160 8 8
+    - image: solid-color(39, 20, 0, 255, 8, 8)
+      bounds: 312 160 8 8
+    - image: solid-color(40, 20, 0, 255, 8, 8)
+      bounds: 320 160 8 8
+    - image: solid-color(41, 20, 0, 255, 8, 8)
+      bounds: 328 160 8 8
+    - image: solid-color(42, 20, 0, 255, 8, 8)
+      bounds: 336 160 8 8
+    - image: solid-color(43, 20, 0, 255, 8, 8)
+      bounds: 344 160 8 8
+    - image: solid-color(44, 20, 0, 255, 8, 8)
+      bounds: 352 160 8 8
+    - image: solid-color(45, 20, 0, 255, 8, 8)
+      bounds: 360 160 8 8
+    - image: solid-color(46, 20, 0, 255, 8, 8)
+      bounds: 368 160 8 8
+    - image: solid-color(47, 20, 0, 255, 8, 8)
+      bounds: 376 160 8 8
+    - image: solid-color(48, 20, 0, 255, 8, 8)
+      bounds: 384 160 8 8
+    - image: solid-color(49, 20, 0, 255, 8, 8)
+      bounds: 392 160 8 8
+    - image: solid-color(50, 20, 0, 255, 8, 8)
+      bounds: 400 160 8 8
+    - image: solid-color(51, 20, 0, 255, 8, 8)
+      bounds: 408 160 8 8
+    - image: solid-color(52, 20, 0, 255, 8, 8)
+      bounds: 416 160 8 8
+    - image: solid-color(53, 20, 0, 255, 8, 8)
+      bounds: 424 160 8 8
+    - image: solid-color(54, 20, 0, 255, 8, 8)
+      bounds: 432 160 8 8
+    - image: solid-color(55, 20, 0, 255, 8, 8)
+      bounds: 440 160 8 8
+    - image: solid-color(56, 20, 0, 255, 8, 8)
+      bounds: 448 160 8 8
+    - image: solid-color(57, 20, 0, 255, 8, 8)
+      bounds: 456 160 8 8
+    - image: solid-color(58, 20, 0, 255, 8, 8)
+      bounds: 464 160 8 8
+    - image: solid-color(59, 20, 0, 255, 8, 8)
+      bounds: 472 160 8 8
+    - image: solid-color(60, 20, 0, 255, 8, 8)
+      bounds: 480 160 8 8
+    - image: solid-color(61, 20, 0, 255, 8, 8)
+      bounds: 488 160 8 8
+    - image: solid-color(62, 20, 0, 255, 8, 8)
+      bounds: 496 160 8 8
+    - image: solid-color(63, 20, 0, 255, 8, 8)
+      bounds: 504 160 8 8
+    - image: solid-color(64, 20, 0, 255, 8, 8)
+      bounds: 512 160 8 8
+    - image: solid-color(65, 20, 0, 255, 8, 8)
+      bounds: 520 160 8 8
+    - image: solid-color(66, 20, 0, 255, 8, 8)
+      bounds: 528 160 8 8
+    - image: solid-color(67, 20, 0, 255, 8, 8)
+      bounds: 536 160 8 8
+    - image: solid-color(68, 20, 0, 255, 8, 8)
+      bounds: 544 160 8 8
+    - image: solid-color(69, 20, 0, 255, 8, 8)
+      bounds: 552 160 8 8
+    - image: solid-color(70, 20, 0, 255, 8, 8)
+      bounds: 560 160 8 8
+    - image: solid-color(71, 20, 0, 255, 8, 8)
+      bounds: 568 160 8 8
+    - image: solid-color(72, 20, 0, 255, 8, 8)
+      bounds: 576 160 8 8
+    - image: solid-color(73, 20, 0, 255, 8, 8)
+      bounds: 584 160 8 8
+    - image: solid-color(74, 20, 0, 255, 8, 8)
+      bounds: 592 160 8 8
+    - image: solid-color(75, 20, 0, 255, 8, 8)
+      bounds: 600 160 8 8
+    - image: solid-color(76, 20, 0, 255, 8, 8)
+      bounds: 608 160 8 8
+    - image: solid-color(77, 20, 0, 255, 8, 8)
+      bounds: 616 160 8 8
+    - image: solid-color(78, 20, 0, 255, 8, 8)
+      bounds: 624 160 8 8
+    - image: solid-color(79, 20, 0, 255, 8, 8)
+      bounds: 632 160 8 8
+    - image: solid-color(80, 20, 0, 255, 8, 8)
+      bounds: 640 160 8 8
+    - image: solid-color(81, 20, 0, 255, 8, 8)
+      bounds: 648 160 8 8
+    - image: solid-color(82, 20, 0, 255, 8, 8)
+      bounds: 656 160 8 8
+    - image: solid-color(83, 20, 0, 255, 8, 8)
+      bounds: 664 160 8 8
+    - image: solid-color(84, 20, 0, 255, 8, 8)
+      bounds: 672 160 8 8
+    - image: solid-color(85, 20, 0, 255, 8, 8)
+      bounds: 680 160 8 8
+    - image: solid-color(86, 20, 0, 255, 8, 8)
+      bounds: 688 160 8 8
+    - image: solid-color(87, 20, 0, 255, 8, 8)
+      bounds: 696 160 8 8
+    - image: solid-color(88, 20, 0, 255, 8, 8)
+      bounds: 704 160 8 8
+    - image: solid-color(89, 20, 0, 255, 8, 8)
+      bounds: 712 160 8 8
+    - image: solid-color(90, 20, 0, 255, 8, 8)
+      bounds: 720 160 8 8
+    - image: solid-color(91, 20, 0, 255, 8, 8)
+      bounds: 728 160 8 8
+    - image: solid-color(92, 20, 0, 255, 8, 8)
+      bounds: 736 160 8 8
+    - image: solid-color(93, 20, 0, 255, 8, 8)
+      bounds: 744 160 8 8
+    - image: solid-color(94, 20, 0, 255, 8, 8)
+      bounds: 752 160 8 8
+    - image: solid-color(95, 20, 0, 255, 8, 8)
+      bounds: 760 160 8 8
+    - image: solid-color(96, 20, 0, 255, 8, 8)
+      bounds: 768 160 8 8
+    - image: solid-color(97, 20, 0, 255, 8, 8)
+      bounds: 776 160 8 8
+    - image: solid-color(98, 20, 0, 255, 8, 8)
+      bounds: 784 160 8 8
+    - image: solid-color(99, 20, 0, 255, 8, 8)
+      bounds: 792 160 8 8
+    - image: solid-color(100, 20, 0, 255, 8, 8)
+      bounds: 800 160 8 8
+    - image: solid-color(101, 20, 0, 255, 8, 8)
+      bounds: 808 160 8 8
+    - image: solid-color(102, 20, 0, 255, 8, 8)
+      bounds: 816 160 8 8
+    - image: solid-color(103, 20, 0, 255, 8, 8)
+      bounds: 824 160 8 8
+    - image: solid-color(104, 20, 0, 255, 8, 8)
+      bounds: 832 160 8 8
+    - image: solid-color(105, 20, 0, 255, 8, 8)
+      bounds: 840 160 8 8
+    - image: solid-color(106, 20, 0, 255, 8, 8)
+      bounds: 848 160 8 8
+    - image: solid-color(107, 20, 0, 255, 8, 8)
+      bounds: 856 160 8 8
+    - image: solid-color(108, 20, 0, 255, 8, 8)
+      bounds: 864 160 8 8
+    - image: solid-color(109, 20, 0, 255, 8, 8)
+      bounds: 872 160 8 8
+    - image: solid-color(110, 20, 0, 255, 8, 8)
+      bounds: 880 160 8 8
+    - image: solid-color(111, 20, 0, 255, 8, 8)
+      bounds: 888 160 8 8
+    - image: solid-color(112, 20, 0, 255, 8, 8)
+      bounds: 896 160 8 8
+    - image: solid-color(113, 20, 0, 255, 8, 8)
+      bounds: 904 160 8 8
+    - image: solid-color(114, 20, 0, 255, 8, 8)
+      bounds: 912 160 8 8
+    - image: solid-color(115, 20, 0, 255, 8, 8)
+      bounds: 920 160 8 8
+    - image: solid-color(116, 20, 0, 255, 8, 8)
+      bounds: 928 160 8 8
+    - image: solid-color(117, 20, 0, 255, 8, 8)
+      bounds: 936 160 8 8
+    - image: solid-color(118, 20, 0, 255, 8, 8)
+      bounds: 944 160 8 8
+    - image: solid-color(119, 20, 0, 255, 8, 8)
+      bounds: 952 160 8 8
+    - image: solid-color(120, 20, 0, 255, 8, 8)
+      bounds: 960 160 8 8
+    - image: solid-color(121, 20, 0, 255, 8, 8)
+      bounds: 968 160 8 8
+    - image: solid-color(122, 20, 0, 255, 8, 8)
+      bounds: 976 160 8 8
+    - image: solid-color(123, 20, 0, 255, 8, 8)
+      bounds: 984 160 8 8
+    - image: solid-color(124, 20, 0, 255, 8, 8)
+      bounds: 992 160 8 8
+    - image: solid-color(125, 20, 0, 255, 8, 8)
+      bounds: 1000 160 8 8
+    - image: solid-color(126, 20, 0, 255, 8, 8)
+      bounds: 1008 160 8 8
+    - image: solid-color(127, 20, 0, 255, 8, 8)
+      bounds: 1016 160 8 8
+    - image: solid-color(0, 21, 0, 255, 8, 8)
+      bounds: 0 168 8 8
+    - image: solid-color(1, 21, 0, 255, 8, 8)
+      bounds: 8 168 8 8
+    - image: solid-color(2, 21, 0, 255, 8, 8)
+      bounds: 16 168 8 8
+    - image: solid-color(3, 21, 0, 255, 8, 8)
+      bounds: 24 168 8 8
+    - image: solid-color(4, 21, 0, 255, 8, 8)
+      bounds: 32 168 8 8
+    - image: solid-color(5, 21, 0, 255, 8, 8)
+      bounds: 40 168 8 8
+    - image: solid-color(6, 21, 0, 255, 8, 8)
+      bounds: 48 168 8 8
+    - image: solid-color(7, 21, 0, 255, 8, 8)
+      bounds: 56 168 8 8
+    - image: solid-color(8, 21, 0, 255, 8, 8)
+      bounds: 64 168 8 8
+    - image: solid-color(9, 21, 0, 255, 8, 8)
+      bounds: 72 168 8 8
+    - image: solid-color(10, 21, 0, 255, 8, 8)
+      bounds: 80 168 8 8
+    - image: solid-color(11, 21, 0, 255, 8, 8)
+      bounds: 88 168 8 8
+    - image: solid-color(12, 21, 0, 255, 8, 8)
+      bounds: 96 168 8 8
+    - image: solid-color(13, 21, 0, 255, 8, 8)
+      bounds: 104 168 8 8
+    - image: solid-color(14, 21, 0, 255, 8, 8)
+      bounds: 112 168 8 8
+    - image: solid-color(15, 21, 0, 255, 8, 8)
+      bounds: 120 168 8 8
+    - image: solid-color(16, 21, 0, 255, 8, 8)
+      bounds: 128 168 8 8
+    - image: solid-color(17, 21, 0, 255, 8, 8)
+      bounds: 136 168 8 8
+    - image: solid-color(18, 21, 0, 255, 8, 8)
+      bounds: 144 168 8 8
+    - image: solid-color(19, 21, 0, 255, 8, 8)
+      bounds: 152 168 8 8
+    - image: solid-color(20, 21, 0, 255, 8, 8)
+      bounds: 160 168 8 8
+    - image: solid-color(21, 21, 0, 255, 8, 8)
+      bounds: 168 168 8 8
+    - image: solid-color(22, 21, 0, 255, 8, 8)
+      bounds: 176 168 8 8
+    - image: solid-color(23, 21, 0, 255, 8, 8)
+      bounds: 184 168 8 8
+    - image: solid-color(24, 21, 0, 255, 8, 8)
+      bounds: 192 168 8 8
+    - image: solid-color(25, 21, 0, 255, 8, 8)
+      bounds: 200 168 8 8
+    - image: solid-color(26, 21, 0, 255, 8, 8)
+      bounds: 208 168 8 8
+    - image: solid-color(27, 21, 0, 255, 8, 8)
+      bounds: 216 168 8 8
+    - image: solid-color(28, 21, 0, 255, 8, 8)
+      bounds: 224 168 8 8
+    - image: solid-color(29, 21, 0, 255, 8, 8)
+      bounds: 232 168 8 8
+    - image: solid-color(30, 21, 0, 255, 8, 8)
+      bounds: 240 168 8 8
+    - image: solid-color(31, 21, 0, 255, 8, 8)
+      bounds: 248 168 8 8
+    - image: solid-color(32, 21, 0, 255, 8, 8)
+      bounds: 256 168 8 8
+    - image: solid-color(33, 21, 0, 255, 8, 8)
+      bounds: 264 168 8 8
+    - image: solid-color(34, 21, 0, 255, 8, 8)
+      bounds: 272 168 8 8
+    - image: solid-color(35, 21, 0, 255, 8, 8)
+      bounds: 280 168 8 8
+    - image: solid-color(36, 21, 0, 255, 8, 8)
+      bounds: 288 168 8 8
+    - image: solid-color(37, 21, 0, 255, 8, 8)
+      bounds: 296 168 8 8
+    - image: solid-color(38, 21, 0, 255, 8, 8)
+      bounds: 304 168 8 8
+    - image: solid-color(39, 21, 0, 255, 8, 8)
+      bounds: 312 168 8 8
+    - image: solid-color(40, 21, 0, 255, 8, 8)
+      bounds: 320 168 8 8
+    - image: solid-color(41, 21, 0, 255, 8, 8)
+      bounds: 328 168 8 8
+    - image: solid-color(42, 21, 0, 255, 8, 8)
+      bounds: 336 168 8 8
+    - image: solid-color(43, 21, 0, 255, 8, 8)
+      bounds: 344 168 8 8
+    - image: solid-color(44, 21, 0, 255, 8, 8)
+      bounds: 352 168 8 8
+    - image: solid-color(45, 21, 0, 255, 8, 8)
+      bounds: 360 168 8 8
+    - image: solid-color(46, 21, 0, 255, 8, 8)
+      bounds: 368 168 8 8
+    - image: solid-color(47, 21, 0, 255, 8, 8)
+      bounds: 376 168 8 8
+    - image: solid-color(48, 21, 0, 255, 8, 8)
+      bounds: 384 168 8 8
+    - image: solid-color(49, 21, 0, 255, 8, 8)
+      bounds: 392 168 8 8
+    - image: solid-color(50, 21, 0, 255, 8, 8)
+      bounds: 400 168 8 8
+    - image: solid-color(51, 21, 0, 255, 8, 8)
+      bounds: 408 168 8 8
+    - image: solid-color(52, 21, 0, 255, 8, 8)
+      bounds: 416 168 8 8
+    - image: solid-color(53, 21, 0, 255, 8, 8)
+      bounds: 424 168 8 8
+    - image: solid-color(54, 21, 0, 255, 8, 8)
+      bounds: 432 168 8 8
+    - image: solid-color(55, 21, 0, 255, 8, 8)
+      bounds: 440 168 8 8
+    - image: solid-color(56, 21, 0, 255, 8, 8)
+      bounds: 448 168 8 8
+    - image: solid-color(57, 21, 0, 255, 8, 8)
+      bounds: 456 168 8 8
+    - image: solid-color(58, 21, 0, 255, 8, 8)
+      bounds: 464 168 8 8
+    - image: solid-color(59, 21, 0, 255, 8, 8)
+      bounds: 472 168 8 8
+    - image: solid-color(60, 21, 0, 255, 8, 8)
+      bounds: 480 168 8 8
+    - image: solid-color(61, 21, 0, 255, 8, 8)
+      bounds: 488 168 8 8
+    - image: solid-color(62, 21, 0, 255, 8, 8)
+      bounds: 496 168 8 8
+    - image: solid-color(63, 21, 0, 255, 8, 8)
+      bounds: 504 168 8 8
+    - image: solid-color(64, 21, 0, 255, 8, 8)
+      bounds: 512 168 8 8
+    - image: solid-color(65, 21, 0, 255, 8, 8)
+      bounds: 520 168 8 8
+    - image: solid-color(66, 21, 0, 255, 8, 8)
+      bounds: 528 168 8 8
+    - image: solid-color(67, 21, 0, 255, 8, 8)
+      bounds: 536 168 8 8
+    - image: solid-color(68, 21, 0, 255, 8, 8)
+      bounds: 544 168 8 8
+    - image: solid-color(69, 21, 0, 255, 8, 8)
+      bounds: 552 168 8 8
+    - image: solid-color(70, 21, 0, 255, 8, 8)
+      bounds: 560 168 8 8
+    - image: solid-color(71, 21, 0, 255, 8, 8)
+      bounds: 568 168 8 8
+    - image: solid-color(72, 21, 0, 255, 8, 8)
+      bounds: 576 168 8 8
+    - image: solid-color(73, 21, 0, 255, 8, 8)
+      bounds: 584 168 8 8
+    - image: solid-color(74, 21, 0, 255, 8, 8)
+      bounds: 592 168 8 8
+    - image: solid-color(75, 21, 0, 255, 8, 8)
+      bounds: 600 168 8 8
+    - image: solid-color(76, 21, 0, 255, 8, 8)
+      bounds: 608 168 8 8
+    - image: solid-color(77, 21, 0, 255, 8, 8)
+      bounds: 616 168 8 8
+    - image: solid-color(78, 21, 0, 255, 8, 8)
+      bounds: 624 168 8 8
+    - image: solid-color(79, 21, 0, 255, 8, 8)
+      bounds: 632 168 8 8
+    - image: solid-color(80, 21, 0, 255, 8, 8)
+      bounds: 640 168 8 8
+    - image: solid-color(81, 21, 0, 255, 8, 8)
+      bounds: 648 168 8 8
+    - image: solid-color(82, 21, 0, 255, 8, 8)
+      bounds: 656 168 8 8
+    - image: solid-color(83, 21, 0, 255, 8, 8)
+      bounds: 664 168 8 8
+    - image: solid-color(84, 21, 0, 255, 8, 8)
+      bounds: 672 168 8 8
+    - image: solid-color(85, 21, 0, 255, 8, 8)
+      bounds: 680 168 8 8
+    - image: solid-color(86, 21, 0, 255, 8, 8)
+      bounds: 688 168 8 8
+    - image: solid-color(87, 21, 0, 255, 8, 8)
+      bounds: 696 168 8 8
+    - image: solid-color(88, 21, 0, 255, 8, 8)
+      bounds: 704 168 8 8
+    - image: solid-color(89, 21, 0, 255, 8, 8)
+      bounds: 712 168 8 8
+    - image: solid-color(90, 21, 0, 255, 8, 8)
+      bounds: 720 168 8 8
+    - image: solid-color(91, 21, 0, 255, 8, 8)
+      bounds: 728 168 8 8
+    - image: solid-color(92, 21, 0, 255, 8, 8)
+      bounds: 736 168 8 8
+    - image: solid-color(93, 21, 0, 255, 8, 8)
+      bounds: 744 168 8 8
+    - image: solid-color(94, 21, 0, 255, 8, 8)
+      bounds: 752 168 8 8
+    - image: solid-color(95, 21, 0, 255, 8, 8)
+      bounds: 760 168 8 8
+    - image: solid-color(96, 21, 0, 255, 8, 8)
+      bounds: 768 168 8 8
+    - image: solid-color(97, 21, 0, 255, 8, 8)
+      bounds: 776 168 8 8
+    - image: solid-color(98, 21, 0, 255, 8, 8)
+      bounds: 784 168 8 8
+    - image: solid-color(99, 21, 0, 255, 8, 8)
+      bounds: 792 168 8 8
+    - image: solid-color(100, 21, 0, 255, 8, 8)
+      bounds: 800 168 8 8
+    - image: solid-color(101, 21, 0, 255, 8, 8)
+      bounds: 808 168 8 8
+    - image: solid-color(102, 21, 0, 255, 8, 8)
+      bounds: 816 168 8 8
+    - image: solid-color(103, 21, 0, 255, 8, 8)
+      bounds: 824 168 8 8
+    - image: solid-color(104, 21, 0, 255, 8, 8)
+      bounds: 832 168 8 8
+    - image: solid-color(105, 21, 0, 255, 8, 8)
+      bounds: 840 168 8 8
+    - image: solid-color(106, 21, 0, 255, 8, 8)
+      bounds: 848 168 8 8
+    - image: solid-color(107, 21, 0, 255, 8, 8)
+      bounds: 856 168 8 8
+    - image: solid-color(108, 21, 0, 255, 8, 8)
+      bounds: 864 168 8 8
+    - image: solid-color(109, 21, 0, 255, 8, 8)
+      bounds: 872 168 8 8
+    - image: solid-color(110, 21, 0, 255, 8, 8)
+      bounds: 880 168 8 8
+    - image: solid-color(111, 21, 0, 255, 8, 8)
+      bounds: 888 168 8 8
+    - image: solid-color(112, 21, 0, 255, 8, 8)
+      bounds: 896 168 8 8
+    - image: solid-color(113, 21, 0, 255, 8, 8)
+      bounds: 904 168 8 8
+    - image: solid-color(114, 21, 0, 255, 8, 8)
+      bounds: 912 168 8 8
+    - image: solid-color(115, 21, 0, 255, 8, 8)
+      bounds: 920 168 8 8
+    - image: solid-color(116, 21, 0, 255, 8, 8)
+      bounds: 928 168 8 8
+    - image: solid-color(117, 21, 0, 255, 8, 8)
+      bounds: 936 168 8 8
+    - image: solid-color(118, 21, 0, 255, 8, 8)
+      bounds: 944 168 8 8
+    - image: solid-color(119, 21, 0, 255, 8, 8)
+      bounds: 952 168 8 8
+    - image: solid-color(120, 21, 0, 255, 8, 8)
+      bounds: 960 168 8 8
+    - image: solid-color(121, 21, 0, 255, 8, 8)
+      bounds: 968 168 8 8
+    - image: solid-color(122, 21, 0, 255, 8, 8)
+      bounds: 976 168 8 8
+    - image: solid-color(123, 21, 0, 255, 8, 8)
+      bounds: 984 168 8 8
+    - image: solid-color(124, 21, 0, 255, 8, 8)
+      bounds: 992 168 8 8
+    - image: solid-color(125, 21, 0, 255, 8, 8)
+      bounds: 1000 168 8 8
+    - image: solid-color(126, 21, 0, 255, 8, 8)
+      bounds: 1008 168 8 8
+    - image: solid-color(127, 21, 0, 255, 8, 8)
+      bounds: 1016 168 8 8
+    - image: solid-color(0, 22, 0, 255, 8, 8)
+      bounds: 0 176 8 8
+    - image: solid-color(1, 22, 0, 255, 8, 8)
+      bounds: 8 176 8 8
+    - image: solid-color(2, 22, 0, 255, 8, 8)
+      bounds: 16 176 8 8
+    - image: solid-color(3, 22, 0, 255, 8, 8)
+      bounds: 24 176 8 8
+    - image: solid-color(4, 22, 0, 255, 8, 8)
+      bounds: 32 176 8 8
+    - image: solid-color(5, 22, 0, 255, 8, 8)
+      bounds: 40 176 8 8
+    - image: solid-color(6, 22, 0, 255, 8, 8)
+      bounds: 48 176 8 8
+    - image: solid-color(7, 22, 0, 255, 8, 8)
+      bounds: 56 176 8 8
+    - image: solid-color(8, 22, 0, 255, 8, 8)
+      bounds: 64 176 8 8
+    - image: solid-color(9, 22, 0, 255, 8, 8)
+      bounds: 72 176 8 8
+    - image: solid-color(10, 22, 0, 255, 8, 8)
+      bounds: 80 176 8 8
+    - image: solid-color(11, 22, 0, 255, 8, 8)
+      bounds: 88 176 8 8
+    - image: solid-color(12, 22, 0, 255, 8, 8)
+      bounds: 96 176 8 8
+    - image: solid-color(13, 22, 0, 255, 8, 8)
+      bounds: 104 176 8 8
+    - image: solid-color(14, 22, 0, 255, 8, 8)
+      bounds: 112 176 8 8
+    - image: solid-color(15, 22, 0, 255, 8, 8)
+      bounds: 120 176 8 8
+    - image: solid-color(16, 22, 0, 255, 8, 8)
+      bounds: 128 176 8 8
+    - image: solid-color(17, 22, 0, 255, 8, 8)
+      bounds: 136 176 8 8
+    - image: solid-color(18, 22, 0, 255, 8, 8)
+      bounds: 144 176 8 8
+    - image: solid-color(19, 22, 0, 255, 8, 8)
+      bounds: 152 176 8 8
+    - image: solid-color(20, 22, 0, 255, 8, 8)
+      bounds: 160 176 8 8
+    - image: solid-color(21, 22, 0, 255, 8, 8)
+      bounds: 168 176 8 8
+    - image: solid-color(22, 22, 0, 255, 8, 8)
+      bounds: 176 176 8 8
+    - image: solid-color(23, 22, 0, 255, 8, 8)
+      bounds: 184 176 8 8
+    - image: solid-color(24, 22, 0, 255, 8, 8)
+      bounds: 192 176 8 8
+    - image: solid-color(25, 22, 0, 255, 8, 8)
+      bounds: 200 176 8 8
+    - image: solid-color(26, 22, 0, 255, 8, 8)
+      bounds: 208 176 8 8
+    - image: solid-color(27, 22, 0, 255, 8, 8)
+      bounds: 216 176 8 8
+    - image: solid-color(28, 22, 0, 255, 8, 8)
+      bounds: 224 176 8 8
+    - image: solid-color(29, 22, 0, 255, 8, 8)
+      bounds: 232 176 8 8
+    - image: solid-color(30, 22, 0, 255, 8, 8)
+      bounds: 240 176 8 8
+    - image: solid-color(31, 22, 0, 255, 8, 8)
+      bounds: 248 176 8 8
+    - image: solid-color(32, 22, 0, 255, 8, 8)
+      bounds: 256 176 8 8
+    - image: solid-color(33, 22, 0, 255, 8, 8)
+      bounds: 264 176 8 8
+    - image: solid-color(34, 22, 0, 255, 8, 8)
+      bounds: 272 176 8 8
+    - image: solid-color(35, 22, 0, 255, 8, 8)
+      bounds: 280 176 8 8
+    - image: solid-color(36, 22, 0, 255, 8, 8)
+      bounds: 288 176 8 8
+    - image: solid-color(37, 22, 0, 255, 8, 8)
+      bounds: 296 176 8 8
+    - image: solid-color(38, 22, 0, 255, 8, 8)
+      bounds: 304 176 8 8
+    - image: solid-color(39, 22, 0, 255, 8, 8)
+      bounds: 312 176 8 8
+    - image: solid-color(40, 22, 0, 255, 8, 8)
+      bounds: 320 176 8 8
+    - image: solid-color(41, 22, 0, 255, 8, 8)
+      bounds: 328 176 8 8
+    - image: solid-color(42, 22, 0, 255, 8, 8)
+      bounds: 336 176 8 8
+    - image: solid-color(43, 22, 0, 255, 8, 8)
+      bounds: 344 176 8 8
+    - image: solid-color(44, 22, 0, 255, 8, 8)
+      bounds: 352 176 8 8
+    - image: solid-color(45, 22, 0, 255, 8, 8)
+      bounds: 360 176 8 8
+    - image: solid-color(46, 22, 0, 255, 8, 8)
+      bounds: 368 176 8 8
+    - image: solid-color(47, 22, 0, 255, 8, 8)
+      bounds: 376 176 8 8
+    - image: solid-color(48, 22, 0, 255, 8, 8)
+      bounds: 384 176 8 8
+    - image: solid-color(49, 22, 0, 255, 8, 8)
+      bounds: 392 176 8 8
+    - image: solid-color(50, 22, 0, 255, 8, 8)
+      bounds: 400 176 8 8
+    - image: solid-color(51, 22, 0, 255, 8, 8)
+      bounds: 408 176 8 8
+    - image: solid-color(52, 22, 0, 255, 8, 8)
+      bounds: 416 176 8 8
+    - image: solid-color(53, 22, 0, 255, 8, 8)
+      bounds: 424 176 8 8
+    - image: solid-color(54, 22, 0, 255, 8, 8)
+      bounds: 432 176 8 8
+    - image: solid-color(55, 22, 0, 255, 8, 8)
+      bounds: 440 176 8 8
+    - image: solid-color(56, 22, 0, 255, 8, 8)
+      bounds: 448 176 8 8
+    - image: solid-color(57, 22, 0, 255, 8, 8)
+      bounds: 456 176 8 8
+    - image: solid-color(58, 22, 0, 255, 8, 8)
+      bounds: 464 176 8 8
+    - image: solid-color(59, 22, 0, 255, 8, 8)
+      bounds: 472 176 8 8
+    - image: solid-color(60, 22, 0, 255, 8, 8)
+      bounds: 480 176 8 8
+    - image: solid-color(61, 22, 0, 255, 8, 8)
+      bounds: 488 176 8 8
+    - image: solid-color(62, 22, 0, 255, 8, 8)
+      bounds: 496 176 8 8
+    - image: solid-color(63, 22, 0, 255, 8, 8)
+      bounds: 504 176 8 8
+    - image: solid-color(64, 22, 0, 255, 8, 8)
+      bounds: 512 176 8 8
+    - image: solid-color(65, 22, 0, 255, 8, 8)
+      bounds: 520 176 8 8
+    - image: solid-color(66, 22, 0, 255, 8, 8)
+      bounds: 528 176 8 8
+    - image: solid-color(67, 22, 0, 255, 8, 8)
+      bounds: 536 176 8 8
+    - image: solid-color(68, 22, 0, 255, 8, 8)
+      bounds: 544 176 8 8
+    - image: solid-color(69, 22, 0, 255, 8, 8)
+      bounds: 552 176 8 8
+    - image: solid-color(70, 22, 0, 255, 8, 8)
+      bounds: 560 176 8 8
+    - image: solid-color(71, 22, 0, 255, 8, 8)
+      bounds: 568 176 8 8
+    - image: solid-color(72, 22, 0, 255, 8, 8)
+      bounds: 576 176 8 8
+    - image: solid-color(73, 22, 0, 255, 8, 8)
+      bounds: 584 176 8 8
+    - image: solid-color(74, 22, 0, 255, 8, 8)
+      bounds: 592 176 8 8
+    - image: solid-color(75, 22, 0, 255, 8, 8)
+      bounds: 600 176 8 8
+    - image: solid-color(76, 22, 0, 255, 8, 8)
+      bounds: 608 176 8 8
+    - image: solid-color(77, 22, 0, 255, 8, 8)
+      bounds: 616 176 8 8
+    - image: solid-color(78, 22, 0, 255, 8, 8)
+      bounds: 624 176 8 8
+    - image: solid-color(79, 22, 0, 255, 8, 8)
+      bounds: 632 176 8 8
+    - image: solid-color(80, 22, 0, 255, 8, 8)
+      bounds: 640 176 8 8
+    - image: solid-color(81, 22, 0, 255, 8, 8)
+      bounds: 648 176 8 8
+    - image: solid-color(82, 22, 0, 255, 8, 8)
+      bounds: 656 176 8 8
+    - image: solid-color(83, 22, 0, 255, 8, 8)
+      bounds: 664 176 8 8
+    - image: solid-color(84, 22, 0, 255, 8, 8)
+      bounds: 672 176 8 8
+    - image: solid-color(85, 22, 0, 255, 8, 8)
+      bounds: 680 176 8 8
+    - image: solid-color(86, 22, 0, 255, 8, 8)
+      bounds: 688 176 8 8
+    - image: solid-color(87, 22, 0, 255, 8, 8)
+      bounds: 696 176 8 8
+    - image: solid-color(88, 22, 0, 255, 8, 8)
+      bounds: 704 176 8 8
+    - image: solid-color(89, 22, 0, 255, 8, 8)
+      bounds: 712 176 8 8
+    - image: solid-color(90, 22, 0, 255, 8, 8)
+      bounds: 720 176 8 8
+    - image: solid-color(91, 22, 0, 255, 8, 8)
+      bounds: 728 176 8 8
+    - image: solid-color(92, 22, 0, 255, 8, 8)
+      bounds: 736 176 8 8
+    - image: solid-color(93, 22, 0, 255, 8, 8)
+      bounds: 744 176 8 8
+    - image: solid-color(94, 22, 0, 255, 8, 8)
+      bounds: 752 176 8 8
+    - image: solid-color(95, 22, 0, 255, 8, 8)
+      bounds: 760 176 8 8
+    - image: solid-color(96, 22, 0, 255, 8, 8)
+      bounds: 768 176 8 8
+    - image: solid-color(97, 22, 0, 255, 8, 8)
+      bounds: 776 176 8 8
+    - image: solid-color(98, 22, 0, 255, 8, 8)
+      bounds: 784 176 8 8
+    - image: solid-color(99, 22, 0, 255, 8, 8)
+      bounds: 792 176 8 8
+    - image: solid-color(100, 22, 0, 255, 8, 8)
+      bounds: 800 176 8 8
+    - image: solid-color(101, 22, 0, 255, 8, 8)
+      bounds: 808 176 8 8
+    - image: solid-color(102, 22, 0, 255, 8, 8)
+      bounds: 816 176 8 8
+    - image: solid-color(103, 22, 0, 255, 8, 8)
+      bounds: 824 176 8 8
+    - image: solid-color(104, 22, 0, 255, 8, 8)
+      bounds: 832 176 8 8
+    - image: solid-color(105, 22, 0, 255, 8, 8)
+      bounds: 840 176 8 8
+    - image: solid-color(106, 22, 0, 255, 8, 8)
+      bounds: 848 176 8 8
+    - image: solid-color(107, 22, 0, 255, 8, 8)
+      bounds: 856 176 8 8
+    - image: solid-color(108, 22, 0, 255, 8, 8)
+      bounds: 864 176 8 8
+    - image: solid-color(109, 22, 0, 255, 8, 8)
+      bounds: 872 176 8 8
+    - image: solid-color(110, 22, 0, 255, 8, 8)
+      bounds: 880 176 8 8
+    - image: solid-color(111, 22, 0, 255, 8, 8)
+      bounds: 888 176 8 8
+    - image: solid-color(112, 22, 0, 255, 8, 8)
+      bounds: 896 176 8 8
+    - image: solid-color(113, 22, 0, 255, 8, 8)
+      bounds: 904 176 8 8
+    - image: solid-color(114, 22, 0, 255, 8, 8)
+      bounds: 912 176 8 8
+    - image: solid-color(115, 22, 0, 255, 8, 8)
+      bounds: 920 176 8 8
+    - image: solid-color(116, 22, 0, 255, 8, 8)
+      bounds: 928 176 8 8
+    - image: solid-color(117, 22, 0, 255, 8, 8)
+      bounds: 936 176 8 8
+    - image: solid-color(118, 22, 0, 255, 8, 8)
+      bounds: 944 176 8 8
+    - image: solid-color(119, 22, 0, 255, 8, 8)
+      bounds: 952 176 8 8
+    - image: solid-color(120, 22, 0, 255, 8, 8)
+      bounds: 960 176 8 8
+    - image: solid-color(121, 22, 0, 255, 8, 8)
+      bounds: 968 176 8 8
+    - image: solid-color(122, 22, 0, 255, 8, 8)
+      bounds: 976 176 8 8
+    - image: solid-color(123, 22, 0, 255, 8, 8)
+      bounds: 984 176 8 8
+    - image: solid-color(124, 22, 0, 255, 8, 8)
+      bounds: 992 176 8 8
+    - image: solid-color(125, 22, 0, 255, 8, 8)
+      bounds: 1000 176 8 8
+    - image: solid-color(126, 22, 0, 255, 8, 8)
+      bounds: 1008 176 8 8
+    - image: solid-color(127, 22, 0, 255, 8, 8)
+      bounds: 1016 176 8 8
+    - image: solid-color(0, 23, 0, 255, 8, 8)
+      bounds: 0 184 8 8
+    - image: solid-color(1, 23, 0, 255, 8, 8)
+      bounds: 8 184 8 8
+    - image: solid-color(2, 23, 0, 255, 8, 8)
+      bounds: 16 184 8 8
+    - image: solid-color(3, 23, 0, 255, 8, 8)
+      bounds: 24 184 8 8
+    - image: solid-color(4, 23, 0, 255, 8, 8)
+      bounds: 32 184 8 8
+    - image: solid-color(5, 23, 0, 255, 8, 8)
+      bounds: 40 184 8 8
+    - image: solid-color(6, 23, 0, 255, 8, 8)
+      bounds: 48 184 8 8
+    - image: solid-color(7, 23, 0, 255, 8, 8)
+      bounds: 56 184 8 8
+    - image: solid-color(8, 23, 0, 255, 8, 8)
+      bounds: 64 184 8 8
+    - image: solid-color(9, 23, 0, 255, 8, 8)
+      bounds: 72 184 8 8
+    - image: solid-color(10, 23, 0, 255, 8, 8)
+      bounds: 80 184 8 8
+    - image: solid-color(11, 23, 0, 255, 8, 8)
+      bounds: 88 184 8 8
+    - image: solid-color(12, 23, 0, 255, 8, 8)
+      bounds: 96 184 8 8
+    - image: solid-color(13, 23, 0, 255, 8, 8)
+      bounds: 104 184 8 8
+    - image: solid-color(14, 23, 0, 255, 8, 8)
+      bounds: 112 184 8 8
+    - image: solid-color(15, 23, 0, 255, 8, 8)
+      bounds: 120 184 8 8
+    - image: solid-color(16, 23, 0, 255, 8, 8)
+      bounds: 128 184 8 8
+    - image: solid-color(17, 23, 0, 255, 8, 8)
+      bounds: 136 184 8 8
+    - image: solid-color(18, 23, 0, 255, 8, 8)
+      bounds: 144 184 8 8
+    - image: solid-color(19, 23, 0, 255, 8, 8)
+      bounds: 152 184 8 8
+    - image: solid-color(20, 23, 0, 255, 8, 8)
+      bounds: 160 184 8 8
+    - image: solid-color(21, 23, 0, 255, 8, 8)
+      bounds: 168 184 8 8
+    - image: solid-color(22, 23, 0, 255, 8, 8)
+      bounds: 176 184 8 8
+    - image: solid-color(23, 23, 0, 255, 8, 8)
+      bounds: 184 184 8 8
+    - image: solid-color(24, 23, 0, 255, 8, 8)
+      bounds: 192 184 8 8
+    - image: solid-color(25, 23, 0, 255, 8, 8)
+      bounds: 200 184 8 8
+    - image: solid-color(26, 23, 0, 255, 8, 8)
+      bounds: 208 184 8 8
+    - image: solid-color(27, 23, 0, 255, 8, 8)
+      bounds: 216 184 8 8
+    - image: solid-color(28, 23, 0, 255, 8, 8)
+      bounds: 224 184 8 8
+    - image: solid-color(29, 23, 0, 255, 8, 8)
+      bounds: 232 184 8 8
+    - image: solid-color(30, 23, 0, 255, 8, 8)
+      bounds: 240 184 8 8
+    - image: solid-color(31, 23, 0, 255, 8, 8)
+      bounds: 248 184 8 8
+    - image: solid-color(32, 23, 0, 255, 8, 8)
+      bounds: 256 184 8 8
+    - image: solid-color(33, 23, 0, 255, 8, 8)
+      bounds: 264 184 8 8
+    - image: solid-color(34, 23, 0, 255, 8, 8)
+      bounds: 272 184 8 8
+    - image: solid-color(35, 23, 0, 255, 8, 8)
+      bounds: 280 184 8 8
+    - image: solid-color(36, 23, 0, 255, 8, 8)
+      bounds: 288 184 8 8
+    - image: solid-color(37, 23, 0, 255, 8, 8)
+      bounds: 296 184 8 8
+    - image: solid-color(38, 23, 0, 255, 8, 8)
+      bounds: 304 184 8 8
+    - image: solid-color(39, 23, 0, 255, 8, 8)
+      bounds: 312 184 8 8
+    - image: solid-color(40, 23, 0, 255, 8, 8)
+      bounds: 320 184 8 8
+    - image: solid-color(41, 23, 0, 255, 8, 8)
+      bounds: 328 184 8 8
+    - image: solid-color(42, 23, 0, 255, 8, 8)
+      bounds: 336 184 8 8
+    - image: solid-color(43, 23, 0, 255, 8, 8)
+      bounds: 344 184 8 8
+    - image: solid-color(44, 23, 0, 255, 8, 8)
+      bounds: 352 184 8 8
+    - image: solid-color(45, 23, 0, 255, 8, 8)
+      bounds: 360 184 8 8
+    - image: solid-color(46, 23, 0, 255, 8, 8)
+      bounds: 368 184 8 8
+    - image: solid-color(47, 23, 0, 255, 8, 8)
+      bounds: 376 184 8 8
+    - image: solid-color(48, 23, 0, 255, 8, 8)
+      bounds: 384 184 8 8
+    - image: solid-color(49, 23, 0, 255, 8, 8)
+      bounds: 392 184 8 8
+    - image: solid-color(50, 23, 0, 255, 8, 8)
+      bounds: 400 184 8 8
+    - image: solid-color(51, 23, 0, 255, 8, 8)
+      bounds: 408 184 8 8
+    - image: solid-color(52, 23, 0, 255, 8, 8)
+      bounds: 416 184 8 8
+    - image: solid-color(53, 23, 0, 255, 8, 8)
+      bounds: 424 184 8 8
+    - image: solid-color(54, 23, 0, 255, 8, 8)
+      bounds: 432 184 8 8
+    - image: solid-color(55, 23, 0, 255, 8, 8)
+      bounds: 440 184 8 8
+    - image: solid-color(56, 23, 0, 255, 8, 8)
+      bounds: 448 184 8 8
+    - image: solid-color(57, 23, 0, 255, 8, 8)
+      bounds: 456 184 8 8
+    - image: solid-color(58, 23, 0, 255, 8, 8)
+      bounds: 464 184 8 8
+    - image: solid-color(59, 23, 0, 255, 8, 8)
+      bounds: 472 184 8 8
+    - image: solid-color(60, 23, 0, 255, 8, 8)
+      bounds: 480 184 8 8
+    - image: solid-color(61, 23, 0, 255, 8, 8)
+      bounds: 488 184 8 8
+    - image: solid-color(62, 23, 0, 255, 8, 8)
+      bounds: 496 184 8 8
+    - image: solid-color(63, 23, 0, 255, 8, 8)
+      bounds: 504 184 8 8
+    - image: solid-color(64, 23, 0, 255, 8, 8)
+      bounds: 512 184 8 8
+    - image: solid-color(65, 23, 0, 255, 8, 8)
+      bounds: 520 184 8 8
+    - image: solid-color(66, 23, 0, 255, 8, 8)
+      bounds: 528 184 8 8
+    - image: solid-color(67, 23, 0, 255, 8, 8)
+      bounds: 536 184 8 8
+    - image: solid-color(68, 23, 0, 255, 8, 8)
+      bounds: 544 184 8 8
+    - image: solid-color(69, 23, 0, 255, 8, 8)
+      bounds: 552 184 8 8
+    - image: solid-color(70, 23, 0, 255, 8, 8)
+      bounds: 560 184 8 8
+    - image: solid-color(71, 23, 0, 255, 8, 8)
+      bounds: 568 184 8 8
+    - image: solid-color(72, 23, 0, 255, 8, 8)
+      bounds: 576 184 8 8
+    - image: solid-color(73, 23, 0, 255, 8, 8)
+      bounds: 584 184 8 8
+    - image: solid-color(74, 23, 0, 255, 8, 8)
+      bounds: 592 184 8 8
+    - image: solid-color(75, 23, 0, 255, 8, 8)
+      bounds: 600 184 8 8
+    - image: solid-color(76, 23, 0, 255, 8, 8)
+      bounds: 608 184 8 8
+    - image: solid-color(77, 23, 0, 255, 8, 8)
+      bounds: 616 184 8 8
+    - image: solid-color(78, 23, 0, 255, 8, 8)
+      bounds: 624 184 8 8
+    - image: solid-color(79, 23, 0, 255, 8, 8)
+      bounds: 632 184 8 8
+    - image: solid-color(80, 23, 0, 255, 8, 8)
+      bounds: 640 184 8 8
+    - image: solid-color(81, 23, 0, 255, 8, 8)
+      bounds: 648 184 8 8
+    - image: solid-color(82, 23, 0, 255, 8, 8)
+      bounds: 656 184 8 8
+    - image: solid-color(83, 23, 0, 255, 8, 8)
+      bounds: 664 184 8 8
+    - image: solid-color(84, 23, 0, 255, 8, 8)
+      bounds: 672 184 8 8
+    - image: solid-color(85, 23, 0, 255, 8, 8)
+      bounds: 680 184 8 8
+    - image: solid-color(86, 23, 0, 255, 8, 8)
+      bounds: 688 184 8 8
+    - image: solid-color(87, 23, 0, 255, 8, 8)
+      bounds: 696 184 8 8
+    - image: solid-color(88, 23, 0, 255, 8, 8)
+      bounds: 704 184 8 8
+    - image: solid-color(89, 23, 0, 255, 8, 8)
+      bounds: 712 184 8 8
+    - image: solid-color(90, 23, 0, 255, 8, 8)
+      bounds: 720 184 8 8
+    - image: solid-color(91, 23, 0, 255, 8, 8)
+      bounds: 728 184 8 8
+    - image: solid-color(92, 23, 0, 255, 8, 8)
+      bounds: 736 184 8 8
+    - image: solid-color(93, 23, 0, 255, 8, 8)
+      bounds: 744 184 8 8
+    - image: solid-color(94, 23, 0, 255, 8, 8)
+      bounds: 752 184 8 8
+    - image: solid-color(95, 23, 0, 255, 8, 8)
+      bounds: 760 184 8 8
+    - image: solid-color(96, 23, 0, 255, 8, 8)
+      bounds: 768 184 8 8
+    - image: solid-color(97, 23, 0, 255, 8, 8)
+      bounds: 776 184 8 8
+    - image: solid-color(98, 23, 0, 255, 8, 8)
+      bounds: 784 184 8 8
+    - image: solid-color(99, 23, 0, 255, 8, 8)
+      bounds: 792 184 8 8
+    - image: solid-color(100, 23, 0, 255, 8, 8)
+      bounds: 800 184 8 8
+    - image: solid-color(101, 23, 0, 255, 8, 8)
+      bounds: 808 184 8 8
+    - image: solid-color(102, 23, 0, 255, 8, 8)
+      bounds: 816 184 8 8
+    - image: solid-color(103, 23, 0, 255, 8, 8)
+      bounds: 824 184 8 8
+    - image: solid-color(104, 23, 0, 255, 8, 8)
+      bounds: 832 184 8 8
+    - image: solid-color(105, 23, 0, 255, 8, 8)
+      bounds: 840 184 8 8
+    - image: solid-color(106, 23, 0, 255, 8, 8)
+      bounds: 848 184 8 8
+    - image: solid-color(107, 23, 0, 255, 8, 8)
+      bounds: 856 184 8 8
+    - image: solid-color(108, 23, 0, 255, 8, 8)
+      bounds: 864 184 8 8
+    - image: solid-color(109, 23, 0, 255, 8, 8)
+      bounds: 872 184 8 8
+    - image: solid-color(110, 23, 0, 255, 8, 8)
+      bounds: 880 184 8 8
+    - image: solid-color(111, 23, 0, 255, 8, 8)
+      bounds: 888 184 8 8
+    - image: solid-color(112, 23, 0, 255, 8, 8)
+      bounds: 896 184 8 8
+    - image: solid-color(113, 23, 0, 255, 8, 8)
+      bounds: 904 184 8 8
+    - image: solid-color(114, 23, 0, 255, 8, 8)
+      bounds: 912 184 8 8
+    - image: solid-color(115, 23, 0, 255, 8, 8)
+      bounds: 920 184 8 8
+    - image: solid-color(116, 23, 0, 255, 8, 8)
+      bounds: 928 184 8 8
+    - image: solid-color(117, 23, 0, 255, 8, 8)
+      bounds: 936 184 8 8
+    - image: solid-color(118, 23, 0, 255, 8, 8)
+      bounds: 944 184 8 8
+    - image: solid-color(119, 23, 0, 255, 8, 8)
+      bounds: 952 184 8 8
+    - image: solid-color(120, 23, 0, 255, 8, 8)
+      bounds: 960 184 8 8
+    - image: solid-color(121, 23, 0, 255, 8, 8)
+      bounds: 968 184 8 8
+    - image: solid-color(122, 23, 0, 255, 8, 8)
+      bounds: 976 184 8 8
+    - image: solid-color(123, 23, 0, 255, 8, 8)
+      bounds: 984 184 8 8
+    - image: solid-color(124, 23, 0, 255, 8, 8)
+      bounds: 992 184 8 8
+    - image: solid-color(125, 23, 0, 255, 8, 8)
+      bounds: 1000 184 8 8
+    - image: solid-color(126, 23, 0, 255, 8, 8)
+      bounds: 1008 184 8 8
+    - image: solid-color(127, 23, 0, 255, 8, 8)
+      bounds: 1016 184 8 8
+    - image: solid-color(0, 24, 0, 255, 8, 8)
+      bounds: 0 192 8 8
+    - image: solid-color(1, 24, 0, 255, 8, 8)
+      bounds: 8 192 8 8
+    - image: solid-color(2, 24, 0, 255, 8, 8)
+      bounds: 16 192 8 8
+    - image: solid-color(3, 24, 0, 255, 8, 8)
+      bounds: 24 192 8 8
+    - image: solid-color(4, 24, 0, 255, 8, 8)
+      bounds: 32 192 8 8
+    - image: solid-color(5, 24, 0, 255, 8, 8)
+      bounds: 40 192 8 8
+    - image: solid-color(6, 24, 0, 255, 8, 8)
+      bounds: 48 192 8 8
+    - image: solid-color(7, 24, 0, 255, 8, 8)
+      bounds: 56 192 8 8
+    - image: solid-color(8, 24, 0, 255, 8, 8)
+      bounds: 64 192 8 8
+    - image: solid-color(9, 24, 0, 255, 8, 8)
+      bounds: 72 192 8 8
+    - image: solid-color(10, 24, 0, 255, 8, 8)
+      bounds: 80 192 8 8
+    - image: solid-color(11, 24, 0, 255, 8, 8)
+      bounds: 88 192 8 8
+    - image: solid-color(12, 24, 0, 255, 8, 8)
+      bounds: 96 192 8 8
+    - image: solid-color(13, 24, 0, 255, 8, 8)
+      bounds: 104 192 8 8
+    - image: solid-color(14, 24, 0, 255, 8, 8)
+      bounds: 112 192 8 8
+    - image: solid-color(15, 24, 0, 255, 8, 8)
+      bounds: 120 192 8 8
+    - image: solid-color(16, 24, 0, 255, 8, 8)
+      bounds: 128 192 8 8
+    - image: solid-color(17, 24, 0, 255, 8, 8)
+      bounds: 136 192 8 8
+    - image: solid-color(18, 24, 0, 255, 8, 8)
+      bounds: 144 192 8 8
+    - image: solid-color(19, 24, 0, 255, 8, 8)
+      bounds: 152 192 8 8
+    - image: solid-color(20, 24, 0, 255, 8, 8)
+      bounds: 160 192 8 8
+    - image: solid-color(21, 24, 0, 255, 8, 8)
+      bounds: 168 192 8 8
+    - image: solid-color(22, 24, 0, 255, 8, 8)
+      bounds: 176 192 8 8
+    - image: solid-color(23, 24, 0, 255, 8, 8)
+      bounds: 184 192 8 8
+    - image: solid-color(24, 24, 0, 255, 8, 8)
+      bounds: 192 192 8 8
+    - image: solid-color(25, 24, 0, 255, 8, 8)
+      bounds: 200 192 8 8
+    - image: solid-color(26, 24, 0, 255, 8, 8)
+      bounds: 208 192 8 8
+    - image: solid-color(27, 24, 0, 255, 8, 8)
+      bounds: 216 192 8 8
+    - image: solid-color(28, 24, 0, 255, 8, 8)
+      bounds: 224 192 8 8
+    - image: solid-color(29, 24, 0, 255, 8, 8)
+      bounds: 232 192 8 8
+    - image: solid-color(30, 24, 0, 255, 8, 8)
+      bounds: 240 192 8 8
+    - image: solid-color(31, 24, 0, 255, 8, 8)
+      bounds: 248 192 8 8
+    - image: solid-color(32, 24, 0, 255, 8, 8)
+      bounds: 256 192 8 8
+    - image: solid-color(33, 24, 0, 255, 8, 8)
+      bounds: 264 192 8 8
+    - image: solid-color(34, 24, 0, 255, 8, 8)
+      bounds: 272 192 8 8
+    - image: solid-color(35, 24, 0, 255, 8, 8)
+      bounds: 280 192 8 8
+    - image: solid-color(36, 24, 0, 255, 8, 8)
+      bounds: 288 192 8 8
+    - image: solid-color(37, 24, 0, 255, 8, 8)
+      bounds: 296 192 8 8
+    - image: solid-color(38, 24, 0, 255, 8, 8)
+      bounds: 304 192 8 8
+    - image: solid-color(39, 24, 0, 255, 8, 8)
+      bounds: 312 192 8 8
+    - image: solid-color(40, 24, 0, 255, 8, 8)
+      bounds: 320 192 8 8
+    - image: solid-color(41, 24, 0, 255, 8, 8)
+      bounds: 328 192 8 8
+    - image: solid-color(42, 24, 0, 255, 8, 8)
+      bounds: 336 192 8 8
+    - image: solid-color(43, 24, 0, 255, 8, 8)
+      bounds: 344 192 8 8
+    - image: solid-color(44, 24, 0, 255, 8, 8)
+      bounds: 352 192 8 8
+    - image: solid-color(45, 24, 0, 255, 8, 8)
+      bounds: 360 192 8 8
+    - image: solid-color(46, 24, 0, 255, 8, 8)
+      bounds: 368 192 8 8
+    - image: solid-color(47, 24, 0, 255, 8, 8)
+      bounds: 376 192 8 8
+    - image: solid-color(48, 24, 0, 255, 8, 8)
+      bounds: 384 192 8 8
+    - image: solid-color(49, 24, 0, 255, 8, 8)
+      bounds: 392 192 8 8
+    - image: solid-color(50, 24, 0, 255, 8, 8)
+      bounds: 400 192 8 8
+    - image: solid-color(51, 24, 0, 255, 8, 8)
+      bounds: 408 192 8 8
+    - image: solid-color(52, 24, 0, 255, 8, 8)
+      bounds: 416 192 8 8
+    - image: solid-color(53, 24, 0, 255, 8, 8)
+      bounds: 424 192 8 8
+    - image: solid-color(54, 24, 0, 255, 8, 8)
+      bounds: 432 192 8 8
+    - image: solid-color(55, 24, 0, 255, 8, 8)
+      bounds: 440 192 8 8
+    - image: solid-color(56, 24, 0, 255, 8, 8)
+      bounds: 448 192 8 8
+    - image: solid-color(57, 24, 0, 255, 8, 8)
+      bounds: 456 192 8 8
+    - image: solid-color(58, 24, 0, 255, 8, 8)
+      bounds: 464 192 8 8
+    - image: solid-color(59, 24, 0, 255, 8, 8)
+      bounds: 472 192 8 8
+    - image: solid-color(60, 24, 0, 255, 8, 8)
+      bounds: 480 192 8 8
+    - image: solid-color(61, 24, 0, 255, 8, 8)
+      bounds: 488 192 8 8
+    - image: solid-color(62, 24, 0, 255, 8, 8)
+      bounds: 496 192 8 8
+    - image: solid-color(63, 24, 0, 255, 8, 8)
+      bounds: 504 192 8 8
+    - image: solid-color(64, 24, 0, 255, 8, 8)
+      bounds: 512 192 8 8
+    - image: solid-color(65, 24, 0, 255, 8, 8)
+      bounds: 520 192 8 8
+    - image: solid-color(66, 24, 0, 255, 8, 8)
+      bounds: 528 192 8 8
+    - image: solid-color(67, 24, 0, 255, 8, 8)
+      bounds: 536 192 8 8
+    - image: solid-color(68, 24, 0, 255, 8, 8)
+      bounds: 544 192 8 8
+    - image: solid-color(69, 24, 0, 255, 8, 8)
+      bounds: 552 192 8 8
+    - image: solid-color(70, 24, 0, 255, 8, 8)
+      bounds: 560 192 8 8
+    - image: solid-color(71, 24, 0, 255, 8, 8)
+      bounds: 568 192 8 8
+    - image: solid-color(72, 24, 0, 255, 8, 8)
+      bounds: 576 192 8 8
+    - image: solid-color(73, 24, 0, 255, 8, 8)
+      bounds: 584 192 8 8
+    - image: solid-color(74, 24, 0, 255, 8, 8)
+      bounds: 592 192 8 8
+    - image: solid-color(75, 24, 0, 255, 8, 8)
+      bounds: 600 192 8 8
+    - image: solid-color(76, 24, 0, 255, 8, 8)
+      bounds: 608 192 8 8
+    - image: solid-color(77, 24, 0, 255, 8, 8)
+      bounds: 616 192 8 8
+    - image: solid-color(78, 24, 0, 255, 8, 8)
+      bounds: 624 192 8 8
+    - image: solid-color(79, 24, 0, 255, 8, 8)
+      bounds: 632 192 8 8
+    - image: solid-color(80, 24, 0, 255, 8, 8)
+      bounds: 640 192 8 8
+    - image: solid-color(81, 24, 0, 255, 8, 8)
+      bounds: 648 192 8 8
+    - image: solid-color(82, 24, 0, 255, 8, 8)
+      bounds: 656 192 8 8
+    - image: solid-color(83, 24, 0, 255, 8, 8)
+      bounds: 664 192 8 8
+    - image: solid-color(84, 24, 0, 255, 8, 8)
+      bounds: 672 192 8 8
+    - image: solid-color(85, 24, 0, 255, 8, 8)
+      bounds: 680 192 8 8
+    - image: solid-color(86, 24, 0, 255, 8, 8)
+      bounds: 688 192 8 8
+    - image: solid-color(87, 24, 0, 255, 8, 8)
+      bounds: 696 192 8 8
+    - image: solid-color(88, 24, 0, 255, 8, 8)
+      bounds: 704 192 8 8
+    - image: solid-color(89, 24, 0, 255, 8, 8)
+      bounds: 712 192 8 8
+    - image: solid-color(90, 24, 0, 255, 8, 8)
+      bounds: 720 192 8 8
+    - image: solid-color(91, 24, 0, 255, 8, 8)
+      bounds: 728 192 8 8
+    - image: solid-color(92, 24, 0, 255, 8, 8)
+      bounds: 736 192 8 8
+    - image: solid-color(93, 24, 0, 255, 8, 8)
+      bounds: 744 192 8 8
+    - image: solid-color(94, 24, 0, 255, 8, 8)
+      bounds: 752 192 8 8
+    - image: solid-color(95, 24, 0, 255, 8, 8)
+      bounds: 760 192 8 8
+    - image: solid-color(96, 24, 0, 255, 8, 8)
+      bounds: 768 192 8 8
+    - image: solid-color(97, 24, 0, 255, 8, 8)
+      bounds: 776 192 8 8
+    - image: solid-color(98, 24, 0, 255, 8, 8)
+      bounds: 784 192 8 8
+    - image: solid-color(99, 24, 0, 255, 8, 8)
+      bounds: 792 192 8 8
+    - image: solid-color(100, 24, 0, 255, 8, 8)
+      bounds: 800 192 8 8
+    - image: solid-color(101, 24, 0, 255, 8, 8)
+      bounds: 808 192 8 8
+    - image: solid-color(102, 24, 0, 255, 8, 8)
+      bounds: 816 192 8 8
+    - image: solid-color(103, 24, 0, 255, 8, 8)
+      bounds: 824 192 8 8
+    - image: solid-color(104, 24, 0, 255, 8, 8)
+      bounds: 832 192 8 8
+    - image: solid-color(105, 24, 0, 255, 8, 8)
+      bounds: 840 192 8 8
+    - image: solid-color(106, 24, 0, 255, 8, 8)
+      bounds: 848 192 8 8
+    - image: solid-color(107, 24, 0, 255, 8, 8)
+      bounds: 856 192 8 8
+    - image: solid-color(108, 24, 0, 255, 8, 8)
+      bounds: 864 192 8 8
+    - image: solid-color(109, 24, 0, 255, 8, 8)
+      bounds: 872 192 8 8
+    - image: solid-color(110, 24, 0, 255, 8, 8)
+      bounds: 880 192 8 8
+    - image: solid-color(111, 24, 0, 255, 8, 8)
+      bounds: 888 192 8 8
+    - image: solid-color(112, 24, 0, 255, 8, 8)
+      bounds: 896 192 8 8
+    - image: solid-color(113, 24, 0, 255, 8, 8)
+      bounds: 904 192 8 8
+    - image: solid-color(114, 24, 0, 255, 8, 8)
+      bounds: 912 192 8 8
+    - image: solid-color(115, 24, 0, 255, 8, 8)
+      bounds: 920 192 8 8
+    - image: solid-color(116, 24, 0, 255, 8, 8)
+      bounds: 928 192 8 8
+    - image: solid-color(117, 24, 0, 255, 8, 8)
+      bounds: 936 192 8 8
+    - image: solid-color(118, 24, 0, 255, 8, 8)
+      bounds: 944 192 8 8
+    - image: solid-color(119, 24, 0, 255, 8, 8)
+      bounds: 952 192 8 8
+    - image: solid-color(120, 24, 0, 255, 8, 8)
+      bounds: 960 192 8 8
+    - image: solid-color(121, 24, 0, 255, 8, 8)
+      bounds: 968 192 8 8
+    - image: solid-color(122, 24, 0, 255, 8, 8)
+      bounds: 976 192 8 8
+    - image: solid-color(123, 24, 0, 255, 8, 8)
+      bounds: 984 192 8 8
+    - image: solid-color(124, 24, 0, 255, 8, 8)
+      bounds: 992 192 8 8
+    - image: solid-color(125, 24, 0, 255, 8, 8)
+      bounds: 1000 192 8 8
+    - image: solid-color(126, 24, 0, 255, 8, 8)
+      bounds: 1008 192 8 8
+    - image: solid-color(127, 24, 0, 255, 8, 8)
+      bounds: 1016 192 8 8
+    - image: solid-color(0, 25, 0, 255, 8, 8)
+      bounds: 0 200 8 8
+    - image: solid-color(1, 25, 0, 255, 8, 8)
+      bounds: 8 200 8 8
+    - image: solid-color(2, 25, 0, 255, 8, 8)
+      bounds: 16 200 8 8
+    - image: solid-color(3, 25, 0, 255, 8, 8)
+      bounds: 24 200 8 8
+    - image: solid-color(4, 25, 0, 255, 8, 8)
+      bounds: 32 200 8 8
+    - image: solid-color(5, 25, 0, 255, 8, 8)
+      bounds: 40 200 8 8
+    - image: solid-color(6, 25, 0, 255, 8, 8)
+      bounds: 48 200 8 8
+    - image: solid-color(7, 25, 0, 255, 8, 8)
+      bounds: 56 200 8 8
+    - image: solid-color(8, 25, 0, 255, 8, 8)
+      bounds: 64 200 8 8
+    - image: solid-color(9, 25, 0, 255, 8, 8)
+      bounds: 72 200 8 8
+    - image: solid-color(10, 25, 0, 255, 8, 8)
+      bounds: 80 200 8 8
+    - image: solid-color(11, 25, 0, 255, 8, 8)
+      bounds: 88 200 8 8
+    - image: solid-color(12, 25, 0, 255, 8, 8)
+      bounds: 96 200 8 8
+    - image: solid-color(13, 25, 0, 255, 8, 8)
+      bounds: 104 200 8 8
+    - image: solid-color(14, 25, 0, 255, 8, 8)
+      bounds: 112 200 8 8
+    - image: solid-color(15, 25, 0, 255, 8, 8)
+      bounds: 120 200 8 8
+    - image: solid-color(16, 25, 0, 255, 8, 8)
+      bounds: 128 200 8 8
+    - image: solid-color(17, 25, 0, 255, 8, 8)
+      bounds: 136 200 8 8
+    - image: solid-color(18, 25, 0, 255, 8, 8)
+      bounds: 144 200 8 8
+    - image: solid-color(19, 25, 0, 255, 8, 8)
+      bounds: 152 200 8 8
+    - image: solid-color(20, 25, 0, 255, 8, 8)
+      bounds: 160 200 8 8
+    - image: solid-color(21, 25, 0, 255, 8, 8)
+      bounds: 168 200 8 8
+    - image: solid-color(22, 25, 0, 255, 8, 8)
+      bounds: 176 200 8 8
+    - image: solid-color(23, 25, 0, 255, 8, 8)
+      bounds: 184 200 8 8
+    - image: solid-color(24, 25, 0, 255, 8, 8)
+      bounds: 192 200 8 8
+    - image: solid-color(25, 25, 0, 255, 8, 8)
+      bounds: 200 200 8 8
+    - image: solid-color(26, 25, 0, 255, 8, 8)
+      bounds: 208 200 8 8
+    - image: solid-color(27, 25, 0, 255, 8, 8)
+      bounds: 216 200 8 8
+    - image: solid-color(28, 25, 0, 255, 8, 8)
+      bounds: 224 200 8 8
+    - image: solid-color(29, 25, 0, 255, 8, 8)
+      bounds: 232 200 8 8
+    - image: solid-color(30, 25, 0, 255, 8, 8)
+      bounds: 240 200 8 8
+    - image: solid-color(31, 25, 0, 255, 8, 8)
+      bounds: 248 200 8 8
+    - image: solid-color(32, 25, 0, 255, 8, 8)
+      bounds: 256 200 8 8
+    - image: solid-color(33, 25, 0, 255, 8, 8)
+      bounds: 264 200 8 8
+    - image: solid-color(34, 25, 0, 255, 8, 8)
+      bounds: 272 200 8 8
+    - image: solid-color(35, 25, 0, 255, 8, 8)
+      bounds: 280 200 8 8
+    - image: solid-color(36, 25, 0, 255, 8, 8)
+      bounds: 288 200 8 8
+    - image: solid-color(37, 25, 0, 255, 8, 8)
+      bounds: 296 200 8 8
+    - image: solid-color(38, 25, 0, 255, 8, 8)
+      bounds: 304 200 8 8
+    - image: solid-color(39, 25, 0, 255, 8, 8)
+      bounds: 312 200 8 8
+    - image: solid-color(40, 25, 0, 255, 8, 8)
+      bounds: 320 200 8 8
+    - image: solid-color(41, 25, 0, 255, 8, 8)
+      bounds: 328 200 8 8
+    - image: solid-color(42, 25, 0, 255, 8, 8)
+      bounds: 336 200 8 8
+    - image: solid-color(43, 25, 0, 255, 8, 8)
+      bounds: 344 200 8 8
+    - image: solid-color(44, 25, 0, 255, 8, 8)
+      bounds: 352 200 8 8
+    - image: solid-color(45, 25, 0, 255, 8, 8)
+      bounds: 360 200 8 8
+    - image: solid-color(46, 25, 0, 255, 8, 8)
+      bounds: 368 200 8 8
+    - image: solid-color(47, 25, 0, 255, 8, 8)
+      bounds: 376 200 8 8
+    - image: solid-color(48, 25, 0, 255, 8, 8)
+      bounds: 384 200 8 8
+    - image: solid-color(49, 25, 0, 255, 8, 8)
+      bounds: 392 200 8 8
+    - image: solid-color(50, 25, 0, 255, 8, 8)
+      bounds: 400 200 8 8
+    - image: solid-color(51, 25, 0, 255, 8, 8)
+      bounds: 408 200 8 8
+    - image: solid-color(52, 25, 0, 255, 8, 8)
+      bounds: 416 200 8 8
+    - image: solid-color(53, 25, 0, 255, 8, 8)
+      bounds: 424 200 8 8
+    - image: solid-color(54, 25, 0, 255, 8, 8)
+      bounds: 432 200 8 8
+    - image: solid-color(55, 25, 0, 255, 8, 8)
+      bounds: 440 200 8 8
+    - image: solid-color(56, 25, 0, 255, 8, 8)
+      bounds: 448 200 8 8
+    - image: solid-color(57, 25, 0, 255, 8, 8)
+      bounds: 456 200 8 8
+    - image: solid-color(58, 25, 0, 255, 8, 8)
+      bounds: 464 200 8 8
+    - image: solid-color(59, 25, 0, 255, 8, 8)
+      bounds: 472 200 8 8
+    - image: solid-color(60, 25, 0, 255, 8, 8)
+      bounds: 480 200 8 8
+    - image: solid-color(61, 25, 0, 255, 8, 8)
+      bounds: 488 200 8 8
+    - image: solid-color(62, 25, 0, 255, 8, 8)
+      bounds: 496 200 8 8
+    - image: solid-color(63, 25, 0, 255, 8, 8)
+      bounds: 504 200 8 8
+    - image: solid-color(64, 25, 0, 255, 8, 8)
+      bounds: 512 200 8 8
+    - image: solid-color(65, 25, 0, 255, 8, 8)
+      bounds: 520 200 8 8
+    - image: solid-color(66, 25, 0, 255, 8, 8)
+      bounds: 528 200 8 8
+    - image: solid-color(67, 25, 0, 255, 8, 8)
+      bounds: 536 200 8 8
+    - image: solid-color(68, 25, 0, 255, 8, 8)
+      bounds: 544 200 8 8
+    - image: solid-color(69, 25, 0, 255, 8, 8)
+      bounds: 552 200 8 8
+    - image: solid-color(70, 25, 0, 255, 8, 8)
+      bounds: 560 200 8 8
+    - image: solid-color(71, 25, 0, 255, 8, 8)
+      bounds: 568 200 8 8
+    - image: solid-color(72, 25, 0, 255, 8, 8)
+      bounds: 576 200 8 8
+    - image: solid-color(73, 25, 0, 255, 8, 8)
+      bounds: 584 200 8 8
+    - image: solid-color(74, 25, 0, 255, 8, 8)
+      bounds: 592 200 8 8
+    - image: solid-color(75, 25, 0, 255, 8, 8)
+      bounds: 600 200 8 8
+    - image: solid-color(76, 25, 0, 255, 8, 8)
+      bounds: 608 200 8 8
+    - image: solid-color(77, 25, 0, 255, 8, 8)
+      bounds: 616 200 8 8
+    - image: solid-color(78, 25, 0, 255, 8, 8)
+      bounds: 624 200 8 8
+    - image: solid-color(79, 25, 0, 255, 8, 8)
+      bounds: 632 200 8 8
+    - image: solid-color(80, 25, 0, 255, 8, 8)
+      bounds: 640 200 8 8
+    - image: solid-color(81, 25, 0, 255, 8, 8)
+      bounds: 648 200 8 8
+    - image: solid-color(82, 25, 0, 255, 8, 8)
+      bounds: 656 200 8 8
+    - image: solid-color(83, 25, 0, 255, 8, 8)
+      bounds: 664 200 8 8
+    - image: solid-color(84, 25, 0, 255, 8, 8)
+      bounds: 672 200 8 8
+    - image: solid-color(85, 25, 0, 255, 8, 8)
+      bounds: 680 200 8 8
+    - image: solid-color(86, 25, 0, 255, 8, 8)
+      bounds: 688 200 8 8
+    - image: solid-color(87, 25, 0, 255, 8, 8)
+      bounds: 696 200 8 8
+    - image: solid-color(88, 25, 0, 255, 8, 8)
+      bounds: 704 200 8 8
+    - image: solid-color(89, 25, 0, 255, 8, 8)
+      bounds: 712 200 8 8
+    - image: solid-color(90, 25, 0, 255, 8, 8)
+      bounds: 720 200 8 8
+    - image: solid-color(91, 25, 0, 255, 8, 8)
+      bounds: 728 200 8 8
+    - image: solid-color(92, 25, 0, 255, 8, 8)
+      bounds: 736 200 8 8
+    - image: solid-color(93, 25, 0, 255, 8, 8)
+      bounds: 744 200 8 8
+    - image: solid-color(94, 25, 0, 255, 8, 8)
+      bounds: 752 200 8 8
+    - image: solid-color(95, 25, 0, 255, 8, 8)
+      bounds: 760 200 8 8
+    - image: solid-color(96, 25, 0, 255, 8, 8)
+      bounds: 768 200 8 8
+    - image: solid-color(97, 25, 0, 255, 8, 8)
+      bounds: 776 200 8 8
+    - image: solid-color(98, 25, 0, 255, 8, 8)
+      bounds: 784 200 8 8
+    - image: solid-color(99, 25, 0, 255, 8, 8)
+      bounds: 792 200 8 8
+    - image: solid-color(100, 25, 0, 255, 8, 8)
+      bounds: 800 200 8 8
+    - image: solid-color(101, 25, 0, 255, 8, 8)
+      bounds: 808 200 8 8
+    - image: solid-color(102, 25, 0, 255, 8, 8)
+      bounds: 816 200 8 8
+    - image: solid-color(103, 25, 0, 255, 8, 8)
+      bounds: 824 200 8 8
+    - image: solid-color(104, 25, 0, 255, 8, 8)
+      bounds: 832 200 8 8
+    - image: solid-color(105, 25, 0, 255, 8, 8)
+      bounds: 840 200 8 8
+    - image: solid-color(106, 25, 0, 255, 8, 8)
+      bounds: 848 200 8 8
+    - image: solid-color(107, 25, 0, 255, 8, 8)
+      bounds: 856 200 8 8
+    - image: solid-color(108, 25, 0, 255, 8, 8)
+      bounds: 864 200 8 8
+    - image: solid-color(109, 25, 0, 255, 8, 8)
+      bounds: 872 200 8 8
+    - image: solid-color(110, 25, 0, 255, 8, 8)
+      bounds: 880 200 8 8
+    - image: solid-color(111, 25, 0, 255, 8, 8)
+      bounds: 888 200 8 8
+    - image: solid-color(112, 25, 0, 255, 8, 8)
+      bounds: 896 200 8 8
+    - image: solid-color(113, 25, 0, 255, 8, 8)
+      bounds: 904 200 8 8
+    - image: solid-color(114, 25, 0, 255, 8, 8)
+      bounds: 912 200 8 8
+    - image: solid-color(115, 25, 0, 255, 8, 8)
+      bounds: 920 200 8 8
+    - image: solid-color(116, 25, 0, 255, 8, 8)
+      bounds: 928 200 8 8
+    - image: solid-color(117, 25, 0, 255, 8, 8)
+      bounds: 936 200 8 8
+    - image: solid-color(118, 25, 0, 255, 8, 8)
+      bounds: 944 200 8 8
+    - image: solid-color(119, 25, 0, 255, 8, 8)
+      bounds: 952 200 8 8
+    - image: solid-color(120, 25, 0, 255, 8, 8)
+      bounds: 960 200 8 8
+    - image: solid-color(121, 25, 0, 255, 8, 8)
+      bounds: 968 200 8 8
+    - image: solid-color(122, 25, 0, 255, 8, 8)
+      bounds: 976 200 8 8
+    - image: solid-color(123, 25, 0, 255, 8, 8)
+      bounds: 984 200 8 8
+    - image: solid-color(124, 25, 0, 255, 8, 8)
+      bounds: 992 200 8 8
+    - image: solid-color(125, 25, 0, 255, 8, 8)
+      bounds: 1000 200 8 8
+    - image: solid-color(126, 25, 0, 255, 8, 8)
+      bounds: 1008 200 8 8
+    - image: solid-color(127, 25, 0, 255, 8, 8)
+      bounds: 1016 200 8 8
+    - image: solid-color(0, 26, 0, 255, 8, 8)
+      bounds: 0 208 8 8
+    - image: solid-color(1, 26, 0, 255, 8, 8)
+      bounds: 8 208 8 8
+    - image: solid-color(2, 26, 0, 255, 8, 8)
+      bounds: 16 208 8 8
+    - image: solid-color(3, 26, 0, 255, 8, 8)
+      bounds: 24 208 8 8
+    - image: solid-color(4, 26, 0, 255, 8, 8)
+      bounds: 32 208 8 8
+    - image: solid-color(5, 26, 0, 255, 8, 8)
+      bounds: 40 208 8 8
+    - image: solid-color(6, 26, 0, 255, 8, 8)
+      bounds: 48 208 8 8
+    - image: solid-color(7, 26, 0, 255, 8, 8)
+      bounds: 56 208 8 8
+    - image: solid-color(8, 26, 0, 255, 8, 8)
+      bounds: 64 208 8 8
+    - image: solid-color(9, 26, 0, 255, 8, 8)
+      bounds: 72 208 8 8
+    - image: solid-color(10, 26, 0, 255, 8, 8)
+      bounds: 80 208 8 8
+    - image: solid-color(11, 26, 0, 255, 8, 8)
+      bounds: 88 208 8 8
+    - image: solid-color(12, 26, 0, 255, 8, 8)
+      bounds: 96 208 8 8
+    - image: solid-color(13, 26, 0, 255, 8, 8)
+      bounds: 104 208 8 8
+    - image: solid-color(14, 26, 0, 255, 8, 8)
+      bounds: 112 208 8 8
+    - image: solid-color(15, 26, 0, 255, 8, 8)
+      bounds: 120 208 8 8
+    - image: solid-color(16, 26, 0, 255, 8, 8)
+      bounds: 128 208 8 8
+    - image: solid-color(17, 26, 0, 255, 8, 8)
+      bounds: 136 208 8 8
+    - image: solid-color(18, 26, 0, 255, 8, 8)
+      bounds: 144 208 8 8
+    - image: solid-color(19, 26, 0, 255, 8, 8)
+      bounds: 152 208 8 8
+    - image: solid-color(20, 26, 0, 255, 8, 8)
+      bounds: 160 208 8 8
+    - image: solid-color(21, 26, 0, 255, 8, 8)
+      bounds: 168 208 8 8
+    - image: solid-color(22, 26, 0, 255, 8, 8)
+      bounds: 176 208 8 8
+    - image: solid-color(23, 26, 0, 255, 8, 8)
+      bounds: 184 208 8 8
+    - image: solid-color(24, 26, 0, 255, 8, 8)
+      bounds: 192 208 8 8
+    - image: solid-color(25, 26, 0, 255, 8, 8)
+      bounds: 200 208 8 8
+    - image: solid-color(26, 26, 0, 255, 8, 8)
+      bounds: 208 208 8 8
+    - image: solid-color(27, 26, 0, 255, 8, 8)
+      bounds: 216 208 8 8
+    - image: solid-color(28, 26, 0, 255, 8, 8)
+      bounds: 224 208 8 8
+    - image: solid-color(29, 26, 0, 255, 8, 8)
+      bounds: 232 208 8 8
+    - image: solid-color(30, 26, 0, 255, 8, 8)
+      bounds: 240 208 8 8
+    - image: solid-color(31, 26, 0, 255, 8, 8)
+      bounds: 248 208 8 8
+    - image: solid-color(32, 26, 0, 255, 8, 8)
+      bounds: 256 208 8 8
+    - image: solid-color(33, 26, 0, 255, 8, 8)
+      bounds: 264 208 8 8
+    - image: solid-color(34, 26, 0, 255, 8, 8)
+      bounds: 272 208 8 8
+    - image: solid-color(35, 26, 0, 255, 8, 8)
+      bounds: 280 208 8 8
+    - image: solid-color(36, 26, 0, 255, 8, 8)
+      bounds: 288 208 8 8
+    - image: solid-color(37, 26, 0, 255, 8, 8)
+      bounds: 296 208 8 8
+    - image: solid-color(38, 26, 0, 255, 8, 8)
+      bounds: 304 208 8 8
+    - image: solid-color(39, 26, 0, 255, 8, 8)
+      bounds: 312 208 8 8
+    - image: solid-color(40, 26, 0, 255, 8, 8)
+      bounds: 320 208 8 8
+    - image: solid-color(41, 26, 0, 255, 8, 8)
+      bounds: 328 208 8 8
+    - image: solid-color(42, 26, 0, 255, 8, 8)
+      bounds: 336 208 8 8
+    - image: solid-color(43, 26, 0, 255, 8, 8)
+      bounds: 344 208 8 8
+    - image: solid-color(44, 26, 0, 255, 8, 8)
+      bounds: 352 208 8 8
+    - image: solid-color(45, 26, 0, 255, 8, 8)
+      bounds: 360 208 8 8
+    - image: solid-color(46, 26, 0, 255, 8, 8)
+      bounds: 368 208 8 8
+    - image: solid-color(47, 26, 0, 255, 8, 8)
+      bounds: 376 208 8 8
+    - image: solid-color(48, 26, 0, 255, 8, 8)
+      bounds: 384 208 8 8
+    - image: solid-color(49, 26, 0, 255, 8, 8)
+      bounds: 392 208 8 8
+    - image: solid-color(50, 26, 0, 255, 8, 8)
+      bounds: 400 208 8 8
+    - image: solid-color(51, 26, 0, 255, 8, 8)
+      bounds: 408 208 8 8
+    - image: solid-color(52, 26, 0, 255, 8, 8)
+      bounds: 416 208 8 8
+    - image: solid-color(53, 26, 0, 255, 8, 8)
+      bounds: 424 208 8 8
+    - image: solid-color(54, 26, 0, 255, 8, 8)
+      bounds: 432 208 8 8
+    - image: solid-color(55, 26, 0, 255, 8, 8)
+      bounds: 440 208 8 8
+    - image: solid-color(56, 26, 0, 255, 8, 8)
+      bounds: 448 208 8 8
+    - image: solid-color(57, 26, 0, 255, 8, 8)
+      bounds: 456 208 8 8
+    - image: solid-color(58, 26, 0, 255, 8, 8)
+      bounds: 464 208 8 8
+    - image: solid-color(59, 26, 0, 255, 8, 8)
+      bounds: 472 208 8 8
+    - image: solid-color(60, 26, 0, 255, 8, 8)
+      bounds: 480 208 8 8
+    - image: solid-color(61, 26, 0, 255, 8, 8)
+      bounds: 488 208 8 8
+    - image: solid-color(62, 26, 0, 255, 8, 8)
+      bounds: 496 208 8 8
+    - image: solid-color(63, 26, 0, 255, 8, 8)
+      bounds: 504 208 8 8
+    - image: solid-color(64, 26, 0, 255, 8, 8)
+      bounds: 512 208 8 8
+    - image: solid-color(65, 26, 0, 255, 8, 8)
+      bounds: 520 208 8 8
+    - image: solid-color(66, 26, 0, 255, 8, 8)
+      bounds: 528 208 8 8
+    - image: solid-color(67, 26, 0, 255, 8, 8)
+      bounds: 536 208 8 8
+    - image: solid-color(68, 26, 0, 255, 8, 8)
+      bounds: 544 208 8 8
+    - image: solid-color(69, 26, 0, 255, 8, 8)
+      bounds: 552 208 8 8
+    - image: solid-color(70, 26, 0, 255, 8, 8)
+      bounds: 560 208 8 8
+    - image: solid-color(71, 26, 0, 255, 8, 8)
+      bounds: 568 208 8 8
+    - image: solid-color(72, 26, 0, 255, 8, 8)
+      bounds: 576 208 8 8
+    - image: solid-color(73, 26, 0, 255, 8, 8)
+      bounds: 584 208 8 8
+    - image: solid-color(74, 26, 0, 255, 8, 8)
+      bounds: 592 208 8 8
+    - image: solid-color(75, 26, 0, 255, 8, 8)
+      bounds: 600 208 8 8
+    - image: solid-color(76, 26, 0, 255, 8, 8)
+      bounds: 608 208 8 8
+    - image: solid-color(77, 26, 0, 255, 8, 8)
+      bounds: 616 208 8 8
+    - image: solid-color(78, 26, 0, 255, 8, 8)
+      bounds: 624 208 8 8
+    - image: solid-color(79, 26, 0, 255, 8, 8)
+      bounds: 632 208 8 8
+    - image: solid-color(80, 26, 0, 255, 8, 8)
+      bounds: 640 208 8 8
+    - image: solid-color(81, 26, 0, 255, 8, 8)
+      bounds: 648 208 8 8
+    - image: solid-color(82, 26, 0, 255, 8, 8)
+      bounds: 656 208 8 8
+    - image: solid-color(83, 26, 0, 255, 8, 8)
+      bounds: 664 208 8 8
+    - image: solid-color(84, 26, 0, 255, 8, 8)
+      bounds: 672 208 8 8
+    - image: solid-color(85, 26, 0, 255, 8, 8)
+      bounds: 680 208 8 8
+    - image: solid-color(86, 26, 0, 255, 8, 8)
+      bounds: 688 208 8 8
+    - image: solid-color(87, 26, 0, 255, 8, 8)
+      bounds: 696 208 8 8
+    - image: solid-color(88, 26, 0, 255, 8, 8)
+      bounds: 704 208 8 8
+    - image: solid-color(89, 26, 0, 255, 8, 8)
+      bounds: 712 208 8 8
+    - image: solid-color(90, 26, 0, 255, 8, 8)
+      bounds: 720 208 8 8
+    - image: solid-color(91, 26, 0, 255, 8, 8)
+      bounds: 728 208 8 8
+    - image: solid-color(92, 26, 0, 255, 8, 8)
+      bounds: 736 208 8 8
+    - image: solid-color(93, 26, 0, 255, 8, 8)
+      bounds: 744 208 8 8
+    - image: solid-color(94, 26, 0, 255, 8, 8)
+      bounds: 752 208 8 8
+    - image: solid-color(95, 26, 0, 255, 8, 8)
+      bounds: 760 208 8 8
+    - image: solid-color(96, 26, 0, 255, 8, 8)
+      bounds: 768 208 8 8
+    - image: solid-color(97, 26, 0, 255, 8, 8)
+      bounds: 776 208 8 8
+    - image: solid-color(98, 26, 0, 255, 8, 8)
+      bounds: 784 208 8 8
+    - image: solid-color(99, 26, 0, 255, 8, 8)
+      bounds: 792 208 8 8
+    - image: solid-color(100, 26, 0, 255, 8, 8)
+      bounds: 800 208 8 8
+    - image: solid-color(101, 26, 0, 255, 8, 8)
+      bounds: 808 208 8 8
+    - image: solid-color(102, 26, 0, 255, 8, 8)
+      bounds: 816 208 8 8
+    - image: solid-color(103, 26, 0, 255, 8, 8)
+      bounds: 824 208 8 8
+    - image: solid-color(104, 26, 0, 255, 8, 8)
+      bounds: 832 208 8 8
+    - image: solid-color(105, 26, 0, 255, 8, 8)
+      bounds: 840 208 8 8
+    - image: solid-color(106, 26, 0, 255, 8, 8)
+      bounds: 848 208 8 8
+    - image: solid-color(107, 26, 0, 255, 8, 8)
+      bounds: 856 208 8 8
+    - image: solid-color(108, 26, 0, 255, 8, 8)
+      bounds: 864 208 8 8
+    - image: solid-color(109, 26, 0, 255, 8, 8)
+      bounds: 872 208 8 8
+    - image: solid-color(110, 26, 0, 255, 8, 8)
+      bounds: 880 208 8 8
+    - image: solid-color(111, 26, 0, 255, 8, 8)
+      bounds: 888 208 8 8
+    - image: solid-color(112, 26, 0, 255, 8, 8)
+      bounds: 896 208 8 8
+    - image: solid-color(113, 26, 0, 255, 8, 8)
+      bounds: 904 208 8 8
+    - image: solid-color(114, 26, 0, 255, 8, 8)
+      bounds: 912 208 8 8
+    - image: solid-color(115, 26, 0, 255, 8, 8)
+      bounds: 920 208 8 8
+    - image: solid-color(116, 26, 0, 255, 8, 8)
+      bounds: 928 208 8 8
+    - image: solid-color(117, 26, 0, 255, 8, 8)
+      bounds: 936 208 8 8
+    - image: solid-color(118, 26, 0, 255, 8, 8)
+      bounds: 944 208 8 8
+    - image: solid-color(119, 26, 0, 255, 8, 8)
+      bounds: 952 208 8 8
+    - image: solid-color(120, 26, 0, 255, 8, 8)
+      bounds: 960 208 8 8
+    - image: solid-color(121, 26, 0, 255, 8, 8)
+      bounds: 968 208 8 8
+    - image: solid-color(122, 26, 0, 255, 8, 8)
+      bounds: 976 208 8 8
+    - image: solid-color(123, 26, 0, 255, 8, 8)
+      bounds: 984 208 8 8
+    - image: solid-color(124, 26, 0, 255, 8, 8)
+      bounds: 992 208 8 8
+    - image: solid-color(125, 26, 0, 255, 8, 8)
+      bounds: 1000 208 8 8
+    - image: solid-color(126, 26, 0, 255, 8, 8)
+      bounds: 1008 208 8 8
+    - image: solid-color(127, 26, 0, 255, 8, 8)
+      bounds: 1016 208 8 8
+    - image: solid-color(0, 27, 0, 255, 8, 8)
+      bounds: 0 216 8 8
+    - image: solid-color(1, 27, 0, 255, 8, 8)
+      bounds: 8 216 8 8
+    - image: solid-color(2, 27, 0, 255, 8, 8)
+      bounds: 16 216 8 8
+    - image: solid-color(3, 27, 0, 255, 8, 8)
+      bounds: 24 216 8 8
+    - image: solid-color(4, 27, 0, 255, 8, 8)
+      bounds: 32 216 8 8
+    - image: solid-color(5, 27, 0, 255, 8, 8)
+      bounds: 40 216 8 8
+    - image: solid-color(6, 27, 0, 255, 8, 8)
+      bounds: 48 216 8 8
+    - image: solid-color(7, 27, 0, 255, 8, 8)
+      bounds: 56 216 8 8
+    - image: solid-color(8, 27, 0, 255, 8, 8)
+      bounds: 64 216 8 8
+    - image: solid-color(9, 27, 0, 255, 8, 8)
+      bounds: 72 216 8 8
+    - image: solid-color(10, 27, 0, 255, 8, 8)
+      bounds: 80 216 8 8
+    - image: solid-color(11, 27, 0, 255, 8, 8)
+      bounds: 88 216 8 8
+    - image: solid-color(12, 27, 0, 255, 8, 8)
+      bounds: 96 216 8 8
+    - image: solid-color(13, 27, 0, 255, 8, 8)
+      bounds: 104 216 8 8
+    - image: solid-color(14, 27, 0, 255, 8, 8)
+      bounds: 112 216 8 8
+    - image: solid-color(15, 27, 0, 255, 8, 8)
+      bounds: 120 216 8 8
+    - image: solid-color(16, 27, 0, 255, 8, 8)
+      bounds: 128 216 8 8
+    - image: solid-color(17, 27, 0, 255, 8, 8)
+      bounds: 136 216 8 8
+    - image: solid-color(18, 27, 0, 255, 8, 8)
+      bounds: 144 216 8 8
+    - image: solid-color(19, 27, 0, 255, 8, 8)
+      bounds: 152 216 8 8
+    - image: solid-color(20, 27, 0, 255, 8, 8)
+      bounds: 160 216 8 8
+    - image: solid-color(21, 27, 0, 255, 8, 8)
+      bounds: 168 216 8 8
+    - image: solid-color(22, 27, 0, 255, 8, 8)
+      bounds: 176 216 8 8
+    - image: solid-color(23, 27, 0, 255, 8, 8)
+      bounds: 184 216 8 8
+    - image: solid-color(24, 27, 0, 255, 8, 8)
+      bounds: 192 216 8 8
+    - image: solid-color(25, 27, 0, 255, 8, 8)
+      bounds: 200 216 8 8
+    - image: solid-color(26, 27, 0, 255, 8, 8)
+      bounds: 208 216 8 8
+    - image: solid-color(27, 27, 0, 255, 8, 8)
+      bounds: 216 216 8 8
+    - image: solid-color(28, 27, 0, 255, 8, 8)
+      bounds: 224 216 8 8
+    - image: solid-color(29, 27, 0, 255, 8, 8)
+      bounds: 232 216 8 8
+    - image: solid-color(30, 27, 0, 255, 8, 8)
+      bounds: 240 216 8 8
+    - image: solid-color(31, 27, 0, 255, 8, 8)
+      bounds: 248 216 8 8
+    - image: solid-color(32, 27, 0, 255, 8, 8)
+      bounds: 256 216 8 8
+    - image: solid-color(33, 27, 0, 255, 8, 8)
+      bounds: 264 216 8 8
+    - image: solid-color(34, 27, 0, 255, 8, 8)
+      bounds: 272 216 8 8
+    - image: solid-color(35, 27, 0, 255, 8, 8)
+      bounds: 280 216 8 8
+    - image: solid-color(36, 27, 0, 255, 8, 8)
+      bounds: 288 216 8 8
+    - image: solid-color(37, 27, 0, 255, 8, 8)
+      bounds: 296 216 8 8
+    - image: solid-color(38, 27, 0, 255, 8, 8)
+      bounds: 304 216 8 8
+    - image: solid-color(39, 27, 0, 255, 8, 8)
+      bounds: 312 216 8 8
+    - image: solid-color(40, 27, 0, 255, 8, 8)
+      bounds: 320 216 8 8
+    - image: solid-color(41, 27, 0, 255, 8, 8)
+      bounds: 328 216 8 8
+    - image: solid-color(42, 27, 0, 255, 8, 8)
+      bounds: 336 216 8 8
+    - image: solid-color(43, 27, 0, 255, 8, 8)
+      bounds: 344 216 8 8
+    - image: solid-color(44, 27, 0, 255, 8, 8)
+      bounds: 352 216 8 8
+    - image: solid-color(45, 27, 0, 255, 8, 8)
+      bounds: 360 216 8 8
+    - image: solid-color(46, 27, 0, 255, 8, 8)
+      bounds: 368 216 8 8
+    - image: solid-color(47, 27, 0, 255, 8, 8)
+      bounds: 376 216 8 8
+    - image: solid-color(48, 27, 0, 255, 8, 8)
+      bounds: 384 216 8 8
+    - image: solid-color(49, 27, 0, 255, 8, 8)
+      bounds: 392 216 8 8
+    - image: solid-color(50, 27, 0, 255, 8, 8)
+      bounds: 400 216 8 8
+    - image: solid-color(51, 27, 0, 255, 8, 8)
+      bounds: 408 216 8 8
+    - image: solid-color(52, 27, 0, 255, 8, 8)
+      bounds: 416 216 8 8
+    - image: solid-color(53, 27, 0, 255, 8, 8)
+      bounds: 424 216 8 8
+    - image: solid-color(54, 27, 0, 255, 8, 8)
+      bounds: 432 216 8 8
+    - image: solid-color(55, 27, 0, 255, 8, 8)
+      bounds: 440 216 8 8
+    - image: solid-color(56, 27, 0, 255, 8, 8)
+      bounds: 448 216 8 8
+    - image: solid-color(57, 27, 0, 255, 8, 8)
+      bounds: 456 216 8 8
+    - image: solid-color(58, 27, 0, 255, 8, 8)
+      bounds: 464 216 8 8
+    - image: solid-color(59, 27, 0, 255, 8, 8)
+      bounds: 472 216 8 8
+    - image: solid-color(60, 27, 0, 255, 8, 8)
+      bounds: 480 216 8 8
+    - image: solid-color(61, 27, 0, 255, 8, 8)
+      bounds: 488 216 8 8
+    - image: solid-color(62, 27, 0, 255, 8, 8)
+      bounds: 496 216 8 8
+    - image: solid-color(63, 27, 0, 255, 8, 8)
+      bounds: 504 216 8 8
+    - image: solid-color(64, 27, 0, 255, 8, 8)
+      bounds: 512 216 8 8
+    - image: solid-color(65, 27, 0, 255, 8, 8)
+      bounds: 520 216 8 8
+    - image: solid-color(66, 27, 0, 255, 8, 8)
+      bounds: 528 216 8 8
+    - image: solid-color(67, 27, 0, 255, 8, 8)
+      bounds: 536 216 8 8
+    - image: solid-color(68, 27, 0, 255, 8, 8)
+      bounds: 544 216 8 8
+    - image: solid-color(69, 27, 0, 255, 8, 8)
+      bounds: 552 216 8 8
+    - image: solid-color(70, 27, 0, 255, 8, 8)
+      bounds: 560 216 8 8
+    - image: solid-color(71, 27, 0, 255, 8, 8)
+      bounds: 568 216 8 8
+    - image: solid-color(72, 27, 0, 255, 8, 8)
+      bounds: 576 216 8 8
+    - image: solid-color(73, 27, 0, 255, 8, 8)
+      bounds: 584 216 8 8
+    - image: solid-color(74, 27, 0, 255, 8, 8)
+      bounds: 592 216 8 8
+    - image: solid-color(75, 27, 0, 255, 8, 8)
+      bounds: 600 216 8 8
+    - image: solid-color(76, 27, 0, 255, 8, 8)
+      bounds: 608 216 8 8
+    - image: solid-color(77, 27, 0, 255, 8, 8)
+      bounds: 616 216 8 8
+    - image: solid-color(78, 27, 0, 255, 8, 8)
+      bounds: 624 216 8 8
+    - image: solid-color(79, 27, 0, 255, 8, 8)
+      bounds: 632 216 8 8
+    - image: solid-color(80, 27, 0, 255, 8, 8)
+      bounds: 640 216 8 8
+    - image: solid-color(81, 27, 0, 255, 8, 8)
+      bounds: 648 216 8 8
+    - image: solid-color(82, 27, 0, 255, 8, 8)
+      bounds: 656 216 8 8
+    - image: solid-color(83, 27, 0, 255, 8, 8)
+      bounds: 664 216 8 8
+    - image: solid-color(84, 27, 0, 255, 8, 8)
+      bounds: 672 216 8 8
+    - image: solid-color(85, 27, 0, 255, 8, 8)
+      bounds: 680 216 8 8
+    - image: solid-color(86, 27, 0, 255, 8, 8)
+      bounds: 688 216 8 8
+    - image: solid-color(87, 27, 0, 255, 8, 8)
+      bounds: 696 216 8 8
+    - image: solid-color(88, 27, 0, 255, 8, 8)
+      bounds: 704 216 8 8
+    - image: solid-color(89, 27, 0, 255, 8, 8)
+      bounds: 712 216 8 8
+    - image: solid-color(90, 27, 0, 255, 8, 8)
+      bounds: 720 216 8 8
+    - image: solid-color(91, 27, 0, 255, 8, 8)
+      bounds: 728 216 8 8
+    - image: solid-color(92, 27, 0, 255, 8, 8)
+      bounds: 736 216 8 8
+    - image: solid-color(93, 27, 0, 255, 8, 8)
+      bounds: 744 216 8 8
+    - image: solid-color(94, 27, 0, 255, 8, 8)
+      bounds: 752 216 8 8
+    - image: solid-color(95, 27, 0, 255, 8, 8)
+      bounds: 760 216 8 8
+    - image: solid-color(96, 27, 0, 255, 8, 8)
+      bounds: 768 216 8 8
+    - image: solid-color(97, 27, 0, 255, 8, 8)
+      bounds: 776 216 8 8
+    - image: solid-color(98, 27, 0, 255, 8, 8)
+      bounds: 784 216 8 8
+    - image: solid-color(99, 27, 0, 255, 8, 8)
+      bounds: 792 216 8 8
+    - image: solid-color(100, 27, 0, 255, 8, 8)
+      bounds: 800 216 8 8
+    - image: solid-color(101, 27, 0, 255, 8, 8)
+      bounds: 808 216 8 8
+    - image: solid-color(102, 27, 0, 255, 8, 8)
+      bounds: 816 216 8 8
+    - image: solid-color(103, 27, 0, 255, 8, 8)
+      bounds: 824 216 8 8
+    - image: solid-color(104, 27, 0, 255, 8, 8)
+      bounds: 832 216 8 8
+    - image: solid-color(105, 27, 0, 255, 8, 8)
+      bounds: 840 216 8 8
+    - image: solid-color(106, 27, 0, 255, 8, 8)
+      bounds: 848 216 8 8
+    - image: solid-color(107, 27, 0, 255, 8, 8)
+      bounds: 856 216 8 8
+    - image: solid-color(108, 27, 0, 255, 8, 8)
+      bounds: 864 216 8 8
+    - image: solid-color(109, 27, 0, 255, 8, 8)
+      bounds: 872 216 8 8
+    - image: solid-color(110, 27, 0, 255, 8, 8)
+      bounds: 880 216 8 8
+    - image: solid-color(111, 27, 0, 255, 8, 8)
+      bounds: 888 216 8 8
+    - image: solid-color(112, 27, 0, 255, 8, 8)
+      bounds: 896 216 8 8
+    - image: solid-color(113, 27, 0, 255, 8, 8)
+      bounds: 904 216 8 8
+    - image: solid-color(114, 27, 0, 255, 8, 8)
+      bounds: 912 216 8 8
+    - image: solid-color(115, 27, 0, 255, 8, 8)
+      bounds: 920 216 8 8
+    - image: solid-color(116, 27, 0, 255, 8, 8)
+      bounds: 928 216 8 8
+    - image: solid-color(117, 27, 0, 255, 8, 8)
+      bounds: 936 216 8 8
+    - image: solid-color(118, 27, 0, 255, 8, 8)
+      bounds: 944 216 8 8
+    - image: solid-color(119, 27, 0, 255, 8, 8)
+      bounds: 952 216 8 8
+    - image: solid-color(120, 27, 0, 255, 8, 8)
+      bounds: 960 216 8 8
+    - image: solid-color(121, 27, 0, 255, 8, 8)
+      bounds: 968 216 8 8
+    - image: solid-color(122, 27, 0, 255, 8, 8)
+      bounds: 976 216 8 8
+    - image: solid-color(123, 27, 0, 255, 8, 8)
+      bounds: 984 216 8 8
+    - image: solid-color(124, 27, 0, 255, 8, 8)
+      bounds: 992 216 8 8
+    - image: solid-color(125, 27, 0, 255, 8, 8)
+      bounds: 1000 216 8 8
+    - image: solid-color(126, 27, 0, 255, 8, 8)
+      bounds: 1008 216 8 8
+    - image: solid-color(127, 27, 0, 255, 8, 8)
+      bounds: 1016 216 8 8
+    - image: solid-color(0, 28, 0, 255, 8, 8)
+      bounds: 0 224 8 8
+    - image: solid-color(1, 28, 0, 255, 8, 8)
+      bounds: 8 224 8 8
+    - image: solid-color(2, 28, 0, 255, 8, 8)
+      bounds: 16 224 8 8
+    - image: solid-color(3, 28, 0, 255, 8, 8)
+      bounds: 24 224 8 8
+    - image: solid-color(4, 28, 0, 255, 8, 8)
+      bounds: 32 224 8 8
+    - image: solid-color(5, 28, 0, 255, 8, 8)
+      bounds: 40 224 8 8
+    - image: solid-color(6, 28, 0, 255, 8, 8)
+      bounds: 48 224 8 8
+    - image: solid-color(7, 28, 0, 255, 8, 8)
+      bounds: 56 224 8 8
+    - image: solid-color(8, 28, 0, 255, 8, 8)
+      bounds: 64 224 8 8
+    - image: solid-color(9, 28, 0, 255, 8, 8)
+      bounds: 72 224 8 8
+    - image: solid-color(10, 28, 0, 255, 8, 8)
+      bounds: 80 224 8 8
+    - image: solid-color(11, 28, 0, 255, 8, 8)
+      bounds: 88 224 8 8
+    - image: solid-color(12, 28, 0, 255, 8, 8)
+      bounds: 96 224 8 8
+    - image: solid-color(13, 28, 0, 255, 8, 8)
+      bounds: 104 224 8 8
+    - image: solid-color(14, 28, 0, 255, 8, 8)
+      bounds: 112 224 8 8
+    - image: solid-color(15, 28, 0, 255, 8, 8)
+      bounds: 120 224 8 8
+    - image: solid-color(16, 28, 0, 255, 8, 8)
+      bounds: 128 224 8 8
+    - image: solid-color(17, 28, 0, 255, 8, 8)
+      bounds: 136 224 8 8
+    - image: solid-color(18, 28, 0, 255, 8, 8)
+      bounds: 144 224 8 8
+    - image: solid-color(19, 28, 0, 255, 8, 8)
+      bounds: 152 224 8 8
+    - image: solid-color(20, 28, 0, 255, 8, 8)
+      bounds: 160 224 8 8
+    - image: solid-color(21, 28, 0, 255, 8, 8)
+      bounds: 168 224 8 8
+    - image: solid-color(22, 28, 0, 255, 8, 8)
+      bounds: 176 224 8 8
+    - image: solid-color(23, 28, 0, 255, 8, 8)
+      bounds: 184 224 8 8
+    - image: solid-color(24, 28, 0, 255, 8, 8)
+      bounds: 192 224 8 8
+    - image: solid-color(25, 28, 0, 255, 8, 8)
+      bounds: 200 224 8 8
+    - image: solid-color(26, 28, 0, 255, 8, 8)
+      bounds: 208 224 8 8
+    - image: solid-color(27, 28, 0, 255, 8, 8)
+      bounds: 216 224 8 8
+    - image: solid-color(28, 28, 0, 255, 8, 8)
+      bounds: 224 224 8 8
+    - image: solid-color(29, 28, 0, 255, 8, 8)
+      bounds: 232 224 8 8
+    - image: solid-color(30, 28, 0, 255, 8, 8)
+      bounds: 240 224 8 8
+    - image: solid-color(31, 28, 0, 255, 8, 8)
+      bounds: 248 224 8 8
+    - image: solid-color(32, 28, 0, 255, 8, 8)
+      bounds: 256 224 8 8
+    - image: solid-color(33, 28, 0, 255, 8, 8)
+      bounds: 264 224 8 8
+    - image: solid-color(34, 28, 0, 255, 8, 8)
+      bounds: 272 224 8 8
+    - image: solid-color(35, 28, 0, 255, 8, 8)
+      bounds: 280 224 8 8
+    - image: solid-color(36, 28, 0, 255, 8, 8)
+      bounds: 288 224 8 8
+    - image: solid-color(37, 28, 0, 255, 8, 8)
+      bounds: 296 224 8 8
+    - image: solid-color(38, 28, 0, 255, 8, 8)
+      bounds: 304 224 8 8
+    - image: solid-color(39, 28, 0, 255, 8, 8)
+      bounds: 312 224 8 8
+    - image: solid-color(40, 28, 0, 255, 8, 8)
+      bounds: 320 224 8 8
+    - image: solid-color(41, 28, 0, 255, 8, 8)
+      bounds: 328 224 8 8
+    - image: solid-color(42, 28, 0, 255, 8, 8)
+      bounds: 336 224 8 8
+    - image: solid-color(43, 28, 0, 255, 8, 8)
+      bounds: 344 224 8 8
+    - image: solid-color(44, 28, 0, 255, 8, 8)
+      bounds: 352 224 8 8
+    - image: solid-color(45, 28, 0, 255, 8, 8)
+      bounds: 360 224 8 8
+    - image: solid-color(46, 28, 0, 255, 8, 8)
+      bounds: 368 224 8 8
+    - image: solid-color(47, 28, 0, 255, 8, 8)
+      bounds: 376 224 8 8
+    - image: solid-color(48, 28, 0, 255, 8, 8)
+      bounds: 384 224 8 8
+    - image: solid-color(49, 28, 0, 255, 8, 8)
+      bounds: 392 224 8 8
+    - image: solid-color(50, 28, 0, 255, 8, 8)
+      bounds: 400 224 8 8
+    - image: solid-color(51, 28, 0, 255, 8, 8)
+      bounds: 408 224 8 8
+    - image: solid-color(52, 28, 0, 255, 8, 8)
+      bounds: 416 224 8 8
+    - image: solid-color(53, 28, 0, 255, 8, 8)
+      bounds: 424 224 8 8
+    - image: solid-color(54, 28, 0, 255, 8, 8)
+      bounds: 432 224 8 8
+    - image: solid-color(55, 28, 0, 255, 8, 8)
+      bounds: 440 224 8 8
+    - image: solid-color(56, 28, 0, 255, 8, 8)
+      bounds: 448 224 8 8
+    - image: solid-color(57, 28, 0, 255, 8, 8)
+      bounds: 456 224 8 8
+    - image: solid-color(58, 28, 0, 255, 8, 8)
+      bounds: 464 224 8 8
+    - image: solid-color(59, 28, 0, 255, 8, 8)
+      bounds: 472 224 8 8
+    - image: solid-color(60, 28, 0, 255, 8, 8)
+      bounds: 480 224 8 8
+    - image: solid-color(61, 28, 0, 255, 8, 8)
+      bounds: 488 224 8 8
+    - image: solid-color(62, 28, 0, 255, 8, 8)
+      bounds: 496 224 8 8
+    - image: solid-color(63, 28, 0, 255, 8, 8)
+      bounds: 504 224 8 8
+    - image: solid-color(64, 28, 0, 255, 8, 8)
+      bounds: 512 224 8 8
+    - image: solid-color(65, 28, 0, 255, 8, 8)
+      bounds: 520 224 8 8
+    - image: solid-color(66, 28, 0, 255, 8, 8)
+      bounds: 528 224 8 8
+    - image: solid-color(67, 28, 0, 255, 8, 8)
+      bounds: 536 224 8 8
+    - image: solid-color(68, 28, 0, 255, 8, 8)
+      bounds: 544 224 8 8
+    - image: solid-color(69, 28, 0, 255, 8, 8)
+      bounds: 552 224 8 8
+    - image: solid-color(70, 28, 0, 255, 8, 8)
+      bounds: 560 224 8 8
+    - image: solid-color(71, 28, 0, 255, 8, 8)
+      bounds: 568 224 8 8
+    - image: solid-color(72, 28, 0, 255, 8, 8)
+      bounds: 576 224 8 8
+    - image: solid-color(73, 28, 0, 255, 8, 8)
+      bounds: 584 224 8 8
+    - image: solid-color(74, 28, 0, 255, 8, 8)
+      bounds: 592 224 8 8
+    - image: solid-color(75, 28, 0, 255, 8, 8)
+      bounds: 600 224 8 8
+    - image: solid-color(76, 28, 0, 255, 8, 8)
+      bounds: 608 224 8 8
+    - image: solid-color(77, 28, 0, 255, 8, 8)
+      bounds: 616 224 8 8
+    - image: solid-color(78, 28, 0, 255, 8, 8)
+      bounds: 624 224 8 8
+    - image: solid-color(79, 28, 0, 255, 8, 8)
+      bounds: 632 224 8 8
+    - image: solid-color(80, 28, 0, 255, 8, 8)
+      bounds: 640 224 8 8
+    - image: solid-color(81, 28, 0, 255, 8, 8)
+      bounds: 648 224 8 8
+    - image: solid-color(82, 28, 0, 255, 8, 8)
+      bounds: 656 224 8 8
+    - image: solid-color(83, 28, 0, 255, 8, 8)
+      bounds: 664 224 8 8
+    - image: solid-color(84, 28, 0, 255, 8, 8)
+      bounds: 672 224 8 8
+    - image: solid-color(85, 28, 0, 255, 8, 8)
+      bounds: 680 224 8 8
+    - image: solid-color(86, 28, 0, 255, 8, 8)
+      bounds: 688 224 8 8
+    - image: solid-color(87, 28, 0, 255, 8, 8)
+      bounds: 696 224 8 8
+    - image: solid-color(88, 28, 0, 255, 8, 8)
+      bounds: 704 224 8 8
+    - image: solid-color(89, 28, 0, 255, 8, 8)
+      bounds: 712 224 8 8
+    - image: solid-color(90, 28, 0, 255, 8, 8)
+      bounds: 720 224 8 8
+    - image: solid-color(91, 28, 0, 255, 8, 8)
+      bounds: 728 224 8 8
+    - image: solid-color(92, 28, 0, 255, 8, 8)
+      bounds: 736 224 8 8
+    - image: solid-color(93, 28, 0, 255, 8, 8)
+      bounds: 744 224 8 8
+    - image: solid-color(94, 28, 0, 255, 8, 8)
+      bounds: 752 224 8 8
+    - image: solid-color(95, 28, 0, 255, 8, 8)
+      bounds: 760 224 8 8
+    - image: solid-color(96, 28, 0, 255, 8, 8)
+      bounds: 768 224 8 8
+    - image: solid-color(97, 28, 0, 255, 8, 8)
+      bounds: 776 224 8 8
+    - image: solid-color(98, 28, 0, 255, 8, 8)
+      bounds: 784 224 8 8
+    - image: solid-color(99, 28, 0, 255, 8, 8)
+      bounds: 792 224 8 8
+    - image: solid-color(100, 28, 0, 255, 8, 8)
+      bounds: 800 224 8 8
+    - image: solid-color(101, 28, 0, 255, 8, 8)
+      bounds: 808 224 8 8
+    - image: solid-color(102, 28, 0, 255, 8, 8)
+      bounds: 816 224 8 8
+    - image: solid-color(103, 28, 0, 255, 8, 8)
+      bounds: 824 224 8 8
+    - image: solid-color(104, 28, 0, 255, 8, 8)
+      bounds: 832 224 8 8
+    - image: solid-color(105, 28, 0, 255, 8, 8)
+      bounds: 840 224 8 8
+    - image: solid-color(106, 28, 0, 255, 8, 8)
+      bounds: 848 224 8 8
+    - image: solid-color(107, 28, 0, 255, 8, 8)
+      bounds: 856 224 8 8
+    - image: solid-color(108, 28, 0, 255, 8, 8)
+      bounds: 864 224 8 8
+    - image: solid-color(109, 28, 0, 255, 8, 8)
+      bounds: 872 224 8 8
+    - image: solid-color(110, 28, 0, 255, 8, 8)
+      bounds: 880 224 8 8
+    - image: solid-color(111, 28, 0, 255, 8, 8)
+      bounds: 888 224 8 8
+    - image: solid-color(112, 28, 0, 255, 8, 8)
+      bounds: 896 224 8 8
+    - image: solid-color(113, 28, 0, 255, 8, 8)
+      bounds: 904 224 8 8
+    - image: solid-color(114, 28, 0, 255, 8, 8)
+      bounds: 912 224 8 8
+    - image: solid-color(115, 28, 0, 255, 8, 8)
+      bounds: 920 224 8 8
+    - image: solid-color(116, 28, 0, 255, 8, 8)
+      bounds: 928 224 8 8
+    - image: solid-color(117, 28, 0, 255, 8, 8)
+      bounds: 936 224 8 8
+    - image: solid-color(118, 28, 0, 255, 8, 8)
+      bounds: 944 224 8 8
+    - image: solid-color(119, 28, 0, 255, 8, 8)
+      bounds: 952 224 8 8
+    - image: solid-color(120, 28, 0, 255, 8, 8)
+      bounds: 960 224 8 8
+    - image: solid-color(121, 28, 0, 255, 8, 8)
+      bounds: 968 224 8 8
+    - image: solid-color(122, 28, 0, 255, 8, 8)
+      bounds: 976 224 8 8
+    - image: solid-color(123, 28, 0, 255, 8, 8)
+      bounds: 984 224 8 8
+    - image: solid-color(124, 28, 0, 255, 8, 8)
+      bounds: 992 224 8 8
+    - image: solid-color(125, 28, 0, 255, 8, 8)
+      bounds: 1000 224 8 8
+    - image: solid-color(126, 28, 0, 255, 8, 8)
+      bounds: 1008 224 8 8
+    - image: solid-color(127, 28, 0, 255, 8, 8)
+      bounds: 1016 224 8 8
+    - image: solid-color(0, 29, 0, 255, 8, 8)
+      bounds: 0 232 8 8
+    - image: solid-color(1, 29, 0, 255, 8, 8)
+      bounds: 8 232 8 8
+    - image: solid-color(2, 29, 0, 255, 8, 8)
+      bounds: 16 232 8 8
+    - image: solid-color(3, 29, 0, 255, 8, 8)
+      bounds: 24 232 8 8
+    - image: solid-color(4, 29, 0, 255, 8, 8)
+      bounds: 32 232 8 8
+    - image: solid-color(5, 29, 0, 255, 8, 8)
+      bounds: 40 232 8 8
+    - image: solid-color(6, 29, 0, 255, 8, 8)
+      bounds: 48 232 8 8
+    - image: solid-color(7, 29, 0, 255, 8, 8)
+      bounds: 56 232 8 8
+    - image: solid-color(8, 29, 0, 255, 8, 8)
+      bounds: 64 232 8 8
+    - image: solid-color(9, 29, 0, 255, 8, 8)
+      bounds: 72 232 8 8
+    - image: solid-color(10, 29, 0, 255, 8, 8)
+      bounds: 80 232 8 8
+    - image: solid-color(11, 29, 0, 255, 8, 8)
+      bounds: 88 232 8 8
+    - image: solid-color(12, 29, 0, 255, 8, 8)
+      bounds: 96 232 8 8
+    - image: solid-color(13, 29, 0, 255, 8, 8)
+      bounds: 104 232 8 8
+    - image: solid-color(14, 29, 0, 255, 8, 8)
+      bounds: 112 232 8 8
+    - image: solid-color(15, 29, 0, 255, 8, 8)
+      bounds: 120 232 8 8
+    - image: solid-color(16, 29, 0, 255, 8, 8)
+      bounds: 128 232 8 8
+    - image: solid-color(17, 29, 0, 255, 8, 8)
+      bounds: 136 232 8 8
+    - image: solid-color(18, 29, 0, 255, 8, 8)
+      bounds: 144 232 8 8
+    - image: solid-color(19, 29, 0, 255, 8, 8)
+      bounds: 152 232 8 8
+    - image: solid-color(20, 29, 0, 255, 8, 8)
+      bounds: 160 232 8 8
+    - image: solid-color(21, 29, 0, 255, 8, 8)
+      bounds: 168 232 8 8
+    - image: solid-color(22, 29, 0, 255, 8, 8)
+      bounds: 176 232 8 8
+    - image: solid-color(23, 29, 0, 255, 8, 8)
+      bounds: 184 232 8 8
+    - image: solid-color(24, 29, 0, 255, 8, 8)
+      bounds: 192 232 8 8
+    - image: solid-color(25, 29, 0, 255, 8, 8)
+      bounds: 200 232 8 8
+    - image: solid-color(26, 29, 0, 255, 8, 8)
+      bounds: 208 232 8 8
+    - image: solid-color(27, 29, 0, 255, 8, 8)
+      bounds: 216 232 8 8
+    - image: solid-color(28, 29, 0, 255, 8, 8)
+      bounds: 224 232 8 8
+    - image: solid-color(29, 29, 0, 255, 8, 8)
+      bounds: 232 232 8 8
+    - image: solid-color(30, 29, 0, 255, 8, 8)
+      bounds: 240 232 8 8
+    - image: solid-color(31, 29, 0, 255, 8, 8)
+      bounds: 248 232 8 8
+    - image: solid-color(32, 29, 0, 255, 8, 8)
+      bounds: 256 232 8 8
+    - image: solid-color(33, 29, 0, 255, 8, 8)
+      bounds: 264 232 8 8
+    - image: solid-color(34, 29, 0, 255, 8, 8)
+      bounds: 272 232 8 8
+    - image: solid-color(35, 29, 0, 255, 8, 8)
+      bounds: 280 232 8 8
+    - image: solid-color(36, 29, 0, 255, 8, 8)
+      bounds: 288 232 8 8
+    - image: solid-color(37, 29, 0, 255, 8, 8)
+      bounds: 296 232 8 8
+    - image: solid-color(38, 29, 0, 255, 8, 8)
+      bounds: 304 232 8 8
+    - image: solid-color(39, 29, 0, 255, 8, 8)
+      bounds: 312 232 8 8
+    - image: solid-color(40, 29, 0, 255, 8, 8)
+      bounds: 320 232 8 8
+    - image: solid-color(41, 29, 0, 255, 8, 8)
+      bounds: 328 232 8 8
+    - image: solid-color(42, 29, 0, 255, 8, 8)
+      bounds: 336 232 8 8
+    - image: solid-color(43, 29, 0, 255, 8, 8)
+      bounds: 344 232 8 8
+    - image: solid-color(44, 29, 0, 255, 8, 8)
+      bounds: 352 232 8 8
+    - image: solid-color(45, 29, 0, 255, 8, 8)
+      bounds: 360 232 8 8
+    - image: solid-color(46, 29, 0, 255, 8, 8)
+      bounds: 368 232 8 8
+    - image: solid-color(47, 29, 0, 255, 8, 8)
+      bounds: 376 232 8 8
+    - image: solid-color(48, 29, 0, 255, 8, 8)
+      bounds: 384 232 8 8
+    - image: solid-color(49, 29, 0, 255, 8, 8)
+      bounds: 392 232 8 8
+    - image: solid-color(50, 29, 0, 255, 8, 8)
+      bounds: 400 232 8 8
+    - image: solid-color(51, 29, 0, 255, 8, 8)
+      bounds: 408 232 8 8
+    - image: solid-color(52, 29, 0, 255, 8, 8)
+      bounds: 416 232 8 8
+    - image: solid-color(53, 29, 0, 255, 8, 8)
+      bounds: 424 232 8 8
+    - image: solid-color(54, 29, 0, 255, 8, 8)
+      bounds: 432 232 8 8
+    - image: solid-color(55, 29, 0, 255, 8, 8)
+      bounds: 440 232 8 8
+    - image: solid-color(56, 29, 0, 255, 8, 8)
+      bounds: 448 232 8 8
+    - image: solid-color(57, 29, 0, 255, 8, 8)
+      bounds: 456 232 8 8
+    - image: solid-color(58, 29, 0, 255, 8, 8)
+      bounds: 464 232 8 8
+    - image: solid-color(59, 29, 0, 255, 8, 8)
+      bounds: 472 232 8 8
+    - image: solid-color(60, 29, 0, 255, 8, 8)
+      bounds: 480 232 8 8
+    - image: solid-color(61, 29, 0, 255, 8, 8)
+      bounds: 488 232 8 8
+    - image: solid-color(62, 29, 0, 255, 8, 8)
+      bounds: 496 232 8 8
+    - image: solid-color(63, 29, 0, 255, 8, 8)
+      bounds: 504 232 8 8
+    - image: solid-color(64, 29, 0, 255, 8, 8)
+      bounds: 512 232 8 8
+    - image: solid-color(65, 29, 0, 255, 8, 8)
+      bounds: 520 232 8 8
+    - image: solid-color(66, 29, 0, 255, 8, 8)
+      bounds: 528 232 8 8
+    - image: solid-color(67, 29, 0, 255, 8, 8)
+      bounds: 536 232 8 8
+    - image: solid-color(68, 29, 0, 255, 8, 8)
+      bounds: 544 232 8 8
+    - image: solid-color(69, 29, 0, 255, 8, 8)
+      bounds: 552 232 8 8
+    - image: solid-color(70, 29, 0, 255, 8, 8)
+      bounds: 560 232 8 8
+    - image: solid-color(71, 29, 0, 255, 8, 8)
+      bounds: 568 232 8 8
+    - image: solid-color(72, 29, 0, 255, 8, 8)
+      bounds: 576 232 8 8
+    - image: solid-color(73, 29, 0, 255, 8, 8)
+      bounds: 584 232 8 8
+    - image: solid-color(74, 29, 0, 255, 8, 8)
+      bounds: 592 232 8 8
+    - image: solid-color(75, 29, 0, 255, 8, 8)
+      bounds: 600 232 8 8
+    - image: solid-color(76, 29, 0, 255, 8, 8)
+      bounds: 608 232 8 8
+    - image: solid-color(77, 29, 0, 255, 8, 8)
+      bounds: 616 232 8 8
+    - image: solid-color(78, 29, 0, 255, 8, 8)
+      bounds: 624 232 8 8
+    - image: solid-color(79, 29, 0, 255, 8, 8)
+      bounds: 632 232 8 8
+    - image: solid-color(80, 29, 0, 255, 8, 8)
+      bounds: 640 232 8 8
+    - image: solid-color(81, 29, 0, 255, 8, 8)
+      bounds: 648 232 8 8
+    - image: solid-color(82, 29, 0, 255, 8, 8)
+      bounds: 656 232 8 8
+    - image: solid-color(83, 29, 0, 255, 8, 8)
+      bounds: 664 232 8 8
+    - image: solid-color(84, 29, 0, 255, 8, 8)
+      bounds: 672 232 8 8
+    - image: solid-color(85, 29, 0, 255, 8, 8)
+      bounds: 680 232 8 8
+    - image: solid-color(86, 29, 0, 255, 8, 8)
+      bounds: 688 232 8 8
+    - image: solid-color(87, 29, 0, 255, 8, 8)
+      bounds: 696 232 8 8
+    - image: solid-color(88, 29, 0, 255, 8, 8)
+      bounds: 704 232 8 8
+    - image: solid-color(89, 29, 0, 255, 8, 8)
+      bounds: 712 232 8 8
+    - image: solid-color(90, 29, 0, 255, 8, 8)
+      bounds: 720 232 8 8
+    - image: solid-color(91, 29, 0, 255, 8, 8)
+      bounds: 728 232 8 8
+    - image: solid-color(92, 29, 0, 255, 8, 8)
+      bounds: 736 232 8 8
+    - image: solid-color(93, 29, 0, 255, 8, 8)
+      bounds: 744 232 8 8
+    - image: solid-color(94, 29, 0, 255, 8, 8)
+      bounds: 752 232 8 8
+    - image: solid-color(95, 29, 0, 255, 8, 8)
+      bounds: 760 232 8 8
+    - image: solid-color(96, 29, 0, 255, 8, 8)
+      bounds: 768 232 8 8
+    - image: solid-color(97, 29, 0, 255, 8, 8)
+      bounds: 776 232 8 8
+    - image: solid-color(98, 29, 0, 255, 8, 8)
+      bounds: 784 232 8 8
+    - image: solid-color(99, 29, 0, 255, 8, 8)
+      bounds: 792 232 8 8
+    - image: solid-color(100, 29, 0, 255, 8, 8)
+      bounds: 800 232 8 8
+    - image: solid-color(101, 29, 0, 255, 8, 8)
+      bounds: 808 232 8 8
+    - image: solid-color(102, 29, 0, 255, 8, 8)
+      bounds: 816 232 8 8
+    - image: solid-color(103, 29, 0, 255, 8, 8)
+      bounds: 824 232 8 8
+    - image: solid-color(104, 29, 0, 255, 8, 8)
+      bounds: 832 232 8 8
+    - image: solid-color(105, 29, 0, 255, 8, 8)
+      bounds: 840 232 8 8
+    - image: solid-color(106, 29, 0, 255, 8, 8)
+      bounds: 848 232 8 8
+    - image: solid-color(107, 29, 0, 255, 8, 8)
+      bounds: 856 232 8 8
+    - image: solid-color(108, 29, 0, 255, 8, 8)
+      bounds: 864 232 8 8
+    - image: solid-color(109, 29, 0, 255, 8, 8)
+      bounds: 872 232 8 8
+    - image: solid-color(110, 29, 0, 255, 8, 8)
+      bounds: 880 232 8 8
+    - image: solid-color(111, 29, 0, 255, 8, 8)
+      bounds: 888 232 8 8
+    - image: solid-color(112, 29, 0, 255, 8, 8)
+      bounds: 896 232 8 8
+    - image: solid-color(113, 29, 0, 255, 8, 8)
+      bounds: 904 232 8 8
+    - image: solid-color(114, 29, 0, 255, 8, 8)
+      bounds: 912 232 8 8
+    - image: solid-color(115, 29, 0, 255, 8, 8)
+      bounds: 920 232 8 8
+    - image: solid-color(116, 29, 0, 255, 8, 8)
+      bounds: 928 232 8 8
+    - image: solid-color(117, 29, 0, 255, 8, 8)
+      bounds: 936 232 8 8
+    - image: solid-color(118, 29, 0, 255, 8, 8)
+      bounds: 944 232 8 8
+    - image: solid-color(119, 29, 0, 255, 8, 8)
+      bounds: 952 232 8 8
+    - image: solid-color(120, 29, 0, 255, 8, 8)
+      bounds: 960 232 8 8
+    - image: solid-color(121, 29, 0, 255, 8, 8)
+      bounds: 968 232 8 8
+    - image: solid-color(122, 29, 0, 255, 8, 8)
+      bounds: 976 232 8 8
+    - image: solid-color(123, 29, 0, 255, 8, 8)
+      bounds: 984 232 8 8
+    - image: solid-color(124, 29, 0, 255, 8, 8)
+      bounds: 992 232 8 8
+    - image: solid-color(125, 29, 0, 255, 8, 8)
+      bounds: 1000 232 8 8
+    - image: solid-color(126, 29, 0, 255, 8, 8)
+      bounds: 1008 232 8 8
+    - image: solid-color(127, 29, 0, 255, 8, 8)
+      bounds: 1016 232 8 8
+    - image: solid-color(0, 30, 0, 255, 8, 8)
+      bounds: 0 240 8 8
+    - image: solid-color(1, 30, 0, 255, 8, 8)
+      bounds: 8 240 8 8
+    - image: solid-color(2, 30, 0, 255, 8, 8)
+      bounds: 16 240 8 8
+    - image: solid-color(3, 30, 0, 255, 8, 8)
+      bounds: 24 240 8 8
+    - image: solid-color(4, 30, 0, 255, 8, 8)
+      bounds: 32 240 8 8
+    - image: solid-color(5, 30, 0, 255, 8, 8)
+      bounds: 40 240 8 8
+    - image: solid-color(6, 30, 0, 255, 8, 8)
+      bounds: 48 240 8 8
+    - image: solid-color(7, 30, 0, 255, 8, 8)
+      bounds: 56 240 8 8
+    - image: solid-color(8, 30, 0, 255, 8, 8)
+      bounds: 64 240 8 8
+    - image: solid-color(9, 30, 0, 255, 8, 8)
+      bounds: 72 240 8 8
+    - image: solid-color(10, 30, 0, 255, 8, 8)
+      bounds: 80 240 8 8
+    - image: solid-color(11, 30, 0, 255, 8, 8)
+      bounds: 88 240 8 8
+    - image: solid-color(12, 30, 0, 255, 8, 8)
+      bounds: 96 240 8 8
+    - image: solid-color(13, 30, 0, 255, 8, 8)
+      bounds: 104 240 8 8
+    - image: solid-color(14, 30, 0, 255, 8, 8)
+      bounds: 112 240 8 8
+    - image: solid-color(15, 30, 0, 255, 8, 8)
+      bounds: 120 240 8 8
+    - image: solid-color(16, 30, 0, 255, 8, 8)
+      bounds: 128 240 8 8
+    - image: solid-color(17, 30, 0, 255, 8, 8)
+      bounds: 136 240 8 8
+    - image: solid-color(18, 30, 0, 255, 8, 8)
+      bounds: 144 240 8 8
+    - image: solid-color(19, 30, 0, 255, 8, 8)
+      bounds: 152 240 8 8
+    - image: solid-color(20, 30, 0, 255, 8, 8)
+      bounds: 160 240 8 8
+    - image: solid-color(21, 30, 0, 255, 8, 8)
+      bounds: 168 240 8 8
+    - image: solid-color(22, 30, 0, 255, 8, 8)
+      bounds: 176 240 8 8
+    - image: solid-color(23, 30, 0, 255, 8, 8)
+      bounds: 184 240 8 8
+    - image: solid-color(24, 30, 0, 255, 8, 8)
+      bounds: 192 240 8 8
+    - image: solid-color(25, 30, 0, 255, 8, 8)
+      bounds: 200 240 8 8
+    - image: solid-color(26, 30, 0, 255, 8, 8)
+      bounds: 208 240 8 8
+    - image: solid-color(27, 30, 0, 255, 8, 8)
+      bounds: 216 240 8 8
+    - image: solid-color(28, 30, 0, 255, 8, 8)
+      bounds: 224 240 8 8
+    - image: solid-color(29, 30, 0, 255, 8, 8)
+      bounds: 232 240 8 8
+    - image: solid-color(30, 30, 0, 255, 8, 8)
+      bounds: 240 240 8 8
+    - image: solid-color(31, 30, 0, 255, 8, 8)
+      bounds: 248 240 8 8
+    - image: solid-color(32, 30, 0, 255, 8, 8)
+      bounds: 256 240 8 8
+    - image: solid-color(33, 30, 0, 255, 8, 8)
+      bounds: 264 240 8 8
+    - image: solid-color(34, 30, 0, 255, 8, 8)
+      bounds: 272 240 8 8
+    - image: solid-color(35, 30, 0, 255, 8, 8)
+      bounds: 280 240 8 8
+    - image: solid-color(36, 30, 0, 255, 8, 8)
+      bounds: 288 240 8 8
+    - image: solid-color(37, 30, 0, 255, 8, 8)
+      bounds: 296 240 8 8
+    - image: solid-color(38, 30, 0, 255, 8, 8)
+      bounds: 304 240 8 8
+    - image: solid-color(39, 30, 0, 255, 8, 8)
+      bounds: 312 240 8 8
+    - image: solid-color(40, 30, 0, 255, 8, 8)
+      bounds: 320 240 8 8
+    - image: solid-color(41, 30, 0, 255, 8, 8)
+      bounds: 328 240 8 8
+    - image: solid-color(42, 30, 0, 255, 8, 8)
+      bounds: 336 240 8 8
+    - image: solid-color(43, 30, 0, 255, 8, 8)
+      bounds: 344 240 8 8
+    - image: solid-color(44, 30, 0, 255, 8, 8)
+      bounds: 352 240 8 8
+    - image: solid-color(45, 30, 0, 255, 8, 8)
+      bounds: 360 240 8 8
+    - image: solid-color(46, 30, 0, 255, 8, 8)
+      bounds: 368 240 8 8
+    - image: solid-color(47, 30, 0, 255, 8, 8)
+      bounds: 376 240 8 8
+    - image: solid-color(48, 30, 0, 255, 8, 8)
+      bounds: 384 240 8 8
+    - image: solid-color(49, 30, 0, 255, 8, 8)
+      bounds: 392 240 8 8
+    - image: solid-color(50, 30, 0, 255, 8, 8)
+      bounds: 400 240 8 8
+    - image: solid-color(51, 30, 0, 255, 8, 8)
+      bounds: 408 240 8 8
+    - image: solid-color(52, 30, 0, 255, 8, 8)
+      bounds: 416 240 8 8
+    - image: solid-color(53, 30, 0, 255, 8, 8)
+      bounds: 424 240 8 8
+    - image: solid-color(54, 30, 0, 255, 8, 8)
+      bounds: 432 240 8 8
+    - image: solid-color(55, 30, 0, 255, 8, 8)
+      bounds: 440 240 8 8
+    - image: solid-color(56, 30, 0, 255, 8, 8)
+      bounds: 448 240 8 8
+    - image: solid-color(57, 30, 0, 255, 8, 8)
+      bounds: 456 240 8 8
+    - image: solid-color(58, 30, 0, 255, 8, 8)
+      bounds: 464 240 8 8
+    - image: solid-color(59, 30, 0, 255, 8, 8)
+      bounds: 472 240 8 8
+    - image: solid-color(60, 30, 0, 255, 8, 8)
+      bounds: 480 240 8 8
+    - image: solid-color(61, 30, 0, 255, 8, 8)
+      bounds: 488 240 8 8
+    - image: solid-color(62, 30, 0, 255, 8, 8)
+      bounds: 496 240 8 8
+    - image: solid-color(63, 30, 0, 255, 8, 8)
+      bounds: 504 240 8 8
+    - image: solid-color(64, 30, 0, 255, 8, 8)
+      bounds: 512 240 8 8
+    - image: solid-color(65, 30, 0, 255, 8, 8)
+      bounds: 520 240 8 8
+    - image: solid-color(66, 30, 0, 255, 8, 8)
+      bounds: 528 240 8 8
+    - image: solid-color(67, 30, 0, 255, 8, 8)
+      bounds: 536 240 8 8
+    - image: solid-color(68, 30, 0, 255, 8, 8)
+      bounds: 544 240 8 8
+    - image: solid-color(69, 30, 0, 255, 8, 8)
+      bounds: 552 240 8 8
+    - image: solid-color(70, 30, 0, 255, 8, 8)
+      bounds: 560 240 8 8
+    - image: solid-color(71, 30, 0, 255, 8, 8)
+      bounds: 568 240 8 8
+    - image: solid-color(72, 30, 0, 255, 8, 8)
+      bounds: 576 240 8 8
+    - image: solid-color(73, 30, 0, 255, 8, 8)
+      bounds: 584 240 8 8
+    - image: solid-color(74, 30, 0, 255, 8, 8)
+      bounds: 592 240 8 8
+    - image: solid-color(75, 30, 0, 255, 8, 8)
+      bounds: 600 240 8 8
+    - image: solid-color(76, 30, 0, 255, 8, 8)
+      bounds: 608 240 8 8
+    - image: solid-color(77, 30, 0, 255, 8, 8)
+      bounds: 616 240 8 8
+    - image: solid-color(78, 30, 0, 255, 8, 8)
+      bounds: 624 240 8 8
+    - image: solid-color(79, 30, 0, 255, 8, 8)
+      bounds: 632 240 8 8
+    - image: solid-color(80, 30, 0, 255, 8, 8)
+      bounds: 640 240 8 8
+    - image: solid-color(81, 30, 0, 255, 8, 8)
+      bounds: 648 240 8 8
+    - image: solid-color(82, 30, 0, 255, 8, 8)
+      bounds: 656 240 8 8
+    - image: solid-color(83, 30, 0, 255, 8, 8)
+      bounds: 664 240 8 8
+    - image: solid-color(84, 30, 0, 255, 8, 8)
+      bounds: 672 240 8 8
+    - image: solid-color(85, 30, 0, 255, 8, 8)
+      bounds: 680 240 8 8
+    - image: solid-color(86, 30, 0, 255, 8, 8)
+      bounds: 688 240 8 8
+    - image: solid-color(87, 30, 0, 255, 8, 8)
+      bounds: 696 240 8 8
+    - image: solid-color(88, 30, 0, 255, 8, 8)
+      bounds: 704 240 8 8
+    - image: solid-color(89, 30, 0, 255, 8, 8)
+      bounds: 712 240 8 8
+    - image: solid-color(90, 30, 0, 255, 8, 8)
+      bounds: 720 240 8 8
+    - image: solid-color(91, 30, 0, 255, 8, 8)
+      bounds: 728 240 8 8
+    - image: solid-color(92, 30, 0, 255, 8, 8)
+      bounds: 736 240 8 8
+    - image: solid-color(93, 30, 0, 255, 8, 8)
+      bounds: 744 240 8 8
+    - image: solid-color(94, 30, 0, 255, 8, 8)
+      bounds: 752 240 8 8
+    - image: solid-color(95, 30, 0, 255, 8, 8)
+      bounds: 760 240 8 8
+    - image: solid-color(96, 30, 0, 255, 8, 8)
+      bounds: 768 240 8 8
+    - image: solid-color(97, 30, 0, 255, 8, 8)
+      bounds: 776 240 8 8
+    - image: solid-color(98, 30, 0, 255, 8, 8)
+      bounds: 784 240 8 8
+    - image: solid-color(99, 30, 0, 255, 8, 8)
+      bounds: 792 240 8 8
+    - image: solid-color(100, 30, 0, 255, 8, 8)
+      bounds: 800 240 8 8
+    - image: solid-color(101, 30, 0, 255, 8, 8)
+      bounds: 808 240 8 8
+    - image: solid-color(102, 30, 0, 255, 8, 8)
+      bounds: 816 240 8 8
+    - image: solid-color(103, 30, 0, 255, 8, 8)
+      bounds: 824 240 8 8
+    - image: solid-color(104, 30, 0, 255, 8, 8)
+      bounds: 832 240 8 8
+    - image: solid-color(105, 30, 0, 255, 8, 8)
+      bounds: 840 240 8 8
+    - image: solid-color(106, 30, 0, 255, 8, 8)
+      bounds: 848 240 8 8
+    - image: solid-color(107, 30, 0, 255, 8, 8)
+      bounds: 856 240 8 8
+    - image: solid-color(108, 30, 0, 255, 8, 8)
+      bounds: 864 240 8 8
+    - image: solid-color(109, 30, 0, 255, 8, 8)
+      bounds: 872 240 8 8
+    - image: solid-color(110, 30, 0, 255, 8, 8)
+      bounds: 880 240 8 8
+    - image: solid-color(111, 30, 0, 255, 8, 8)
+      bounds: 888 240 8 8
+    - image: solid-color(112, 30, 0, 255, 8, 8)
+      bounds: 896 240 8 8
+    - image: solid-color(113, 30, 0, 255, 8, 8)
+      bounds: 904 240 8 8
+    - image: solid-color(114, 30, 0, 255, 8, 8)
+      bounds: 912 240 8 8
+    - image: solid-color(115, 30, 0, 255, 8, 8)
+      bounds: 920 240 8 8
+    - image: solid-color(116, 30, 0, 255, 8, 8)
+      bounds: 928 240 8 8
+    - image: solid-color(117, 30, 0, 255, 8, 8)
+      bounds: 936 240 8 8
+    - image: solid-color(118, 30, 0, 255, 8, 8)
+      bounds: 944 240 8 8
+    - image: solid-color(119, 30, 0, 255, 8, 8)
+      bounds: 952 240 8 8
+    - image: solid-color(120, 30, 0, 255, 8, 8)
+      bounds: 960 240 8 8
+    - image: solid-color(121, 30, 0, 255, 8, 8)
+      bounds: 968 240 8 8
+    - image: solid-color(122, 30, 0, 255, 8, 8)
+      bounds: 976 240 8 8
+    - image: solid-color(123, 30, 0, 255, 8, 8)
+      bounds: 984 240 8 8
+    - image: solid-color(124, 30, 0, 255, 8, 8)
+      bounds: 992 240 8 8
+    - image: solid-color(125, 30, 0, 255, 8, 8)
+      bounds: 1000 240 8 8
+    - image: solid-color(126, 30, 0, 255, 8, 8)
+      bounds: 1008 240 8 8
+    - image: solid-color(127, 30, 0, 255, 8, 8)
+      bounds: 1016 240 8 8
+    - image: solid-color(0, 31, 0, 255, 8, 8)
+      bounds: 0 248 8 8
+    - image: solid-color(1, 31, 0, 255, 8, 8)
+      bounds: 8 248 8 8
+    - image: solid-color(2, 31, 0, 255, 8, 8)
+      bounds: 16 248 8 8
+    - image: solid-color(3, 31, 0, 255, 8, 8)
+      bounds: 24 248 8 8
+    - image: solid-color(4, 31, 0, 255, 8, 8)
+      bounds: 32 248 8 8
+    - image: solid-color(5, 31, 0, 255, 8, 8)
+      bounds: 40 248 8 8
+    - image: solid-color(6, 31, 0, 255, 8, 8)
+      bounds: 48 248 8 8
+    - image: solid-color(7, 31, 0, 255, 8, 8)
+      bounds: 56 248 8 8
+    - image: solid-color(8, 31, 0, 255, 8, 8)
+      bounds: 64 248 8 8
+    - image: solid-color(9, 31, 0, 255, 8, 8)
+      bounds: 72 248 8 8
+    - image: solid-color(10, 31, 0, 255, 8, 8)
+      bounds: 80 248 8 8
+    - image: solid-color(11, 31, 0, 255, 8, 8)
+      bounds: 88 248 8 8
+    - image: solid-color(12, 31, 0, 255, 8, 8)
+      bounds: 96 248 8 8
+    - image: solid-color(13, 31, 0, 255, 8, 8)
+      bounds: 104 248 8 8
+    - image: solid-color(14, 31, 0, 255, 8, 8)
+      bounds: 112 248 8 8
+    - image: solid-color(15, 31, 0, 255, 8, 8)
+      bounds: 120 248 8 8
+    - image: solid-color(16, 31, 0, 255, 8, 8)
+      bounds: 128 248 8 8
+    - image: solid-color(17, 31, 0, 255, 8, 8)
+      bounds: 136 248 8 8
+    - image: solid-color(18, 31, 0, 255, 8, 8)
+      bounds: 144 248 8 8
+    - image: solid-color(19, 31, 0, 255, 8, 8)
+      bounds: 152 248 8 8
+    - image: solid-color(20, 31, 0, 255, 8, 8)
+      bounds: 160 248 8 8
+    - image: solid-color(21, 31, 0, 255, 8, 8)
+      bounds: 168 248 8 8
+    - image: solid-color(22, 31, 0, 255, 8, 8)
+      bounds: 176 248 8 8
+    - image: solid-color(23, 31, 0, 255, 8, 8)
+      bounds: 184 248 8 8
+    - image: solid-color(24, 31, 0, 255, 8, 8)
+      bounds: 192 248 8 8
+    - image: solid-color(25, 31, 0, 255, 8, 8)
+      bounds: 200 248 8 8
+    - image: solid-color(26, 31, 0, 255, 8, 8)
+      bounds: 208 248 8 8
+    - image: solid-color(27, 31, 0, 255, 8, 8)
+      bounds: 216 248 8 8
+    - image: solid-color(28, 31, 0, 255, 8, 8)
+      bounds: 224 248 8 8
+    - image: solid-color(29, 31, 0, 255, 8, 8)
+      bounds: 232 248 8 8
+    - image: solid-color(30, 31, 0, 255, 8, 8)
+      bounds: 240 248 8 8
+    - image: solid-color(31, 31, 0, 255, 8, 8)
+      bounds: 248 248 8 8
+    - image: solid-color(32, 31, 0, 255, 8, 8)
+      bounds: 256 248 8 8
+    - image: solid-color(33, 31, 0, 255, 8, 8)
+      bounds: 264 248 8 8
+    - image: solid-color(34, 31, 0, 255, 8, 8)
+      bounds: 272 248 8 8
+    - image: solid-color(35, 31, 0, 255, 8, 8)
+      bounds: 280 248 8 8
+    - image: solid-color(36, 31, 0, 255, 8, 8)
+      bounds: 288 248 8 8
+    - image: solid-color(37, 31, 0, 255, 8, 8)
+      bounds: 296 248 8 8
+    - image: solid-color(38, 31, 0, 255, 8, 8)
+      bounds: 304 248 8 8
+    - image: solid-color(39, 31, 0, 255, 8, 8)
+      bounds: 312 248 8 8
+    - image: solid-color(40, 31, 0, 255, 8, 8)
+      bounds: 320 248 8 8
+    - image: solid-color(41, 31, 0, 255, 8, 8)
+      bounds: 328 248 8 8
+    - image: solid-color(42, 31, 0, 255, 8, 8)
+      bounds: 336 248 8 8
+    - image: solid-color(43, 31, 0, 255, 8, 8)
+      bounds: 344 248 8 8
+    - image: solid-color(44, 31, 0, 255, 8, 8)
+      bounds: 352 248 8 8
+    - image: solid-color(45, 31, 0, 255, 8, 8)
+      bounds: 360 248 8 8
+    - image: solid-color(46, 31, 0, 255, 8, 8)
+      bounds: 368 248 8 8
+    - image: solid-color(47, 31, 0, 255, 8, 8)
+      bounds: 376 248 8 8
+    - image: solid-color(48, 31, 0, 255, 8, 8)
+      bounds: 384 248 8 8
+    - image: solid-color(49, 31, 0, 255, 8, 8)
+      bounds: 392 248 8 8
+    - image: solid-color(50, 31, 0, 255, 8, 8)
+      bounds: 400 248 8 8
+    - image: solid-color(51, 31, 0, 255, 8, 8)
+      bounds: 408 248 8 8
+    - image: solid-color(52, 31, 0, 255, 8, 8)
+      bounds: 416 248 8 8
+    - image: solid-color(53, 31, 0, 255, 8, 8)
+      bounds: 424 248 8 8
+    - image: solid-color(54, 31, 0, 255, 8, 8)
+      bounds: 432 248 8 8
+    - image: solid-color(55, 31, 0, 255, 8, 8)
+      bounds: 440 248 8 8
+    - image: solid-color(56, 31, 0, 255, 8, 8)
+      bounds: 448 248 8 8
+    - image: solid-color(57, 31, 0, 255, 8, 8)
+      bounds: 456 248 8 8
+    - image: solid-color(58, 31, 0, 255, 8, 8)
+      bounds: 464 248 8 8
+    - image: solid-color(59, 31, 0, 255, 8, 8)
+      bounds: 472 248 8 8
+    - image: solid-color(60, 31, 0, 255, 8, 8)
+      bounds: 480 248 8 8
+    - image: solid-color(61, 31, 0, 255, 8, 8)
+      bounds: 488 248 8 8
+    - image: solid-color(62, 31, 0, 255, 8, 8)
+      bounds: 496 248 8 8
+    - image: solid-color(63, 31, 0, 255, 8, 8)
+      bounds: 504 248 8 8
+    - image: solid-color(64, 31, 0, 255, 8, 8)
+      bounds: 512 248 8 8
+    - image: solid-color(65, 31, 0, 255, 8, 8)
+      bounds: 520 248 8 8
+    - image: solid-color(66, 31, 0, 255, 8, 8)
+      bounds: 528 248 8 8
+    - image: solid-color(67, 31, 0, 255, 8, 8)
+      bounds: 536 248 8 8
+    - image: solid-color(68, 31, 0, 255, 8, 8)
+      bounds: 544 248 8 8
+    - image: solid-color(69, 31, 0, 255, 8, 8)
+      bounds: 552 248 8 8
+    - image: solid-color(70, 31, 0, 255, 8, 8)
+      bounds: 560 248 8 8
+    - image: solid-color(71, 31, 0, 255, 8, 8)
+      bounds: 568 248 8 8
+    - image: solid-color(72, 31, 0, 255, 8, 8)
+      bounds: 576 248 8 8
+    - image: solid-color(73, 31, 0, 255, 8, 8)
+      bounds: 584 248 8 8
+    - image: solid-color(74, 31, 0, 255, 8, 8)
+      bounds: 592 248 8 8
+    - image: solid-color(75, 31, 0, 255, 8, 8)
+      bounds: 600 248 8 8
+    - image: solid-color(76, 31, 0, 255, 8, 8)
+      bounds: 608 248 8 8
+    - image: solid-color(77, 31, 0, 255, 8, 8)
+      bounds: 616 248 8 8
+    - image: solid-color(78, 31, 0, 255, 8, 8)
+      bounds: 624 248 8 8
+    - image: solid-color(79, 31, 0, 255, 8, 8)
+      bounds: 632 248 8 8
+    - image: solid-color(80, 31, 0, 255, 8, 8)
+      bounds: 640 248 8 8
+    - image: solid-color(81, 31, 0, 255, 8, 8)
+      bounds: 648 248 8 8
+    - image: solid-color(82, 31, 0, 255, 8, 8)
+      bounds: 656 248 8 8
+    - image: solid-color(83, 31, 0, 255, 8, 8)
+      bounds: 664 248 8 8
+    - image: solid-color(84, 31, 0, 255, 8, 8)
+      bounds: 672 248 8 8
+    - image: solid-color(85, 31, 0, 255, 8, 8)
+      bounds: 680 248 8 8
+    - image: solid-color(86, 31, 0, 255, 8, 8)
+      bounds: 688 248 8 8
+    - image: solid-color(87, 31, 0, 255, 8, 8)
+      bounds: 696 248 8 8
+    - image: solid-color(88, 31, 0, 255, 8, 8)
+      bounds: 704 248 8 8
+    - image: solid-color(89, 31, 0, 255, 8, 8)
+      bounds: 712 248 8 8
+    - image: solid-color(90, 31, 0, 255, 8, 8)
+      bounds: 720 248 8 8
+    - image: solid-color(91, 31, 0, 255, 8, 8)
+      bounds: 728 248 8 8
+    - image: solid-color(92, 31, 0, 255, 8, 8)
+      bounds: 736 248 8 8
+    - image: solid-color(93, 31, 0, 255, 8, 8)
+      bounds: 744 248 8 8
+    - image: solid-color(94, 31, 0, 255, 8, 8)
+      bounds: 752 248 8 8
+    - image: solid-color(95, 31, 0, 255, 8, 8)
+      bounds: 760 248 8 8
+    - image: solid-color(96, 31, 0, 255, 8, 8)
+      bounds: 768 248 8 8
+    - image: solid-color(97, 31, 0, 255, 8, 8)
+      bounds: 776 248 8 8
+    - image: solid-color(98, 31, 0, 255, 8, 8)
+      bounds: 784 248 8 8
+    - image: solid-color(99, 31, 0, 255, 8, 8)
+      bounds: 792 248 8 8
+    - image: solid-color(100, 31, 0, 255, 8, 8)
+      bounds: 800 248 8 8
+    - image: solid-color(101, 31, 0, 255, 8, 8)
+      bounds: 808 248 8 8
+    - image: solid-color(102, 31, 0, 255, 8, 8)
+      bounds: 816 248 8 8
+    - image: solid-color(103, 31, 0, 255, 8, 8)
+      bounds: 824 248 8 8
+    - image: solid-color(104, 31, 0, 255, 8, 8)
+      bounds: 832 248 8 8
+    - image: solid-color(105, 31, 0, 255, 8, 8)
+      bounds: 840 248 8 8
+    - image: solid-color(106, 31, 0, 255, 8, 8)
+      bounds: 848 248 8 8
+    - image: solid-color(107, 31, 0, 255, 8, 8)
+      bounds: 856 248 8 8
+    - image: solid-color(108, 31, 0, 255, 8, 8)
+      bounds: 864 248 8 8
+    - image: solid-color(109, 31, 0, 255, 8, 8)
+      bounds: 872 248 8 8
+    - image: solid-color(110, 31, 0, 255, 8, 8)
+      bounds: 880 248 8 8
+    - image: solid-color(111, 31, 0, 255, 8, 8)
+      bounds: 888 248 8 8
+    - image: solid-color(112, 31, 0, 255, 8, 8)
+      bounds: 896 248 8 8
+    - image: solid-color(113, 31, 0, 255, 8, 8)
+      bounds: 904 248 8 8
+    - image: solid-color(114, 31, 0, 255, 8, 8)
+      bounds: 912 248 8 8
+    - image: solid-color(115, 31, 0, 255, 8, 8)
+      bounds: 920 248 8 8
+    - image: solid-color(116, 31, 0, 255, 8, 8)
+      bounds: 928 248 8 8
+    - image: solid-color(117, 31, 0, 255, 8, 8)
+      bounds: 936 248 8 8
+    - image: solid-color(118, 31, 0, 255, 8, 8)
+      bounds: 944 248 8 8
+    - image: solid-color(119, 31, 0, 255, 8, 8)
+      bounds: 952 248 8 8
+    - image: solid-color(120, 31, 0, 255, 8, 8)
+      bounds: 960 248 8 8
+    - image: solid-color(121, 31, 0, 255, 8, 8)
+      bounds: 968 248 8 8
+    - image: solid-color(122, 31, 0, 255, 8, 8)
+      bounds: 976 248 8 8
+    - image: solid-color(123, 31, 0, 255, 8, 8)
+      bounds: 984 248 8 8
+    - image: solid-color(124, 31, 0, 255, 8, 8)
+      bounds: 992 248 8 8
+    - image: solid-color(125, 31, 0, 255, 8, 8)
+      bounds: 1000 248 8 8
+    - image: solid-color(126, 31, 0, 255, 8, 8)
+      bounds: 1008 248 8 8
+    - image: solid-color(127, 31, 0, 255, 8, 8)
+      bounds: 1016 248 8 8
+    - image: solid-color(0, 32, 0, 255, 8, 8)
+      bounds: 0 256 8 8
+    - image: solid-color(1, 32, 0, 255, 8, 8)
+      bounds: 8 256 8 8
+    - image: solid-color(2, 32, 0, 255, 8, 8)
+      bounds: 16 256 8 8
+    - image: solid-color(3, 32, 0, 255, 8, 8)
+      bounds: 24 256 8 8
+    - image: solid-color(4, 32, 0, 255, 8, 8)
+      bounds: 32 256 8 8
+    - image: solid-color(5, 32, 0, 255, 8, 8)
+      bounds: 40 256 8 8
+    - image: solid-color(6, 32, 0, 255, 8, 8)
+      bounds: 48 256 8 8
+    - image: solid-color(7, 32, 0, 255, 8, 8)
+      bounds: 56 256 8 8
+    - image: solid-color(8, 32, 0, 255, 8, 8)
+      bounds: 64 256 8 8
+    - image: solid-color(9, 32, 0, 255, 8, 8)
+      bounds: 72 256 8 8
+    - image: solid-color(10, 32, 0, 255, 8, 8)
+      bounds: 80 256 8 8
+    - image: solid-color(11, 32, 0, 255, 8, 8)
+      bounds: 88 256 8 8
+    - image: solid-color(12, 32, 0, 255, 8, 8)
+      bounds: 96 256 8 8
+    - image: solid-color(13, 32, 0, 255, 8, 8)
+      bounds: 104 256 8 8
+    - image: solid-color(14, 32, 0, 255, 8, 8)
+      bounds: 112 256 8 8
+    - image: solid-color(15, 32, 0, 255, 8, 8)
+      bounds: 120 256 8 8
+    - image: solid-color(16, 32, 0, 255, 8, 8)
+      bounds: 128 256 8 8
+    - image: solid-color(17, 32, 0, 255, 8, 8)
+      bounds: 136 256 8 8
+    - image: solid-color(18, 32, 0, 255, 8, 8)
+      bounds: 144 256 8 8
+    - image: solid-color(19, 32, 0, 255, 8, 8)
+      bounds: 152 256 8 8
+    - image: solid-color(20, 32, 0, 255, 8, 8)
+      bounds: 160 256 8 8
+    - image: solid-color(21, 32, 0, 255, 8, 8)
+      bounds: 168 256 8 8
+    - image: solid-color(22, 32, 0, 255, 8, 8)
+      bounds: 176 256 8 8
+    - image: solid-color(23, 32, 0, 255, 8, 8)
+      bounds: 184 256 8 8
+    - image: solid-color(24, 32, 0, 255, 8, 8)
+      bounds: 192 256 8 8
+    - image: solid-color(25, 32, 0, 255, 8, 8)
+      bounds: 200 256 8 8
+    - image: solid-color(26, 32, 0, 255, 8, 8)
+      bounds: 208 256 8 8
+    - image: solid-color(27, 32, 0, 255, 8, 8)
+      bounds: 216 256 8 8
+    - image: solid-color(28, 32, 0, 255, 8, 8)
+      bounds: 224 256 8 8
+    - image: solid-color(29, 32, 0, 255, 8, 8)
+      bounds: 232 256 8 8
+    - image: solid-color(30, 32, 0, 255, 8, 8)
+      bounds: 240 256 8 8
+    - image: solid-color(31, 32, 0, 255, 8, 8)
+      bounds: 248 256 8 8
+    - image: solid-color(32, 32, 0, 255, 8, 8)
+      bounds: 256 256 8 8
+    - image: solid-color(33, 32, 0, 255, 8, 8)
+      bounds: 264 256 8 8
+    - image: solid-color(34, 32, 0, 255, 8, 8)
+      bounds: 272 256 8 8
+    - image: solid-color(35, 32, 0, 255, 8, 8)
+      bounds: 280 256 8 8
+    - image: solid-color(36, 32, 0, 255, 8, 8)
+      bounds: 288 256 8 8
+    - image: solid-color(37, 32, 0, 255, 8, 8)
+      bounds: 296 256 8 8
+    - image: solid-color(38, 32, 0, 255, 8, 8)
+      bounds: 304 256 8 8
+    - image: solid-color(39, 32, 0, 255, 8, 8)
+      bounds: 312 256 8 8
+    - image: solid-color(40, 32, 0, 255, 8, 8)
+      bounds: 320 256 8 8
+    - image: solid-color(41, 32, 0, 255, 8, 8)
+      bounds: 328 256 8 8
+    - image: solid-color(42, 32, 0, 255, 8, 8)
+      bounds: 336 256 8 8
+    - image: solid-color(43, 32, 0, 255, 8, 8)
+      bounds: 344 256 8 8
+    - image: solid-color(44, 32, 0, 255, 8, 8)
+      bounds: 352 256 8 8
+    - image: solid-color(45, 32, 0, 255, 8, 8)
+      bounds: 360 256 8 8
+    - image: solid-color(46, 32, 0, 255, 8, 8)
+      bounds: 368 256 8 8
+    - image: solid-color(47, 32, 0, 255, 8, 8)
+      bounds: 376 256 8 8
+    - image: solid-color(48, 32, 0, 255, 8, 8)
+      bounds: 384 256 8 8
+    - image: solid-color(49, 32, 0, 255, 8, 8)
+      bounds: 392 256 8 8
+    - image: solid-color(50, 32, 0, 255, 8, 8)
+      bounds: 400 256 8 8
+    - image: solid-color(51, 32, 0, 255, 8, 8)
+      bounds: 408 256 8 8
+    - image: solid-color(52, 32, 0, 255, 8, 8)
+      bounds: 416 256 8 8
+    - image: solid-color(53, 32, 0, 255, 8, 8)
+      bounds: 424 256 8 8
+    - image: solid-color(54, 32, 0, 255, 8, 8)
+      bounds: 432 256 8 8
+    - image: solid-color(55, 32, 0, 255, 8, 8)
+      bounds: 440 256 8 8
+    - image: solid-color(56, 32, 0, 255, 8, 8)
+      bounds: 448 256 8 8
+    - image: solid-color(57, 32, 0, 255, 8, 8)
+      bounds: 456 256 8 8
+    - image: solid-color(58, 32, 0, 255, 8, 8)
+      bounds: 464 256 8 8
+    - image: solid-color(59, 32, 0, 255, 8, 8)
+      bounds: 472 256 8 8
+    - image: solid-color(60, 32, 0, 255, 8, 8)
+      bounds: 480 256 8 8
+    - image: solid-color(61, 32, 0, 255, 8, 8)
+      bounds: 488 256 8 8
+    - image: solid-color(62, 32, 0, 255, 8, 8)
+      bounds: 496 256 8 8
+    - image: solid-color(63, 32, 0, 255, 8, 8)
+      bounds: 504 256 8 8
+    - image: solid-color(64, 32, 0, 255, 8, 8)
+      bounds: 512 256 8 8
+    - image: solid-color(65, 32, 0, 255, 8, 8)
+      bounds: 520 256 8 8
+    - image: solid-color(66, 32, 0, 255, 8, 8)
+      bounds: 528 256 8 8
+    - image: solid-color(67, 32, 0, 255, 8, 8)
+      bounds: 536 256 8 8
+    - image: solid-color(68, 32, 0, 255, 8, 8)
+      bounds: 544 256 8 8
+    - image: solid-color(69, 32, 0, 255, 8, 8)
+      bounds: 552 256 8 8
+    - image: solid-color(70, 32, 0, 255, 8, 8)
+      bounds: 560 256 8 8
+    - image: solid-color(71, 32, 0, 255, 8, 8)
+      bounds: 568 256 8 8
+    - image: solid-color(72, 32, 0, 255, 8, 8)
+      bounds: 576 256 8 8
+    - image: solid-color(73, 32, 0, 255, 8, 8)
+      bounds: 584 256 8 8
+    - image: solid-color(74, 32, 0, 255, 8, 8)
+      bounds: 592 256 8 8
+    - image: solid-color(75, 32, 0, 255, 8, 8)
+      bounds: 600 256 8 8
+    - image: solid-color(76, 32, 0, 255, 8, 8)
+      bounds: 608 256 8 8
+    - image: solid-color(77, 32, 0, 255, 8, 8)
+      bounds: 616 256 8 8
+    - image: solid-color(78, 32, 0, 255, 8, 8)
+      bounds: 624 256 8 8
+    - image: solid-color(79, 32, 0, 255, 8, 8)
+      bounds: 632 256 8 8
+    - image: solid-color(80, 32, 0, 255, 8, 8)
+      bounds: 640 256 8 8
+    - image: solid-color(81, 32, 0, 255, 8, 8)
+      bounds: 648 256 8 8
+    - image: solid-color(82, 32, 0, 255, 8, 8)
+      bounds: 656 256 8 8
+    - image: solid-color(83, 32, 0, 255, 8, 8)
+      bounds: 664 256 8 8
+    - image: solid-color(84, 32, 0, 255, 8, 8)
+      bounds: 672 256 8 8
+    - image: solid-color(85, 32, 0, 255, 8, 8)
+      bounds: 680 256 8 8
+    - image: solid-color(86, 32, 0, 255, 8, 8)
+      bounds: 688 256 8 8
+    - image: solid-color(87, 32, 0, 255, 8, 8)
+      bounds: 696 256 8 8
+    - image: solid-color(88, 32, 0, 255, 8, 8)
+      bounds: 704 256 8 8
+    - image: solid-color(89, 32, 0, 255, 8, 8)
+      bounds: 712 256 8 8
+    - image: solid-color(90, 32, 0, 255, 8, 8)
+      bounds: 720 256 8 8
+    - image: solid-color(91, 32, 0, 255, 8, 8)
+      bounds: 728 256 8 8
+    - image: solid-color(92, 32, 0, 255, 8, 8)
+      bounds: 736 256 8 8
+    - image: solid-color(93, 32, 0, 255, 8, 8)
+      bounds: 744 256 8 8
+    - image: solid-color(94, 32, 0, 255, 8, 8)
+      bounds: 752 256 8 8
+    - image: solid-color(95, 32, 0, 255, 8, 8)
+      bounds: 760 256 8 8
+    - image: solid-color(96, 32, 0, 255, 8, 8)
+      bounds: 768 256 8 8
+    - image: solid-color(97, 32, 0, 255, 8, 8)
+      bounds: 776 256 8 8
+    - image: solid-color(98, 32, 0, 255, 8, 8)
+      bounds: 784 256 8 8
+    - image: solid-color(99, 32, 0, 255, 8, 8)
+      bounds: 792 256 8 8
+    - image: solid-color(100, 32, 0, 255, 8, 8)
+      bounds: 800 256 8 8
+    - image: solid-color(101, 32, 0, 255, 8, 8)
+      bounds: 808 256 8 8
+    - image: solid-color(102, 32, 0, 255, 8, 8)
+      bounds: 816 256 8 8
+    - image: solid-color(103, 32, 0, 255, 8, 8)
+      bounds: 824 256 8 8
+    - image: solid-color(104, 32, 0, 255, 8, 8)
+      bounds: 832 256 8 8
+    - image: solid-color(105, 32, 0, 255, 8, 8)
+      bounds: 840 256 8 8
+    - image: solid-color(106, 32, 0, 255, 8, 8)
+      bounds: 848 256 8 8
+    - image: solid-color(107, 32, 0, 255, 8, 8)
+      bounds: 856 256 8 8
+    - image: solid-color(108, 32, 0, 255, 8, 8)
+      bounds: 864 256 8 8
+    - image: solid-color(109, 32, 0, 255, 8, 8)
+      bounds: 872 256 8 8
+    - image: solid-color(110, 32, 0, 255, 8, 8)
+      bounds: 880 256 8 8
+    - image: solid-color(111, 32, 0, 255, 8, 8)
+      bounds: 888 256 8 8
+    - image: solid-color(112, 32, 0, 255, 8, 8)
+      bounds: 896 256 8 8
+    - image: solid-color(113, 32, 0, 255, 8, 8)
+      bounds: 904 256 8 8
+    - image: solid-color(114, 32, 0, 255, 8, 8)
+      bounds: 912 256 8 8
+    - image: solid-color(115, 32, 0, 255, 8, 8)
+      bounds: 920 256 8 8
+    - image: solid-color(116, 32, 0, 255, 8, 8)
+      bounds: 928 256 8 8
+    - image: solid-color(117, 32, 0, 255, 8, 8)
+      bounds: 936 256 8 8
+    - image: solid-color(118, 32, 0, 255, 8, 8)
+      bounds: 944 256 8 8
+    - image: solid-color(119, 32, 0, 255, 8, 8)
+      bounds: 952 256 8 8
+    - image: solid-color(120, 32, 0, 255, 8, 8)
+      bounds: 960 256 8 8
+    - image: solid-color(121, 32, 0, 255, 8, 8)
+      bounds: 968 256 8 8
+    - image: solid-color(122, 32, 0, 255, 8, 8)
+      bounds: 976 256 8 8
+    - image: solid-color(123, 32, 0, 255, 8, 8)
+      bounds: 984 256 8 8
+    - image: solid-color(124, 32, 0, 255, 8, 8)
+      bounds: 992 256 8 8
+    - image: solid-color(125, 32, 0, 255, 8, 8)
+      bounds: 1000 256 8 8
+    - image: solid-color(126, 32, 0, 255, 8, 8)
+      bounds: 1008 256 8 8
+    - image: solid-color(127, 32, 0, 255, 8, 8)
+      bounds: 1016 256 8 8
+    - image: solid-color(0, 33, 0, 255, 8, 8)
+      bounds: 0 264 8 8
+    - image: solid-color(1, 33, 0, 255, 8, 8)
+      bounds: 8 264 8 8
+    - image: solid-color(2, 33, 0, 255, 8, 8)
+      bounds: 16 264 8 8
+    - image: solid-color(3, 33, 0, 255, 8, 8)
+      bounds: 24 264 8 8
+    - image: solid-color(4, 33, 0, 255, 8, 8)
+      bounds: 32 264 8 8
+    - image: solid-color(5, 33, 0, 255, 8, 8)
+      bounds: 40 264 8 8
+    - image: solid-color(6, 33, 0, 255, 8, 8)
+      bounds: 48 264 8 8
+    - image: solid-color(7, 33, 0, 255, 8, 8)
+      bounds: 56 264 8 8
+    - image: solid-color(8, 33, 0, 255, 8, 8)
+      bounds: 64 264 8 8
+    - image: solid-color(9, 33, 0, 255, 8, 8)
+      bounds: 72 264 8 8
+    - image: solid-color(10, 33, 0, 255, 8, 8)
+      bounds: 80 264 8 8
+    - image: solid-color(11, 33, 0, 255, 8, 8)
+      bounds: 88 264 8 8
+    - image: solid-color(12, 33, 0, 255, 8, 8)
+      bounds: 96 264 8 8
+    - image: solid-color(13, 33, 0, 255, 8, 8)
+      bounds: 104 264 8 8
+    - image: solid-color(14, 33, 0, 255, 8, 8)
+      bounds: 112 264 8 8
+    - image: solid-color(15, 33, 0, 255, 8, 8)
+      bounds: 120 264 8 8
+    - image: solid-color(16, 33, 0, 255, 8, 8)
+      bounds: 128 264 8 8
+    - image: solid-color(17, 33, 0, 255, 8, 8)
+      bounds: 136 264 8 8
+    - image: solid-color(18, 33, 0, 255, 8, 8)
+      bounds: 144 264 8 8
+    - image: solid-color(19, 33, 0, 255, 8, 8)
+      bounds: 152 264 8 8
+    - image: solid-color(20, 33, 0, 255, 8, 8)
+      bounds: 160 264 8 8
+    - image: solid-color(21, 33, 0, 255, 8, 8)
+      bounds: 168 264 8 8
+    - image: solid-color(22, 33, 0, 255, 8, 8)
+      bounds: 176 264 8 8
+    - image: solid-color(23, 33, 0, 255, 8, 8)
+      bounds: 184 264 8 8
+    - image: solid-color(24, 33, 0, 255, 8, 8)
+      bounds: 192 264 8 8
+    - image: solid-color(25, 33, 0, 255, 8, 8)
+      bounds: 200 264 8 8
+    - image: solid-color(26, 33, 0, 255, 8, 8)
+      bounds: 208 264 8 8
+    - image: solid-color(27, 33, 0, 255, 8, 8)
+      bounds: 216 264 8 8
+    - image: solid-color(28, 33, 0, 255, 8, 8)
+      bounds: 224 264 8 8
+    - image: solid-color(29, 33, 0, 255, 8, 8)
+      bounds: 232 264 8 8
+    - image: solid-color(30, 33, 0, 255, 8, 8)
+      bounds: 240 264 8 8
+    - image: solid-color(31, 33, 0, 255, 8, 8)
+      bounds: 248 264 8 8
+    - image: solid-color(32, 33, 0, 255, 8, 8)
+      bounds: 256 264 8 8
+    - image: solid-color(33, 33, 0, 255, 8, 8)
+      bounds: 264 264 8 8
+    - image: solid-color(34, 33, 0, 255, 8, 8)
+      bounds: 272 264 8 8
+    - image: solid-color(35, 33, 0, 255, 8, 8)
+      bounds: 280 264 8 8
+    - image: solid-color(36, 33, 0, 255, 8, 8)
+      bounds: 288 264 8 8
+    - image: solid-color(37, 33, 0, 255, 8, 8)
+      bounds: 296 264 8 8
+    - image: solid-color(38, 33, 0, 255, 8, 8)
+      bounds: 304 264 8 8
+    - image: solid-color(39, 33, 0, 255, 8, 8)
+      bounds: 312 264 8 8
+    - image: solid-color(40, 33, 0, 255, 8, 8)
+      bounds: 320 264 8 8
+    - image: solid-color(41, 33, 0, 255, 8, 8)
+      bounds: 328 264 8 8
+    - image: solid-color(42, 33, 0, 255, 8, 8)
+      bounds: 336 264 8 8
+    - image: solid-color(43, 33, 0, 255, 8, 8)
+      bounds: 344 264 8 8
+    - image: solid-color(44, 33, 0, 255, 8, 8)
+      bounds: 352 264 8 8
+    - image: solid-color(45, 33, 0, 255, 8, 8)
+      bounds: 360 264 8 8
+    - image: solid-color(46, 33, 0, 255, 8, 8)
+      bounds: 368 264 8 8
+    - image: solid-color(47, 33, 0, 255, 8, 8)
+      bounds: 376 264 8 8
+    - image: solid-color(48, 33, 0, 255, 8, 8)
+      bounds: 384 264 8 8
+    - image: solid-color(49, 33, 0, 255, 8, 8)
+      bounds: 392 264 8 8
+    - image: solid-color(50, 33, 0, 255, 8, 8)
+      bounds: 400 264 8 8
+    - image: solid-color(51, 33, 0, 255, 8, 8)
+      bounds: 408 264 8 8
+    - image: solid-color(52, 33, 0, 255, 8, 8)
+      bounds: 416 264 8 8
+    - image: solid-color(53, 33, 0, 255, 8, 8)
+      bounds: 424 264 8 8
+    - image: solid-color(54, 33, 0, 255, 8, 8)
+      bounds: 432 264 8 8
+    - image: solid-color(55, 33, 0, 255, 8, 8)
+      bounds: 440 264 8 8
+    - image: solid-color(56, 33, 0, 255, 8, 8)
+      bounds: 448 264 8 8
+    - image: solid-color(57, 33, 0, 255, 8, 8)
+      bounds: 456 264 8 8
+    - image: solid-color(58, 33, 0, 255, 8, 8)
+      bounds: 464 264 8 8
+    - image: solid-color(59, 33, 0, 255, 8, 8)
+      bounds: 472 264 8 8
+    - image: solid-color(60, 33, 0, 255, 8, 8)
+      bounds: 480 264 8 8
+    - image: solid-color(61, 33, 0, 255, 8, 8)
+      bounds: 488 264 8 8
+    - image: solid-color(62, 33, 0, 255, 8, 8)
+      bounds: 496 264 8 8
+    - image: solid-color(63, 33, 0, 255, 8, 8)
+      bounds: 504 264 8 8
+    - image: solid-color(64, 33, 0, 255, 8, 8)
+      bounds: 512 264 8 8
+    - image: solid-color(65, 33, 0, 255, 8, 8)
+      bounds: 520 264 8 8
+    - image: solid-color(66, 33, 0, 255, 8, 8)
+      bounds: 528 264 8 8
+    - image: solid-color(67, 33, 0, 255, 8, 8)
+      bounds: 536 264 8 8
+    - image: solid-color(68, 33, 0, 255, 8, 8)
+      bounds: 544 264 8 8
+    - image: solid-color(69, 33, 0, 255, 8, 8)
+      bounds: 552 264 8 8
+    - image: solid-color(70, 33, 0, 255, 8, 8)
+      bounds: 560 264 8 8
+    - image: solid-color(71, 33, 0, 255, 8, 8)
+      bounds: 568 264 8 8
+    - image: solid-color(72, 33, 0, 255, 8, 8)
+      bounds: 576 264 8 8
+    - image: solid-color(73, 33, 0, 255, 8, 8)
+      bounds: 584 264 8 8
+    - image: solid-color(74, 33, 0, 255, 8, 8)
+      bounds: 592 264 8 8
+    - image: solid-color(75, 33, 0, 255, 8, 8)
+      bounds: 600 264 8 8
+    - image: solid-color(76, 33, 0, 255, 8, 8)
+      bounds: 608 264 8 8
+    - image: solid-color(77, 33, 0, 255, 8, 8)
+      bounds: 616 264 8 8
+    - image: solid-color(78, 33, 0, 255, 8, 8)
+      bounds: 624 264 8 8
+    - image: solid-color(79, 33, 0, 255, 8, 8)
+      bounds: 632 264 8 8
+    - image: solid-color(80, 33, 0, 255, 8, 8)
+      bounds: 640 264 8 8
+    - image: solid-color(81, 33, 0, 255, 8, 8)
+      bounds: 648 264 8 8
+    - image: solid-color(82, 33, 0, 255, 8, 8)
+      bounds: 656 264 8 8
+    - image: solid-color(83, 33, 0, 255, 8, 8)
+      bounds: 664 264 8 8
+    - image: solid-color(84, 33, 0, 255, 8, 8)
+      bounds: 672 264 8 8
+    - image: solid-color(85, 33, 0, 255, 8, 8)
+      bounds: 680 264 8 8
+    - image: solid-color(86, 33, 0, 255, 8, 8)
+      bounds: 688 264 8 8
+    - image: solid-color(87, 33, 0, 255, 8, 8)
+      bounds: 696 264 8 8
+    - image: solid-color(88, 33, 0, 255, 8, 8)
+      bounds: 704 264 8 8
+    - image: solid-color(89, 33, 0, 255, 8, 8)
+      bounds: 712 264 8 8
+    - image: solid-color(90, 33, 0, 255, 8, 8)
+      bounds: 720 264 8 8
+    - image: solid-color(91, 33, 0, 255, 8, 8)
+      bounds: 728 264 8 8
+    - image: solid-color(92, 33, 0, 255, 8, 8)
+      bounds: 736 264 8 8
+    - image: solid-color(93, 33, 0, 255, 8, 8)
+      bounds: 744 264 8 8
+    - image: solid-color(94, 33, 0, 255, 8, 8)
+      bounds: 752 264 8 8
+    - image: solid-color(95, 33, 0, 255, 8, 8)
+      bounds: 760 264 8 8
+    - image: solid-color(96, 33, 0, 255, 8, 8)
+      bounds: 768 264 8 8
+    - image: solid-color(97, 33, 0, 255, 8, 8)
+      bounds: 776 264 8 8
+    - image: solid-color(98, 33, 0, 255, 8, 8)
+      bounds: 784 264 8 8
+    - image: solid-color(99, 33, 0, 255, 8, 8)
+      bounds: 792 264 8 8
+    - image: solid-color(100, 33, 0, 255, 8, 8)
+      bounds: 800 264 8 8
+    - image: solid-color(101, 33, 0, 255, 8, 8)
+      bounds: 808 264 8 8
+    - image: solid-color(102, 33, 0, 255, 8, 8)
+      bounds: 816 264 8 8
+    - image: solid-color(103, 33, 0, 255, 8, 8)
+      bounds: 824 264 8 8
+    - image: solid-color(104, 33, 0, 255, 8, 8)
+      bounds: 832 264 8 8
+    - image: solid-color(105, 33, 0, 255, 8, 8)
+      bounds: 840 264 8 8
+    - image: solid-color(106, 33, 0, 255, 8, 8)
+      bounds: 848 264 8 8
+    - image: solid-color(107, 33, 0, 255, 8, 8)
+      bounds: 856 264 8 8
+    - image: solid-color(108, 33, 0, 255, 8, 8)
+      bounds: 864 264 8 8
+    - image: solid-color(109, 33, 0, 255, 8, 8)
+      bounds: 872 264 8 8
+    - image: solid-color(110, 33, 0, 255, 8, 8)
+      bounds: 880 264 8 8
+    - image: solid-color(111, 33, 0, 255, 8, 8)
+      bounds: 888 264 8 8
+    - image: solid-color(112, 33, 0, 255, 8, 8)
+      bounds: 896 264 8 8
+    - image: solid-color(113, 33, 0, 255, 8, 8)
+      bounds: 904 264 8 8
+    - image: solid-color(114, 33, 0, 255, 8, 8)
+      bounds: 912 264 8 8
+    - image: solid-color(115, 33, 0, 255, 8, 8)
+      bounds: 920 264 8 8
+    - image: solid-color(116, 33, 0, 255, 8, 8)
+      bounds: 928 264 8 8
+    - image: solid-color(117, 33, 0, 255, 8, 8)
+      bounds: 936 264 8 8
+    - image: solid-color(118, 33, 0, 255, 8, 8)
+      bounds: 944 264 8 8
+    - image: solid-color(119, 33, 0, 255, 8, 8)
+      bounds: 952 264 8 8
+    - image: solid-color(120, 33, 0, 255, 8, 8)
+      bounds: 960 264 8 8
+    - image: solid-color(121, 33, 0, 255, 8, 8)
+      bounds: 968 264 8 8
+    - image: solid-color(122, 33, 0, 255, 8, 8)
+      bounds: 976 264 8 8
+    - image: solid-color(123, 33, 0, 255, 8, 8)
+      bounds: 984 264 8 8
+    - image: solid-color(124, 33, 0, 255, 8, 8)
+      bounds: 992 264 8 8
+    - image: solid-color(125, 33, 0, 255, 8, 8)
+      bounds: 1000 264 8 8
+    - image: solid-color(126, 33, 0, 255, 8, 8)
+      bounds: 1008 264 8 8
+    - image: solid-color(127, 33, 0, 255, 8, 8)
+      bounds: 1016 264 8 8
+    - image: solid-color(0, 34, 0, 255, 8, 8)
+      bounds: 0 272 8 8
+    - image: solid-color(1, 34, 0, 255, 8, 8)
+      bounds: 8 272 8 8
+    - image: solid-color(2, 34, 0, 255, 8, 8)
+      bounds: 16 272 8 8
+    - image: solid-color(3, 34, 0, 255, 8, 8)
+      bounds: 24 272 8 8
+    - image: solid-color(4, 34, 0, 255, 8, 8)
+      bounds: 32 272 8 8
+    - image: solid-color(5, 34, 0, 255, 8, 8)
+      bounds: 40 272 8 8
+    - image: solid-color(6, 34, 0, 255, 8, 8)
+      bounds: 48 272 8 8
+    - image: solid-color(7, 34, 0, 255, 8, 8)
+      bounds: 56 272 8 8
+    - image: solid-color(8, 34, 0, 255, 8, 8)
+      bounds: 64 272 8 8
+    - image: solid-color(9, 34, 0, 255, 8, 8)
+      bounds: 72 272 8 8
+    - image: solid-color(10, 34, 0, 255, 8, 8)
+      bounds: 80 272 8 8
+    - image: solid-color(11, 34, 0, 255, 8, 8)
+      bounds: 88 272 8 8
+    - image: solid-color(12, 34, 0, 255, 8, 8)
+      bounds: 96 272 8 8
+    - image: solid-color(13, 34, 0, 255, 8, 8)
+      bounds: 104 272 8 8
+    - image: solid-color(14, 34, 0, 255, 8, 8)
+      bounds: 112 272 8 8
+    - image: solid-color(15, 34, 0, 255, 8, 8)
+      bounds: 120 272 8 8
+    - image: solid-color(16, 34, 0, 255, 8, 8)
+      bounds: 128 272 8 8
+    - image: solid-color(17, 34, 0, 255, 8, 8)
+      bounds: 136 272 8 8
+    - image: solid-color(18, 34, 0, 255, 8, 8)
+      bounds: 144 272 8 8
+    - image: solid-color(19, 34, 0, 255, 8, 8)
+      bounds: 152 272 8 8
+    - image: solid-color(20, 34, 0, 255, 8, 8)
+      bounds: 160 272 8 8
+    - image: solid-color(21, 34, 0, 255, 8, 8)
+      bounds: 168 272 8 8
+    - image: solid-color(22, 34, 0, 255, 8, 8)
+      bounds: 176 272 8 8
+    - image: solid-color(23, 34, 0, 255, 8, 8)
+      bounds: 184 272 8 8
+    - image: solid-color(24, 34, 0, 255, 8, 8)
+      bounds: 192 272 8 8
+    - image: solid-color(25, 34, 0, 255, 8, 8)
+      bounds: 200 272 8 8
+    - image: solid-color(26, 34, 0, 255, 8, 8)
+      bounds: 208 272 8 8
+    - image: solid-color(27, 34, 0, 255, 8, 8)
+      bounds: 216 272 8 8
+    - image: solid-color(28, 34, 0, 255, 8, 8)
+      bounds: 224 272 8 8
+    - image: solid-color(29, 34, 0, 255, 8, 8)
+      bounds: 232 272 8 8
+    - image: solid-color(30, 34, 0, 255, 8, 8)
+      bounds: 240 272 8 8
+    - image: solid-color(31, 34, 0, 255, 8, 8)
+      bounds: 248 272 8 8
+    - image: solid-color(32, 34, 0, 255, 8, 8)
+      bounds: 256 272 8 8
+    - image: solid-color(33, 34, 0, 255, 8, 8)
+      bounds: 264 272 8 8
+    - image: solid-color(34, 34, 0, 255, 8, 8)
+      bounds: 272 272 8 8
+    - image: solid-color(35, 34, 0, 255, 8, 8)
+      bounds: 280 272 8 8
+    - image: solid-color(36, 34, 0, 255, 8, 8)
+      bounds: 288 272 8 8
+    - image: solid-color(37, 34, 0, 255, 8, 8)
+      bounds: 296 272 8 8
+    - image: solid-color(38, 34, 0, 255, 8, 8)
+      bounds: 304 272 8 8
+    - image: solid-color(39, 34, 0, 255, 8, 8)
+      bounds: 312 272 8 8
+    - image: solid-color(40, 34, 0, 255, 8, 8)
+      bounds: 320 272 8 8
+    - image: solid-color(41, 34, 0, 255, 8, 8)
+      bounds: 328 272 8 8
+    - image: solid-color(42, 34, 0, 255, 8, 8)
+      bounds: 336 272 8 8
+    - image: solid-color(43, 34, 0, 255, 8, 8)
+      bounds: 344 272 8 8
+    - image: solid-color(44, 34, 0, 255, 8, 8)
+      bounds: 352 272 8 8
+    - image: solid-color(45, 34, 0, 255, 8, 8)
+      bounds: 360 272 8 8
+    - image: solid-color(46, 34, 0, 255, 8, 8)
+      bounds: 368 272 8 8
+    - image: solid-color(47, 34, 0, 255, 8, 8)
+      bounds: 376 272 8 8
+    - image: solid-color(48, 34, 0, 255, 8, 8)
+      bounds: 384 272 8 8
+    - image: solid-color(49, 34, 0, 255, 8, 8)
+      bounds: 392 272 8 8
+    - image: solid-color(50, 34, 0, 255, 8, 8)
+      bounds: 400 272 8 8
+    - image: solid-color(51, 34, 0, 255, 8, 8)
+      bounds: 408 272 8 8
+    - image: solid-color(52, 34, 0, 255, 8, 8)
+      bounds: 416 272 8 8
+    - image: solid-color(53, 34, 0, 255, 8, 8)
+      bounds: 424 272 8 8
+    - image: solid-color(54, 34, 0, 255, 8, 8)
+      bounds: 432 272 8 8
+    - image: solid-color(55, 34, 0, 255, 8, 8)
+      bounds: 440 272 8 8
+    - image: solid-color(56, 34, 0, 255, 8, 8)
+      bounds: 448 272 8 8
+    - image: solid-color(57, 34, 0, 255, 8, 8)
+      bounds: 456 272 8 8
+    - image: solid-color(58, 34, 0, 255, 8, 8)
+      bounds: 464 272 8 8
+    - image: solid-color(59, 34, 0, 255, 8, 8)
+      bounds: 472 272 8 8
+    - image: solid-color(60, 34, 0, 255, 8, 8)
+      bounds: 480 272 8 8
+    - image: solid-color(61, 34, 0, 255, 8, 8)
+      bounds: 488 272 8 8
+    - image: solid-color(62, 34, 0, 255, 8, 8)
+      bounds: 496 272 8 8
+    - image: solid-color(63, 34, 0, 255, 8, 8)
+      bounds: 504 272 8 8
+    - image: solid-color(64, 34, 0, 255, 8, 8)
+      bounds: 512 272 8 8
+    - image: solid-color(65, 34, 0, 255, 8, 8)
+      bounds: 520 272 8 8
+    - image: solid-color(66, 34, 0, 255, 8, 8)
+      bounds: 528 272 8 8
+    - image: solid-color(67, 34, 0, 255, 8, 8)
+      bounds: 536 272 8 8
+    - image: solid-color(68, 34, 0, 255, 8, 8)
+      bounds: 544 272 8 8
+    - image: solid-color(69, 34, 0, 255, 8, 8)
+      bounds: 552 272 8 8
+    - image: solid-color(70, 34, 0, 255, 8, 8)
+      bounds: 560 272 8 8
+    - image: solid-color(71, 34, 0, 255, 8, 8)
+      bounds: 568 272 8 8
+    - image: solid-color(72, 34, 0, 255, 8, 8)
+      bounds: 576 272 8 8
+    - image: solid-color(73, 34, 0, 255, 8, 8)
+      bounds: 584 272 8 8
+    - image: solid-color(74, 34, 0, 255, 8, 8)
+      bounds: 592 272 8 8
+    - image: solid-color(75, 34, 0, 255, 8, 8)
+      bounds: 600 272 8 8
+    - image: solid-color(76, 34, 0, 255, 8, 8)
+      bounds: 608 272 8 8
+    - image: solid-color(77, 34, 0, 255, 8, 8)
+      bounds: 616 272 8 8
+    - image: solid-color(78, 34, 0, 255, 8, 8)
+      bounds: 624 272 8 8
+    - image: solid-color(79, 34, 0, 255, 8, 8)
+      bounds: 632 272 8 8
+    - image: solid-color(80, 34, 0, 255, 8, 8)
+      bounds: 640 272 8 8
+    - image: solid-color(81, 34, 0, 255, 8, 8)
+      bounds: 648 272 8 8
+    - image: solid-color(82, 34, 0, 255, 8, 8)
+      bounds: 656 272 8 8
+    - image: solid-color(83, 34, 0, 255, 8, 8)
+      bounds: 664 272 8 8
+    - image: solid-color(84, 34, 0, 255, 8, 8)
+      bounds: 672 272 8 8
+    - image: solid-color(85, 34, 0, 255, 8, 8)
+      bounds: 680 272 8 8
+    - image: solid-color(86, 34, 0, 255, 8, 8)
+      bounds: 688 272 8 8
+    - image: solid-color(87, 34, 0, 255, 8, 8)
+      bounds: 696 272 8 8
+    - image: solid-color(88, 34, 0, 255, 8, 8)
+      bounds: 704 272 8 8
+    - image: solid-color(89, 34, 0, 255, 8, 8)
+      bounds: 712 272 8 8
+    - image: solid-color(90, 34, 0, 255, 8, 8)
+      bounds: 720 272 8 8
+    - image: solid-color(91, 34, 0, 255, 8, 8)
+      bounds: 728 272 8 8
+    - image: solid-color(92, 34, 0, 255, 8, 8)
+      bounds: 736 272 8 8
+    - image: solid-color(93, 34, 0, 255, 8, 8)
+      bounds: 744 272 8 8
+    - image: solid-color(94, 34, 0, 255, 8, 8)
+      bounds: 752 272 8 8
+    - image: solid-color(95, 34, 0, 255, 8, 8)
+      bounds: 760 272 8 8
+    - image: solid-color(96, 34, 0, 255, 8, 8)
+      bounds: 768 272 8 8
+    - image: solid-color(97, 34, 0, 255, 8, 8)
+      bounds: 776 272 8 8
+    - image: solid-color(98, 34, 0, 255, 8, 8)
+      bounds: 784 272 8 8
+    - image: solid-color(99, 34, 0, 255, 8, 8)
+      bounds: 792 272 8 8
+    - image: solid-color(100, 34, 0, 255, 8, 8)
+      bounds: 800 272 8 8
+    - image: solid-color(101, 34, 0, 255, 8, 8)
+      bounds: 808 272 8 8
+    - image: solid-color(102, 34, 0, 255, 8, 8)
+      bounds: 816 272 8 8
+    - image: solid-color(103, 34, 0, 255, 8, 8)
+      bounds: 824 272 8 8
+    - image: solid-color(104, 34, 0, 255, 8, 8)
+      bounds: 832 272 8 8
+    - image: solid-color(105, 34, 0, 255, 8, 8)
+      bounds: 840 272 8 8
+    - image: solid-color(106, 34, 0, 255, 8, 8)
+      bounds: 848 272 8 8
+    - image: solid-color(107, 34, 0, 255, 8, 8)
+      bounds: 856 272 8 8
+    - image: solid-color(108, 34, 0, 255, 8, 8)
+      bounds: 864 272 8 8
+    - image: solid-color(109, 34, 0, 255, 8, 8)
+      bounds: 872 272 8 8
+    - image: solid-color(110, 34, 0, 255, 8, 8)
+      bounds: 880 272 8 8
+    - image: solid-color(111, 34, 0, 255, 8, 8)
+      bounds: 888 272 8 8
+    - image: solid-color(112, 34, 0, 255, 8, 8)
+      bounds: 896 272 8 8
+    - image: solid-color(113, 34, 0, 255, 8, 8)
+      bounds: 904 272 8 8
+    - image: solid-color(114, 34, 0, 255, 8, 8)
+      bounds: 912 272 8 8
+    - image: solid-color(115, 34, 0, 255, 8, 8)
+      bounds: 920 272 8 8
+    - image: solid-color(116, 34, 0, 255, 8, 8)
+      bounds: 928 272 8 8
+    - image: solid-color(117, 34, 0, 255, 8, 8)
+      bounds: 936 272 8 8
+    - image: solid-color(118, 34, 0, 255, 8, 8)
+      bounds: 944 272 8 8
+    - image: solid-color(119, 34, 0, 255, 8, 8)
+      bounds: 952 272 8 8
+    - image: solid-color(120, 34, 0, 255, 8, 8)
+      bounds: 960 272 8 8
+    - image: solid-color(121, 34, 0, 255, 8, 8)
+      bounds: 968 272 8 8
+    - image: solid-color(122, 34, 0, 255, 8, 8)
+      bounds: 976 272 8 8
+    - image: solid-color(123, 34, 0, 255, 8, 8)
+      bounds: 984 272 8 8
+    - image: solid-color(124, 34, 0, 255, 8, 8)
+      bounds: 992 272 8 8
+    - image: solid-color(125, 34, 0, 255, 8, 8)
+      bounds: 1000 272 8 8
+    - image: solid-color(126, 34, 0, 255, 8, 8)
+      bounds: 1008 272 8 8
+    - image: solid-color(127, 34, 0, 255, 8, 8)
+      bounds: 1016 272 8 8
+    - image: solid-color(0, 35, 0, 255, 8, 8)
+      bounds: 0 280 8 8
+    - image: solid-color(1, 35, 0, 255, 8, 8)
+      bounds: 8 280 8 8
+    - image: solid-color(2, 35, 0, 255, 8, 8)
+      bounds: 16 280 8 8
+    - image: solid-color(3, 35, 0, 255, 8, 8)
+      bounds: 24 280 8 8
+    - image: solid-color(4, 35, 0, 255, 8, 8)
+      bounds: 32 280 8 8
+    - image: solid-color(5, 35, 0, 255, 8, 8)
+      bounds: 40 280 8 8
+    - image: solid-color(6, 35, 0, 255, 8, 8)
+      bounds: 48 280 8 8
+    - image: solid-color(7, 35, 0, 255, 8, 8)
+      bounds: 56 280 8 8
+    - image: solid-color(8, 35, 0, 255, 8, 8)
+      bounds: 64 280 8 8
+    - image: solid-color(9, 35, 0, 255, 8, 8)
+      bounds: 72 280 8 8
+    - image: solid-color(10, 35, 0, 255, 8, 8)
+      bounds: 80 280 8 8
+    - image: solid-color(11, 35, 0, 255, 8, 8)
+      bounds: 88 280 8 8
+    - image: solid-color(12, 35, 0, 255, 8, 8)
+      bounds: 96 280 8 8
+    - image: solid-color(13, 35, 0, 255, 8, 8)
+      bounds: 104 280 8 8
+    - image: solid-color(14, 35, 0, 255, 8, 8)
+      bounds: 112 280 8 8
+    - image: solid-color(15, 35, 0, 255, 8, 8)
+      bounds: 120 280 8 8
+    - image: solid-color(16, 35, 0, 255, 8, 8)
+      bounds: 128 280 8 8
+    - image: solid-color(17, 35, 0, 255, 8, 8)
+      bounds: 136 280 8 8
+    - image: solid-color(18, 35, 0, 255, 8, 8)
+      bounds: 144 280 8 8
+    - image: solid-color(19, 35, 0, 255, 8, 8)
+      bounds: 152 280 8 8
+    - image: solid-color(20, 35, 0, 255, 8, 8)
+      bounds: 160 280 8 8
+    - image: solid-color(21, 35, 0, 255, 8, 8)
+      bounds: 168 280 8 8
+    - image: solid-color(22, 35, 0, 255, 8, 8)
+      bounds: 176 280 8 8
+    - image: solid-color(23, 35, 0, 255, 8, 8)
+      bounds: 184 280 8 8
+    - image: solid-color(24, 35, 0, 255, 8, 8)
+      bounds: 192 280 8 8
+    - image: solid-color(25, 35, 0, 255, 8, 8)
+      bounds: 200 280 8 8
+    - image: solid-color(26, 35, 0, 255, 8, 8)
+      bounds: 208 280 8 8
+    - image: solid-color(27, 35, 0, 255, 8, 8)
+      bounds: 216 280 8 8
+    - image: solid-color(28, 35, 0, 255, 8, 8)
+      bounds: 224 280 8 8
+    - image: solid-color(29, 35, 0, 255, 8, 8)
+      bounds: 232 280 8 8
+    - image: solid-color(30, 35, 0, 255, 8, 8)
+      bounds: 240 280 8 8
+    - image: solid-color(31, 35, 0, 255, 8, 8)
+      bounds: 248 280 8 8
+    - image: solid-color(32, 35, 0, 255, 8, 8)
+      bounds: 256 280 8 8
+    - image: solid-color(33, 35, 0, 255, 8, 8)
+      bounds: 264 280 8 8
+    - image: solid-color(34, 35, 0, 255, 8, 8)
+      bounds: 272 280 8 8
+    - image: solid-color(35, 35, 0, 255, 8, 8)
+      bounds: 280 280 8 8
+    - image: solid-color(36, 35, 0, 255, 8, 8)
+      bounds: 288 280 8 8
+    - image: solid-color(37, 35, 0, 255, 8, 8)
+      bounds: 296 280 8 8
+    - image: solid-color(38, 35, 0, 255, 8, 8)
+      bounds: 304 280 8 8
+    - image: solid-color(39, 35, 0, 255, 8, 8)
+      bounds: 312 280 8 8
+    - image: solid-color(40, 35, 0, 255, 8, 8)
+      bounds: 320 280 8 8
+    - image: solid-color(41, 35, 0, 255, 8, 8)
+      bounds: 328 280 8 8
+    - image: solid-color(42, 35, 0, 255, 8, 8)
+      bounds: 336 280 8 8
+    - image: solid-color(43, 35, 0, 255, 8, 8)
+      bounds: 344 280 8 8
+    - image: solid-color(44, 35, 0, 255, 8, 8)
+      bounds: 352 280 8 8
+    - image: solid-color(45, 35, 0, 255, 8, 8)
+      bounds: 360 280 8 8
+    - image: solid-color(46, 35, 0, 255, 8, 8)
+      bounds: 368 280 8 8
+    - image: solid-color(47, 35, 0, 255, 8, 8)
+      bounds: 376 280 8 8
+    - image: solid-color(48, 35, 0, 255, 8, 8)
+      bounds: 384 280 8 8
+    - image: solid-color(49, 35, 0, 255, 8, 8)
+      bounds: 392 280 8 8
+    - image: solid-color(50, 35, 0, 255, 8, 8)
+      bounds: 400 280 8 8
+    - image: solid-color(51, 35, 0, 255, 8, 8)
+      bounds: 408 280 8 8
+    - image: solid-color(52, 35, 0, 255, 8, 8)
+      bounds: 416 280 8 8
+    - image: solid-color(53, 35, 0, 255, 8, 8)
+      bounds: 424 280 8 8
+    - image: solid-color(54, 35, 0, 255, 8, 8)
+      bounds: 432 280 8 8
+    - image: solid-color(55, 35, 0, 255, 8, 8)
+      bounds: 440 280 8 8
+    - image: solid-color(56, 35, 0, 255, 8, 8)
+      bounds: 448 280 8 8
+    - image: solid-color(57, 35, 0, 255, 8, 8)
+      bounds: 456 280 8 8
+    - image: solid-color(58, 35, 0, 255, 8, 8)
+      bounds: 464 280 8 8
+    - image: solid-color(59, 35, 0, 255, 8, 8)
+      bounds: 472 280 8 8
+    - image: solid-color(60, 35, 0, 255, 8, 8)
+      bounds: 480 280 8 8
+    - image: solid-color(61, 35, 0, 255, 8, 8)
+      bounds: 488 280 8 8
+    - image: solid-color(62, 35, 0, 255, 8, 8)
+      bounds: 496 280 8 8
+    - image: solid-color(63, 35, 0, 255, 8, 8)
+      bounds: 504 280 8 8
+    - image: solid-color(64, 35, 0, 255, 8, 8)
+      bounds: 512 280 8 8
+    - image: solid-color(65, 35, 0, 255, 8, 8)
+      bounds: 520 280 8 8
+    - image: solid-color(66, 35, 0, 255, 8, 8)
+      bounds: 528 280 8 8
+    - image: solid-color(67, 35, 0, 255, 8, 8)
+      bounds: 536 280 8 8
+    - image: solid-color(68, 35, 0, 255, 8, 8)
+      bounds: 544 280 8 8
+    - image: solid-color(69, 35, 0, 255, 8, 8)
+      bounds: 552 280 8 8
+    - image: solid-color(70, 35, 0, 255, 8, 8)
+      bounds: 560 280 8 8
+    - image: solid-color(71, 35, 0, 255, 8, 8)
+      bounds: 568 280 8 8
+    - image: solid-color(72, 35, 0, 255, 8, 8)
+      bounds: 576 280 8 8
+    - image: solid-color(73, 35, 0, 255, 8, 8)
+      bounds: 584 280 8 8
+    - image: solid-color(74, 35, 0, 255, 8, 8)
+      bounds: 592 280 8 8
+    - image: solid-color(75, 35, 0, 255, 8, 8)
+      bounds: 600 280 8 8
+    - image: solid-color(76, 35, 0, 255, 8, 8)
+      bounds: 608 280 8 8
+    - image: solid-color(77, 35, 0, 255, 8, 8)
+      bounds: 616 280 8 8
+    - image: solid-color(78, 35, 0, 255, 8, 8)
+      bounds: 624 280 8 8
+    - image: solid-color(79, 35, 0, 255, 8, 8)
+      bounds: 632 280 8 8
+    - image: solid-color(80, 35, 0, 255, 8, 8)
+      bounds: 640 280 8 8
+    - image: solid-color(81, 35, 0, 255, 8, 8)
+      bounds: 648 280 8 8
+    - image: solid-color(82, 35, 0, 255, 8, 8)
+      bounds: 656 280 8 8
+    - image: solid-color(83, 35, 0, 255, 8, 8)
+      bounds: 664 280 8 8
+    - image: solid-color(84, 35, 0, 255, 8, 8)
+      bounds: 672 280 8 8
+    - image: solid-color(85, 35, 0, 255, 8, 8)
+      bounds: 680 280 8 8
+    - image: solid-color(86, 35, 0, 255, 8, 8)
+      bounds: 688 280 8 8
+    - image: solid-color(87, 35, 0, 255, 8, 8)
+      bounds: 696 280 8 8
+    - image: solid-color(88, 35, 0, 255, 8, 8)
+      bounds: 704 280 8 8
+    - image: solid-color(89, 35, 0, 255, 8, 8)
+      bounds: 712 280 8 8
+    - image: solid-color(90, 35, 0, 255, 8, 8)
+      bounds: 720 280 8 8
+    - image: solid-color(91, 35, 0, 255, 8, 8)
+      bounds: 728 280 8 8
+    - image: solid-color(92, 35, 0, 255, 8, 8)
+      bounds: 736 280 8 8
+    - image: solid-color(93, 35, 0, 255, 8, 8)
+      bounds: 744 280 8 8
+    - image: solid-color(94, 35, 0, 255, 8, 8)
+      bounds: 752 280 8 8
+    - image: solid-color(95, 35, 0, 255, 8, 8)
+      bounds: 760 280 8 8
+    - image: solid-color(96, 35, 0, 255, 8, 8)
+      bounds: 768 280 8 8
+    - image: solid-color(97, 35, 0, 255, 8, 8)
+      bounds: 776 280 8 8
+    - image: solid-color(98, 35, 0, 255, 8, 8)
+      bounds: 784 280 8 8
+    - image: solid-color(99, 35, 0, 255, 8, 8)
+      bounds: 792 280 8 8
+    - image: solid-color(100, 35, 0, 255, 8, 8)
+      bounds: 800 280 8 8
+    - image: solid-color(101, 35, 0, 255, 8, 8)
+      bounds: 808 280 8 8
+    - image: solid-color(102, 35, 0, 255, 8, 8)
+      bounds: 816 280 8 8
+    - image: solid-color(103, 35, 0, 255, 8, 8)
+      bounds: 824 280 8 8
+    - image: solid-color(104, 35, 0, 255, 8, 8)
+      bounds: 832 280 8 8
+    - image: solid-color(105, 35, 0, 255, 8, 8)
+      bounds: 840 280 8 8
+    - image: solid-color(106, 35, 0, 255, 8, 8)
+      bounds: 848 280 8 8
+    - image: solid-color(107, 35, 0, 255, 8, 8)
+      bounds: 856 280 8 8
+    - image: solid-color(108, 35, 0, 255, 8, 8)
+      bounds: 864 280 8 8
+    - image: solid-color(109, 35, 0, 255, 8, 8)
+      bounds: 872 280 8 8
+    - image: solid-color(110, 35, 0, 255, 8, 8)
+      bounds: 880 280 8 8
+    - image: solid-color(111, 35, 0, 255, 8, 8)
+      bounds: 888 280 8 8
+    - image: solid-color(112, 35, 0, 255, 8, 8)
+      bounds: 896 280 8 8
+    - image: solid-color(113, 35, 0, 255, 8, 8)
+      bounds: 904 280 8 8
+    - image: solid-color(114, 35, 0, 255, 8, 8)
+      bounds: 912 280 8 8
+    - image: solid-color(115, 35, 0, 255, 8, 8)
+      bounds: 920 280 8 8
+    - image: solid-color(116, 35, 0, 255, 8, 8)
+      bounds: 928 280 8 8
+    - image: solid-color(117, 35, 0, 255, 8, 8)
+      bounds: 936 280 8 8
+    - image: solid-color(118, 35, 0, 255, 8, 8)
+      bounds: 944 280 8 8
+    - image: solid-color(119, 35, 0, 255, 8, 8)
+      bounds: 952 280 8 8
+    - image: solid-color(120, 35, 0, 255, 8, 8)
+      bounds: 960 280 8 8
+    - image: solid-color(121, 35, 0, 255, 8, 8)
+      bounds: 968 280 8 8
+    - image: solid-color(122, 35, 0, 255, 8, 8)
+      bounds: 976 280 8 8
+    - image: solid-color(123, 35, 0, 255, 8, 8)
+      bounds: 984 280 8 8
+    - image: solid-color(124, 35, 0, 255, 8, 8)
+      bounds: 992 280 8 8
+    - image: solid-color(125, 35, 0, 255, 8, 8)
+      bounds: 1000 280 8 8
+    - image: solid-color(126, 35, 0, 255, 8, 8)
+      bounds: 1008 280 8 8
+    - image: solid-color(127, 35, 0, 255, 8, 8)
+      bounds: 1016 280 8 8
+    - image: solid-color(0, 36, 0, 255, 8, 8)
+      bounds: 0 288 8 8
+    - image: solid-color(1, 36, 0, 255, 8, 8)
+      bounds: 8 288 8 8
+    - image: solid-color(2, 36, 0, 255, 8, 8)
+      bounds: 16 288 8 8
+    - image: solid-color(3, 36, 0, 255, 8, 8)
+      bounds: 24 288 8 8
+    - image: solid-color(4, 36, 0, 255, 8, 8)
+      bounds: 32 288 8 8
+    - image: solid-color(5, 36, 0, 255, 8, 8)
+      bounds: 40 288 8 8
+    - image: solid-color(6, 36, 0, 255, 8, 8)
+      bounds: 48 288 8 8
+    - image: solid-color(7, 36, 0, 255, 8, 8)
+      bounds: 56 288 8 8
+    - image: solid-color(8, 36, 0, 255, 8, 8)
+      bounds: 64 288 8 8
+    - image: solid-color(9, 36, 0, 255, 8, 8)
+      bounds: 72 288 8 8
+    - image: solid-color(10, 36, 0, 255, 8, 8)
+      bounds: 80 288 8 8
+    - image: solid-color(11, 36, 0, 255, 8, 8)
+      bounds: 88 288 8 8
+    - image: solid-color(12, 36, 0, 255, 8, 8)
+      bounds: 96 288 8 8
+    - image: solid-color(13, 36, 0, 255, 8, 8)
+      bounds: 104 288 8 8
+    - image: solid-color(14, 36, 0, 255, 8, 8)
+      bounds: 112 288 8 8
+    - image: solid-color(15, 36, 0, 255, 8, 8)
+      bounds: 120 288 8 8
+    - image: solid-color(16, 36, 0, 255, 8, 8)
+      bounds: 128 288 8 8
+    - image: solid-color(17, 36, 0, 255, 8, 8)
+      bounds: 136 288 8 8
+    - image: solid-color(18, 36, 0, 255, 8, 8)
+      bounds: 144 288 8 8
+    - image: solid-color(19, 36, 0, 255, 8, 8)
+      bounds: 152 288 8 8
+    - image: solid-color(20, 36, 0, 255, 8, 8)
+      bounds: 160 288 8 8
+    - image: solid-color(21, 36, 0, 255, 8, 8)
+      bounds: 168 288 8 8
+    - image: solid-color(22, 36, 0, 255, 8, 8)
+      bounds: 176 288 8 8
+    - image: solid-color(23, 36, 0, 255, 8, 8)
+      bounds: 184 288 8 8
+    - image: solid-color(24, 36, 0, 255, 8, 8)
+      bounds: 192 288 8 8
+    - image: solid-color(25, 36, 0, 255, 8, 8)
+      bounds: 200 288 8 8
+    - image: solid-color(26, 36, 0, 255, 8, 8)
+      bounds: 208 288 8 8
+    - image: solid-color(27, 36, 0, 255, 8, 8)
+      bounds: 216 288 8 8
+    - image: solid-color(28, 36, 0, 255, 8, 8)
+      bounds: 224 288 8 8
+    - image: solid-color(29, 36, 0, 255, 8, 8)
+      bounds: 232 288 8 8
+    - image: solid-color(30, 36, 0, 255, 8, 8)
+      bounds: 240 288 8 8
+    - image: solid-color(31, 36, 0, 255, 8, 8)
+      bounds: 248 288 8 8
+    - image: solid-color(32, 36, 0, 255, 8, 8)
+      bounds: 256 288 8 8
+    - image: solid-color(33, 36, 0, 255, 8, 8)
+      bounds: 264 288 8 8
+    - image: solid-color(34, 36, 0, 255, 8, 8)
+      bounds: 272 288 8 8
+    - image: solid-color(35, 36, 0, 255, 8, 8)
+      bounds: 280 288 8 8
+    - image: solid-color(36, 36, 0, 255, 8, 8)
+      bounds: 288 288 8 8
+    - image: solid-color(37, 36, 0, 255, 8, 8)
+      bounds: 296 288 8 8
+    - image: solid-color(38, 36, 0, 255, 8, 8)
+      bounds: 304 288 8 8
+    - image: solid-color(39, 36, 0, 255, 8, 8)
+      bounds: 312 288 8 8
+    - image: solid-color(40, 36, 0, 255, 8, 8)
+      bounds: 320 288 8 8
+    - image: solid-color(41, 36, 0, 255, 8, 8)
+      bounds: 328 288 8 8
+    - image: solid-color(42, 36, 0, 255, 8, 8)
+      bounds: 336 288 8 8
+    - image: solid-color(43, 36, 0, 255, 8, 8)
+      bounds: 344 288 8 8
+    - image: solid-color(44, 36, 0, 255, 8, 8)
+      bounds: 352 288 8 8
+    - image: solid-color(45, 36, 0, 255, 8, 8)
+      bounds: 360 288 8 8
+    - image: solid-color(46, 36, 0, 255, 8, 8)
+      bounds: 368 288 8 8
+    - image: solid-color(47, 36, 0, 255, 8, 8)
+      bounds: 376 288 8 8
+    - image: solid-color(48, 36, 0, 255, 8, 8)
+      bounds: 384 288 8 8
+    - image: solid-color(49, 36, 0, 255, 8, 8)
+      bounds: 392 288 8 8
+    - image: solid-color(50, 36, 0, 255, 8, 8)
+      bounds: 400 288 8 8
+    - image: solid-color(51, 36, 0, 255, 8, 8)
+      bounds: 408 288 8 8
+    - image: solid-color(52, 36, 0, 255, 8, 8)
+      bounds: 416 288 8 8
+    - image: solid-color(53, 36, 0, 255, 8, 8)
+      bounds: 424 288 8 8
+    - image: solid-color(54, 36, 0, 255, 8, 8)
+      bounds: 432 288 8 8
+    - image: solid-color(55, 36, 0, 255, 8, 8)
+      bounds: 440 288 8 8
+    - image: solid-color(56, 36, 0, 255, 8, 8)
+      bounds: 448 288 8 8
+    - image: solid-color(57, 36, 0, 255, 8, 8)
+      bounds: 456 288 8 8
+    - image: solid-color(58, 36, 0, 255, 8, 8)
+      bounds: 464 288 8 8
+    - image: solid-color(59, 36, 0, 255, 8, 8)
+      bounds: 472 288 8 8
+    - image: solid-color(60, 36, 0, 255, 8, 8)
+      bounds: 480 288 8 8
+    - image: solid-color(61, 36, 0, 255, 8, 8)
+      bounds: 488 288 8 8
+    - image: solid-color(62, 36, 0, 255, 8, 8)
+      bounds: 496 288 8 8
+    - image: solid-color(63, 36, 0, 255, 8, 8)
+      bounds: 504 288 8 8
+    - image: solid-color(64, 36, 0, 255, 8, 8)
+      bounds: 512 288 8 8
+    - image: solid-color(65, 36, 0, 255, 8, 8)
+      bounds: 520 288 8 8
+    - image: solid-color(66, 36, 0, 255, 8, 8)
+      bounds: 528 288 8 8
+    - image: solid-color(67, 36, 0, 255, 8, 8)
+      bounds: 536 288 8 8
+    - image: solid-color(68, 36, 0, 255, 8, 8)
+      bounds: 544 288 8 8
+    - image: solid-color(69, 36, 0, 255, 8, 8)
+      bounds: 552 288 8 8
+    - image: solid-color(70, 36, 0, 255, 8, 8)
+      bounds: 560 288 8 8
+    - image: solid-color(71, 36, 0, 255, 8, 8)
+      bounds: 568 288 8 8
+    - image: solid-color(72, 36, 0, 255, 8, 8)
+      bounds: 576 288 8 8
+    - image: solid-color(73, 36, 0, 255, 8, 8)
+      bounds: 584 288 8 8
+    - image: solid-color(74, 36, 0, 255, 8, 8)
+      bounds: 592 288 8 8
+    - image: solid-color(75, 36, 0, 255, 8, 8)
+      bounds: 600 288 8 8
+    - image: solid-color(76, 36, 0, 255, 8, 8)
+      bounds: 608 288 8 8
+    - image: solid-color(77, 36, 0, 255, 8, 8)
+      bounds: 616 288 8 8
+    - image: solid-color(78, 36, 0, 255, 8, 8)
+      bounds: 624 288 8 8
+    - image: solid-color(79, 36, 0, 255, 8, 8)
+      bounds: 632 288 8 8
+    - image: solid-color(80, 36, 0, 255, 8, 8)
+      bounds: 640 288 8 8
+    - image: solid-color(81, 36, 0, 255, 8, 8)
+      bounds: 648 288 8 8
+    - image: solid-color(82, 36, 0, 255, 8, 8)
+      bounds: 656 288 8 8
+    - image: solid-color(83, 36, 0, 255, 8, 8)
+      bounds: 664 288 8 8
+    - image: solid-color(84, 36, 0, 255, 8, 8)
+      bounds: 672 288 8 8
+    - image: solid-color(85, 36, 0, 255, 8, 8)
+      bounds: 680 288 8 8
+    - image: solid-color(86, 36, 0, 255, 8, 8)
+      bounds: 688 288 8 8
+    - image: solid-color(87, 36, 0, 255, 8, 8)
+      bounds: 696 288 8 8
+    - image: solid-color(88, 36, 0, 255, 8, 8)
+      bounds: 704 288 8 8
+    - image: solid-color(89, 36, 0, 255, 8, 8)
+      bounds: 712 288 8 8
+    - image: solid-color(90, 36, 0, 255, 8, 8)
+      bounds: 720 288 8 8
+    - image: solid-color(91, 36, 0, 255, 8, 8)
+      bounds: 728 288 8 8
+    - image: solid-color(92, 36, 0, 255, 8, 8)
+      bounds: 736 288 8 8
+    - image: solid-color(93, 36, 0, 255, 8, 8)
+      bounds: 744 288 8 8
+    - image: solid-color(94, 36, 0, 255, 8, 8)
+      bounds: 752 288 8 8
+    - image: solid-color(95, 36, 0, 255, 8, 8)
+      bounds: 760 288 8 8
+    - image: solid-color(96, 36, 0, 255, 8, 8)
+      bounds: 768 288 8 8
+    - image: solid-color(97, 36, 0, 255, 8, 8)
+      bounds: 776 288 8 8
+    - image: solid-color(98, 36, 0, 255, 8, 8)
+      bounds: 784 288 8 8
+    - image: solid-color(99, 36, 0, 255, 8, 8)
+      bounds: 792 288 8 8
+    - image: solid-color(100, 36, 0, 255, 8, 8)
+      bounds: 800 288 8 8
+    - image: solid-color(101, 36, 0, 255, 8, 8)
+      bounds: 808 288 8 8
+    - image: solid-color(102, 36, 0, 255, 8, 8)
+      bounds: 816 288 8 8
+    - image: solid-color(103, 36, 0, 255, 8, 8)
+      bounds: 824 288 8 8
+    - image: solid-color(104, 36, 0, 255, 8, 8)
+      bounds: 832 288 8 8
+    - image: solid-color(105, 36, 0, 255, 8, 8)
+      bounds: 840 288 8 8
+    - image: solid-color(106, 36, 0, 255, 8, 8)
+      bounds: 848 288 8 8
+    - image: solid-color(107, 36, 0, 255, 8, 8)
+      bounds: 856 288 8 8
+    - image: solid-color(108, 36, 0, 255, 8, 8)
+      bounds: 864 288 8 8
+    - image: solid-color(109, 36, 0, 255, 8, 8)
+      bounds: 872 288 8 8
+    - image: solid-color(110, 36, 0, 255, 8, 8)
+      bounds: 880 288 8 8
+    - image: solid-color(111, 36, 0, 255, 8, 8)
+      bounds: 888 288 8 8
+    - image: solid-color(112, 36, 0, 255, 8, 8)
+      bounds: 896 288 8 8
+    - image: solid-color(113, 36, 0, 255, 8, 8)
+      bounds: 904 288 8 8
+    - image: solid-color(114, 36, 0, 255, 8, 8)
+      bounds: 912 288 8 8
+    - image: solid-color(115, 36, 0, 255, 8, 8)
+      bounds: 920 288 8 8
+    - image: solid-color(116, 36, 0, 255, 8, 8)
+      bounds: 928 288 8 8
+    - image: solid-color(117, 36, 0, 255, 8, 8)
+      bounds: 936 288 8 8
+    - image: solid-color(118, 36, 0, 255, 8, 8)
+      bounds: 944 288 8 8
+    - image: solid-color(119, 36, 0, 255, 8, 8)
+      bounds: 952 288 8 8
+    - image: solid-color(120, 36, 0, 255, 8, 8)
+      bounds: 960 288 8 8
+    - image: solid-color(121, 36, 0, 255, 8, 8)
+      bounds: 968 288 8 8
+    - image: solid-color(122, 36, 0, 255, 8, 8)
+      bounds: 976 288 8 8
+    - image: solid-color(123, 36, 0, 255, 8, 8)
+      bounds: 984 288 8 8
+    - image: solid-color(124, 36, 0, 255, 8, 8)
+      bounds: 992 288 8 8
+    - image: solid-color(125, 36, 0, 255, 8, 8)
+      bounds: 1000 288 8 8
+    - image: solid-color(126, 36, 0, 255, 8, 8)
+      bounds: 1008 288 8 8
+    - image: solid-color(127, 36, 0, 255, 8, 8)
+      bounds: 1016 288 8 8
+    - image: solid-color(0, 37, 0, 255, 8, 8)
+      bounds: 0 296 8 8
+    - image: solid-color(1, 37, 0, 255, 8, 8)
+      bounds: 8 296 8 8
+    - image: solid-color(2, 37, 0, 255, 8, 8)
+      bounds: 16 296 8 8
+    - image: solid-color(3, 37, 0, 255, 8, 8)
+      bounds: 24 296 8 8
+    - image: solid-color(4, 37, 0, 255, 8, 8)
+      bounds: 32 296 8 8
+    - image: solid-color(5, 37, 0, 255, 8, 8)
+      bounds: 40 296 8 8
+    - image: solid-color(6, 37, 0, 255, 8, 8)
+      bounds: 48 296 8 8
+    - image: solid-color(7, 37, 0, 255, 8, 8)
+      bounds: 56 296 8 8
+    - image: solid-color(8, 37, 0, 255, 8, 8)
+      bounds: 64 296 8 8
+    - image: solid-color(9, 37, 0, 255, 8, 8)
+      bounds: 72 296 8 8
+    - image: solid-color(10, 37, 0, 255, 8, 8)
+      bounds: 80 296 8 8
+    - image: solid-color(11, 37, 0, 255, 8, 8)
+      bounds: 88 296 8 8
+    - image: solid-color(12, 37, 0, 255, 8, 8)
+      bounds: 96 296 8 8
+    - image: solid-color(13, 37, 0, 255, 8, 8)
+      bounds: 104 296 8 8
+    - image: solid-color(14, 37, 0, 255, 8, 8)
+      bounds: 112 296 8 8
+    - image: solid-color(15, 37, 0, 255, 8, 8)
+      bounds: 120 296 8 8
+    - image: solid-color(16, 37, 0, 255, 8, 8)
+      bounds: 128 296 8 8
+    - image: solid-color(17, 37, 0, 255, 8, 8)
+      bounds: 136 296 8 8
+    - image: solid-color(18, 37, 0, 255, 8, 8)
+      bounds: 144 296 8 8
+    - image: solid-color(19, 37, 0, 255, 8, 8)
+      bounds: 152 296 8 8
+    - image: solid-color(20, 37, 0, 255, 8, 8)
+      bounds: 160 296 8 8
+    - image: solid-color(21, 37, 0, 255, 8, 8)
+      bounds: 168 296 8 8
+    - image: solid-color(22, 37, 0, 255, 8, 8)
+      bounds: 176 296 8 8
+    - image: solid-color(23, 37, 0, 255, 8, 8)
+      bounds: 184 296 8 8
+    - image: solid-color(24, 37, 0, 255, 8, 8)
+      bounds: 192 296 8 8
+    - image: solid-color(25, 37, 0, 255, 8, 8)
+      bounds: 200 296 8 8
+    - image: solid-color(26, 37, 0, 255, 8, 8)
+      bounds: 208 296 8 8
+    - image: solid-color(27, 37, 0, 255, 8, 8)
+      bounds: 216 296 8 8
+    - image: solid-color(28, 37, 0, 255, 8, 8)
+      bounds: 224 296 8 8
+    - image: solid-color(29, 37, 0, 255, 8, 8)
+      bounds: 232 296 8 8
+    - image: solid-color(30, 37, 0, 255, 8, 8)
+      bounds: 240 296 8 8
+    - image: solid-color(31, 37, 0, 255, 8, 8)
+      bounds: 248 296 8 8
+    - image: solid-color(32, 37, 0, 255, 8, 8)
+      bounds: 256 296 8 8
+    - image: solid-color(33, 37, 0, 255, 8, 8)
+      bounds: 264 296 8 8
+    - image: solid-color(34, 37, 0, 255, 8, 8)
+      bounds: 272 296 8 8
+    - image: solid-color(35, 37, 0, 255, 8, 8)
+      bounds: 280 296 8 8
+    - image: solid-color(36, 37, 0, 255, 8, 8)
+      bounds: 288 296 8 8
+    - image: solid-color(37, 37, 0, 255, 8, 8)
+      bounds: 296 296 8 8
+    - image: solid-color(38, 37, 0, 255, 8, 8)
+      bounds: 304 296 8 8
+    - image: solid-color(39, 37, 0, 255, 8, 8)
+      bounds: 312 296 8 8
+    - image: solid-color(40, 37, 0, 255, 8, 8)
+      bounds: 320 296 8 8
+    - image: solid-color(41, 37, 0, 255, 8, 8)
+      bounds: 328 296 8 8
+    - image: solid-color(42, 37, 0, 255, 8, 8)
+      bounds: 336 296 8 8
+    - image: solid-color(43, 37, 0, 255, 8, 8)
+      bounds: 344 296 8 8
+    - image: solid-color(44, 37, 0, 255, 8, 8)
+      bounds: 352 296 8 8
+    - image: solid-color(45, 37, 0, 255, 8, 8)
+      bounds: 360 296 8 8
+    - image: solid-color(46, 37, 0, 255, 8, 8)
+      bounds: 368 296 8 8
+    - image: solid-color(47, 37, 0, 255, 8, 8)
+      bounds: 376 296 8 8
+    - image: solid-color(48, 37, 0, 255, 8, 8)
+      bounds: 384 296 8 8
+    - image: solid-color(49, 37, 0, 255, 8, 8)
+      bounds: 392 296 8 8
+    - image: solid-color(50, 37, 0, 255, 8, 8)
+      bounds: 400 296 8 8
+    - image: solid-color(51, 37, 0, 255, 8, 8)
+      bounds: 408 296 8 8
+    - image: solid-color(52, 37, 0, 255, 8, 8)
+      bounds: 416 296 8 8
+    - image: solid-color(53, 37, 0, 255, 8, 8)
+      bounds: 424 296 8 8
+    - image: solid-color(54, 37, 0, 255, 8, 8)
+      bounds: 432 296 8 8
+    - image: solid-color(55, 37, 0, 255, 8, 8)
+      bounds: 440 296 8 8
+    - image: solid-color(56, 37, 0, 255, 8, 8)
+      bounds: 448 296 8 8
+    - image: solid-color(57, 37, 0, 255, 8, 8)
+      bounds: 456 296 8 8
+    - image: solid-color(58, 37, 0, 255, 8, 8)
+      bounds: 464 296 8 8
+    - image: solid-color(59, 37, 0, 255, 8, 8)
+      bounds: 472 296 8 8
+    - image: solid-color(60, 37, 0, 255, 8, 8)
+      bounds: 480 296 8 8
+    - image: solid-color(61, 37, 0, 255, 8, 8)
+      bounds: 488 296 8 8
+    - image: solid-color(62, 37, 0, 255, 8, 8)
+      bounds: 496 296 8 8
+    - image: solid-color(63, 37, 0, 255, 8, 8)
+      bounds: 504 296 8 8
+    - image: solid-color(64, 37, 0, 255, 8, 8)
+      bounds: 512 296 8 8
+    - image: solid-color(65, 37, 0, 255, 8, 8)
+      bounds: 520 296 8 8
+    - image: solid-color(66, 37, 0, 255, 8, 8)
+      bounds: 528 296 8 8
+    - image: solid-color(67, 37, 0, 255, 8, 8)
+      bounds: 536 296 8 8
+    - image: solid-color(68, 37, 0, 255, 8, 8)
+      bounds: 544 296 8 8
+    - image: solid-color(69, 37, 0, 255, 8, 8)
+      bounds: 552 296 8 8
+    - image: solid-color(70, 37, 0, 255, 8, 8)
+      bounds: 560 296 8 8
+    - image: solid-color(71, 37, 0, 255, 8, 8)
+      bounds: 568 296 8 8
+    - image: solid-color(72, 37, 0, 255, 8, 8)
+      bounds: 576 296 8 8
+    - image: solid-color(73, 37, 0, 255, 8, 8)
+      bounds: 584 296 8 8
+    - image: solid-color(74, 37, 0, 255, 8, 8)
+      bounds: 592 296 8 8
+    - image: solid-color(75, 37, 0, 255, 8, 8)
+      bounds: 600 296 8 8
+    - image: solid-color(76, 37, 0, 255, 8, 8)
+      bounds: 608 296 8 8
+    - image: solid-color(77, 37, 0, 255, 8, 8)
+      bounds: 616 296 8 8
+    - image: solid-color(78, 37, 0, 255, 8, 8)
+      bounds: 624 296 8 8
+    - image: solid-color(79, 37, 0, 255, 8, 8)
+      bounds: 632 296 8 8
+    - image: solid-color(80, 37, 0, 255, 8, 8)
+      bounds: 640 296 8 8
+    - image: solid-color(81, 37, 0, 255, 8, 8)
+      bounds: 648 296 8 8
+    - image: solid-color(82, 37, 0, 255, 8, 8)
+      bounds: 656 296 8 8
+    - image: solid-color(83, 37, 0, 255, 8, 8)
+      bounds: 664 296 8 8
+    - image: solid-color(84, 37, 0, 255, 8, 8)
+      bounds: 672 296 8 8
+    - image: solid-color(85, 37, 0, 255, 8, 8)
+      bounds: 680 296 8 8
+    - image: solid-color(86, 37, 0, 255, 8, 8)
+      bounds: 688 296 8 8
+    - image: solid-color(87, 37, 0, 255, 8, 8)
+      bounds: 696 296 8 8
+    - image: solid-color(88, 37, 0, 255, 8, 8)
+      bounds: 704 296 8 8
+    - image: solid-color(89, 37, 0, 255, 8, 8)
+      bounds: 712 296 8 8
+    - image: solid-color(90, 37, 0, 255, 8, 8)
+      bounds: 720 296 8 8
+    - image: solid-color(91, 37, 0, 255, 8, 8)
+      bounds: 728 296 8 8
+    - image: solid-color(92, 37, 0, 255, 8, 8)
+      bounds: 736 296 8 8
+    - image: solid-color(93, 37, 0, 255, 8, 8)
+      bounds: 744 296 8 8
+    - image: solid-color(94, 37, 0, 255, 8, 8)
+      bounds: 752 296 8 8
+    - image: solid-color(95, 37, 0, 255, 8, 8)
+      bounds: 760 296 8 8
+    - image: solid-color(96, 37, 0, 255, 8, 8)
+      bounds: 768 296 8 8
+    - image: solid-color(97, 37, 0, 255, 8, 8)
+      bounds: 776 296 8 8
+    - image: solid-color(98, 37, 0, 255, 8, 8)
+      bounds: 784 296 8 8
+    - image: solid-color(99, 37, 0, 255, 8, 8)
+      bounds: 792 296 8 8
+    - image: solid-color(100, 37, 0, 255, 8, 8)
+      bounds: 800 296 8 8
+    - image: solid-color(101, 37, 0, 255, 8, 8)
+      bounds: 808 296 8 8
+    - image: solid-color(102, 37, 0, 255, 8, 8)
+      bounds: 816 296 8 8
+    - image: solid-color(103, 37, 0, 255, 8, 8)
+      bounds: 824 296 8 8
+    - image: solid-color(104, 37, 0, 255, 8, 8)
+      bounds: 832 296 8 8
+    - image: solid-color(105, 37, 0, 255, 8, 8)
+      bounds: 840 296 8 8
+    - image: solid-color(106, 37, 0, 255, 8, 8)
+      bounds: 848 296 8 8
+    - image: solid-color(107, 37, 0, 255, 8, 8)
+      bounds: 856 296 8 8
+    - image: solid-color(108, 37, 0, 255, 8, 8)
+      bounds: 864 296 8 8
+    - image: solid-color(109, 37, 0, 255, 8, 8)
+      bounds: 872 296 8 8
+    - image: solid-color(110, 37, 0, 255, 8, 8)
+      bounds: 880 296 8 8
+    - image: solid-color(111, 37, 0, 255, 8, 8)
+      bounds: 888 296 8 8
+    - image: solid-color(112, 37, 0, 255, 8, 8)
+      bounds: 896 296 8 8
+    - image: solid-color(113, 37, 0, 255, 8, 8)
+      bounds: 904 296 8 8
+    - image: solid-color(114, 37, 0, 255, 8, 8)
+      bounds: 912 296 8 8
+    - image: solid-color(115, 37, 0, 255, 8, 8)
+      bounds: 920 296 8 8
+    - image: solid-color(116, 37, 0, 255, 8, 8)
+      bounds: 928 296 8 8
+    - image: solid-color(117, 37, 0, 255, 8, 8)
+      bounds: 936 296 8 8
+    - image: solid-color(118, 37, 0, 255, 8, 8)
+      bounds: 944 296 8 8
+    - image: solid-color(119, 37, 0, 255, 8, 8)
+      bounds: 952 296 8 8
+    - image: solid-color(120, 37, 0, 255, 8, 8)
+      bounds: 960 296 8 8
+    - image: solid-color(121, 37, 0, 255, 8, 8)
+      bounds: 968 296 8 8
+    - image: solid-color(122, 37, 0, 255, 8, 8)
+      bounds: 976 296 8 8
+    - image: solid-color(123, 37, 0, 255, 8, 8)
+      bounds: 984 296 8 8
+    - image: solid-color(124, 37, 0, 255, 8, 8)
+      bounds: 992 296 8 8
+    - image: solid-color(125, 37, 0, 255, 8, 8)
+      bounds: 1000 296 8 8
+    - image: solid-color(126, 37, 0, 255, 8, 8)
+      bounds: 1008 296 8 8
+    - image: solid-color(127, 37, 0, 255, 8, 8)
+      bounds: 1016 296 8 8
+    - image: solid-color(0, 38, 0, 255, 8, 8)
+      bounds: 0 304 8 8
+    - image: solid-color(1, 38, 0, 255, 8, 8)
+      bounds: 8 304 8 8
+    - image: solid-color(2, 38, 0, 255, 8, 8)
+      bounds: 16 304 8 8
+    - image: solid-color(3, 38, 0, 255, 8, 8)
+      bounds: 24 304 8 8
+    - image: solid-color(4, 38, 0, 255, 8, 8)
+      bounds: 32 304 8 8
+    - image: solid-color(5, 38, 0, 255, 8, 8)
+      bounds: 40 304 8 8
+    - image: solid-color(6, 38, 0, 255, 8, 8)
+      bounds: 48 304 8 8
+    - image: solid-color(7, 38, 0, 255, 8, 8)
+      bounds: 56 304 8 8
+    - image: solid-color(8, 38, 0, 255, 8, 8)
+      bounds: 64 304 8 8
+    - image: solid-color(9, 38, 0, 255, 8, 8)
+      bounds: 72 304 8 8
+    - image: solid-color(10, 38, 0, 255, 8, 8)
+      bounds: 80 304 8 8
+    - image: solid-color(11, 38, 0, 255, 8, 8)
+      bounds: 88 304 8 8
+    - image: solid-color(12, 38, 0, 255, 8, 8)
+      bounds: 96 304 8 8
+    - image: solid-color(13, 38, 0, 255, 8, 8)
+      bounds: 104 304 8 8
+    - image: solid-color(14, 38, 0, 255, 8, 8)
+      bounds: 112 304 8 8
+    - image: solid-color(15, 38, 0, 255, 8, 8)
+      bounds: 120 304 8 8
+    - image: solid-color(16, 38, 0, 255, 8, 8)
+      bounds: 128 304 8 8
+    - image: solid-color(17, 38, 0, 255, 8, 8)
+      bounds: 136 304 8 8
+    - image: solid-color(18, 38, 0, 255, 8, 8)
+      bounds: 144 304 8 8
+    - image: solid-color(19, 38, 0, 255, 8, 8)
+      bounds: 152 304 8 8
+    - image: solid-color(20, 38, 0, 255, 8, 8)
+      bounds: 160 304 8 8
+    - image: solid-color(21, 38, 0, 255, 8, 8)
+      bounds: 168 304 8 8
+    - image: solid-color(22, 38, 0, 255, 8, 8)
+      bounds: 176 304 8 8
+    - image: solid-color(23, 38, 0, 255, 8, 8)
+      bounds: 184 304 8 8
+    - image: solid-color(24, 38, 0, 255, 8, 8)
+      bounds: 192 304 8 8
+    - image: solid-color(25, 38, 0, 255, 8, 8)
+      bounds: 200 304 8 8
+    - image: solid-color(26, 38, 0, 255, 8, 8)
+      bounds: 208 304 8 8
+    - image: solid-color(27, 38, 0, 255, 8, 8)
+      bounds: 216 304 8 8
+    - image: solid-color(28, 38, 0, 255, 8, 8)
+      bounds: 224 304 8 8
+    - image: solid-color(29, 38, 0, 255, 8, 8)
+      bounds: 232 304 8 8
+    - image: solid-color(30, 38, 0, 255, 8, 8)
+      bounds: 240 304 8 8
+    - image: solid-color(31, 38, 0, 255, 8, 8)
+      bounds: 248 304 8 8
+    - image: solid-color(32, 38, 0, 255, 8, 8)
+      bounds: 256 304 8 8
+    - image: solid-color(33, 38, 0, 255, 8, 8)
+      bounds: 264 304 8 8
+    - image: solid-color(34, 38, 0, 255, 8, 8)
+      bounds: 272 304 8 8
+    - image: solid-color(35, 38, 0, 255, 8, 8)
+      bounds: 280 304 8 8
+    - image: solid-color(36, 38, 0, 255, 8, 8)
+      bounds: 288 304 8 8
+    - image: solid-color(37, 38, 0, 255, 8, 8)
+      bounds: 296 304 8 8
+    - image: solid-color(38, 38, 0, 255, 8, 8)
+      bounds: 304 304 8 8
+    - image: solid-color(39, 38, 0, 255, 8, 8)
+      bounds: 312 304 8 8
+    - image: solid-color(40, 38, 0, 255, 8, 8)
+      bounds: 320 304 8 8
+    - image: solid-color(41, 38, 0, 255, 8, 8)
+      bounds: 328 304 8 8
+    - image: solid-color(42, 38, 0, 255, 8, 8)
+      bounds: 336 304 8 8
+    - image: solid-color(43, 38, 0, 255, 8, 8)
+      bounds: 344 304 8 8
+    - image: solid-color(44, 38, 0, 255, 8, 8)
+      bounds: 352 304 8 8
+    - image: solid-color(45, 38, 0, 255, 8, 8)
+      bounds: 360 304 8 8
+    - image: solid-color(46, 38, 0, 255, 8, 8)
+      bounds: 368 304 8 8
+    - image: solid-color(47, 38, 0, 255, 8, 8)
+      bounds: 376 304 8 8
+    - image: solid-color(48, 38, 0, 255, 8, 8)
+      bounds: 384 304 8 8
+    - image: solid-color(49, 38, 0, 255, 8, 8)
+      bounds: 392 304 8 8
+    - image: solid-color(50, 38, 0, 255, 8, 8)
+      bounds: 400 304 8 8
+    - image: solid-color(51, 38, 0, 255, 8, 8)
+      bounds: 408 304 8 8
+    - image: solid-color(52, 38, 0, 255, 8, 8)
+      bounds: 416 304 8 8
+    - image: solid-color(53, 38, 0, 255, 8, 8)
+      bounds: 424 304 8 8
+    - image: solid-color(54, 38, 0, 255, 8, 8)
+      bounds: 432 304 8 8
+    - image: solid-color(55, 38, 0, 255, 8, 8)
+      bounds: 440 304 8 8
+    - image: solid-color(56, 38, 0, 255, 8, 8)
+      bounds: 448 304 8 8
+    - image: solid-color(57, 38, 0, 255, 8, 8)
+      bounds: 456 304 8 8
+    - image: solid-color(58, 38, 0, 255, 8, 8)
+      bounds: 464 304 8 8
+    - image: solid-color(59, 38, 0, 255, 8, 8)
+      bounds: 472 304 8 8
+    - image: solid-color(60, 38, 0, 255, 8, 8)
+      bounds: 480 304 8 8
+    - image: solid-color(61, 38, 0, 255, 8, 8)
+      bounds: 488 304 8 8
+    - image: solid-color(62, 38, 0, 255, 8, 8)
+      bounds: 496 304 8 8
+    - image: solid-color(63, 38, 0, 255, 8, 8)
+      bounds: 504 304 8 8
+    - image: solid-color(64, 38, 0, 255, 8, 8)
+      bounds: 512 304 8 8
+    - image: solid-color(65, 38, 0, 255, 8, 8)
+      bounds: 520 304 8 8
+    - image: solid-color(66, 38, 0, 255, 8, 8)
+      bounds: 528 304 8 8
+    - image: solid-color(67, 38, 0, 255, 8, 8)
+      bounds: 536 304 8 8
+    - image: solid-color(68, 38, 0, 255, 8, 8)
+      bounds: 544 304 8 8
+    - image: solid-color(69, 38, 0, 255, 8, 8)
+      bounds: 552 304 8 8
+    - image: solid-color(70, 38, 0, 255, 8, 8)
+      bounds: 560 304 8 8
+    - image: solid-color(71, 38, 0, 255, 8, 8)
+      bounds: 568 304 8 8
+    - image: solid-color(72, 38, 0, 255, 8, 8)
+      bounds: 576 304 8 8
+    - image: solid-color(73, 38, 0, 255, 8, 8)
+      bounds: 584 304 8 8
+    - image: solid-color(74, 38, 0, 255, 8, 8)
+      bounds: 592 304 8 8
+    - image: solid-color(75, 38, 0, 255, 8, 8)
+      bounds: 600 304 8 8
+    - image: solid-color(76, 38, 0, 255, 8, 8)
+      bounds: 608 304 8 8
+    - image: solid-color(77, 38, 0, 255, 8, 8)
+      bounds: 616 304 8 8
+    - image: solid-color(78, 38, 0, 255, 8, 8)
+      bounds: 624 304 8 8
+    - image: solid-color(79, 38, 0, 255, 8, 8)
+      bounds: 632 304 8 8
+    - image: solid-color(80, 38, 0, 255, 8, 8)
+      bounds: 640 304 8 8
+    - image: solid-color(81, 38, 0, 255, 8, 8)
+      bounds: 648 304 8 8
+    - image: solid-color(82, 38, 0, 255, 8, 8)
+      bounds: 656 304 8 8
+    - image: solid-color(83, 38, 0, 255, 8, 8)
+      bounds: 664 304 8 8
+    - image: solid-color(84, 38, 0, 255, 8, 8)
+      bounds: 672 304 8 8
+    - image: solid-color(85, 38, 0, 255, 8, 8)
+      bounds: 680 304 8 8
+    - image: solid-color(86, 38, 0, 255, 8, 8)
+      bounds: 688 304 8 8
+    - image: solid-color(87, 38, 0, 255, 8, 8)
+      bounds: 696 304 8 8
+    - image: solid-color(88, 38, 0, 255, 8, 8)
+      bounds: 704 304 8 8
+    - image: solid-color(89, 38, 0, 255, 8, 8)
+      bounds: 712 304 8 8
+    - image: solid-color(90, 38, 0, 255, 8, 8)
+      bounds: 720 304 8 8
+    - image: solid-color(91, 38, 0, 255, 8, 8)
+      bounds: 728 304 8 8
+    - image: solid-color(92, 38, 0, 255, 8, 8)
+      bounds: 736 304 8 8
+    - image: solid-color(93, 38, 0, 255, 8, 8)
+      bounds: 744 304 8 8
+    - image: solid-color(94, 38, 0, 255, 8, 8)
+      bounds: 752 304 8 8
+    - image: solid-color(95, 38, 0, 255, 8, 8)
+      bounds: 760 304 8 8
+    - image: solid-color(96, 38, 0, 255, 8, 8)
+      bounds: 768 304 8 8
+    - image: solid-color(97, 38, 0, 255, 8, 8)
+      bounds: 776 304 8 8
+    - image: solid-color(98, 38, 0, 255, 8, 8)
+      bounds: 784 304 8 8
+    - image: solid-color(99, 38, 0, 255, 8, 8)
+      bounds: 792 304 8 8
+    - image: solid-color(100, 38, 0, 255, 8, 8)
+      bounds: 800 304 8 8
+    - image: solid-color(101, 38, 0, 255, 8, 8)
+      bounds: 808 304 8 8
+    - image: solid-color(102, 38, 0, 255, 8, 8)
+      bounds: 816 304 8 8
+    - image: solid-color(103, 38, 0, 255, 8, 8)
+      bounds: 824 304 8 8
+    - image: solid-color(104, 38, 0, 255, 8, 8)
+      bounds: 832 304 8 8
+    - image: solid-color(105, 38, 0, 255, 8, 8)
+      bounds: 840 304 8 8
+    - image: solid-color(106, 38, 0, 255, 8, 8)
+      bounds: 848 304 8 8
+    - image: solid-color(107, 38, 0, 255, 8, 8)
+      bounds: 856 304 8 8
+    - image: solid-color(108, 38, 0, 255, 8, 8)
+      bounds: 864 304 8 8
+    - image: solid-color(109, 38, 0, 255, 8, 8)
+      bounds: 872 304 8 8
+    - image: solid-color(110, 38, 0, 255, 8, 8)
+      bounds: 880 304 8 8
+    - image: solid-color(111, 38, 0, 255, 8, 8)
+      bounds: 888 304 8 8
+    - image: solid-color(112, 38, 0, 255, 8, 8)
+      bounds: 896 304 8 8
+    - image: solid-color(113, 38, 0, 255, 8, 8)
+      bounds: 904 304 8 8
+    - image: solid-color(114, 38, 0, 255, 8, 8)
+      bounds: 912 304 8 8
+    - image: solid-color(115, 38, 0, 255, 8, 8)
+      bounds: 920 304 8 8
+    - image: solid-color(116, 38, 0, 255, 8, 8)
+      bounds: 928 304 8 8
+    - image: solid-color(117, 38, 0, 255, 8, 8)
+      bounds: 936 304 8 8
+    - image: solid-color(118, 38, 0, 255, 8, 8)
+      bounds: 944 304 8 8
+    - image: solid-color(119, 38, 0, 255, 8, 8)
+      bounds: 952 304 8 8
+    - image: solid-color(120, 38, 0, 255, 8, 8)
+      bounds: 960 304 8 8
+    - image: solid-color(121, 38, 0, 255, 8, 8)
+      bounds: 968 304 8 8
+    - image: solid-color(122, 38, 0, 255, 8, 8)
+      bounds: 976 304 8 8
+    - image: solid-color(123, 38, 0, 255, 8, 8)
+      bounds: 984 304 8 8
+    - image: solid-color(124, 38, 0, 255, 8, 8)
+      bounds: 992 304 8 8
+    - image: solid-color(125, 38, 0, 255, 8, 8)
+      bounds: 1000 304 8 8
+    - image: solid-color(126, 38, 0, 255, 8, 8)
+      bounds: 1008 304 8 8
+    - image: solid-color(127, 38, 0, 255, 8, 8)
+      bounds: 1016 304 8 8
+    - image: solid-color(0, 39, 0, 255, 8, 8)
+      bounds: 0 312 8 8
+    - image: solid-color(1, 39, 0, 255, 8, 8)
+      bounds: 8 312 8 8
+    - image: solid-color(2, 39, 0, 255, 8, 8)
+      bounds: 16 312 8 8
+    - image: solid-color(3, 39, 0, 255, 8, 8)
+      bounds: 24 312 8 8
+    - image: solid-color(4, 39, 0, 255, 8, 8)
+      bounds: 32 312 8 8
+    - image: solid-color(5, 39, 0, 255, 8, 8)
+      bounds: 40 312 8 8
+    - image: solid-color(6, 39, 0, 255, 8, 8)
+      bounds: 48 312 8 8
+    - image: solid-color(7, 39, 0, 255, 8, 8)
+      bounds: 56 312 8 8
+    - image: solid-color(8, 39, 0, 255, 8, 8)
+      bounds: 64 312 8 8
+    - image: solid-color(9, 39, 0, 255, 8, 8)
+      bounds: 72 312 8 8
+    - image: solid-color(10, 39, 0, 255, 8, 8)
+      bounds: 80 312 8 8
+    - image: solid-color(11, 39, 0, 255, 8, 8)
+      bounds: 88 312 8 8
+    - image: solid-color(12, 39, 0, 255, 8, 8)
+      bounds: 96 312 8 8
+    - image: solid-color(13, 39, 0, 255, 8, 8)
+      bounds: 104 312 8 8
+    - image: solid-color(14, 39, 0, 255, 8, 8)
+      bounds: 112 312 8 8
+    - image: solid-color(15, 39, 0, 255, 8, 8)
+      bounds: 120 312 8 8
+    - image: solid-color(16, 39, 0, 255, 8, 8)
+      bounds: 128 312 8 8
+    - image: solid-color(17, 39, 0, 255, 8, 8)
+      bounds: 136 312 8 8
+    - image: solid-color(18, 39, 0, 255, 8, 8)
+      bounds: 144 312 8 8
+    - image: solid-color(19, 39, 0, 255, 8, 8)
+      bounds: 152 312 8 8
+    - image: solid-color(20, 39, 0, 255, 8, 8)
+      bounds: 160 312 8 8
+    - image: solid-color(21, 39, 0, 255, 8, 8)
+      bounds: 168 312 8 8
+    - image: solid-color(22, 39, 0, 255, 8, 8)
+      bounds: 176 312 8 8
+    - image: solid-color(23, 39, 0, 255, 8, 8)
+      bounds: 184 312 8 8
+    - image: solid-color(24, 39, 0, 255, 8, 8)
+      bounds: 192 312 8 8
+    - image: solid-color(25, 39, 0, 255, 8, 8)
+      bounds: 200 312 8 8
+    - image: solid-color(26, 39, 0, 255, 8, 8)
+      bounds: 208 312 8 8
+    - image: solid-color(27, 39, 0, 255, 8, 8)
+      bounds: 216 312 8 8
+    - image: solid-color(28, 39, 0, 255, 8, 8)
+      bounds: 224 312 8 8
+    - image: solid-color(29, 39, 0, 255, 8, 8)
+      bounds: 232 312 8 8
+    - image: solid-color(30, 39, 0, 255, 8, 8)
+      bounds: 240 312 8 8
+    - image: solid-color(31, 39, 0, 255, 8, 8)
+      bounds: 248 312 8 8
+    - image: solid-color(32, 39, 0, 255, 8, 8)
+      bounds: 256 312 8 8
+    - image: solid-color(33, 39, 0, 255, 8, 8)
+      bounds: 264 312 8 8
+    - image: solid-color(34, 39, 0, 255, 8, 8)
+      bounds: 272 312 8 8
+    - image: solid-color(35, 39, 0, 255, 8, 8)
+      bounds: 280 312 8 8
+    - image: solid-color(36, 39, 0, 255, 8, 8)
+      bounds: 288 312 8 8
+    - image: solid-color(37, 39, 0, 255, 8, 8)
+      bounds: 296 312 8 8
+    - image: solid-color(38, 39, 0, 255, 8, 8)
+      bounds: 304 312 8 8
+    - image: solid-color(39, 39, 0, 255, 8, 8)
+      bounds: 312 312 8 8
+    - image: solid-color(40, 39, 0, 255, 8, 8)
+      bounds: 320 312 8 8
+    - image: solid-color(41, 39, 0, 255, 8, 8)
+      bounds: 328 312 8 8
+    - image: solid-color(42, 39, 0, 255, 8, 8)
+      bounds: 336 312 8 8
+    - image: solid-color(43, 39, 0, 255, 8, 8)
+      bounds: 344 312 8 8
+    - image: solid-color(44, 39, 0, 255, 8, 8)
+      bounds: 352 312 8 8
+    - image: solid-color(45, 39, 0, 255, 8, 8)
+      bounds: 360 312 8 8
+    - image: solid-color(46, 39, 0, 255, 8, 8)
+      bounds: 368 312 8 8
+    - image: solid-color(47, 39, 0, 255, 8, 8)
+      bounds: 376 312 8 8
+    - image: solid-color(48, 39, 0, 255, 8, 8)
+      bounds: 384 312 8 8
+    - image: solid-color(49, 39, 0, 255, 8, 8)
+      bounds: 392 312 8 8
+    - image: solid-color(50, 39, 0, 255, 8, 8)
+      bounds: 400 312 8 8
+    - image: solid-color(51, 39, 0, 255, 8, 8)
+      bounds: 408 312 8 8
+    - image: solid-color(52, 39, 0, 255, 8, 8)
+      bounds: 416 312 8 8
+    - image: solid-color(53, 39, 0, 255, 8, 8)
+      bounds: 424 312 8 8
+    - image: solid-color(54, 39, 0, 255, 8, 8)
+      bounds: 432 312 8 8
+    - image: solid-color(55, 39, 0, 255, 8, 8)
+      bounds: 440 312 8 8
+    - image: solid-color(56, 39, 0, 255, 8, 8)
+      bounds: 448 312 8 8
+    - image: solid-color(57, 39, 0, 255, 8, 8)
+      bounds: 456 312 8 8
+    - image: solid-color(58, 39, 0, 255, 8, 8)
+      bounds: 464 312 8 8
+    - image: solid-color(59, 39, 0, 255, 8, 8)
+      bounds: 472 312 8 8
+    - image: solid-color(60, 39, 0, 255, 8, 8)
+      bounds: 480 312 8 8
+    - image: solid-color(61, 39, 0, 255, 8, 8)
+      bounds: 488 312 8 8
+    - image: solid-color(62, 39, 0, 255, 8, 8)
+      bounds: 496 312 8 8
+    - image: solid-color(63, 39, 0, 255, 8, 8)
+      bounds: 504 312 8 8
+    - image: solid-color(64, 39, 0, 255, 8, 8)
+      bounds: 512 312 8 8
+    - image: solid-color(65, 39, 0, 255, 8, 8)
+      bounds: 520 312 8 8
+    - image: solid-color(66, 39, 0, 255, 8, 8)
+      bounds: 528 312 8 8
+    - image: solid-color(67, 39, 0, 255, 8, 8)
+      bounds: 536 312 8 8
+    - image: solid-color(68, 39, 0, 255, 8, 8)
+      bounds: 544 312 8 8
+    - image: solid-color(69, 39, 0, 255, 8, 8)
+      bounds: 552 312 8 8
+    - image: solid-color(70, 39, 0, 255, 8, 8)
+      bounds: 560 312 8 8
+    - image: solid-color(71, 39, 0, 255, 8, 8)
+      bounds: 568 312 8 8
+    - image: solid-color(72, 39, 0, 255, 8, 8)
+      bounds: 576 312 8 8
+    - image: solid-color(73, 39, 0, 255, 8, 8)
+      bounds: 584 312 8 8
+    - image: solid-color(74, 39, 0, 255, 8, 8)
+      bounds: 592 312 8 8
+    - image: solid-color(75, 39, 0, 255, 8, 8)
+      bounds: 600 312 8 8
+    - image: solid-color(76, 39, 0, 255, 8, 8)
+      bounds: 608 312 8 8
+    - image: solid-color(77, 39, 0, 255, 8, 8)
+      bounds: 616 312 8 8
+    - image: solid-color(78, 39, 0, 255, 8, 8)
+      bounds: 624 312 8 8
+    - image: solid-color(79, 39, 0, 255, 8, 8)
+      bounds: 632 312 8 8
+    - image: solid-color(80, 39, 0, 255, 8, 8)
+      bounds: 640 312 8 8
+    - image: solid-color(81, 39, 0, 255, 8, 8)
+      bounds: 648 312 8 8
+    - image: solid-color(82, 39, 0, 255, 8, 8)
+      bounds: 656 312 8 8
+    - image: solid-color(83, 39, 0, 255, 8, 8)
+      bounds: 664 312 8 8
+    - image: solid-color(84, 39, 0, 255, 8, 8)
+      bounds: 672 312 8 8
+    - image: solid-color(85, 39, 0, 255, 8, 8)
+      bounds: 680 312 8 8
+    - image: solid-color(86, 39, 0, 255, 8, 8)
+      bounds: 688 312 8 8
+    - image: solid-color(87, 39, 0, 255, 8, 8)
+      bounds: 696 312 8 8
+    - image: solid-color(88, 39, 0, 255, 8, 8)
+      bounds: 704 312 8 8
+    - image: solid-color(89, 39, 0, 255, 8, 8)
+      bounds: 712 312 8 8
+    - image: solid-color(90, 39, 0, 255, 8, 8)
+      bounds: 720 312 8 8
+    - image: solid-color(91, 39, 0, 255, 8, 8)
+      bounds: 728 312 8 8
+    - image: solid-color(92, 39, 0, 255, 8, 8)
+      bounds: 736 312 8 8
+    - image: solid-color(93, 39, 0, 255, 8, 8)
+      bounds: 744 312 8 8
+    - image: solid-color(94, 39, 0, 255, 8, 8)
+      bounds: 752 312 8 8
+    - image: solid-color(95, 39, 0, 255, 8, 8)
+      bounds: 760 312 8 8
+    - image: solid-color(96, 39, 0, 255, 8, 8)
+      bounds: 768 312 8 8
+    - image: solid-color(97, 39, 0, 255, 8, 8)
+      bounds: 776 312 8 8
+    - image: solid-color(98, 39, 0, 255, 8, 8)
+      bounds: 784 312 8 8
+    - image: solid-color(99, 39, 0, 255, 8, 8)
+      bounds: 792 312 8 8
+    - image: solid-color(100, 39, 0, 255, 8, 8)
+      bounds: 800 312 8 8
+    - image: solid-color(101, 39, 0, 255, 8, 8)
+      bounds: 808 312 8 8
+    - image: solid-color(102, 39, 0, 255, 8, 8)
+      bounds: 816 312 8 8
+    - image: solid-color(103, 39, 0, 255, 8, 8)
+      bounds: 824 312 8 8
+    - image: solid-color(104, 39, 0, 255, 8, 8)
+      bounds: 832 312 8 8
+    - image: solid-color(105, 39, 0, 255, 8, 8)
+      bounds: 840 312 8 8
+    - image: solid-color(106, 39, 0, 255, 8, 8)
+      bounds: 848 312 8 8
+    - image: solid-color(107, 39, 0, 255, 8, 8)
+      bounds: 856 312 8 8
+    - image: solid-color(108, 39, 0, 255, 8, 8)
+      bounds: 864 312 8 8
+    - image: solid-color(109, 39, 0, 255, 8, 8)
+      bounds: 872 312 8 8
+    - image: solid-color(110, 39, 0, 255, 8, 8)
+      bounds: 880 312 8 8
+    - image: solid-color(111, 39, 0, 255, 8, 8)
+      bounds: 888 312 8 8
+    - image: solid-color(112, 39, 0, 255, 8, 8)
+      bounds: 896 312 8 8
+    - image: solid-color(113, 39, 0, 255, 8, 8)
+      bounds: 904 312 8 8
+    - image: solid-color(114, 39, 0, 255, 8, 8)
+      bounds: 912 312 8 8
+    - image: solid-color(115, 39, 0, 255, 8, 8)
+      bounds: 920 312 8 8
+    - image: solid-color(116, 39, 0, 255, 8, 8)
+      bounds: 928 312 8 8
+    - image: solid-color(117, 39, 0, 255, 8, 8)
+      bounds: 936 312 8 8
+    - image: solid-color(118, 39, 0, 255, 8, 8)
+      bounds: 944 312 8 8
+    - image: solid-color(119, 39, 0, 255, 8, 8)
+      bounds: 952 312 8 8
+    - image: solid-color(120, 39, 0, 255, 8, 8)
+      bounds: 960 312 8 8
+    - image: solid-color(121, 39, 0, 255, 8, 8)
+      bounds: 968 312 8 8
+    - image: solid-color(122, 39, 0, 255, 8, 8)
+      bounds: 976 312 8 8
+    - image: solid-color(123, 39, 0, 255, 8, 8)
+      bounds: 984 312 8 8
+    - image: solid-color(124, 39, 0, 255, 8, 8)
+      bounds: 992 312 8 8
+    - image: solid-color(125, 39, 0, 255, 8, 8)
+      bounds: 1000 312 8 8
+    - image: solid-color(126, 39, 0, 255, 8, 8)
+      bounds: 1008 312 8 8
+    - image: solid-color(127, 39, 0, 255, 8, 8)
+      bounds: 1016 312 8 8
+    - image: solid-color(0, 40, 0, 255, 8, 8)
+      bounds: 0 320 8 8
+    - image: solid-color(1, 40, 0, 255, 8, 8)
+      bounds: 8 320 8 8
+    - image: solid-color(2, 40, 0, 255, 8, 8)
+      bounds: 16 320 8 8
+    - image: solid-color(3, 40, 0, 255, 8, 8)
+      bounds: 24 320 8 8
+    - image: solid-color(4, 40, 0, 255, 8, 8)
+      bounds: 32 320 8 8
+    - image: solid-color(5, 40, 0, 255, 8, 8)
+      bounds: 40 320 8 8
+    - image: solid-color(6, 40, 0, 255, 8, 8)
+      bounds: 48 320 8 8
+    - image: solid-color(7, 40, 0, 255, 8, 8)
+      bounds: 56 320 8 8
+    - image: solid-color(8, 40, 0, 255, 8, 8)
+      bounds: 64 320 8 8
+    - image: solid-color(9, 40, 0, 255, 8, 8)
+      bounds: 72 320 8 8
+    - image: solid-color(10, 40, 0, 255, 8, 8)
+      bounds: 80 320 8 8
+    - image: solid-color(11, 40, 0, 255, 8, 8)
+      bounds: 88 320 8 8
+    - image: solid-color(12, 40, 0, 255, 8, 8)
+      bounds: 96 320 8 8
+    - image: solid-color(13, 40, 0, 255, 8, 8)
+      bounds: 104 320 8 8
+    - image: solid-color(14, 40, 0, 255, 8, 8)
+      bounds: 112 320 8 8
+    - image: solid-color(15, 40, 0, 255, 8, 8)
+      bounds: 120 320 8 8
+    - image: solid-color(16, 40, 0, 255, 8, 8)
+      bounds: 128 320 8 8
+    - image: solid-color(17, 40, 0, 255, 8, 8)
+      bounds: 136 320 8 8
+    - image: solid-color(18, 40, 0, 255, 8, 8)
+      bounds: 144 320 8 8
+    - image: solid-color(19, 40, 0, 255, 8, 8)
+      bounds: 152 320 8 8
+    - image: solid-color(20, 40, 0, 255, 8, 8)
+      bounds: 160 320 8 8
+    - image: solid-color(21, 40, 0, 255, 8, 8)
+      bounds: 168 320 8 8
+    - image: solid-color(22, 40, 0, 255, 8, 8)
+      bounds: 176 320 8 8
+    - image: solid-color(23, 40, 0, 255, 8, 8)
+      bounds: 184 320 8 8
+    - image: solid-color(24, 40, 0, 255, 8, 8)
+      bounds: 192 320 8 8
+    - image: solid-color(25, 40, 0, 255, 8, 8)
+      bounds: 200 320 8 8
+    - image: solid-color(26, 40, 0, 255, 8, 8)
+      bounds: 208 320 8 8
+    - image: solid-color(27, 40, 0, 255, 8, 8)
+      bounds: 216 320 8 8
+    - image: solid-color(28, 40, 0, 255, 8, 8)
+      bounds: 224 320 8 8
+    - image: solid-color(29, 40, 0, 255, 8, 8)
+      bounds: 232 320 8 8
+    - image: solid-color(30, 40, 0, 255, 8, 8)
+      bounds: 240 320 8 8
+    - image: solid-color(31, 40, 0, 255, 8, 8)
+      bounds: 248 320 8 8
+    - image: solid-color(32, 40, 0, 255, 8, 8)
+      bounds: 256 320 8 8
+    - image: solid-color(33, 40, 0, 255, 8, 8)
+      bounds: 264 320 8 8
+    - image: solid-color(34, 40, 0, 255, 8, 8)
+      bounds: 272 320 8 8
+    - image: solid-color(35, 40, 0, 255, 8, 8)
+      bounds: 280 320 8 8
+    - image: solid-color(36, 40, 0, 255, 8, 8)
+      bounds: 288 320 8 8
+    - image: solid-color(37, 40, 0, 255, 8, 8)
+      bounds: 296 320 8 8
+    - image: solid-color(38, 40, 0, 255, 8, 8)
+      bounds: 304 320 8 8
+    - image: solid-color(39, 40, 0, 255, 8, 8)
+      bounds: 312 320 8 8
+    - image: solid-color(40, 40, 0, 255, 8, 8)
+      bounds: 320 320 8 8
+    - image: solid-color(41, 40, 0, 255, 8, 8)
+      bounds: 328 320 8 8
+    - image: solid-color(42, 40, 0, 255, 8, 8)
+      bounds: 336 320 8 8
+    - image: solid-color(43, 40, 0, 255, 8, 8)
+      bounds: 344 320 8 8
+    - image: solid-color(44, 40, 0, 255, 8, 8)
+      bounds: 352 320 8 8
+    - image: solid-color(45, 40, 0, 255, 8, 8)
+      bounds: 360 320 8 8
+    - image: solid-color(46, 40, 0, 255, 8, 8)
+      bounds: 368 320 8 8
+    - image: solid-color(47, 40, 0, 255, 8, 8)
+      bounds: 376 320 8 8
+    - image: solid-color(48, 40, 0, 255, 8, 8)
+      bounds: 384 320 8 8
+    - image: solid-color(49, 40, 0, 255, 8, 8)
+      bounds: 392 320 8 8
+    - image: solid-color(50, 40, 0, 255, 8, 8)
+      bounds: 400 320 8 8
+    - image: solid-color(51, 40, 0, 255, 8, 8)
+      bounds: 408 320 8 8
+    - image: solid-color(52, 40, 0, 255, 8, 8)
+      bounds: 416 320 8 8
+    - image: solid-color(53, 40, 0, 255, 8, 8)
+      bounds: 424 320 8 8
+    - image: solid-color(54, 40, 0, 255, 8, 8)
+      bounds: 432 320 8 8
+    - image: solid-color(55, 40, 0, 255, 8, 8)
+      bounds: 440 320 8 8
+    - image: solid-color(56, 40, 0, 255, 8, 8)
+      bounds: 448 320 8 8
+    - image: solid-color(57, 40, 0, 255, 8, 8)
+      bounds: 456 320 8 8
+    - image: solid-color(58, 40, 0, 255, 8, 8)
+      bounds: 464 320 8 8
+    - image: solid-color(59, 40, 0, 255, 8, 8)
+      bounds: 472 320 8 8
+    - image: solid-color(60, 40, 0, 255, 8, 8)
+      bounds: 480 320 8 8
+    - image: solid-color(61, 40, 0, 255, 8, 8)
+      bounds: 488 320 8 8
+    - image: solid-color(62, 40, 0, 255, 8, 8)
+      bounds: 496 320 8 8
+    - image: solid-color(63, 40, 0, 255, 8, 8)
+      bounds: 504 320 8 8
+    - image: solid-color(64, 40, 0, 255, 8, 8)
+      bounds: 512 320 8 8
+    - image: solid-color(65, 40, 0, 255, 8, 8)
+      bounds: 520 320 8 8
+    - image: solid-color(66, 40, 0, 255, 8, 8)
+      bounds: 528 320 8 8
+    - image: solid-color(67, 40, 0, 255, 8, 8)
+      bounds: 536 320 8 8
+    - image: solid-color(68, 40, 0, 255, 8, 8)
+      bounds: 544 320 8 8
+    - image: solid-color(69, 40, 0, 255, 8, 8)
+      bounds: 552 320 8 8
+    - image: solid-color(70, 40, 0, 255, 8, 8)
+      bounds: 560 320 8 8
+    - image: solid-color(71, 40, 0, 255, 8, 8)
+      bounds: 568 320 8 8
+    - image: solid-color(72, 40, 0, 255, 8, 8)
+      bounds: 576 320 8 8
+    - image: solid-color(73, 40, 0, 255, 8, 8)
+      bounds: 584 320 8 8
+    - image: solid-color(74, 40, 0, 255, 8, 8)
+      bounds: 592 320 8 8
+    - image: solid-color(75, 40, 0, 255, 8, 8)
+      bounds: 600 320 8 8
+    - image: solid-color(76, 40, 0, 255, 8, 8)
+      bounds: 608 320 8 8
+    - image: solid-color(77, 40, 0, 255, 8, 8)
+      bounds: 616 320 8 8
+    - image: solid-color(78, 40, 0, 255, 8, 8)
+      bounds: 624 320 8 8
+    - image: solid-color(79, 40, 0, 255, 8, 8)
+      bounds: 632 320 8 8
+    - image: solid-color(80, 40, 0, 255, 8, 8)
+      bounds: 640 320 8 8
+    - image: solid-color(81, 40, 0, 255, 8, 8)
+      bounds: 648 320 8 8
+    - image: solid-color(82, 40, 0, 255, 8, 8)
+      bounds: 656 320 8 8
+    - image: solid-color(83, 40, 0, 255, 8, 8)
+      bounds: 664 320 8 8
+    - image: solid-color(84, 40, 0, 255, 8, 8)
+      bounds: 672 320 8 8
+    - image: solid-color(85, 40, 0, 255, 8, 8)
+      bounds: 680 320 8 8
+    - image: solid-color(86, 40, 0, 255, 8, 8)
+      bounds: 688 320 8 8
+    - image: solid-color(87, 40, 0, 255, 8, 8)
+      bounds: 696 320 8 8
+    - image: solid-color(88, 40, 0, 255, 8, 8)
+      bounds: 704 320 8 8
+    - image: solid-color(89, 40, 0, 255, 8, 8)
+      bounds: 712 320 8 8
+    - image: solid-color(90, 40, 0, 255, 8, 8)
+      bounds: 720 320 8 8
+    - image: solid-color(91, 40, 0, 255, 8, 8)
+      bounds: 728 320 8 8
+    - image: solid-color(92, 40, 0, 255, 8, 8)
+      bounds: 736 320 8 8
+    - image: solid-color(93, 40, 0, 255, 8, 8)
+      bounds: 744 320 8 8
+    - image: solid-color(94, 40, 0, 255, 8, 8)
+      bounds: 752 320 8 8
+    - image: solid-color(95, 40, 0, 255, 8, 8)
+      bounds: 760 320 8 8
+    - image: solid-color(96, 40, 0, 255, 8, 8)
+      bounds: 768 320 8 8
+    - image: solid-color(97, 40, 0, 255, 8, 8)
+      bounds: 776 320 8 8
+    - image: solid-color(98, 40, 0, 255, 8, 8)
+      bounds: 784 320 8 8
+    - image: solid-color(99, 40, 0, 255, 8, 8)
+      bounds: 792 320 8 8
+    - image: solid-color(100, 40, 0, 255, 8, 8)
+      bounds: 800 320 8 8
+    - image: solid-color(101, 40, 0, 255, 8, 8)
+      bounds: 808 320 8 8
+    - image: solid-color(102, 40, 0, 255, 8, 8)
+      bounds: 816 320 8 8
+    - image: solid-color(103, 40, 0, 255, 8, 8)
+      bounds: 824 320 8 8
+    - image: solid-color(104, 40, 0, 255, 8, 8)
+      bounds: 832 320 8 8
+    - image: solid-color(105, 40, 0, 255, 8, 8)
+      bounds: 840 320 8 8
+    - image: solid-color(106, 40, 0, 255, 8, 8)
+      bounds: 848 320 8 8
+    - image: solid-color(107, 40, 0, 255, 8, 8)
+      bounds: 856 320 8 8
+    - image: solid-color(108, 40, 0, 255, 8, 8)
+      bounds: 864 320 8 8
+    - image: solid-color(109, 40, 0, 255, 8, 8)
+      bounds: 872 320 8 8
+    - image: solid-color(110, 40, 0, 255, 8, 8)
+      bounds: 880 320 8 8
+    - image: solid-color(111, 40, 0, 255, 8, 8)
+      bounds: 888 320 8 8
+    - image: solid-color(112, 40, 0, 255, 8, 8)
+      bounds: 896 320 8 8
+    - image: solid-color(113, 40, 0, 255, 8, 8)
+      bounds: 904 320 8 8
+    - image: solid-color(114, 40, 0, 255, 8, 8)
+      bounds: 912 320 8 8
+    - image: solid-color(115, 40, 0, 255, 8, 8)
+      bounds: 920 320 8 8
+    - image: solid-color(116, 40, 0, 255, 8, 8)
+      bounds: 928 320 8 8
+    - image: solid-color(117, 40, 0, 255, 8, 8)
+      bounds: 936 320 8 8
+    - image: solid-color(118, 40, 0, 255, 8, 8)
+      bounds: 944 320 8 8
+    - image: solid-color(119, 40, 0, 255, 8, 8)
+      bounds: 952 320 8 8
+    - image: solid-color(120, 40, 0, 255, 8, 8)
+      bounds: 960 320 8 8
+    - image: solid-color(121, 40, 0, 255, 8, 8)
+      bounds: 968 320 8 8
+    - image: solid-color(122, 40, 0, 255, 8, 8)
+      bounds: 976 320 8 8
+    - image: solid-color(123, 40, 0, 255, 8, 8)
+      bounds: 984 320 8 8
+    - image: solid-color(124, 40, 0, 255, 8, 8)
+      bounds: 992 320 8 8
+    - image: solid-color(125, 40, 0, 255, 8, 8)
+      bounds: 1000 320 8 8
+    - image: solid-color(126, 40, 0, 255, 8, 8)
+      bounds: 1008 320 8 8
+    - image: solid-color(127, 40, 0, 255, 8, 8)
+      bounds: 1016 320 8 8
+    - image: solid-color(0, 41, 0, 255, 8, 8)
+      bounds: 0 328 8 8
+    - image: solid-color(1, 41, 0, 255, 8, 8)
+      bounds: 8 328 8 8
+    - image: solid-color(2, 41, 0, 255, 8, 8)
+      bounds: 16 328 8 8
+    - image: solid-color(3, 41, 0, 255, 8, 8)
+      bounds: 24 328 8 8
+    - image: solid-color(4, 41, 0, 255, 8, 8)
+      bounds: 32 328 8 8
+    - image: solid-color(5, 41, 0, 255, 8, 8)
+      bounds: 40 328 8 8
+    - image: solid-color(6, 41, 0, 255, 8, 8)
+      bounds: 48 328 8 8
+    - image: solid-color(7, 41, 0, 255, 8, 8)
+      bounds: 56 328 8 8
+    - image: solid-color(8, 41, 0, 255, 8, 8)
+      bounds: 64 328 8 8
+    - image: solid-color(9, 41, 0, 255, 8, 8)
+      bounds: 72 328 8 8
+    - image: solid-color(10, 41, 0, 255, 8, 8)
+      bounds: 80 328 8 8
+    - image: solid-color(11, 41, 0, 255, 8, 8)
+      bounds: 88 328 8 8
+    - image: solid-color(12, 41, 0, 255, 8, 8)
+      bounds: 96 328 8 8
+    - image: solid-color(13, 41, 0, 255, 8, 8)
+      bounds: 104 328 8 8
+    - image: solid-color(14, 41, 0, 255, 8, 8)
+      bounds: 112 328 8 8
+    - image: solid-color(15, 41, 0, 255, 8, 8)
+      bounds: 120 328 8 8
+    - image: solid-color(16, 41, 0, 255, 8, 8)
+      bounds: 128 328 8 8
+    - image: solid-color(17, 41, 0, 255, 8, 8)
+      bounds: 136 328 8 8
+    - image: solid-color(18, 41, 0, 255, 8, 8)
+      bounds: 144 328 8 8
+    - image: solid-color(19, 41, 0, 255, 8, 8)
+      bounds: 152 328 8 8
+    - image: solid-color(20, 41, 0, 255, 8, 8)
+      bounds: 160 328 8 8
+    - image: solid-color(21, 41, 0, 255, 8, 8)
+      bounds: 168 328 8 8
+    - image: solid-color(22, 41, 0, 255, 8, 8)
+      bounds: 176 328 8 8
+    - image: solid-color(23, 41, 0, 255, 8, 8)
+      bounds: 184 328 8 8
+    - image: solid-color(24, 41, 0, 255, 8, 8)
+      bounds: 192 328 8 8
+    - image: solid-color(25, 41, 0, 255, 8, 8)
+      bounds: 200 328 8 8
+    - image: solid-color(26, 41, 0, 255, 8, 8)
+      bounds: 208 328 8 8
+    - image: solid-color(27, 41, 0, 255, 8, 8)
+      bounds: 216 328 8 8
+    - image: solid-color(28, 41, 0, 255, 8, 8)
+      bounds: 224 328 8 8
+    - image: solid-color(29, 41, 0, 255, 8, 8)
+      bounds: 232 328 8 8
+    - image: solid-color(30, 41, 0, 255, 8, 8)
+      bounds: 240 328 8 8
+    - image: solid-color(31, 41, 0, 255, 8, 8)
+      bounds: 248 328 8 8
+    - image: solid-color(32, 41, 0, 255, 8, 8)
+      bounds: 256 328 8 8
+    - image: solid-color(33, 41, 0, 255, 8, 8)
+      bounds: 264 328 8 8
+    - image: solid-color(34, 41, 0, 255, 8, 8)
+      bounds: 272 328 8 8
+    - image: solid-color(35, 41, 0, 255, 8, 8)
+      bounds: 280 328 8 8
+    - image: solid-color(36, 41, 0, 255, 8, 8)
+      bounds: 288 328 8 8
+    - image: solid-color(37, 41, 0, 255, 8, 8)
+      bounds: 296 328 8 8
+    - image: solid-color(38, 41, 0, 255, 8, 8)
+      bounds: 304 328 8 8
+    - image: solid-color(39, 41, 0, 255, 8, 8)
+      bounds: 312 328 8 8
+    - image: solid-color(40, 41, 0, 255, 8, 8)
+      bounds: 320 328 8 8
+    - image: solid-color(41, 41, 0, 255, 8, 8)
+      bounds: 328 328 8 8
+    - image: solid-color(42, 41, 0, 255, 8, 8)
+      bounds: 336 328 8 8
+    - image: solid-color(43, 41, 0, 255, 8, 8)
+      bounds: 344 328 8 8
+    - image: solid-color(44, 41, 0, 255, 8, 8)
+      bounds: 352 328 8 8
+    - image: solid-color(45, 41, 0, 255, 8, 8)
+      bounds: 360 328 8 8
+    - image: solid-color(46, 41, 0, 255, 8, 8)
+      bounds: 368 328 8 8
+    - image: solid-color(47, 41, 0, 255, 8, 8)
+      bounds: 376 328 8 8
+    - image: solid-color(48, 41, 0, 255, 8, 8)
+      bounds: 384 328 8 8
+    - image: solid-color(49, 41, 0, 255, 8, 8)
+      bounds: 392 328 8 8
+    - image: solid-color(50, 41, 0, 255, 8, 8)
+      bounds: 400 328 8 8
+    - image: solid-color(51, 41, 0, 255, 8, 8)
+      bounds: 408 328 8 8
+    - image: solid-color(52, 41, 0, 255, 8, 8)
+      bounds: 416 328 8 8
+    - image: solid-color(53, 41, 0, 255, 8, 8)
+      bounds: 424 328 8 8
+    - image: solid-color(54, 41, 0, 255, 8, 8)
+      bounds: 432 328 8 8
+    - image: solid-color(55, 41, 0, 255, 8, 8)
+      bounds: 440 328 8 8
+    - image: solid-color(56, 41, 0, 255, 8, 8)
+      bounds: 448 328 8 8
+    - image: solid-color(57, 41, 0, 255, 8, 8)
+      bounds: 456 328 8 8
+    - image: solid-color(58, 41, 0, 255, 8, 8)
+      bounds: 464 328 8 8
+    - image: solid-color(59, 41, 0, 255, 8, 8)
+      bounds: 472 328 8 8
+    - image: solid-color(60, 41, 0, 255, 8, 8)
+      bounds: 480 328 8 8
+    - image: solid-color(61, 41, 0, 255, 8, 8)
+      bounds: 488 328 8 8
+    - image: solid-color(62, 41, 0, 255, 8, 8)
+      bounds: 496 328 8 8
+    - image: solid-color(63, 41, 0, 255, 8, 8)
+      bounds: 504 328 8 8
+    - image: solid-color(64, 41, 0, 255, 8, 8)
+      bounds: 512 328 8 8
+    - image: solid-color(65, 41, 0, 255, 8, 8)
+      bounds: 520 328 8 8
+    - image: solid-color(66, 41, 0, 255, 8, 8)
+      bounds: 528 328 8 8
+    - image: solid-color(67, 41, 0, 255, 8, 8)
+      bounds: 536 328 8 8
+    - image: solid-color(68, 41, 0, 255, 8, 8)
+      bounds: 544 328 8 8
+    - image: solid-color(69, 41, 0, 255, 8, 8)
+      bounds: 552 328 8 8
+    - image: solid-color(70, 41, 0, 255, 8, 8)
+      bounds: 560 328 8 8
+    - image: solid-color(71, 41, 0, 255, 8, 8)
+      bounds: 568 328 8 8
+    - image: solid-color(72, 41, 0, 255, 8, 8)
+      bounds: 576 328 8 8
+    - image: solid-color(73, 41, 0, 255, 8, 8)
+      bounds: 584 328 8 8
+    - image: solid-color(74, 41, 0, 255, 8, 8)
+      bounds: 592 328 8 8
+    - image: solid-color(75, 41, 0, 255, 8, 8)
+      bounds: 600 328 8 8
+    - image: solid-color(76, 41, 0, 255, 8, 8)
+      bounds: 608 328 8 8
+    - image: solid-color(77, 41, 0, 255, 8, 8)
+      bounds: 616 328 8 8
+    - image: solid-color(78, 41, 0, 255, 8, 8)
+      bounds: 624 328 8 8
+    - image: solid-color(79, 41, 0, 255, 8, 8)
+      bounds: 632 328 8 8
+    - image: solid-color(80, 41, 0, 255, 8, 8)
+      bounds: 640 328 8 8
+    - image: solid-color(81, 41, 0, 255, 8, 8)
+      bounds: 648 328 8 8
+    - image: solid-color(82, 41, 0, 255, 8, 8)
+      bounds: 656 328 8 8
+    - image: solid-color(83, 41, 0, 255, 8, 8)
+      bounds: 664 328 8 8
+    - image: solid-color(84, 41, 0, 255, 8, 8)
+      bounds: 672 328 8 8
+    - image: solid-color(85, 41, 0, 255, 8, 8)
+      bounds: 680 328 8 8
+    - image: solid-color(86, 41, 0, 255, 8, 8)
+      bounds: 688 328 8 8
+    - image: solid-color(87, 41, 0, 255, 8, 8)
+      bounds: 696 328 8 8
+    - image: solid-color(88, 41, 0, 255, 8, 8)
+      bounds: 704 328 8 8
+    - image: solid-color(89, 41, 0, 255, 8, 8)
+      bounds: 712 328 8 8
+    - image: solid-color(90, 41, 0, 255, 8, 8)
+      bounds: 720 328 8 8
+    - image: solid-color(91, 41, 0, 255, 8, 8)
+      bounds: 728 328 8 8
+    - image: solid-color(92, 41, 0, 255, 8, 8)
+      bounds: 736 328 8 8
+    - image: solid-color(93, 41, 0, 255, 8, 8)
+      bounds: 744 328 8 8
+    - image: solid-color(94, 41, 0, 255, 8, 8)
+      bounds: 752 328 8 8
+    - image: solid-color(95, 41, 0, 255, 8, 8)
+      bounds: 760 328 8 8
+    - image: solid-color(96, 41, 0, 255, 8, 8)
+      bounds: 768 328 8 8
+    - image: solid-color(97, 41, 0, 255, 8, 8)
+      bounds: 776 328 8 8
+    - image: solid-color(98, 41, 0, 255, 8, 8)
+      bounds: 784 328 8 8
+    - image: solid-color(99, 41, 0, 255, 8, 8)
+      bounds: 792 328 8 8
+    - image: solid-color(100, 41, 0, 255, 8, 8)
+      bounds: 800 328 8 8
+    - image: solid-color(101, 41, 0, 255, 8, 8)
+      bounds: 808 328 8 8
+    - image: solid-color(102, 41, 0, 255, 8, 8)
+      bounds: 816 328 8 8
+    - image: solid-color(103, 41, 0, 255, 8, 8)
+      bounds: 824 328 8 8
+    - image: solid-color(104, 41, 0, 255, 8, 8)
+      bounds: 832 328 8 8
+    - image: solid-color(105, 41, 0, 255, 8, 8)
+      bounds: 840 328 8 8
+    - image: solid-color(106, 41, 0, 255, 8, 8)
+      bounds: 848 328 8 8
+    - image: solid-color(107, 41, 0, 255, 8, 8)
+      bounds: 856 328 8 8
+    - image: solid-color(108, 41, 0, 255, 8, 8)
+      bounds: 864 328 8 8
+    - image: solid-color(109, 41, 0, 255, 8, 8)
+      bounds: 872 328 8 8
+    - image: solid-color(110, 41, 0, 255, 8, 8)
+      bounds: 880 328 8 8
+    - image: solid-color(111, 41, 0, 255, 8, 8)
+      bounds: 888 328 8 8
+    - image: solid-color(112, 41, 0, 255, 8, 8)
+      bounds: 896 328 8 8
+    - image: solid-color(113, 41, 0, 255, 8, 8)
+      bounds: 904 328 8 8
+    - image: solid-color(114, 41, 0, 255, 8, 8)
+      bounds: 912 328 8 8
+    - image: solid-color(115, 41, 0, 255, 8, 8)
+      bounds: 920 328 8 8
+    - image: solid-color(116, 41, 0, 255, 8, 8)
+      bounds: 928 328 8 8
+    - image: solid-color(117, 41, 0, 255, 8, 8)
+      bounds: 936 328 8 8
+    - image: solid-color(118, 41, 0, 255, 8, 8)
+      bounds: 944 328 8 8
+    - image: solid-color(119, 41, 0, 255, 8, 8)
+      bounds: 952 328 8 8
+    - image: solid-color(120, 41, 0, 255, 8, 8)
+      bounds: 960 328 8 8
+    - image: solid-color(121, 41, 0, 255, 8, 8)
+      bounds: 968 328 8 8
+    - image: solid-color(122, 41, 0, 255, 8, 8)
+      bounds: 976 328 8 8
+    - image: solid-color(123, 41, 0, 255, 8, 8)
+      bounds: 984 328 8 8
+    - image: solid-color(124, 41, 0, 255, 8, 8)
+      bounds: 992 328 8 8
+    - image: solid-color(125, 41, 0, 255, 8, 8)
+      bounds: 1000 328 8 8
+    - image: solid-color(126, 41, 0, 255, 8, 8)
+      bounds: 1008 328 8 8
+    - image: solid-color(127, 41, 0, 255, 8, 8)
+      bounds: 1016 328 8 8
+    - image: solid-color(0, 42, 0, 255, 8, 8)
+      bounds: 0 336 8 8
+    - image: solid-color(1, 42, 0, 255, 8, 8)
+      bounds: 8 336 8 8
+    - image: solid-color(2, 42, 0, 255, 8, 8)
+      bounds: 16 336 8 8
+    - image: solid-color(3, 42, 0, 255, 8, 8)
+      bounds: 24 336 8 8
+    - image: solid-color(4, 42, 0, 255, 8, 8)
+      bounds: 32 336 8 8
+    - image: solid-color(5, 42, 0, 255, 8, 8)
+      bounds: 40 336 8 8
+    - image: solid-color(6, 42, 0, 255, 8, 8)
+      bounds: 48 336 8 8
+    - image: solid-color(7, 42, 0, 255, 8, 8)
+      bounds: 56 336 8 8
+    - image: solid-color(8, 42, 0, 255, 8, 8)
+      bounds: 64 336 8 8
+    - image: solid-color(9, 42, 0, 255, 8, 8)
+      bounds: 72 336 8 8
+    - image: solid-color(10, 42, 0, 255, 8, 8)
+      bounds: 80 336 8 8
+    - image: solid-color(11, 42, 0, 255, 8, 8)
+      bounds: 88 336 8 8
+    - image: solid-color(12, 42, 0, 255, 8, 8)
+      bounds: 96 336 8 8
+    - image: solid-color(13, 42, 0, 255, 8, 8)
+      bounds: 104 336 8 8
+    - image: solid-color(14, 42, 0, 255, 8, 8)
+      bounds: 112 336 8 8
+    - image: solid-color(15, 42, 0, 255, 8, 8)
+      bounds: 120 336 8 8
+    - image: solid-color(16, 42, 0, 255, 8, 8)
+      bounds: 128 336 8 8
+    - image: solid-color(17, 42, 0, 255, 8, 8)
+      bounds: 136 336 8 8
+    - image: solid-color(18, 42, 0, 255, 8, 8)
+      bounds: 144 336 8 8
+    - image: solid-color(19, 42, 0, 255, 8, 8)
+      bounds: 152 336 8 8
+    - image: solid-color(20, 42, 0, 255, 8, 8)
+      bounds: 160 336 8 8
+    - image: solid-color(21, 42, 0, 255, 8, 8)
+      bounds: 168 336 8 8
+    - image: solid-color(22, 42, 0, 255, 8, 8)
+      bounds: 176 336 8 8
+    - image: solid-color(23, 42, 0, 255, 8, 8)
+      bounds: 184 336 8 8
+    - image: solid-color(24, 42, 0, 255, 8, 8)
+      bounds: 192 336 8 8
+    - image: solid-color(25, 42, 0, 255, 8, 8)
+      bounds: 200 336 8 8
+    - image: solid-color(26, 42, 0, 255, 8, 8)
+      bounds: 208 336 8 8
+    - image: solid-color(27, 42, 0, 255, 8, 8)
+      bounds: 216 336 8 8
+    - image: solid-color(28, 42, 0, 255, 8, 8)
+      bounds: 224 336 8 8
+    - image: solid-color(29, 42, 0, 255, 8, 8)
+      bounds: 232 336 8 8
+    - image: solid-color(30, 42, 0, 255, 8, 8)
+      bounds: 240 336 8 8
+    - image: solid-color(31, 42, 0, 255, 8, 8)
+      bounds: 248 336 8 8
+    - image: solid-color(32, 42, 0, 255, 8, 8)
+      bounds: 256 336 8 8
+    - image: solid-color(33, 42, 0, 255, 8, 8)
+      bounds: 264 336 8 8
+    - image: solid-color(34, 42, 0, 255, 8, 8)
+      bounds: 272 336 8 8
+    - image: solid-color(35, 42, 0, 255, 8, 8)
+      bounds: 280 336 8 8
+    - image: solid-color(36, 42, 0, 255, 8, 8)
+      bounds: 288 336 8 8
+    - image: solid-color(37, 42, 0, 255, 8, 8)
+      bounds: 296 336 8 8
+    - image: solid-color(38, 42, 0, 255, 8, 8)
+      bounds: 304 336 8 8
+    - image: solid-color(39, 42, 0, 255, 8, 8)
+      bounds: 312 336 8 8
+    - image: solid-color(40, 42, 0, 255, 8, 8)
+      bounds: 320 336 8 8
+    - image: solid-color(41, 42, 0, 255, 8, 8)
+      bounds: 328 336 8 8
+    - image: solid-color(42, 42, 0, 255, 8, 8)
+      bounds: 336 336 8 8
+    - image: solid-color(43, 42, 0, 255, 8, 8)
+      bounds: 344 336 8 8
+    - image: solid-color(44, 42, 0, 255, 8, 8)
+      bounds: 352 336 8 8
+    - image: solid-color(45, 42, 0, 255, 8, 8)
+      bounds: 360 336 8 8
+    - image: solid-color(46, 42, 0, 255, 8, 8)
+      bounds: 368 336 8 8
+    - image: solid-color(47, 42, 0, 255, 8, 8)
+      bounds: 376 336 8 8
+    - image: solid-color(48, 42, 0, 255, 8, 8)
+      bounds: 384 336 8 8
+    - image: solid-color(49, 42, 0, 255, 8, 8)
+      bounds: 392 336 8 8
+    - image: solid-color(50, 42, 0, 255, 8, 8)
+      bounds: 400 336 8 8
+    - image: solid-color(51, 42, 0, 255, 8, 8)
+      bounds: 408 336 8 8
+    - image: solid-color(52, 42, 0, 255, 8, 8)
+      bounds: 416 336 8 8
+    - image: solid-color(53, 42, 0, 255, 8, 8)
+      bounds: 424 336 8 8
+    - image: solid-color(54, 42, 0, 255, 8, 8)
+      bounds: 432 336 8 8
+    - image: solid-color(55, 42, 0, 255, 8, 8)
+      bounds: 440 336 8 8
+    - image: solid-color(56, 42, 0, 255, 8, 8)
+      bounds: 448 336 8 8
+    - image: solid-color(57, 42, 0, 255, 8, 8)
+      bounds: 456 336 8 8
+    - image: solid-color(58, 42, 0, 255, 8, 8)
+      bounds: 464 336 8 8
+    - image: solid-color(59, 42, 0, 255, 8, 8)
+      bounds: 472 336 8 8
+    - image: solid-color(60, 42, 0, 255, 8, 8)
+      bounds: 480 336 8 8
+    - image: solid-color(61, 42, 0, 255, 8, 8)
+      bounds: 488 336 8 8
+    - image: solid-color(62, 42, 0, 255, 8, 8)
+      bounds: 496 336 8 8
+    - image: solid-color(63, 42, 0, 255, 8, 8)
+      bounds: 504 336 8 8
+    - image: solid-color(64, 42, 0, 255, 8, 8)
+      bounds: 512 336 8 8
+    - image: solid-color(65, 42, 0, 255, 8, 8)
+      bounds: 520 336 8 8
+    - image: solid-color(66, 42, 0, 255, 8, 8)
+      bounds: 528 336 8 8
+    - image: solid-color(67, 42, 0, 255, 8, 8)
+      bounds: 536 336 8 8
+    - image: solid-color(68, 42, 0, 255, 8, 8)
+      bounds: 544 336 8 8
+    - image: solid-color(69, 42, 0, 255, 8, 8)
+      bounds: 552 336 8 8
+    - image: solid-color(70, 42, 0, 255, 8, 8)
+      bounds: 560 336 8 8
+    - image: solid-color(71, 42, 0, 255, 8, 8)
+      bounds: 568 336 8 8
+    - image: solid-color(72, 42, 0, 255, 8, 8)
+      bounds: 576 336 8 8
+    - image: solid-color(73, 42, 0, 255, 8, 8)
+      bounds: 584 336 8 8
+    - image: solid-color(74, 42, 0, 255, 8, 8)
+      bounds: 592 336 8 8
+    - image: solid-color(75, 42, 0, 255, 8, 8)
+      bounds: 600 336 8 8
+    - image: solid-color(76, 42, 0, 255, 8, 8)
+      bounds: 608 336 8 8
+    - image: solid-color(77, 42, 0, 255, 8, 8)
+      bounds: 616 336 8 8
+    - image: solid-color(78, 42, 0, 255, 8, 8)
+      bounds: 624 336 8 8
+    - image: solid-color(79, 42, 0, 255, 8, 8)
+      bounds: 632 336 8 8
+    - image: solid-color(80, 42, 0, 255, 8, 8)
+      bounds: 640 336 8 8
+    - image: solid-color(81, 42, 0, 255, 8, 8)
+      bounds: 648 336 8 8
+    - image: solid-color(82, 42, 0, 255, 8, 8)
+      bounds: 656 336 8 8
+    - image: solid-color(83, 42, 0, 255, 8, 8)
+      bounds: 664 336 8 8
+    - image: solid-color(84, 42, 0, 255, 8, 8)
+      bounds: 672 336 8 8
+    - image: solid-color(85, 42, 0, 255, 8, 8)
+      bounds: 680 336 8 8
+    - image: solid-color(86, 42, 0, 255, 8, 8)
+      bounds: 688 336 8 8
+    - image: solid-color(87, 42, 0, 255, 8, 8)
+      bounds: 696 336 8 8
+    - image: solid-color(88, 42, 0, 255, 8, 8)
+      bounds: 704 336 8 8
+    - image: solid-color(89, 42, 0, 255, 8, 8)
+      bounds: 712 336 8 8
+    - image: solid-color(90, 42, 0, 255, 8, 8)
+      bounds: 720 336 8 8
+    - image: solid-color(91, 42, 0, 255, 8, 8)
+      bounds: 728 336 8 8
+    - image: solid-color(92, 42, 0, 255, 8, 8)
+      bounds: 736 336 8 8
+    - image: solid-color(93, 42, 0, 255, 8, 8)
+      bounds: 744 336 8 8
+    - image: solid-color(94, 42, 0, 255, 8, 8)
+      bounds: 752 336 8 8
+    - image: solid-color(95, 42, 0, 255, 8, 8)
+      bounds: 760 336 8 8
+    - image: solid-color(96, 42, 0, 255, 8, 8)
+      bounds: 768 336 8 8
+    - image: solid-color(97, 42, 0, 255, 8, 8)
+      bounds: 776 336 8 8
+    - image: solid-color(98, 42, 0, 255, 8, 8)
+      bounds: 784 336 8 8
+    - image: solid-color(99, 42, 0, 255, 8, 8)
+      bounds: 792 336 8 8
+    - image: solid-color(100, 42, 0, 255, 8, 8)
+      bounds: 800 336 8 8
+    - image: solid-color(101, 42, 0, 255, 8, 8)
+      bounds: 808 336 8 8
+    - image: solid-color(102, 42, 0, 255, 8, 8)
+      bounds: 816 336 8 8
+    - image: solid-color(103, 42, 0, 255, 8, 8)
+      bounds: 824 336 8 8
+    - image: solid-color(104, 42, 0, 255, 8, 8)
+      bounds: 832 336 8 8
+    - image: solid-color(105, 42, 0, 255, 8, 8)
+      bounds: 840 336 8 8
+    - image: solid-color(106, 42, 0, 255, 8, 8)
+      bounds: 848 336 8 8
+    - image: solid-color(107, 42, 0, 255, 8, 8)
+      bounds: 856 336 8 8
+    - image: solid-color(108, 42, 0, 255, 8, 8)
+      bounds: 864 336 8 8
+    - image: solid-color(109, 42, 0, 255, 8, 8)
+      bounds: 872 336 8 8
+    - image: solid-color(110, 42, 0, 255, 8, 8)
+      bounds: 880 336 8 8
+    - image: solid-color(111, 42, 0, 255, 8, 8)
+      bounds: 888 336 8 8
+    - image: solid-color(112, 42, 0, 255, 8, 8)
+      bounds: 896 336 8 8
+    - image: solid-color(113, 42, 0, 255, 8, 8)
+      bounds: 904 336 8 8
+    - image: solid-color(114, 42, 0, 255, 8, 8)
+      bounds: 912 336 8 8
+    - image: solid-color(115, 42, 0, 255, 8, 8)
+      bounds: 920 336 8 8
+    - image: solid-color(116, 42, 0, 255, 8, 8)
+      bounds: 928 336 8 8
+    - image: solid-color(117, 42, 0, 255, 8, 8)
+      bounds: 936 336 8 8
+    - image: solid-color(118, 42, 0, 255, 8, 8)
+      bounds: 944 336 8 8
+    - image: solid-color(119, 42, 0, 255, 8, 8)
+      bounds: 952 336 8 8
+    - image: solid-color(120, 42, 0, 255, 8, 8)
+      bounds: 960 336 8 8
+    - image: solid-color(121, 42, 0, 255, 8, 8)
+      bounds: 968 336 8 8
+    - image: solid-color(122, 42, 0, 255, 8, 8)
+      bounds: 976 336 8 8
+    - image: solid-color(123, 42, 0, 255, 8, 8)
+      bounds: 984 336 8 8
+    - image: solid-color(124, 42, 0, 255, 8, 8)
+      bounds: 992 336 8 8
+    - image: solid-color(125, 42, 0, 255, 8, 8)
+      bounds: 1000 336 8 8
+    - image: solid-color(126, 42, 0, 255, 8, 8)
+      bounds: 1008 336 8 8
+    - image: solid-color(127, 42, 0, 255, 8, 8)
+      bounds: 1016 336 8 8
+    - image: solid-color(0, 43, 0, 255, 8, 8)
+      bounds: 0 344 8 8
+    - image: solid-color(1, 43, 0, 255, 8, 8)
+      bounds: 8 344 8 8
+    - image: solid-color(2, 43, 0, 255, 8, 8)
+      bounds: 16 344 8 8
+    - image: solid-color(3, 43, 0, 255, 8, 8)
+      bounds: 24 344 8 8
+    - image: solid-color(4, 43, 0, 255, 8, 8)
+      bounds: 32 344 8 8
+    - image: solid-color(5, 43, 0, 255, 8, 8)
+      bounds: 40 344 8 8
+    - image: solid-color(6, 43, 0, 255, 8, 8)
+      bounds: 48 344 8 8
+    - image: solid-color(7, 43, 0, 255, 8, 8)
+      bounds: 56 344 8 8
+    - image: solid-color(8, 43, 0, 255, 8, 8)
+      bounds: 64 344 8 8
+    - image: solid-color(9, 43, 0, 255, 8, 8)
+      bounds: 72 344 8 8
+    - image: solid-color(10, 43, 0, 255, 8, 8)
+      bounds: 80 344 8 8
+    - image: solid-color(11, 43, 0, 255, 8, 8)
+      bounds: 88 344 8 8
+    - image: solid-color(12, 43, 0, 255, 8, 8)
+      bounds: 96 344 8 8
+    - image: solid-color(13, 43, 0, 255, 8, 8)
+      bounds: 104 344 8 8
+    - image: solid-color(14, 43, 0, 255, 8, 8)
+      bounds: 112 344 8 8
+    - image: solid-color(15, 43, 0, 255, 8, 8)
+      bounds: 120 344 8 8
+    - image: solid-color(16, 43, 0, 255, 8, 8)
+      bounds: 128 344 8 8
+    - image: solid-color(17, 43, 0, 255, 8, 8)
+      bounds: 136 344 8 8
+    - image: solid-color(18, 43, 0, 255, 8, 8)
+      bounds: 144 344 8 8
+    - image: solid-color(19, 43, 0, 255, 8, 8)
+      bounds: 152 344 8 8
+    - image: solid-color(20, 43, 0, 255, 8, 8)
+      bounds: 160 344 8 8
+    - image: solid-color(21, 43, 0, 255, 8, 8)
+      bounds: 168 344 8 8
+    - image: solid-color(22, 43, 0, 255, 8, 8)
+      bounds: 176 344 8 8
+    - image: solid-color(23, 43, 0, 255, 8, 8)
+      bounds: 184 344 8 8
+    - image: solid-color(24, 43, 0, 255, 8, 8)
+      bounds: 192 344 8 8
+    - image: solid-color(25, 43, 0, 255, 8, 8)
+      bounds: 200 344 8 8
+    - image: solid-color(26, 43, 0, 255, 8, 8)
+      bounds: 208 344 8 8
+    - image: solid-color(27, 43, 0, 255, 8, 8)
+      bounds: 216 344 8 8
+    - image: solid-color(28, 43, 0, 255, 8, 8)
+      bounds: 224 344 8 8
+    - image: solid-color(29, 43, 0, 255, 8, 8)
+      bounds: 232 344 8 8
+    - image: solid-color(30, 43, 0, 255, 8, 8)
+      bounds: 240 344 8 8
+    - image: solid-color(31, 43, 0, 255, 8, 8)
+      bounds: 248 344 8 8
+    - image: solid-color(32, 43, 0, 255, 8, 8)
+      bounds: 256 344 8 8
+    - image: solid-color(33, 43, 0, 255, 8, 8)
+      bounds: 264 344 8 8
+    - image: solid-color(34, 43, 0, 255, 8, 8)
+      bounds: 272 344 8 8
+    - image: solid-color(35, 43, 0, 255, 8, 8)
+      bounds: 280 344 8 8
+    - image: solid-color(36, 43, 0, 255, 8, 8)
+      bounds: 288 344 8 8
+    - image: solid-color(37, 43, 0, 255, 8, 8)
+      bounds: 296 344 8 8
+    - image: solid-color(38, 43, 0, 255, 8, 8)
+      bounds: 304 344 8 8
+    - image: solid-color(39, 43, 0, 255, 8, 8)
+      bounds: 312 344 8 8
+    - image: solid-color(40, 43, 0, 255, 8, 8)
+      bounds: 320 344 8 8
+    - image: solid-color(41, 43, 0, 255, 8, 8)
+      bounds: 328 344 8 8
+    - image: solid-color(42, 43, 0, 255, 8, 8)
+      bounds: 336 344 8 8
+    - image: solid-color(43, 43, 0, 255, 8, 8)
+      bounds: 344 344 8 8
+    - image: solid-color(44, 43, 0, 255, 8, 8)
+      bounds: 352 344 8 8
+    - image: solid-color(45, 43, 0, 255, 8, 8)
+      bounds: 360 344 8 8
+    - image: solid-color(46, 43, 0, 255, 8, 8)
+      bounds: 368 344 8 8
+    - image: solid-color(47, 43, 0, 255, 8, 8)
+      bounds: 376 344 8 8
+    - image: solid-color(48, 43, 0, 255, 8, 8)
+      bounds: 384 344 8 8
+    - image: solid-color(49, 43, 0, 255, 8, 8)
+      bounds: 392 344 8 8
+    - image: solid-color(50, 43, 0, 255, 8, 8)
+      bounds: 400 344 8 8
+    - image: solid-color(51, 43, 0, 255, 8, 8)
+      bounds: 408 344 8 8
+    - image: solid-color(52, 43, 0, 255, 8, 8)
+      bounds: 416 344 8 8
+    - image: solid-color(53, 43, 0, 255, 8, 8)
+      bounds: 424 344 8 8
+    - image: solid-color(54, 43, 0, 255, 8, 8)
+      bounds: 432 344 8 8
+    - image: solid-color(55, 43, 0, 255, 8, 8)
+      bounds: 440 344 8 8
+    - image: solid-color(56, 43, 0, 255, 8, 8)
+      bounds: 448 344 8 8
+    - image: solid-color(57, 43, 0, 255, 8, 8)
+      bounds: 456 344 8 8
+    - image: solid-color(58, 43, 0, 255, 8, 8)
+      bounds: 464 344 8 8
+    - image: solid-color(59, 43, 0, 255, 8, 8)
+      bounds: 472 344 8 8
+    - image: solid-color(60, 43, 0, 255, 8, 8)
+      bounds: 480 344 8 8
+    - image: solid-color(61, 43, 0, 255, 8, 8)
+      bounds: 488 344 8 8
+    - image: solid-color(62, 43, 0, 255, 8, 8)
+      bounds: 496 344 8 8
+    - image: solid-color(63, 43, 0, 255, 8, 8)
+      bounds: 504 344 8 8
+    - image: solid-color(64, 43, 0, 255, 8, 8)
+      bounds: 512 344 8 8
+    - image: solid-color(65, 43, 0, 255, 8, 8)
+      bounds: 520 344 8 8
+    - image: solid-color(66, 43, 0, 255, 8, 8)
+      bounds: 528 344 8 8
+    - image: solid-color(67, 43, 0, 255, 8, 8)
+      bounds: 536 344 8 8
+    - image: solid-color(68, 43, 0, 255, 8, 8)
+      bounds: 544 344 8 8
+    - image: solid-color(69, 43, 0, 255, 8, 8)
+      bounds: 552 344 8 8
+    - image: solid-color(70, 43, 0, 255, 8, 8)
+      bounds: 560 344 8 8
+    - image: solid-color(71, 43, 0, 255, 8, 8)
+      bounds: 568 344 8 8
+    - image: solid-color(72, 43, 0, 255, 8, 8)
+      bounds: 576 344 8 8
+    - image: solid-color(73, 43, 0, 255, 8, 8)
+      bounds: 584 344 8 8
+    - image: solid-color(74, 43, 0, 255, 8, 8)
+      bounds: 592 344 8 8
+    - image: solid-color(75, 43, 0, 255, 8, 8)
+      bounds: 600 344 8 8
+    - image: solid-color(76, 43, 0, 255, 8, 8)
+      bounds: 608 344 8 8
+    - image: solid-color(77, 43, 0, 255, 8, 8)
+      bounds: 616 344 8 8
+    - image: solid-color(78, 43, 0, 255, 8, 8)
+      bounds: 624 344 8 8
+    - image: solid-color(79, 43, 0, 255, 8, 8)
+      bounds: 632 344 8 8
+    - image: solid-color(80, 43, 0, 255, 8, 8)
+      bounds: 640 344 8 8
+    - image: solid-color(81, 43, 0, 255, 8, 8)
+      bounds: 648 344 8 8
+    - image: solid-color(82, 43, 0, 255, 8, 8)
+      bounds: 656 344 8 8
+    - image: solid-color(83, 43, 0, 255, 8, 8)
+      bounds: 664 344 8 8
+    - image: solid-color(84, 43, 0, 255, 8, 8)
+      bounds: 672 344 8 8
+    - image: solid-color(85, 43, 0, 255, 8, 8)
+      bounds: 680 344 8 8
+    - image: solid-color(86, 43, 0, 255, 8, 8)
+      bounds: 688 344 8 8
+    - image: solid-color(87, 43, 0, 255, 8, 8)
+      bounds: 696 344 8 8
+    - image: solid-color(88, 43, 0, 255, 8, 8)
+      bounds: 704 344 8 8
+    - image: solid-color(89, 43, 0, 255, 8, 8)
+      bounds: 712 344 8 8
+    - image: solid-color(90, 43, 0, 255, 8, 8)
+      bounds: 720 344 8 8
+    - image: solid-color(91, 43, 0, 255, 8, 8)
+      bounds: 728 344 8 8
+    - image: solid-color(92, 43, 0, 255, 8, 8)
+      bounds: 736 344 8 8
+    - image: solid-color(93, 43, 0, 255, 8, 8)
+      bounds: 744 344 8 8
+    - image: solid-color(94, 43, 0, 255, 8, 8)
+      bounds: 752 344 8 8
+    - image: solid-color(95, 43, 0, 255, 8, 8)
+      bounds: 760 344 8 8
+    - image: solid-color(96, 43, 0, 255, 8, 8)
+      bounds: 768 344 8 8
+    - image: solid-color(97, 43, 0, 255, 8, 8)
+      bounds: 776 344 8 8
+    - image: solid-color(98, 43, 0, 255, 8, 8)
+      bounds: 784 344 8 8
+    - image: solid-color(99, 43, 0, 255, 8, 8)
+      bounds: 792 344 8 8
+    - image: solid-color(100, 43, 0, 255, 8, 8)
+      bounds: 800 344 8 8
+    - image: solid-color(101, 43, 0, 255, 8, 8)
+      bounds: 808 344 8 8
+    - image: solid-color(102, 43, 0, 255, 8, 8)
+      bounds: 816 344 8 8
+    - image: solid-color(103, 43, 0, 255, 8, 8)
+      bounds: 824 344 8 8
+    - image: solid-color(104, 43, 0, 255, 8, 8)
+      bounds: 832 344 8 8
+    - image: solid-color(105, 43, 0, 255, 8, 8)
+      bounds: 840 344 8 8
+    - image: solid-color(106, 43, 0, 255, 8, 8)
+      bounds: 848 344 8 8
+    - image: solid-color(107, 43, 0, 255, 8, 8)
+      bounds: 856 344 8 8
+    - image: solid-color(108, 43, 0, 255, 8, 8)
+      bounds: 864 344 8 8
+    - image: solid-color(109, 43, 0, 255, 8, 8)
+      bounds: 872 344 8 8
+    - image: solid-color(110, 43, 0, 255, 8, 8)
+      bounds: 880 344 8 8
+    - image: solid-color(111, 43, 0, 255, 8, 8)
+      bounds: 888 344 8 8
+    - image: solid-color(112, 43, 0, 255, 8, 8)
+      bounds: 896 344 8 8
+    - image: solid-color(113, 43, 0, 255, 8, 8)
+      bounds: 904 344 8 8
+    - image: solid-color(114, 43, 0, 255, 8, 8)
+      bounds: 912 344 8 8
+    - image: solid-color(115, 43, 0, 255, 8, 8)
+      bounds: 920 344 8 8
+    - image: solid-color(116, 43, 0, 255, 8, 8)
+      bounds: 928 344 8 8
+    - image: solid-color(117, 43, 0, 255, 8, 8)
+      bounds: 936 344 8 8
+    - image: solid-color(118, 43, 0, 255, 8, 8)
+      bounds: 944 344 8 8
+    - image: solid-color(119, 43, 0, 255, 8, 8)
+      bounds: 952 344 8 8
+    - image: solid-color(120, 43, 0, 255, 8, 8)
+      bounds: 960 344 8 8
+    - image: solid-color(121, 43, 0, 255, 8, 8)
+      bounds: 968 344 8 8
+    - image: solid-color(122, 43, 0, 255, 8, 8)
+      bounds: 976 344 8 8
+    - image: solid-color(123, 43, 0, 255, 8, 8)
+      bounds: 984 344 8 8
+    - image: solid-color(124, 43, 0, 255, 8, 8)
+      bounds: 992 344 8 8
+    - image: solid-color(125, 43, 0, 255, 8, 8)
+      bounds: 1000 344 8 8
+    - image: solid-color(126, 43, 0, 255, 8, 8)
+      bounds: 1008 344 8 8
+    - image: solid-color(127, 43, 0, 255, 8, 8)
+      bounds: 1016 344 8 8
+    - image: solid-color(0, 44, 0, 255, 8, 8)
+      bounds: 0 352 8 8
+    - image: solid-color(1, 44, 0, 255, 8, 8)
+      bounds: 8 352 8 8
+    - image: solid-color(2, 44, 0, 255, 8, 8)
+      bounds: 16 352 8 8
+    - image: solid-color(3, 44, 0, 255, 8, 8)
+      bounds: 24 352 8 8
+    - image: solid-color(4, 44, 0, 255, 8, 8)
+      bounds: 32 352 8 8
+    - image: solid-color(5, 44, 0, 255, 8, 8)
+      bounds: 40 352 8 8
+    - image: solid-color(6, 44, 0, 255, 8, 8)
+      bounds: 48 352 8 8
+    - image: solid-color(7, 44, 0, 255, 8, 8)
+      bounds: 56 352 8 8
+    - image: solid-color(8, 44, 0, 255, 8, 8)
+      bounds: 64 352 8 8
+    - image: solid-color(9, 44, 0, 255, 8, 8)
+      bounds: 72 352 8 8
+    - image: solid-color(10, 44, 0, 255, 8, 8)
+      bounds: 80 352 8 8
+    - image: solid-color(11, 44, 0, 255, 8, 8)
+      bounds: 88 352 8 8
+    - image: solid-color(12, 44, 0, 255, 8, 8)
+      bounds: 96 352 8 8
+    - image: solid-color(13, 44, 0, 255, 8, 8)
+      bounds: 104 352 8 8
+    - image: solid-color(14, 44, 0, 255, 8, 8)
+      bounds: 112 352 8 8
+    - image: solid-color(15, 44, 0, 255, 8, 8)
+      bounds: 120 352 8 8
+    - image: solid-color(16, 44, 0, 255, 8, 8)
+      bounds: 128 352 8 8
+    - image: solid-color(17, 44, 0, 255, 8, 8)
+      bounds: 136 352 8 8
+    - image: solid-color(18, 44, 0, 255, 8, 8)
+      bounds: 144 352 8 8
+    - image: solid-color(19, 44, 0, 255, 8, 8)
+      bounds: 152 352 8 8
+    - image: solid-color(20, 44, 0, 255, 8, 8)
+      bounds: 160 352 8 8
+    - image: solid-color(21, 44, 0, 255, 8, 8)
+      bounds: 168 352 8 8
+    - image: solid-color(22, 44, 0, 255, 8, 8)
+      bounds: 176 352 8 8
+    - image: solid-color(23, 44, 0, 255, 8, 8)
+      bounds: 184 352 8 8
+    - image: solid-color(24, 44, 0, 255, 8, 8)
+      bounds: 192 352 8 8
+    - image: solid-color(25, 44, 0, 255, 8, 8)
+      bounds: 200 352 8 8
+    - image: solid-color(26, 44, 0, 255, 8, 8)
+      bounds: 208 352 8 8
+    - image: solid-color(27, 44, 0, 255, 8, 8)
+      bounds: 216 352 8 8
+    - image: solid-color(28, 44, 0, 255, 8, 8)
+      bounds: 224 352 8 8
+    - image: solid-color(29, 44, 0, 255, 8, 8)
+      bounds: 232 352 8 8
+    - image: solid-color(30, 44, 0, 255, 8, 8)
+      bounds: 240 352 8 8
+    - image: solid-color(31, 44, 0, 255, 8, 8)
+      bounds: 248 352 8 8
+    - image: solid-color(32, 44, 0, 255, 8, 8)
+      bounds: 256 352 8 8
+    - image: solid-color(33, 44, 0, 255, 8, 8)
+      bounds: 264 352 8 8
+    - image: solid-color(34, 44, 0, 255, 8, 8)
+      bounds: 272 352 8 8
+    - image: solid-color(35, 44, 0, 255, 8, 8)
+      bounds: 280 352 8 8
+    - image: solid-color(36, 44, 0, 255, 8, 8)
+      bounds: 288 352 8 8
+    - image: solid-color(37, 44, 0, 255, 8, 8)
+      bounds: 296 352 8 8
+    - image: solid-color(38, 44, 0, 255, 8, 8)
+      bounds: 304 352 8 8
+    - image: solid-color(39, 44, 0, 255, 8, 8)
+      bounds: 312 352 8 8
+    - image: solid-color(40, 44, 0, 255, 8, 8)
+      bounds: 320 352 8 8
+    - image: solid-color(41, 44, 0, 255, 8, 8)
+      bounds: 328 352 8 8
+    - image: solid-color(42, 44, 0, 255, 8, 8)
+      bounds: 336 352 8 8
+    - image: solid-color(43, 44, 0, 255, 8, 8)
+      bounds: 344 352 8 8
+    - image: solid-color(44, 44, 0, 255, 8, 8)
+      bounds: 352 352 8 8
+    - image: solid-color(45, 44, 0, 255, 8, 8)
+      bounds: 360 352 8 8
+    - image: solid-color(46, 44, 0, 255, 8, 8)
+      bounds: 368 352 8 8
+    - image: solid-color(47, 44, 0, 255, 8, 8)
+      bounds: 376 352 8 8
+    - image: solid-color(48, 44, 0, 255, 8, 8)
+      bounds: 384 352 8 8
+    - image: solid-color(49, 44, 0, 255, 8, 8)
+      bounds: 392 352 8 8
+    - image: solid-color(50, 44, 0, 255, 8, 8)
+      bounds: 400 352 8 8
+    - image: solid-color(51, 44, 0, 255, 8, 8)
+      bounds: 408 352 8 8
+    - image: solid-color(52, 44, 0, 255, 8, 8)
+      bounds: 416 352 8 8
+    - image: solid-color(53, 44, 0, 255, 8, 8)
+      bounds: 424 352 8 8
+    - image: solid-color(54, 44, 0, 255, 8, 8)
+      bounds: 432 352 8 8
+    - image: solid-color(55, 44, 0, 255, 8, 8)
+      bounds: 440 352 8 8
+    - image: solid-color(56, 44, 0, 255, 8, 8)
+      bounds: 448 352 8 8
+    - image: solid-color(57, 44, 0, 255, 8, 8)
+      bounds: 456 352 8 8
+    - image: solid-color(58, 44, 0, 255, 8, 8)
+      bounds: 464 352 8 8
+    - image: solid-color(59, 44, 0, 255, 8, 8)
+      bounds: 472 352 8 8
+    - image: solid-color(60, 44, 0, 255, 8, 8)
+      bounds: 480 352 8 8
+    - image: solid-color(61, 44, 0, 255, 8, 8)
+      bounds: 488 352 8 8
+    - image: solid-color(62, 44, 0, 255, 8, 8)
+      bounds: 496 352 8 8
+    - image: solid-color(63, 44, 0, 255, 8, 8)
+      bounds: 504 352 8 8
+    - image: solid-color(64, 44, 0, 255, 8, 8)
+      bounds: 512 352 8 8
+    - image: solid-color(65, 44, 0, 255, 8, 8)
+      bounds: 520 352 8 8
+    - image: solid-color(66, 44, 0, 255, 8, 8)
+      bounds: 528 352 8 8
+    - image: solid-color(67, 44, 0, 255, 8, 8)
+      bounds: 536 352 8 8
+    - image: solid-color(68, 44, 0, 255, 8, 8)
+      bounds: 544 352 8 8
+    - image: solid-color(69, 44, 0, 255, 8, 8)
+      bounds: 552 352 8 8
+    - image: solid-color(70, 44, 0, 255, 8, 8)
+      bounds: 560 352 8 8
+    - image: solid-color(71, 44, 0, 255, 8, 8)
+      bounds: 568 352 8 8
+    - image: solid-color(72, 44, 0, 255, 8, 8)
+      bounds: 576 352 8 8
+    - image: solid-color(73, 44, 0, 255, 8, 8)
+      bounds: 584 352 8 8
+    - image: solid-color(74, 44, 0, 255, 8, 8)
+      bounds: 592 352 8 8
+    - image: solid-color(75, 44, 0, 255, 8, 8)
+      bounds: 600 352 8 8
+    - image: solid-color(76, 44, 0, 255, 8, 8)
+      bounds: 608 352 8 8
+    - image: solid-color(77, 44, 0, 255, 8, 8)
+      bounds: 616 352 8 8
+    - image: solid-color(78, 44, 0, 255, 8, 8)
+      bounds: 624 352 8 8
+    - image: solid-color(79, 44, 0, 255, 8, 8)
+      bounds: 632 352 8 8
+    - image: solid-color(80, 44, 0, 255, 8, 8)
+      bounds: 640 352 8 8
+    - image: solid-color(81, 44, 0, 255, 8, 8)
+      bounds: 648 352 8 8
+    - image: solid-color(82, 44, 0, 255, 8, 8)
+      bounds: 656 352 8 8
+    - image: solid-color(83, 44, 0, 255, 8, 8)
+      bounds: 664 352 8 8
+    - image: solid-color(84, 44, 0, 255, 8, 8)
+      bounds: 672 352 8 8
+    - image: solid-color(85, 44, 0, 255, 8, 8)
+      bounds: 680 352 8 8
+    - image: solid-color(86, 44, 0, 255, 8, 8)
+      bounds: 688 352 8 8
+    - image: solid-color(87, 44, 0, 255, 8, 8)
+      bounds: 696 352 8 8
+    - image: solid-color(88, 44, 0, 255, 8, 8)
+      bounds: 704 352 8 8
+    - image: solid-color(89, 44, 0, 255, 8, 8)
+      bounds: 712 352 8 8
+    - image: solid-color(90, 44, 0, 255, 8, 8)
+      bounds: 720 352 8 8
+    - image: solid-color(91, 44, 0, 255, 8, 8)
+      bounds: 728 352 8 8
+    - image: solid-color(92, 44, 0, 255, 8, 8)
+      bounds: 736 352 8 8
+    - image: solid-color(93, 44, 0, 255, 8, 8)
+      bounds: 744 352 8 8
+    - image: solid-color(94, 44, 0, 255, 8, 8)
+      bounds: 752 352 8 8
+    - image: solid-color(95, 44, 0, 255, 8, 8)
+      bounds: 760 352 8 8
+    - image: solid-color(96, 44, 0, 255, 8, 8)
+      bounds: 768 352 8 8
+    - image: solid-color(97, 44, 0, 255, 8, 8)
+      bounds: 776 352 8 8
+    - image: solid-color(98, 44, 0, 255, 8, 8)
+      bounds: 784 352 8 8
+    - image: solid-color(99, 44, 0, 255, 8, 8)
+      bounds: 792 352 8 8
+    - image: solid-color(100, 44, 0, 255, 8, 8)
+      bounds: 800 352 8 8
+    - image: solid-color(101, 44, 0, 255, 8, 8)
+      bounds: 808 352 8 8
+    - image: solid-color(102, 44, 0, 255, 8, 8)
+      bounds: 816 352 8 8
+    - image: solid-color(103, 44, 0, 255, 8, 8)
+      bounds: 824 352 8 8
+    - image: solid-color(104, 44, 0, 255, 8, 8)
+      bounds: 832 352 8 8
+    - image: solid-color(105, 44, 0, 255, 8, 8)
+      bounds: 840 352 8 8
+    - image: solid-color(106, 44, 0, 255, 8, 8)
+      bounds: 848 352 8 8
+    - image: solid-color(107, 44, 0, 255, 8, 8)
+      bounds: 856 352 8 8
+    - image: solid-color(108, 44, 0, 255, 8, 8)
+      bounds: 864 352 8 8
+    - image: solid-color(109, 44, 0, 255, 8, 8)
+      bounds: 872 352 8 8
+    - image: solid-color(110, 44, 0, 255, 8, 8)
+      bounds: 880 352 8 8
+    - image: solid-color(111, 44, 0, 255, 8, 8)
+      bounds: 888 352 8 8
+    - image: solid-color(112, 44, 0, 255, 8, 8)
+      bounds: 896 352 8 8
+    - image: solid-color(113, 44, 0, 255, 8, 8)
+      bounds: 904 352 8 8
+    - image: solid-color(114, 44, 0, 255, 8, 8)
+      bounds: 912 352 8 8
+    - image: solid-color(115, 44, 0, 255, 8, 8)
+      bounds: 920 352 8 8
+    - image: solid-color(116, 44, 0, 255, 8, 8)
+      bounds: 928 352 8 8
+    - image: solid-color(117, 44, 0, 255, 8, 8)
+      bounds: 936 352 8 8
+    - image: solid-color(118, 44, 0, 255, 8, 8)
+      bounds: 944 352 8 8
+    - image: solid-color(119, 44, 0, 255, 8, 8)
+      bounds: 952 352 8 8
+    - image: solid-color(120, 44, 0, 255, 8, 8)
+      bounds: 960 352 8 8
+    - image: solid-color(121, 44, 0, 255, 8, 8)
+      bounds: 968 352 8 8
+    - image: solid-color(122, 44, 0, 255, 8, 8)
+      bounds: 976 352 8 8
+    - image: solid-color(123, 44, 0, 255, 8, 8)
+      bounds: 984 352 8 8
+    - image: solid-color(124, 44, 0, 255, 8, 8)
+      bounds: 992 352 8 8
+    - image: solid-color(125, 44, 0, 255, 8, 8)
+      bounds: 1000 352 8 8
+    - image: solid-color(126, 44, 0, 255, 8, 8)
+      bounds: 1008 352 8 8
+    - image: solid-color(127, 44, 0, 255, 8, 8)
+      bounds: 1016 352 8 8
+    - image: solid-color(0, 45, 0, 255, 8, 8)
+      bounds: 0 360 8 8
+    - image: solid-color(1, 45, 0, 255, 8, 8)
+      bounds: 8 360 8 8
+    - image: solid-color(2, 45, 0, 255, 8, 8)
+      bounds: 16 360 8 8
+    - image: solid-color(3, 45, 0, 255, 8, 8)
+      bounds: 24 360 8 8
+    - image: solid-color(4, 45, 0, 255, 8, 8)
+      bounds: 32 360 8 8
+    - image: solid-color(5, 45, 0, 255, 8, 8)
+      bounds: 40 360 8 8
+    - image: solid-color(6, 45, 0, 255, 8, 8)
+      bounds: 48 360 8 8
+    - image: solid-color(7, 45, 0, 255, 8, 8)
+      bounds: 56 360 8 8
+    - image: solid-color(8, 45, 0, 255, 8, 8)
+      bounds: 64 360 8 8
+    - image: solid-color(9, 45, 0, 255, 8, 8)
+      bounds: 72 360 8 8
+    - image: solid-color(10, 45, 0, 255, 8, 8)
+      bounds: 80 360 8 8
+    - image: solid-color(11, 45, 0, 255, 8, 8)
+      bounds: 88 360 8 8
+    - image: solid-color(12, 45, 0, 255, 8, 8)
+      bounds: 96 360 8 8
+    - image: solid-color(13, 45, 0, 255, 8, 8)
+      bounds: 104 360 8 8
+    - image: solid-color(14, 45, 0, 255, 8, 8)
+      bounds: 112 360 8 8
+    - image: solid-color(15, 45, 0, 255, 8, 8)
+      bounds: 120 360 8 8
+    - image: solid-color(16, 45, 0, 255, 8, 8)
+      bounds: 128 360 8 8
+    - image: solid-color(17, 45, 0, 255, 8, 8)
+      bounds: 136 360 8 8
+    - image: solid-color(18, 45, 0, 255, 8, 8)
+      bounds: 144 360 8 8
+    - image: solid-color(19, 45, 0, 255, 8, 8)
+      bounds: 152 360 8 8
+    - image: solid-color(20, 45, 0, 255, 8, 8)
+      bounds: 160 360 8 8
+    - image: solid-color(21, 45, 0, 255, 8, 8)
+      bounds: 168 360 8 8
+    - image: solid-color(22, 45, 0, 255, 8, 8)
+      bounds: 176 360 8 8
+    - image: solid-color(23, 45, 0, 255, 8, 8)
+      bounds: 184 360 8 8
+    - image: solid-color(24, 45, 0, 255, 8, 8)
+      bounds: 192 360 8 8
+    - image: solid-color(25, 45, 0, 255, 8, 8)
+      bounds: 200 360 8 8
+    - image: solid-color(26, 45, 0, 255, 8, 8)
+      bounds: 208 360 8 8
+    - image: solid-color(27, 45, 0, 255, 8, 8)
+      bounds: 216 360 8 8
+    - image: solid-color(28, 45, 0, 255, 8, 8)
+      bounds: 224 360 8 8
+    - image: solid-color(29, 45, 0, 255, 8, 8)
+      bounds: 232 360 8 8
+    - image: solid-color(30, 45, 0, 255, 8, 8)
+      bounds: 240 360 8 8
+    - image: solid-color(31, 45, 0, 255, 8, 8)
+      bounds: 248 360 8 8
+    - image: solid-color(32, 45, 0, 255, 8, 8)
+      bounds: 256 360 8 8
+    - image: solid-color(33, 45, 0, 255, 8, 8)
+      bounds: 264 360 8 8
+    - image: solid-color(34, 45, 0, 255, 8, 8)
+      bounds: 272 360 8 8
+    - image: solid-color(35, 45, 0, 255, 8, 8)
+      bounds: 280 360 8 8
+    - image: solid-color(36, 45, 0, 255, 8, 8)
+      bounds: 288 360 8 8
+    - image: solid-color(37, 45, 0, 255, 8, 8)
+      bounds: 296 360 8 8
+    - image: solid-color(38, 45, 0, 255, 8, 8)
+      bounds: 304 360 8 8
+    - image: solid-color(39, 45, 0, 255, 8, 8)
+      bounds: 312 360 8 8
+    - image: solid-color(40, 45, 0, 255, 8, 8)
+      bounds: 320 360 8 8
+    - image: solid-color(41, 45, 0, 255, 8, 8)
+      bounds: 328 360 8 8
+    - image: solid-color(42, 45, 0, 255, 8, 8)
+      bounds: 336 360 8 8
+    - image: solid-color(43, 45, 0, 255, 8, 8)
+      bounds: 344 360 8 8
+    - image: solid-color(44, 45, 0, 255, 8, 8)
+      bounds: 352 360 8 8
+    - image: solid-color(45, 45, 0, 255, 8, 8)
+      bounds: 360 360 8 8
+    - image: solid-color(46, 45, 0, 255, 8, 8)
+      bounds: 368 360 8 8
+    - image: solid-color(47, 45, 0, 255, 8, 8)
+      bounds: 376 360 8 8
+    - image: solid-color(48, 45, 0, 255, 8, 8)
+      bounds: 384 360 8 8
+    - image: solid-color(49, 45, 0, 255, 8, 8)
+      bounds: 392 360 8 8
+    - image: solid-color(50, 45, 0, 255, 8, 8)
+      bounds: 400 360 8 8
+    - image: solid-color(51, 45, 0, 255, 8, 8)
+      bounds: 408 360 8 8
+    - image: solid-color(52, 45, 0, 255, 8, 8)
+      bounds: 416 360 8 8
+    - image: solid-color(53, 45, 0, 255, 8, 8)
+      bounds: 424 360 8 8
+    - image: solid-color(54, 45, 0, 255, 8, 8)
+      bounds: 432 360 8 8
+    - image: solid-color(55, 45, 0, 255, 8, 8)
+      bounds: 440 360 8 8
+    - image: solid-color(56, 45, 0, 255, 8, 8)
+      bounds: 448 360 8 8
+    - image: solid-color(57, 45, 0, 255, 8, 8)
+      bounds: 456 360 8 8
+    - image: solid-color(58, 45, 0, 255, 8, 8)
+      bounds: 464 360 8 8
+    - image: solid-color(59, 45, 0, 255, 8, 8)
+      bounds: 472 360 8 8
+    - image: solid-color(60, 45, 0, 255, 8, 8)
+      bounds: 480 360 8 8
+    - image: solid-color(61, 45, 0, 255, 8, 8)
+      bounds: 488 360 8 8
+    - image: solid-color(62, 45, 0, 255, 8, 8)
+      bounds: 496 360 8 8
+    - image: solid-color(63, 45, 0, 255, 8, 8)
+      bounds: 504 360 8 8
+    - image: solid-color(64, 45, 0, 255, 8, 8)
+      bounds: 512 360 8 8
+    - image: solid-color(65, 45, 0, 255, 8, 8)
+      bounds: 520 360 8 8
+    - image: solid-color(66, 45, 0, 255, 8, 8)
+      bounds: 528 360 8 8
+    - image: solid-color(67, 45, 0, 255, 8, 8)
+      bounds: 536 360 8 8
+    - image: solid-color(68, 45, 0, 255, 8, 8)
+      bounds: 544 360 8 8
+    - image: solid-color(69, 45, 0, 255, 8, 8)
+      bounds: 552 360 8 8
+    - image: solid-color(70, 45, 0, 255, 8, 8)
+      bounds: 560 360 8 8
+    - image: solid-color(71, 45, 0, 255, 8, 8)
+      bounds: 568 360 8 8
+    - image: solid-color(72, 45, 0, 255, 8, 8)
+      bounds: 576 360 8 8
+    - image: solid-color(73, 45, 0, 255, 8, 8)
+      bounds: 584 360 8 8
+    - image: solid-color(74, 45, 0, 255, 8, 8)
+      bounds: 592 360 8 8
+    - image: solid-color(75, 45, 0, 255, 8, 8)
+      bounds: 600 360 8 8
+    - image: solid-color(76, 45, 0, 255, 8, 8)
+      bounds: 608 360 8 8
+    - image: solid-color(77, 45, 0, 255, 8, 8)
+      bounds: 616 360 8 8
+    - image: solid-color(78, 45, 0, 255, 8, 8)
+      bounds: 624 360 8 8
+    - image: solid-color(79, 45, 0, 255, 8, 8)
+      bounds: 632 360 8 8
+    - image: solid-color(80, 45, 0, 255, 8, 8)
+      bounds: 640 360 8 8
+    - image: solid-color(81, 45, 0, 255, 8, 8)
+      bounds: 648 360 8 8
+    - image: solid-color(82, 45, 0, 255, 8, 8)
+      bounds: 656 360 8 8
+    - image: solid-color(83, 45, 0, 255, 8, 8)
+      bounds: 664 360 8 8
+    - image: solid-color(84, 45, 0, 255, 8, 8)
+      bounds: 672 360 8 8
+    - image: solid-color(85, 45, 0, 255, 8, 8)
+      bounds: 680 360 8 8
+    - image: solid-color(86, 45, 0, 255, 8, 8)
+      bounds: 688 360 8 8
+    - image: solid-color(87, 45, 0, 255, 8, 8)
+      bounds: 696 360 8 8
+    - image: solid-color(88, 45, 0, 255, 8, 8)
+      bounds: 704 360 8 8
+    - image: solid-color(89, 45, 0, 255, 8, 8)
+      bounds: 712 360 8 8
+    - image: solid-color(90, 45, 0, 255, 8, 8)
+      bounds: 720 360 8 8
+    - image: solid-color(91, 45, 0, 255, 8, 8)
+      bounds: 728 360 8 8
+    - image: solid-color(92, 45, 0, 255, 8, 8)
+      bounds: 736 360 8 8
+    - image: solid-color(93, 45, 0, 255, 8, 8)
+      bounds: 744 360 8 8
+    - image: solid-color(94, 45, 0, 255, 8, 8)
+      bounds: 752 360 8 8
+    - image: solid-color(95, 45, 0, 255, 8, 8)
+      bounds: 760 360 8 8
+    - image: solid-color(96, 45, 0, 255, 8, 8)
+      bounds: 768 360 8 8
+    - image: solid-color(97, 45, 0, 255, 8, 8)
+      bounds: 776 360 8 8
+    - image: solid-color(98, 45, 0, 255, 8, 8)
+      bounds: 784 360 8 8
+    - image: solid-color(99, 45, 0, 255, 8, 8)
+      bounds: 792 360 8 8
+    - image: solid-color(100, 45, 0, 255, 8, 8)
+      bounds: 800 360 8 8
+    - image: solid-color(101, 45, 0, 255, 8, 8)
+      bounds: 808 360 8 8
+    - image: solid-color(102, 45, 0, 255, 8, 8)
+      bounds: 816 360 8 8
+    - image: solid-color(103, 45, 0, 255, 8, 8)
+      bounds: 824 360 8 8
+    - image: solid-color(104, 45, 0, 255, 8, 8)
+      bounds: 832 360 8 8
+    - image: solid-color(105, 45, 0, 255, 8, 8)
+      bounds: 840 360 8 8
+    - image: solid-color(106, 45, 0, 255, 8, 8)
+      bounds: 848 360 8 8
+    - image: solid-color(107, 45, 0, 255, 8, 8)
+      bounds: 856 360 8 8
+    - image: solid-color(108, 45, 0, 255, 8, 8)
+      bounds: 864 360 8 8
+    - image: solid-color(109, 45, 0, 255, 8, 8)
+      bounds: 872 360 8 8
+    - image: solid-color(110, 45, 0, 255, 8, 8)
+      bounds: 880 360 8 8
+    - image: solid-color(111, 45, 0, 255, 8, 8)
+      bounds: 888 360 8 8
+    - image: solid-color(112, 45, 0, 255, 8, 8)
+      bounds: 896 360 8 8
+    - image: solid-color(113, 45, 0, 255, 8, 8)
+      bounds: 904 360 8 8
+    - image: solid-color(114, 45, 0, 255, 8, 8)
+      bounds: 912 360 8 8
+    - image: solid-color(115, 45, 0, 255, 8, 8)
+      bounds: 920 360 8 8
+    - image: solid-color(116, 45, 0, 255, 8, 8)
+      bounds: 928 360 8 8
+    - image: solid-color(117, 45, 0, 255, 8, 8)
+      bounds: 936 360 8 8
+    - image: solid-color(118, 45, 0, 255, 8, 8)
+      bounds: 944 360 8 8
+    - image: solid-color(119, 45, 0, 255, 8, 8)
+      bounds: 952 360 8 8
+    - image: solid-color(120, 45, 0, 255, 8, 8)
+      bounds: 960 360 8 8
+    - image: solid-color(121, 45, 0, 255, 8, 8)
+      bounds: 968 360 8 8
+    - image: solid-color(122, 45, 0, 255, 8, 8)
+      bounds: 976 360 8 8
+    - image: solid-color(123, 45, 0, 255, 8, 8)
+      bounds: 984 360 8 8
+    - image: solid-color(124, 45, 0, 255, 8, 8)
+      bounds: 992 360 8 8
+    - image: solid-color(125, 45, 0, 255, 8, 8)
+      bounds: 1000 360 8 8
+    - image: solid-color(126, 45, 0, 255, 8, 8)
+      bounds: 1008 360 8 8
+    - image: solid-color(127, 45, 0, 255, 8, 8)
+      bounds: 1016 360 8 8
+    - image: solid-color(0, 46, 0, 255, 8, 8)
+      bounds: 0 368 8 8
+    - image: solid-color(1, 46, 0, 255, 8, 8)
+      bounds: 8 368 8 8
+    - image: solid-color(2, 46, 0, 255, 8, 8)
+      bounds: 16 368 8 8
+    - image: solid-color(3, 46, 0, 255, 8, 8)
+      bounds: 24 368 8 8
+    - image: solid-color(4, 46, 0, 255, 8, 8)
+      bounds: 32 368 8 8
+    - image: solid-color(5, 46, 0, 255, 8, 8)
+      bounds: 40 368 8 8
+    - image: solid-color(6, 46, 0, 255, 8, 8)
+      bounds: 48 368 8 8
+    - image: solid-color(7, 46, 0, 255, 8, 8)
+      bounds: 56 368 8 8
+    - image: solid-color(8, 46, 0, 255, 8, 8)
+      bounds: 64 368 8 8
+    - image: solid-color(9, 46, 0, 255, 8, 8)
+      bounds: 72 368 8 8
+    - image: solid-color(10, 46, 0, 255, 8, 8)
+      bounds: 80 368 8 8
+    - image: solid-color(11, 46, 0, 255, 8, 8)
+      bounds: 88 368 8 8
+    - image: solid-color(12, 46, 0, 255, 8, 8)
+      bounds: 96 368 8 8
+    - image: solid-color(13, 46, 0, 255, 8, 8)
+      bounds: 104 368 8 8
+    - image: solid-color(14, 46, 0, 255, 8, 8)
+      bounds: 112 368 8 8
+    - image: solid-color(15, 46, 0, 255, 8, 8)
+      bounds: 120 368 8 8
+    - image: solid-color(16, 46, 0, 255, 8, 8)
+      bounds: 128 368 8 8
+    - image: solid-color(17, 46, 0, 255, 8, 8)
+      bounds: 136 368 8 8
+    - image: solid-color(18, 46, 0, 255, 8, 8)
+      bounds: 144 368 8 8
+    - image: solid-color(19, 46, 0, 255, 8, 8)
+      bounds: 152 368 8 8
+    - image: solid-color(20, 46, 0, 255, 8, 8)
+      bounds: 160 368 8 8
+    - image: solid-color(21, 46, 0, 255, 8, 8)
+      bounds: 168 368 8 8
+    - image: solid-color(22, 46, 0, 255, 8, 8)
+      bounds: 176 368 8 8
+    - image: solid-color(23, 46, 0, 255, 8, 8)
+      bounds: 184 368 8 8
+    - image: solid-color(24, 46, 0, 255, 8, 8)
+      bounds: 192 368 8 8
+    - image: solid-color(25, 46, 0, 255, 8, 8)
+      bounds: 200 368 8 8
+    - image: solid-color(26, 46, 0, 255, 8, 8)
+      bounds: 208 368 8 8
+    - image: solid-color(27, 46, 0, 255, 8, 8)
+      bounds: 216 368 8 8
+    - image: solid-color(28, 46, 0, 255, 8, 8)
+      bounds: 224 368 8 8
+    - image: solid-color(29, 46, 0, 255, 8, 8)
+      bounds: 232 368 8 8
+    - image: solid-color(30, 46, 0, 255, 8, 8)
+      bounds: 240 368 8 8
+    - image: solid-color(31, 46, 0, 255, 8, 8)
+      bounds: 248 368 8 8
+    - image: solid-color(32, 46, 0, 255, 8, 8)
+      bounds: 256 368 8 8
+    - image: solid-color(33, 46, 0, 255, 8, 8)
+      bounds: 264 368 8 8
+    - image: solid-color(34, 46, 0, 255, 8, 8)
+      bounds: 272 368 8 8
+    - image: solid-color(35, 46, 0, 255, 8, 8)
+      bounds: 280 368 8 8
+    - image: solid-color(36, 46, 0, 255, 8, 8)
+      bounds: 288 368 8 8
+    - image: solid-color(37, 46, 0, 255, 8, 8)
+      bounds: 296 368 8 8
+    - image: solid-color(38, 46, 0, 255, 8, 8)
+      bounds: 304 368 8 8
+    - image: solid-color(39, 46, 0, 255, 8, 8)
+      bounds: 312 368 8 8
+    - image: solid-color(40, 46, 0, 255, 8, 8)
+      bounds: 320 368 8 8
+    - image: solid-color(41, 46, 0, 255, 8, 8)
+      bounds: 328 368 8 8
+    - image: solid-color(42, 46, 0, 255, 8, 8)
+      bounds: 336 368 8 8
+    - image: solid-color(43, 46, 0, 255, 8, 8)
+      bounds: 344 368 8 8
+    - image: solid-color(44, 46, 0, 255, 8, 8)
+      bounds: 352 368 8 8
+    - image: solid-color(45, 46, 0, 255, 8, 8)
+      bounds: 360 368 8 8
+    - image: solid-color(46, 46, 0, 255, 8, 8)
+      bounds: 368 368 8 8
+    - image: solid-color(47, 46, 0, 255, 8, 8)
+      bounds: 376 368 8 8
+    - image: solid-color(48, 46, 0, 255, 8, 8)
+      bounds: 384 368 8 8
+    - image: solid-color(49, 46, 0, 255, 8, 8)
+      bounds: 392 368 8 8
+    - image: solid-color(50, 46, 0, 255, 8, 8)
+      bounds: 400 368 8 8
+    - image: solid-color(51, 46, 0, 255, 8, 8)
+      bounds: 408 368 8 8
+    - image: solid-color(52, 46, 0, 255, 8, 8)
+      bounds: 416 368 8 8
+    - image: solid-color(53, 46, 0, 255, 8, 8)
+      bounds: 424 368 8 8
+    - image: solid-color(54, 46, 0, 255, 8, 8)
+      bounds: 432 368 8 8
+    - image: solid-color(55, 46, 0, 255, 8, 8)
+      bounds: 440 368 8 8
+    - image: solid-color(56, 46, 0, 255, 8, 8)
+      bounds: 448 368 8 8
+    - image: solid-color(57, 46, 0, 255, 8, 8)
+      bounds: 456 368 8 8
+    - image: solid-color(58, 46, 0, 255, 8, 8)
+      bounds: 464 368 8 8
+    - image: solid-color(59, 46, 0, 255, 8, 8)
+      bounds: 472 368 8 8
+    - image: solid-color(60, 46, 0, 255, 8, 8)
+      bounds: 480 368 8 8
+    - image: solid-color(61, 46, 0, 255, 8, 8)
+      bounds: 488 368 8 8
+    - image: solid-color(62, 46, 0, 255, 8, 8)
+      bounds: 496 368 8 8
+    - image: solid-color(63, 46, 0, 255, 8, 8)
+      bounds: 504 368 8 8
+    - image: solid-color(64, 46, 0, 255, 8, 8)
+      bounds: 512 368 8 8
+    - image: solid-color(65, 46, 0, 255, 8, 8)
+      bounds: 520 368 8 8
+    - image: solid-color(66, 46, 0, 255, 8, 8)
+      bounds: 528 368 8 8
+    - image: solid-color(67, 46, 0, 255, 8, 8)
+      bounds: 536 368 8 8
+    - image: solid-color(68, 46, 0, 255, 8, 8)
+      bounds: 544 368 8 8
+    - image: solid-color(69, 46, 0, 255, 8, 8)
+      bounds: 552 368 8 8
+    - image: solid-color(70, 46, 0, 255, 8, 8)
+      bounds: 560 368 8 8
+    - image: solid-color(71, 46, 0, 255, 8, 8)
+      bounds: 568 368 8 8
+    - image: solid-color(72, 46, 0, 255, 8, 8)
+      bounds: 576 368 8 8
+    - image: solid-color(73, 46, 0, 255, 8, 8)
+      bounds: 584 368 8 8
+    - image: solid-color(74, 46, 0, 255, 8, 8)
+      bounds: 592 368 8 8
+    - image: solid-color(75, 46, 0, 255, 8, 8)
+      bounds: 600 368 8 8
+    - image: solid-color(76, 46, 0, 255, 8, 8)
+      bounds: 608 368 8 8
+    - image: solid-color(77, 46, 0, 255, 8, 8)
+      bounds: 616 368 8 8
+    - image: solid-color(78, 46, 0, 255, 8, 8)
+      bounds: 624 368 8 8
+    - image: solid-color(79, 46, 0, 255, 8, 8)
+      bounds: 632 368 8 8
+    - image: solid-color(80, 46, 0, 255, 8, 8)
+      bounds: 640 368 8 8
+    - image: solid-color(81, 46, 0, 255, 8, 8)
+      bounds: 648 368 8 8
+    - image: solid-color(82, 46, 0, 255, 8, 8)
+      bounds: 656 368 8 8
+    - image: solid-color(83, 46, 0, 255, 8, 8)
+      bounds: 664 368 8 8
+    - image: solid-color(84, 46, 0, 255, 8, 8)
+      bounds: 672 368 8 8
+    - image: solid-color(85, 46, 0, 255, 8, 8)
+      bounds: 680 368 8 8
+    - image: solid-color(86, 46, 0, 255, 8, 8)
+      bounds: 688 368 8 8
+    - image: solid-color(87, 46, 0, 255, 8, 8)
+      bounds: 696 368 8 8
+    - image: solid-color(88, 46, 0, 255, 8, 8)
+      bounds: 704 368 8 8
+    - image: solid-color(89, 46, 0, 255, 8, 8)
+      bounds: 712 368 8 8
+    - image: solid-color(90, 46, 0, 255, 8, 8)
+      bounds: 720 368 8 8
+    - image: solid-color(91, 46, 0, 255, 8, 8)
+      bounds: 728 368 8 8
+    - image: solid-color(92, 46, 0, 255, 8, 8)
+      bounds: 736 368 8 8
+    - image: solid-color(93, 46, 0, 255, 8, 8)
+      bounds: 744 368 8 8
+    - image: solid-color(94, 46, 0, 255, 8, 8)
+      bounds: 752 368 8 8
+    - image: solid-color(95, 46, 0, 255, 8, 8)
+      bounds: 760 368 8 8
+    - image: solid-color(96, 46, 0, 255, 8, 8)
+      bounds: 768 368 8 8
+    - image: solid-color(97, 46, 0, 255, 8, 8)
+      bounds: 776 368 8 8
+    - image: solid-color(98, 46, 0, 255, 8, 8)
+      bounds: 784 368 8 8
+    - image: solid-color(99, 46, 0, 255, 8, 8)
+      bounds: 792 368 8 8
+    - image: solid-color(100, 46, 0, 255, 8, 8)
+      bounds: 800 368 8 8
+    - image: solid-color(101, 46, 0, 255, 8, 8)
+      bounds: 808 368 8 8
+    - image: solid-color(102, 46, 0, 255, 8, 8)
+      bounds: 816 368 8 8
+    - image: solid-color(103, 46, 0, 255, 8, 8)
+      bounds: 824 368 8 8
+    - image: solid-color(104, 46, 0, 255, 8, 8)
+      bounds: 832 368 8 8
+    - image: solid-color(105, 46, 0, 255, 8, 8)
+      bounds: 840 368 8 8
+    - image: solid-color(106, 46, 0, 255, 8, 8)
+      bounds: 848 368 8 8
+    - image: solid-color(107, 46, 0, 255, 8, 8)
+      bounds: 856 368 8 8
+    - image: solid-color(108, 46, 0, 255, 8, 8)
+      bounds: 864 368 8 8
+    - image: solid-color(109, 46, 0, 255, 8, 8)
+      bounds: 872 368 8 8
+    - image: solid-color(110, 46, 0, 255, 8, 8)
+      bounds: 880 368 8 8
+    - image: solid-color(111, 46, 0, 255, 8, 8)
+      bounds: 888 368 8 8
+    - image: solid-color(112, 46, 0, 255, 8, 8)
+      bounds: 896 368 8 8
+    - image: solid-color(113, 46, 0, 255, 8, 8)
+      bounds: 904 368 8 8
+    - image: solid-color(114, 46, 0, 255, 8, 8)
+      bounds: 912 368 8 8
+    - image: solid-color(115, 46, 0, 255, 8, 8)
+      bounds: 920 368 8 8
+    - image: solid-color(116, 46, 0, 255, 8, 8)
+      bounds: 928 368 8 8
+    - image: solid-color(117, 46, 0, 255, 8, 8)
+      bounds: 936 368 8 8
+    - image: solid-color(118, 46, 0, 255, 8, 8)
+      bounds: 944 368 8 8
+    - image: solid-color(119, 46, 0, 255, 8, 8)
+      bounds: 952 368 8 8
+    - image: solid-color(120, 46, 0, 255, 8, 8)
+      bounds: 960 368 8 8
+    - image: solid-color(121, 46, 0, 255, 8, 8)
+      bounds: 968 368 8 8
+    - image: solid-color(122, 46, 0, 255, 8, 8)
+      bounds: 976 368 8 8
+    - image: solid-color(123, 46, 0, 255, 8, 8)
+      bounds: 984 368 8 8
+    - image: solid-color(124, 46, 0, 255, 8, 8)
+      bounds: 992 368 8 8
+    - image: solid-color(125, 46, 0, 255, 8, 8)
+      bounds: 1000 368 8 8
+    - image: solid-color(126, 46, 0, 255, 8, 8)
+      bounds: 1008 368 8 8
+    - image: solid-color(127, 46, 0, 255, 8, 8)
+      bounds: 1016 368 8 8
+    - image: solid-color(0, 47, 0, 255, 8, 8)
+      bounds: 0 376 8 8
+    - image: solid-color(1, 47, 0, 255, 8, 8)
+      bounds: 8 376 8 8
+    - image: solid-color(2, 47, 0, 255, 8, 8)
+      bounds: 16 376 8 8
+    - image: solid-color(3, 47, 0, 255, 8, 8)
+      bounds: 24 376 8 8
+    - image: solid-color(4, 47, 0, 255, 8, 8)
+      bounds: 32 376 8 8
+    - image: solid-color(5, 47, 0, 255, 8, 8)
+      bounds: 40 376 8 8
+    - image: solid-color(6, 47, 0, 255, 8, 8)
+      bounds: 48 376 8 8
+    - image: solid-color(7, 47, 0, 255, 8, 8)
+      bounds: 56 376 8 8
+    - image: solid-color(8, 47, 0, 255, 8, 8)
+      bounds: 64 376 8 8
+    - image: solid-color(9, 47, 0, 255, 8, 8)
+      bounds: 72 376 8 8
+    - image: solid-color(10, 47, 0, 255, 8, 8)
+      bounds: 80 376 8 8
+    - image: solid-color(11, 47, 0, 255, 8, 8)
+      bounds: 88 376 8 8
+    - image: solid-color(12, 47, 0, 255, 8, 8)
+      bounds: 96 376 8 8
+    - image: solid-color(13, 47, 0, 255, 8, 8)
+      bounds: 104 376 8 8
+    - image: solid-color(14, 47, 0, 255, 8, 8)
+      bounds: 112 376 8 8
+    - image: solid-color(15, 47, 0, 255, 8, 8)
+      bounds: 120 376 8 8
+    - image: solid-color(16, 47, 0, 255, 8, 8)
+      bounds: 128 376 8 8
+    - image: solid-color(17, 47, 0, 255, 8, 8)
+      bounds: 136 376 8 8
+    - image: solid-color(18, 47, 0, 255, 8, 8)
+      bounds: 144 376 8 8
+    - image: solid-color(19, 47, 0, 255, 8, 8)
+      bounds: 152 376 8 8
+    - image: solid-color(20, 47, 0, 255, 8, 8)
+      bounds: 160 376 8 8
+    - image: solid-color(21, 47, 0, 255, 8, 8)
+      bounds: 168 376 8 8
+    - image: solid-color(22, 47, 0, 255, 8, 8)
+      bounds: 176 376 8 8
+    - image: solid-color(23, 47, 0, 255, 8, 8)
+      bounds: 184 376 8 8
+    - image: solid-color(24, 47, 0, 255, 8, 8)
+      bounds: 192 376 8 8
+    - image: solid-color(25, 47, 0, 255, 8, 8)
+      bounds: 200 376 8 8
+    - image: solid-color(26, 47, 0, 255, 8, 8)
+      bounds: 208 376 8 8
+    - image: solid-color(27, 47, 0, 255, 8, 8)
+      bounds: 216 376 8 8
+    - image: solid-color(28, 47, 0, 255, 8, 8)
+      bounds: 224 376 8 8
+    - image: solid-color(29, 47, 0, 255, 8, 8)
+      bounds: 232 376 8 8
+    - image: solid-color(30, 47, 0, 255, 8, 8)
+      bounds: 240 376 8 8
+    - image: solid-color(31, 47, 0, 255, 8, 8)
+      bounds: 248 376 8 8
+    - image: solid-color(32, 47, 0, 255, 8, 8)
+      bounds: 256 376 8 8
+    - image: solid-color(33, 47, 0, 255, 8, 8)
+      bounds: 264 376 8 8
+    - image: solid-color(34, 47, 0, 255, 8, 8)
+      bounds: 272 376 8 8
+    - image: solid-color(35, 47, 0, 255, 8, 8)
+      bounds: 280 376 8 8
+    - image: solid-color(36, 47, 0, 255, 8, 8)
+      bounds: 288 376 8 8
+    - image: solid-color(37, 47, 0, 255, 8, 8)
+      bounds: 296 376 8 8
+    - image: solid-color(38, 47, 0, 255, 8, 8)
+      bounds: 304 376 8 8
+    - image: solid-color(39, 47, 0, 255, 8, 8)
+      bounds: 312 376 8 8
+    - image: solid-color(40, 47, 0, 255, 8, 8)
+      bounds: 320 376 8 8
+    - image: solid-color(41, 47, 0, 255, 8, 8)
+      bounds: 328 376 8 8
+    - image: solid-color(42, 47, 0, 255, 8, 8)
+      bounds: 336 376 8 8
+    - image: solid-color(43, 47, 0, 255, 8, 8)
+      bounds: 344 376 8 8
+    - image: solid-color(44, 47, 0, 255, 8, 8)
+      bounds: 352 376 8 8
+    - image: solid-color(45, 47, 0, 255, 8, 8)
+      bounds: 360 376 8 8
+    - image: solid-color(46, 47, 0, 255, 8, 8)
+      bounds: 368 376 8 8
+    - image: solid-color(47, 47, 0, 255, 8, 8)
+      bounds: 376 376 8 8
+    - image: solid-color(48, 47, 0, 255, 8, 8)
+      bounds: 384 376 8 8
+    - image: solid-color(49, 47, 0, 255, 8, 8)
+      bounds: 392 376 8 8
+    - image: solid-color(50, 47, 0, 255, 8, 8)
+      bounds: 400 376 8 8
+    - image: solid-color(51, 47, 0, 255, 8, 8)
+      bounds: 408 376 8 8
+    - image: solid-color(52, 47, 0, 255, 8, 8)
+      bounds: 416 376 8 8
+    - image: solid-color(53, 47, 0, 255, 8, 8)
+      bounds: 424 376 8 8
+    - image: solid-color(54, 47, 0, 255, 8, 8)
+      bounds: 432 376 8 8
+    - image: solid-color(55, 47, 0, 255, 8, 8)
+      bounds: 440 376 8 8
+    - image: solid-color(56, 47, 0, 255, 8, 8)
+      bounds: 448 376 8 8
+    - image: solid-color(57, 47, 0, 255, 8, 8)
+      bounds: 456 376 8 8
+    - image: solid-color(58, 47, 0, 255, 8, 8)
+      bounds: 464 376 8 8
+    - image: solid-color(59, 47, 0, 255, 8, 8)
+      bounds: 472 376 8 8
+    - image: solid-color(60, 47, 0, 255, 8, 8)
+      bounds: 480 376 8 8
+    - image: solid-color(61, 47, 0, 255, 8, 8)
+      bounds: 488 376 8 8
+    - image: solid-color(62, 47, 0, 255, 8, 8)
+      bounds: 496 376 8 8
+    - image: solid-color(63, 47, 0, 255, 8, 8)
+      bounds: 504 376 8 8
+    - image: solid-color(64, 47, 0, 255, 8, 8)
+      bounds: 512 376 8 8
+    - image: solid-color(65, 47, 0, 255, 8, 8)
+      bounds: 520 376 8 8
+    - image: solid-color(66, 47, 0, 255, 8, 8)
+      bounds: 528 376 8 8
+    - image: solid-color(67, 47, 0, 255, 8, 8)
+      bounds: 536 376 8 8
+    - image: solid-color(68, 47, 0, 255, 8, 8)
+      bounds: 544 376 8 8
+    - image: solid-color(69, 47, 0, 255, 8, 8)
+      bounds: 552 376 8 8
+    - image: solid-color(70, 47, 0, 255, 8, 8)
+      bounds: 560 376 8 8
+    - image: solid-color(71, 47, 0, 255, 8, 8)
+      bounds: 568 376 8 8
+    - image: solid-color(72, 47, 0, 255, 8, 8)
+      bounds: 576 376 8 8
+    - image: solid-color(73, 47, 0, 255, 8, 8)
+      bounds: 584 376 8 8
+    - image: solid-color(74, 47, 0, 255, 8, 8)
+      bounds: 592 376 8 8
+    - image: solid-color(75, 47, 0, 255, 8, 8)
+      bounds: 600 376 8 8
+    - image: solid-color(76, 47, 0, 255, 8, 8)
+      bounds: 608 376 8 8
+    - image: solid-color(77, 47, 0, 255, 8, 8)
+      bounds: 616 376 8 8
+    - image: solid-color(78, 47, 0, 255, 8, 8)
+      bounds: 624 376 8 8
+    - image: solid-color(79, 47, 0, 255, 8, 8)
+      bounds: 632 376 8 8
+    - image: solid-color(80, 47, 0, 255, 8, 8)
+      bounds: 640 376 8 8
+    - image: solid-color(81, 47, 0, 255, 8, 8)
+      bounds: 648 376 8 8
+    - image: solid-color(82, 47, 0, 255, 8, 8)
+      bounds: 656 376 8 8
+    - image: solid-color(83, 47, 0, 255, 8, 8)
+      bounds: 664 376 8 8
+    - image: solid-color(84, 47, 0, 255, 8, 8)
+      bounds: 672 376 8 8
+    - image: solid-color(85, 47, 0, 255, 8, 8)
+      bounds: 680 376 8 8
+    - image: solid-color(86, 47, 0, 255, 8, 8)
+      bounds: 688 376 8 8
+    - image: solid-color(87, 47, 0, 255, 8, 8)
+      bounds: 696 376 8 8
+    - image: solid-color(88, 47, 0, 255, 8, 8)
+      bounds: 704 376 8 8
+    - image: solid-color(89, 47, 0, 255, 8, 8)
+      bounds: 712 376 8 8
+    - image: solid-color(90, 47, 0, 255, 8, 8)
+      bounds: 720 376 8 8
+    - image: solid-color(91, 47, 0, 255, 8, 8)
+      bounds: 728 376 8 8
+    - image: solid-color(92, 47, 0, 255, 8, 8)
+      bounds: 736 376 8 8
+    - image: solid-color(93, 47, 0, 255, 8, 8)
+      bounds: 744 376 8 8
+    - image: solid-color(94, 47, 0, 255, 8, 8)
+      bounds: 752 376 8 8
+    - image: solid-color(95, 47, 0, 255, 8, 8)
+      bounds: 760 376 8 8
+    - image: solid-color(96, 47, 0, 255, 8, 8)
+      bounds: 768 376 8 8
+    - image: solid-color(97, 47, 0, 255, 8, 8)
+      bounds: 776 376 8 8
+    - image: solid-color(98, 47, 0, 255, 8, 8)
+      bounds: 784 376 8 8
+    - image: solid-color(99, 47, 0, 255, 8, 8)
+      bounds: 792 376 8 8
+    - image: solid-color(100, 47, 0, 255, 8, 8)
+      bounds: 800 376 8 8
+    - image: solid-color(101, 47, 0, 255, 8, 8)
+      bounds: 808 376 8 8
+    - image: solid-color(102, 47, 0, 255, 8, 8)
+      bounds: 816 376 8 8
+    - image: solid-color(103, 47, 0, 255, 8, 8)
+      bounds: 824 376 8 8
+    - image: solid-color(104, 47, 0, 255, 8, 8)
+      bounds: 832 376 8 8
+    - image: solid-color(105, 47, 0, 255, 8, 8)
+      bounds: 840 376 8 8
+    - image: solid-color(106, 47, 0, 255, 8, 8)
+      bounds: 848 376 8 8
+    - image: solid-color(107, 47, 0, 255, 8, 8)
+      bounds: 856 376 8 8
+    - image: solid-color(108, 47, 0, 255, 8, 8)
+      bounds: 864 376 8 8
+    - image: solid-color(109, 47, 0, 255, 8, 8)
+      bounds: 872 376 8 8
+    - image: solid-color(110, 47, 0, 255, 8, 8)
+      bounds: 880 376 8 8
+    - image: solid-color(111, 47, 0, 255, 8, 8)
+      bounds: 888 376 8 8
+    - image: solid-color(112, 47, 0, 255, 8, 8)
+      bounds: 896 376 8 8
+    - image: solid-color(113, 47, 0, 255, 8, 8)
+      bounds: 904 376 8 8
+    - image: solid-color(114, 47, 0, 255, 8, 8)
+      bounds: 912 376 8 8
+    - image: solid-color(115, 47, 0, 255, 8, 8)
+      bounds: 920 376 8 8
+    - image: solid-color(116, 47, 0, 255, 8, 8)
+      bounds: 928 376 8 8
+    - image: solid-color(117, 47, 0, 255, 8, 8)
+      bounds: 936 376 8 8
+    - image: solid-color(118, 47, 0, 255, 8, 8)
+      bounds: 944 376 8 8
+    - image: solid-color(119, 47, 0, 255, 8, 8)
+      bounds: 952 376 8 8
+    - image: solid-color(120, 47, 0, 255, 8, 8)
+      bounds: 960 376 8 8
+    - image: solid-color(121, 47, 0, 255, 8, 8)
+      bounds: 968 376 8 8
+    - image: solid-color(122, 47, 0, 255, 8, 8)
+      bounds: 976 376 8 8
+    - image: solid-color(123, 47, 0, 255, 8, 8)
+      bounds: 984 376 8 8
+    - image: solid-color(124, 47, 0, 255, 8, 8)
+      bounds: 992 376 8 8
+    - image: solid-color(125, 47, 0, 255, 8, 8)
+      bounds: 1000 376 8 8
+    - image: solid-color(126, 47, 0, 255, 8, 8)
+      bounds: 1008 376 8 8
+    - image: solid-color(127, 47, 0, 255, 8, 8)
+      bounds: 1016 376 8 8
+    - image: solid-color(0, 48, 0, 255, 8, 8)
+      bounds: 0 384 8 8
+    - image: solid-color(1, 48, 0, 255, 8, 8)
+      bounds: 8 384 8 8
+    - image: solid-color(2, 48, 0, 255, 8, 8)
+      bounds: 16 384 8 8
+    - image: solid-color(3, 48, 0, 255, 8, 8)
+      bounds: 24 384 8 8
+    - image: solid-color(4, 48, 0, 255, 8, 8)
+      bounds: 32 384 8 8
+    - image: solid-color(5, 48, 0, 255, 8, 8)
+      bounds: 40 384 8 8
+    - image: solid-color(6, 48, 0, 255, 8, 8)
+      bounds: 48 384 8 8
+    - image: solid-color(7, 48, 0, 255, 8, 8)
+      bounds: 56 384 8 8
+    - image: solid-color(8, 48, 0, 255, 8, 8)
+      bounds: 64 384 8 8
+    - image: solid-color(9, 48, 0, 255, 8, 8)
+      bounds: 72 384 8 8
+    - image: solid-color(10, 48, 0, 255, 8, 8)
+      bounds: 80 384 8 8
+    - image: solid-color(11, 48, 0, 255, 8, 8)
+      bounds: 88 384 8 8
+    - image: solid-color(12, 48, 0, 255, 8, 8)
+      bounds: 96 384 8 8
+    - image: solid-color(13, 48, 0, 255, 8, 8)
+      bounds: 104 384 8 8
+    - image: solid-color(14, 48, 0, 255, 8, 8)
+      bounds: 112 384 8 8
+    - image: solid-color(15, 48, 0, 255, 8, 8)
+      bounds: 120 384 8 8
+    - image: solid-color(16, 48, 0, 255, 8, 8)
+      bounds: 128 384 8 8
+    - image: solid-color(17, 48, 0, 255, 8, 8)
+      bounds: 136 384 8 8
+    - image: solid-color(18, 48, 0, 255, 8, 8)
+      bounds: 144 384 8 8
+    - image: solid-color(19, 48, 0, 255, 8, 8)
+      bounds: 152 384 8 8
+    - image: solid-color(20, 48, 0, 255, 8, 8)
+      bounds: 160 384 8 8
+    - image: solid-color(21, 48, 0, 255, 8, 8)
+      bounds: 168 384 8 8
+    - image: solid-color(22, 48, 0, 255, 8, 8)
+      bounds: 176 384 8 8
+    - image: solid-color(23, 48, 0, 255, 8, 8)
+      bounds: 184 384 8 8
+    - image: solid-color(24, 48, 0, 255, 8, 8)
+      bounds: 192 384 8 8
+    - image: solid-color(25, 48, 0, 255, 8, 8)
+      bounds: 200 384 8 8
+    - image: solid-color(26, 48, 0, 255, 8, 8)
+      bounds: 208 384 8 8
+    - image: solid-color(27, 48, 0, 255, 8, 8)
+      bounds: 216 384 8 8
+    - image: solid-color(28, 48, 0, 255, 8, 8)
+      bounds: 224 384 8 8
+    - image: solid-color(29, 48, 0, 255, 8, 8)
+      bounds: 232 384 8 8
+    - image: solid-color(30, 48, 0, 255, 8, 8)
+      bounds: 240 384 8 8
+    - image: solid-color(31, 48, 0, 255, 8, 8)
+      bounds: 248 384 8 8
+    - image: solid-color(32, 48, 0, 255, 8, 8)
+      bounds: 256 384 8 8
+    - image: solid-color(33, 48, 0, 255, 8, 8)
+      bounds: 264 384 8 8
+    - image: solid-color(34, 48, 0, 255, 8, 8)
+      bounds: 272 384 8 8
+    - image: solid-color(35, 48, 0, 255, 8, 8)
+      bounds: 280 384 8 8
+    - image: solid-color(36, 48, 0, 255, 8, 8)
+      bounds: 288 384 8 8
+    - image: solid-color(37, 48, 0, 255, 8, 8)
+      bounds: 296 384 8 8
+    - image: solid-color(38, 48, 0, 255, 8, 8)
+      bounds: 304 384 8 8
+    - image: solid-color(39, 48, 0, 255, 8, 8)
+      bounds: 312 384 8 8
+    - image: solid-color(40, 48, 0, 255, 8, 8)
+      bounds: 320 384 8 8
+    - image: solid-color(41, 48, 0, 255, 8, 8)
+      bounds: 328 384 8 8
+    - image: solid-color(42, 48, 0, 255, 8, 8)
+      bounds: 336 384 8 8
+    - image: solid-color(43, 48, 0, 255, 8, 8)
+      bounds: 344 384 8 8
+    - image: solid-color(44, 48, 0, 255, 8, 8)
+      bounds: 352 384 8 8
+    - image: solid-color(45, 48, 0, 255, 8, 8)
+      bounds: 360 384 8 8
+    - image: solid-color(46, 48, 0, 255, 8, 8)
+      bounds: 368 384 8 8
+    - image: solid-color(47, 48, 0, 255, 8, 8)
+      bounds: 376 384 8 8
+    - image: solid-color(48, 48, 0, 255, 8, 8)
+      bounds: 384 384 8 8
+    - image: solid-color(49, 48, 0, 255, 8, 8)
+      bounds: 392 384 8 8
+    - image: solid-color(50, 48, 0, 255, 8, 8)
+      bounds: 400 384 8 8
+    - image: solid-color(51, 48, 0, 255, 8, 8)
+      bounds: 408 384 8 8
+    - image: solid-color(52, 48, 0, 255, 8, 8)
+      bounds: 416 384 8 8
+    - image: solid-color(53, 48, 0, 255, 8, 8)
+      bounds: 424 384 8 8
+    - image: solid-color(54, 48, 0, 255, 8, 8)
+      bounds: 432 384 8 8
+    - image: solid-color(55, 48, 0, 255, 8, 8)
+      bounds: 440 384 8 8
+    - image: solid-color(56, 48, 0, 255, 8, 8)
+      bounds: 448 384 8 8
+    - image: solid-color(57, 48, 0, 255, 8, 8)
+      bounds: 456 384 8 8
+    - image: solid-color(58, 48, 0, 255, 8, 8)
+      bounds: 464 384 8 8
+    - image: solid-color(59, 48, 0, 255, 8, 8)
+      bounds: 472 384 8 8
+    - image: solid-color(60, 48, 0, 255, 8, 8)
+      bounds: 480 384 8 8
+    - image: solid-color(61, 48, 0, 255, 8, 8)
+      bounds: 488 384 8 8
+    - image: solid-color(62, 48, 0, 255, 8, 8)
+      bounds: 496 384 8 8
+    - image: solid-color(63, 48, 0, 255, 8, 8)
+      bounds: 504 384 8 8
+    - image: solid-color(64, 48, 0, 255, 8, 8)
+      bounds: 512 384 8 8
+    - image: solid-color(65, 48, 0, 255, 8, 8)
+      bounds: 520 384 8 8
+    - image: solid-color(66, 48, 0, 255, 8, 8)
+      bounds: 528 384 8 8
+    - image: solid-color(67, 48, 0, 255, 8, 8)
+      bounds: 536 384 8 8
+    - image: solid-color(68, 48, 0, 255, 8, 8)
+      bounds: 544 384 8 8
+    - image: solid-color(69, 48, 0, 255, 8, 8)
+      bounds: 552 384 8 8
+    - image: solid-color(70, 48, 0, 255, 8, 8)
+      bounds: 560 384 8 8
+    - image: solid-color(71, 48, 0, 255, 8, 8)
+      bounds: 568 384 8 8
+    - image: solid-color(72, 48, 0, 255, 8, 8)
+      bounds: 576 384 8 8
+    - image: solid-color(73, 48, 0, 255, 8, 8)
+      bounds: 584 384 8 8
+    - image: solid-color(74, 48, 0, 255, 8, 8)
+      bounds: 592 384 8 8
+    - image: solid-color(75, 48, 0, 255, 8, 8)
+      bounds: 600 384 8 8
+    - image: solid-color(76, 48, 0, 255, 8, 8)
+      bounds: 608 384 8 8
+    - image: solid-color(77, 48, 0, 255, 8, 8)
+      bounds: 616 384 8 8
+    - image: solid-color(78, 48, 0, 255, 8, 8)
+      bounds: 624 384 8 8
+    - image: solid-color(79, 48, 0, 255, 8, 8)
+      bounds: 632 384 8 8
+    - image: solid-color(80, 48, 0, 255, 8, 8)
+      bounds: 640 384 8 8
+    - image: solid-color(81, 48, 0, 255, 8, 8)
+      bounds: 648 384 8 8
+    - image: solid-color(82, 48, 0, 255, 8, 8)
+      bounds: 656 384 8 8
+    - image: solid-color(83, 48, 0, 255, 8, 8)
+      bounds: 664 384 8 8
+    - image: solid-color(84, 48, 0, 255, 8, 8)
+      bounds: 672 384 8 8
+    - image: solid-color(85, 48, 0, 255, 8, 8)
+      bounds: 680 384 8 8
+    - image: solid-color(86, 48, 0, 255, 8, 8)
+      bounds: 688 384 8 8
+    - image: solid-color(87, 48, 0, 255, 8, 8)
+      bounds: 696 384 8 8
+    - image: solid-color(88, 48, 0, 255, 8, 8)
+      bounds: 704 384 8 8
+    - image: solid-color(89, 48, 0, 255, 8, 8)
+      bounds: 712 384 8 8
+    - image: solid-color(90, 48, 0, 255, 8, 8)
+      bounds: 720 384 8 8
+    - image: solid-color(91, 48, 0, 255, 8, 8)
+      bounds: 728 384 8 8
+    - image: solid-color(92, 48, 0, 255, 8, 8)
+      bounds: 736 384 8 8
+    - image: solid-color(93, 48, 0, 255, 8, 8)
+      bounds: 744 384 8 8
+    - image: solid-color(94, 48, 0, 255, 8, 8)
+      bounds: 752 384 8 8
+    - image: solid-color(95, 48, 0, 255, 8, 8)
+      bounds: 760 384 8 8
+    - image: solid-color(96, 48, 0, 255, 8, 8)
+      bounds: 768 384 8 8
+    - image: solid-color(97, 48, 0, 255, 8, 8)
+      bounds: 776 384 8 8
+    - image: solid-color(98, 48, 0, 255, 8, 8)
+      bounds: 784 384 8 8
+    - image: solid-color(99, 48, 0, 255, 8, 8)
+      bounds: 792 384 8 8
+    - image: solid-color(100, 48, 0, 255, 8, 8)
+      bounds: 800 384 8 8
+    - image: solid-color(101, 48, 0, 255, 8, 8)
+      bounds: 808 384 8 8
+    - image: solid-color(102, 48, 0, 255, 8, 8)
+      bounds: 816 384 8 8
+    - image: solid-color(103, 48, 0, 255, 8, 8)
+      bounds: 824 384 8 8
+    - image: solid-color(104, 48, 0, 255, 8, 8)
+      bounds: 832 384 8 8
+    - image: solid-color(105, 48, 0, 255, 8, 8)
+      bounds: 840 384 8 8
+    - image: solid-color(106, 48, 0, 255, 8, 8)
+      bounds: 848 384 8 8
+    - image: solid-color(107, 48, 0, 255, 8, 8)
+      bounds: 856 384 8 8
+    - image: solid-color(108, 48, 0, 255, 8, 8)
+      bounds: 864 384 8 8
+    - image: solid-color(109, 48, 0, 255, 8, 8)
+      bounds: 872 384 8 8
+    - image: solid-color(110, 48, 0, 255, 8, 8)
+      bounds: 880 384 8 8
+    - image: solid-color(111, 48, 0, 255, 8, 8)
+      bounds: 888 384 8 8
+    - image: solid-color(112, 48, 0, 255, 8, 8)
+      bounds: 896 384 8 8
+    - image: solid-color(113, 48, 0, 255, 8, 8)
+      bounds: 904 384 8 8
+    - image: solid-color(114, 48, 0, 255, 8, 8)
+      bounds: 912 384 8 8
+    - image: solid-color(115, 48, 0, 255, 8, 8)
+      bounds: 920 384 8 8
+    - image: solid-color(116, 48, 0, 255, 8, 8)
+      bounds: 928 384 8 8
+    - image: solid-color(117, 48, 0, 255, 8, 8)
+      bounds: 936 384 8 8
+    - image: solid-color(118, 48, 0, 255, 8, 8)
+      bounds: 944 384 8 8
+    - image: solid-color(119, 48, 0, 255, 8, 8)
+      bounds: 952 384 8 8
+    - image: solid-color(120, 48, 0, 255, 8, 8)
+      bounds: 960 384 8 8
+    - image: solid-color(121, 48, 0, 255, 8, 8)
+      bounds: 968 384 8 8
+    - image: solid-color(122, 48, 0, 255, 8, 8)
+      bounds: 976 384 8 8
+    - image: solid-color(123, 48, 0, 255, 8, 8)
+      bounds: 984 384 8 8
+    - image: solid-color(124, 48, 0, 255, 8, 8)
+      bounds: 992 384 8 8
+    - image: solid-color(125, 48, 0, 255, 8, 8)
+      bounds: 1000 384 8 8
+    - image: solid-color(126, 48, 0, 255, 8, 8)
+      bounds: 1008 384 8 8
+    - image: solid-color(127, 48, 0, 255, 8, 8)
+      bounds: 1016 384 8 8
+    - image: solid-color(0, 49, 0, 255, 8, 8)
+      bounds: 0 392 8 8
+    - image: solid-color(1, 49, 0, 255, 8, 8)
+      bounds: 8 392 8 8
+    - image: solid-color(2, 49, 0, 255, 8, 8)
+      bounds: 16 392 8 8
+    - image: solid-color(3, 49, 0, 255, 8, 8)
+      bounds: 24 392 8 8
+    - image: solid-color(4, 49, 0, 255, 8, 8)
+      bounds: 32 392 8 8
+    - image: solid-color(5, 49, 0, 255, 8, 8)
+      bounds: 40 392 8 8
+    - image: solid-color(6, 49, 0, 255, 8, 8)
+      bounds: 48 392 8 8
+    - image: solid-color(7, 49, 0, 255, 8, 8)
+      bounds: 56 392 8 8
+    - image: solid-color(8, 49, 0, 255, 8, 8)
+      bounds: 64 392 8 8
+    - image: solid-color(9, 49, 0, 255, 8, 8)
+      bounds: 72 392 8 8
+    - image: solid-color(10, 49, 0, 255, 8, 8)
+      bounds: 80 392 8 8
+    - image: solid-color(11, 49, 0, 255, 8, 8)
+      bounds: 88 392 8 8
+    - image: solid-color(12, 49, 0, 255, 8, 8)
+      bounds: 96 392 8 8
+    - image: solid-color(13, 49, 0, 255, 8, 8)
+      bounds: 104 392 8 8
+    - image: solid-color(14, 49, 0, 255, 8, 8)
+      bounds: 112 392 8 8
+    - image: solid-color(15, 49, 0, 255, 8, 8)
+      bounds: 120 392 8 8
+    - image: solid-color(16, 49, 0, 255, 8, 8)
+      bounds: 128 392 8 8
+    - image: solid-color(17, 49, 0, 255, 8, 8)
+      bounds: 136 392 8 8
+    - image: solid-color(18, 49, 0, 255, 8, 8)
+      bounds: 144 392 8 8
+    - image: solid-color(19, 49, 0, 255, 8, 8)
+      bounds: 152 392 8 8
+    - image: solid-color(20, 49, 0, 255, 8, 8)
+      bounds: 160 392 8 8
+    - image: solid-color(21, 49, 0, 255, 8, 8)
+      bounds: 168 392 8 8
+    - image: solid-color(22, 49, 0, 255, 8, 8)
+      bounds: 176 392 8 8
+    - image: solid-color(23, 49, 0, 255, 8, 8)
+      bounds: 184 392 8 8
+    - image: solid-color(24, 49, 0, 255, 8, 8)
+      bounds: 192 392 8 8
+    - image: solid-color(25, 49, 0, 255, 8, 8)
+      bounds: 200 392 8 8
+    - image: solid-color(26, 49, 0, 255, 8, 8)
+      bounds: 208 392 8 8
+    - image: solid-color(27, 49, 0, 255, 8, 8)
+      bounds: 216 392 8 8
+    - image: solid-color(28, 49, 0, 255, 8, 8)
+      bounds: 224 392 8 8
+    - image: solid-color(29, 49, 0, 255, 8, 8)
+      bounds: 232 392 8 8
+    - image: solid-color(30, 49, 0, 255, 8, 8)
+      bounds: 240 392 8 8
+    - image: solid-color(31, 49, 0, 255, 8, 8)
+      bounds: 248 392 8 8
+    - image: solid-color(32, 49, 0, 255, 8, 8)
+      bounds: 256 392 8 8
+    - image: solid-color(33, 49, 0, 255, 8, 8)
+      bounds: 264 392 8 8
+    - image: solid-color(34, 49, 0, 255, 8, 8)
+      bounds: 272 392 8 8
+    - image: solid-color(35, 49, 0, 255, 8, 8)
+      bounds: 280 392 8 8
+    - image: solid-color(36, 49, 0, 255, 8, 8)
+      bounds: 288 392 8 8
+    - image: solid-color(37, 49, 0, 255, 8, 8)
+      bounds: 296 392 8 8
+    - image: solid-color(38, 49, 0, 255, 8, 8)
+      bounds: 304 392 8 8
+    - image: solid-color(39, 49, 0, 255, 8, 8)
+      bounds: 312 392 8 8
+    - image: solid-color(40, 49, 0, 255, 8, 8)
+      bounds: 320 392 8 8
+    - image: solid-color(41, 49, 0, 255, 8, 8)
+      bounds: 328 392 8 8
+    - image: solid-color(42, 49, 0, 255, 8, 8)
+      bounds: 336 392 8 8
+    - image: solid-color(43, 49, 0, 255, 8, 8)
+      bounds: 344 392 8 8
+    - image: solid-color(44, 49, 0, 255, 8, 8)
+      bounds: 352 392 8 8
+    - image: solid-color(45, 49, 0, 255, 8, 8)
+      bounds: 360 392 8 8
+    - image: solid-color(46, 49, 0, 255, 8, 8)
+      bounds: 368 392 8 8
+    - image: solid-color(47, 49, 0, 255, 8, 8)
+      bounds: 376 392 8 8
+    - image: solid-color(48, 49, 0, 255, 8, 8)
+      bounds: 384 392 8 8
+    - image: solid-color(49, 49, 0, 255, 8, 8)
+      bounds: 392 392 8 8
+    - image: solid-color(50, 49, 0, 255, 8, 8)
+      bounds: 400 392 8 8
+    - image: solid-color(51, 49, 0, 255, 8, 8)
+      bounds: 408 392 8 8
+    - image: solid-color(52, 49, 0, 255, 8, 8)
+      bounds: 416 392 8 8
+    - image: solid-color(53, 49, 0, 255, 8, 8)
+      bounds: 424 392 8 8
+    - image: solid-color(54, 49, 0, 255, 8, 8)
+      bounds: 432 392 8 8
+    - image: solid-color(55, 49, 0, 255, 8, 8)
+      bounds: 440 392 8 8
+    - image: solid-color(56, 49, 0, 255, 8, 8)
+      bounds: 448 392 8 8
+    - image: solid-color(57, 49, 0, 255, 8, 8)
+      bounds: 456 392 8 8
+    - image: solid-color(58, 49, 0, 255, 8, 8)
+      bounds: 464 392 8 8
+    - image: solid-color(59, 49, 0, 255, 8, 8)
+      bounds: 472 392 8 8
+    - image: solid-color(60, 49, 0, 255, 8, 8)
+      bounds: 480 392 8 8
+    - image: solid-color(61, 49, 0, 255, 8, 8)
+      bounds: 488 392 8 8
+    - image: solid-color(62, 49, 0, 255, 8, 8)
+      bounds: 496 392 8 8
+    - image: solid-color(63, 49, 0, 255, 8, 8)
+      bounds: 504 392 8 8
+    - image: solid-color(64, 49, 0, 255, 8, 8)
+      bounds: 512 392 8 8
+    - image: solid-color(65, 49, 0, 255, 8, 8)
+      bounds: 520 392 8 8
+    - image: solid-color(66, 49, 0, 255, 8, 8)
+      bounds: 528 392 8 8
+    - image: solid-color(67, 49, 0, 255, 8, 8)
+      bounds: 536 392 8 8
+    - image: solid-color(68, 49, 0, 255, 8, 8)
+      bounds: 544 392 8 8
+    - image: solid-color(69, 49, 0, 255, 8, 8)
+      bounds: 552 392 8 8
+    - image: solid-color(70, 49, 0, 255, 8, 8)
+      bounds: 560 392 8 8
+    - image: solid-color(71, 49, 0, 255, 8, 8)
+      bounds: 568 392 8 8
+    - image: solid-color(72, 49, 0, 255, 8, 8)
+      bounds: 576 392 8 8
+    - image: solid-color(73, 49, 0, 255, 8, 8)
+      bounds: 584 392 8 8
+    - image: solid-color(74, 49, 0, 255, 8, 8)
+      bounds: 592 392 8 8
+    - image: solid-color(75, 49, 0, 255, 8, 8)
+      bounds: 600 392 8 8
+    - image: solid-color(76, 49, 0, 255, 8, 8)
+      bounds: 608 392 8 8
+    - image: solid-color(77, 49, 0, 255, 8, 8)
+      bounds: 616 392 8 8
+    - image: solid-color(78, 49, 0, 255, 8, 8)
+      bounds: 624 392 8 8
+    - image: solid-color(79, 49, 0, 255, 8, 8)
+      bounds: 632 392 8 8
+    - image: solid-color(80, 49, 0, 255, 8, 8)
+      bounds: 640 392 8 8
+    - image: solid-color(81, 49, 0, 255, 8, 8)
+      bounds: 648 392 8 8
+    - image: solid-color(82, 49, 0, 255, 8, 8)
+      bounds: 656 392 8 8
+    - image: solid-color(83, 49, 0, 255, 8, 8)
+      bounds: 664 392 8 8
+    - image: solid-color(84, 49, 0, 255, 8, 8)
+      bounds: 672 392 8 8
+    - image: solid-color(85, 49, 0, 255, 8, 8)
+      bounds: 680 392 8 8
+    - image: solid-color(86, 49, 0, 255, 8, 8)
+      bounds: 688 392 8 8
+    - image: solid-color(87, 49, 0, 255, 8, 8)
+      bounds: 696 392 8 8
+    - image: solid-color(88, 49, 0, 255, 8, 8)
+      bounds: 704 392 8 8
+    - image: solid-color(89, 49, 0, 255, 8, 8)
+      bounds: 712 392 8 8
+    - image: solid-color(90, 49, 0, 255, 8, 8)
+      bounds: 720 392 8 8
+    - image: solid-color(91, 49, 0, 255, 8, 8)
+      bounds: 728 392 8 8
+    - image: solid-color(92, 49, 0, 255, 8, 8)
+      bounds: 736 392 8 8
+    - image: solid-color(93, 49, 0, 255, 8, 8)
+      bounds: 744 392 8 8
+    - image: solid-color(94, 49, 0, 255, 8, 8)
+      bounds: 752 392 8 8
+    - image: solid-color(95, 49, 0, 255, 8, 8)
+      bounds: 760 392 8 8
+    - image: solid-color(96, 49, 0, 255, 8, 8)
+      bounds: 768 392 8 8
+    - image: solid-color(97, 49, 0, 255, 8, 8)
+      bounds: 776 392 8 8
+    - image: solid-color(98, 49, 0, 255, 8, 8)
+      bounds: 784 392 8 8
+    - image: solid-color(99, 49, 0, 255, 8, 8)
+      bounds: 792 392 8 8
+    - image: solid-color(100, 49, 0, 255, 8, 8)
+      bounds: 800 392 8 8
+    - image: solid-color(101, 49, 0, 255, 8, 8)
+      bounds: 808 392 8 8
+    - image: solid-color(102, 49, 0, 255, 8, 8)
+      bounds: 816 392 8 8
+    - image: solid-color(103, 49, 0, 255, 8, 8)
+      bounds: 824 392 8 8
+    - image: solid-color(104, 49, 0, 255, 8, 8)
+      bounds: 832 392 8 8
+    - image: solid-color(105, 49, 0, 255, 8, 8)
+      bounds: 840 392 8 8
+    - image: solid-color(106, 49, 0, 255, 8, 8)
+      bounds: 848 392 8 8
+    - image: solid-color(107, 49, 0, 255, 8, 8)
+      bounds: 856 392 8 8
+    - image: solid-color(108, 49, 0, 255, 8, 8)
+      bounds: 864 392 8 8
+    - image: solid-color(109, 49, 0, 255, 8, 8)
+      bounds: 872 392 8 8
+    - image: solid-color(110, 49, 0, 255, 8, 8)
+      bounds: 880 392 8 8
+    - image: solid-color(111, 49, 0, 255, 8, 8)
+      bounds: 888 392 8 8
+    - image: solid-color(112, 49, 0, 255, 8, 8)
+      bounds: 896 392 8 8
+    - image: solid-color(113, 49, 0, 255, 8, 8)
+      bounds: 904 392 8 8
+    - image: solid-color(114, 49, 0, 255, 8, 8)
+      bounds: 912 392 8 8
+    - image: solid-color(115, 49, 0, 255, 8, 8)
+      bounds: 920 392 8 8
+    - image: solid-color(116, 49, 0, 255, 8, 8)
+      bounds: 928 392 8 8
+    - image: solid-color(117, 49, 0, 255, 8, 8)
+      bounds: 936 392 8 8
+    - image: solid-color(118, 49, 0, 255, 8, 8)
+      bounds: 944 392 8 8
+    - image: solid-color(119, 49, 0, 255, 8, 8)
+      bounds: 952 392 8 8
+    - image: solid-color(120, 49, 0, 255, 8, 8)
+      bounds: 960 392 8 8
+    - image: solid-color(121, 49, 0, 255, 8, 8)
+      bounds: 968 392 8 8
+    - image: solid-color(122, 49, 0, 255, 8, 8)
+      bounds: 976 392 8 8
+    - image: solid-color(123, 49, 0, 255, 8, 8)
+      bounds: 984 392 8 8
+    - image: solid-color(124, 49, 0, 255, 8, 8)
+      bounds: 992 392 8 8
+    - image: solid-color(125, 49, 0, 255, 8, 8)
+      bounds: 1000 392 8 8
+    - image: solid-color(126, 49, 0, 255, 8, 8)
+      bounds: 1008 392 8 8
+    - image: solid-color(127, 49, 0, 255, 8, 8)
+      bounds: 1016 392 8 8
+    - image: solid-color(0, 50, 0, 255, 8, 8)
+      bounds: 0 400 8 8
+    - image: solid-color(1, 50, 0, 255, 8, 8)
+      bounds: 8 400 8 8
+    - image: solid-color(2, 50, 0, 255, 8, 8)
+      bounds: 16 400 8 8
+    - image: solid-color(3, 50, 0, 255, 8, 8)
+      bounds: 24 400 8 8
+    - image: solid-color(4, 50, 0, 255, 8, 8)
+      bounds: 32 400 8 8
+    - image: solid-color(5, 50, 0, 255, 8, 8)
+      bounds: 40 400 8 8
+    - image: solid-color(6, 50, 0, 255, 8, 8)
+      bounds: 48 400 8 8
+    - image: solid-color(7, 50, 0, 255, 8, 8)
+      bounds: 56 400 8 8
+    - image: solid-color(8, 50, 0, 255, 8, 8)
+      bounds: 64 400 8 8
+    - image: solid-color(9, 50, 0, 255, 8, 8)
+      bounds: 72 400 8 8
+    - image: solid-color(10, 50, 0, 255, 8, 8)
+      bounds: 80 400 8 8
+    - image: solid-color(11, 50, 0, 255, 8, 8)
+      bounds: 88 400 8 8
+    - image: solid-color(12, 50, 0, 255, 8, 8)
+      bounds: 96 400 8 8
+    - image: solid-color(13, 50, 0, 255, 8, 8)
+      bounds: 104 400 8 8
+    - image: solid-color(14, 50, 0, 255, 8, 8)
+      bounds: 112 400 8 8
+    - image: solid-color(15, 50, 0, 255, 8, 8)
+      bounds: 120 400 8 8
+    - image: solid-color(16, 50, 0, 255, 8, 8)
+      bounds: 128 400 8 8
+    - image: solid-color(17, 50, 0, 255, 8, 8)
+      bounds: 136 400 8 8
+    - image: solid-color(18, 50, 0, 255, 8, 8)
+      bounds: 144 400 8 8
+    - image: solid-color(19, 50, 0, 255, 8, 8)
+      bounds: 152 400 8 8
+    - image: solid-color(20, 50, 0, 255, 8, 8)
+      bounds: 160 400 8 8
+    - image: solid-color(21, 50, 0, 255, 8, 8)
+      bounds: 168 400 8 8
+    - image: solid-color(22, 50, 0, 255, 8, 8)
+      bounds: 176 400 8 8
+    - image: solid-color(23, 50, 0, 255, 8, 8)
+      bounds: 184 400 8 8
+    - image: solid-color(24, 50, 0, 255, 8, 8)
+      bounds: 192 400 8 8
+    - image: solid-color(25, 50, 0, 255, 8, 8)
+      bounds: 200 400 8 8
+    - image: solid-color(26, 50, 0, 255, 8, 8)
+      bounds: 208 400 8 8
+    - image: solid-color(27, 50, 0, 255, 8, 8)
+      bounds: 216 400 8 8
+    - image: solid-color(28, 50, 0, 255, 8, 8)
+      bounds: 224 400 8 8
+    - image: solid-color(29, 50, 0, 255, 8, 8)
+      bounds: 232 400 8 8
+    - image: solid-color(30, 50, 0, 255, 8, 8)
+      bounds: 240 400 8 8
+    - image: solid-color(31, 50, 0, 255, 8, 8)
+      bounds: 248 400 8 8
+    - image: solid-color(32, 50, 0, 255, 8, 8)
+      bounds: 256 400 8 8
+    - image: solid-color(33, 50, 0, 255, 8, 8)
+      bounds: 264 400 8 8
+    - image: solid-color(34, 50, 0, 255, 8, 8)
+      bounds: 272 400 8 8
+    - image: solid-color(35, 50, 0, 255, 8, 8)
+      bounds: 280 400 8 8
+    - image: solid-color(36, 50, 0, 255, 8, 8)
+      bounds: 288 400 8 8
+    - image: solid-color(37, 50, 0, 255, 8, 8)
+      bounds: 296 400 8 8
+    - image: solid-color(38, 50, 0, 255, 8, 8)
+      bounds: 304 400 8 8
+    - image: solid-color(39, 50, 0, 255, 8, 8)
+      bounds: 312 400 8 8
+    - image: solid-color(40, 50, 0, 255, 8, 8)
+      bounds: 320 400 8 8
+    - image: solid-color(41, 50, 0, 255, 8, 8)
+      bounds: 328 400 8 8
+    - image: solid-color(42, 50, 0, 255, 8, 8)
+      bounds: 336 400 8 8
+    - image: solid-color(43, 50, 0, 255, 8, 8)
+      bounds: 344 400 8 8
+    - image: solid-color(44, 50, 0, 255, 8, 8)
+      bounds: 352 400 8 8
+    - image: solid-color(45, 50, 0, 255, 8, 8)
+      bounds: 360 400 8 8
+    - image: solid-color(46, 50, 0, 255, 8, 8)
+      bounds: 368 400 8 8
+    - image: solid-color(47, 50, 0, 255, 8, 8)
+      bounds: 376 400 8 8
+    - image: solid-color(48, 50, 0, 255, 8, 8)
+      bounds: 384 400 8 8
+    - image: solid-color(49, 50, 0, 255, 8, 8)
+      bounds: 392 400 8 8
+    - image: solid-color(50, 50, 0, 255, 8, 8)
+      bounds: 400 400 8 8
+    - image: solid-color(51, 50, 0, 255, 8, 8)
+      bounds: 408 400 8 8
+    - image: solid-color(52, 50, 0, 255, 8, 8)
+      bounds: 416 400 8 8
+    - image: solid-color(53, 50, 0, 255, 8, 8)
+      bounds: 424 400 8 8
+    - image: solid-color(54, 50, 0, 255, 8, 8)
+      bounds: 432 400 8 8
+    - image: solid-color(55, 50, 0, 255, 8, 8)
+      bounds: 440 400 8 8
+    - image: solid-color(56, 50, 0, 255, 8, 8)
+      bounds: 448 400 8 8
+    - image: solid-color(57, 50, 0, 255, 8, 8)
+      bounds: 456 400 8 8
+    - image: solid-color(58, 50, 0, 255, 8, 8)
+      bounds: 464 400 8 8
+    - image: solid-color(59, 50, 0, 255, 8, 8)
+      bounds: 472 400 8 8
+    - image: solid-color(60, 50, 0, 255, 8, 8)
+      bounds: 480 400 8 8
+    - image: solid-color(61, 50, 0, 255, 8, 8)
+      bounds: 488 400 8 8
+    - image: solid-color(62, 50, 0, 255, 8, 8)
+      bounds: 496 400 8 8
+    - image: solid-color(63, 50, 0, 255, 8, 8)
+      bounds: 504 400 8 8
+    - image: solid-color(64, 50, 0, 255, 8, 8)
+      bounds: 512 400 8 8
+    - image: solid-color(65, 50, 0, 255, 8, 8)
+      bounds: 520 400 8 8
+    - image: solid-color(66, 50, 0, 255, 8, 8)
+      bounds: 528 400 8 8
+    - image: solid-color(67, 50, 0, 255, 8, 8)
+      bounds: 536 400 8 8
+    - image: solid-color(68, 50, 0, 255, 8, 8)
+      bounds: 544 400 8 8
+    - image: solid-color(69, 50, 0, 255, 8, 8)
+      bounds: 552 400 8 8
+    - image: solid-color(70, 50, 0, 255, 8, 8)
+      bounds: 560 400 8 8
+    - image: solid-color(71, 50, 0, 255, 8, 8)
+      bounds: 568 400 8 8
+    - image: solid-color(72, 50, 0, 255, 8, 8)
+      bounds: 576 400 8 8
+    - image: solid-color(73, 50, 0, 255, 8, 8)
+      bounds: 584 400 8 8
+    - image: solid-color(74, 50, 0, 255, 8, 8)
+      bounds: 592 400 8 8
+    - image: solid-color(75, 50, 0, 255, 8, 8)
+      bounds: 600 400 8 8
+    - image: solid-color(76, 50, 0, 255, 8, 8)
+      bounds: 608 400 8 8
+    - image: solid-color(77, 50, 0, 255, 8, 8)
+      bounds: 616 400 8 8
+    - image: solid-color(78, 50, 0, 255, 8, 8)
+      bounds: 624 400 8 8
+    - image: solid-color(79, 50, 0, 255, 8, 8)
+      bounds: 632 400 8 8
+    - image: solid-color(80, 50, 0, 255, 8, 8)
+      bounds: 640 400 8 8
+    - image: solid-color(81, 50, 0, 255, 8, 8)
+      bounds: 648 400 8 8
+    - image: solid-color(82, 50, 0, 255, 8, 8)
+      bounds: 656 400 8 8
+    - image: solid-color(83, 50, 0, 255, 8, 8)
+      bounds: 664 400 8 8
+    - image: solid-color(84, 50, 0, 255, 8, 8)
+      bounds: 672 400 8 8
+    - image: solid-color(85, 50, 0, 255, 8, 8)
+      bounds: 680 400 8 8
+    - image: solid-color(86, 50, 0, 255, 8, 8)
+      bounds: 688 400 8 8
+    - image: solid-color(87, 50, 0, 255, 8, 8)
+      bounds: 696 400 8 8
+    - image: solid-color(88, 50, 0, 255, 8, 8)
+      bounds: 704 400 8 8
+    - image: solid-color(89, 50, 0, 255, 8, 8)
+      bounds: 712 400 8 8
+    - image: solid-color(90, 50, 0, 255, 8, 8)
+      bounds: 720 400 8 8
+    - image: solid-color(91, 50, 0, 255, 8, 8)
+      bounds: 728 400 8 8
+    - image: solid-color(92, 50, 0, 255, 8, 8)
+      bounds: 736 400 8 8
+    - image: solid-color(93, 50, 0, 255, 8, 8)
+      bounds: 744 400 8 8
+    - image: solid-color(94, 50, 0, 255, 8, 8)
+      bounds: 752 400 8 8
+    - image: solid-color(95, 50, 0, 255, 8, 8)
+      bounds: 760 400 8 8
+    - image: solid-color(96, 50, 0, 255, 8, 8)
+      bounds: 768 400 8 8
+    - image: solid-color(97, 50, 0, 255, 8, 8)
+      bounds: 776 400 8 8
+    - image: solid-color(98, 50, 0, 255, 8, 8)
+      bounds: 784 400 8 8
+    - image: solid-color(99, 50, 0, 255, 8, 8)
+      bounds: 792 400 8 8
+    - image: solid-color(100, 50, 0, 255, 8, 8)
+      bounds: 800 400 8 8
+    - image: solid-color(101, 50, 0, 255, 8, 8)
+      bounds: 808 400 8 8
+    - image: solid-color(102, 50, 0, 255, 8, 8)
+      bounds: 816 400 8 8
+    - image: solid-color(103, 50, 0, 255, 8, 8)
+      bounds: 824 400 8 8
+    - image: solid-color(104, 50, 0, 255, 8, 8)
+      bounds: 832 400 8 8
+    - image: solid-color(105, 50, 0, 255, 8, 8)
+      bounds: 840 400 8 8
+    - image: solid-color(106, 50, 0, 255, 8, 8)
+      bounds: 848 400 8 8
+    - image: solid-color(107, 50, 0, 255, 8, 8)
+      bounds: 856 400 8 8
+    - image: solid-color(108, 50, 0, 255, 8, 8)
+      bounds: 864 400 8 8
+    - image: solid-color(109, 50, 0, 255, 8, 8)
+      bounds: 872 400 8 8
+    - image: solid-color(110, 50, 0, 255, 8, 8)
+      bounds: 880 400 8 8
+    - image: solid-color(111, 50, 0, 255, 8, 8)
+      bounds: 888 400 8 8
+    - image: solid-color(112, 50, 0, 255, 8, 8)
+      bounds: 896 400 8 8
+    - image: solid-color(113, 50, 0, 255, 8, 8)
+      bounds: 904 400 8 8
+    - image: solid-color(114, 50, 0, 255, 8, 8)
+      bounds: 912 400 8 8
+    - image: solid-color(115, 50, 0, 255, 8, 8)
+      bounds: 920 400 8 8
+    - image: solid-color(116, 50, 0, 255, 8, 8)
+      bounds: 928 400 8 8
+    - image: solid-color(117, 50, 0, 255, 8, 8)
+      bounds: 936 400 8 8
+    - image: solid-color(118, 50, 0, 255, 8, 8)
+      bounds: 944 400 8 8
+    - image: solid-color(119, 50, 0, 255, 8, 8)
+      bounds: 952 400 8 8
+    - image: solid-color(120, 50, 0, 255, 8, 8)
+      bounds: 960 400 8 8
+    - image: solid-color(121, 50, 0, 255, 8, 8)
+      bounds: 968 400 8 8
+    - image: solid-color(122, 50, 0, 255, 8, 8)
+      bounds: 976 400 8 8
+    - image: solid-color(123, 50, 0, 255, 8, 8)
+      bounds: 984 400 8 8
+    - image: solid-color(124, 50, 0, 255, 8, 8)
+      bounds: 992 400 8 8
+    - image: solid-color(125, 50, 0, 255, 8, 8)
+      bounds: 1000 400 8 8
+    - image: solid-color(126, 50, 0, 255, 8, 8)
+      bounds: 1008 400 8 8
+    - image: solid-color(127, 50, 0, 255, 8, 8)
+      bounds: 1016 400 8 8
+    - image: solid-color(0, 51, 0, 255, 8, 8)
+      bounds: 0 408 8 8
+    - image: solid-color(1, 51, 0, 255, 8, 8)
+      bounds: 8 408 8 8
+    - image: solid-color(2, 51, 0, 255, 8, 8)
+      bounds: 16 408 8 8
+    - image: solid-color(3, 51, 0, 255, 8, 8)
+      bounds: 24 408 8 8
+    - image: solid-color(4, 51, 0, 255, 8, 8)
+      bounds: 32 408 8 8
+    - image: solid-color(5, 51, 0, 255, 8, 8)
+      bounds: 40 408 8 8
+    - image: solid-color(6, 51, 0, 255, 8, 8)
+      bounds: 48 408 8 8
+    - image: solid-color(7, 51, 0, 255, 8, 8)
+      bounds: 56 408 8 8
+    - image: solid-color(8, 51, 0, 255, 8, 8)
+      bounds: 64 408 8 8
+    - image: solid-color(9, 51, 0, 255, 8, 8)
+      bounds: 72 408 8 8
+    - image: solid-color(10, 51, 0, 255, 8, 8)
+      bounds: 80 408 8 8
+    - image: solid-color(11, 51, 0, 255, 8, 8)
+      bounds: 88 408 8 8
+    - image: solid-color(12, 51, 0, 255, 8, 8)
+      bounds: 96 408 8 8
+    - image: solid-color(13, 51, 0, 255, 8, 8)
+      bounds: 104 408 8 8
+    - image: solid-color(14, 51, 0, 255, 8, 8)
+      bounds: 112 408 8 8
+    - image: solid-color(15, 51, 0, 255, 8, 8)
+      bounds: 120 408 8 8
+    - image: solid-color(16, 51, 0, 255, 8, 8)
+      bounds: 128 408 8 8
+    - image: solid-color(17, 51, 0, 255, 8, 8)
+      bounds: 136 408 8 8
+    - image: solid-color(18, 51, 0, 255, 8, 8)
+      bounds: 144 408 8 8
+    - image: solid-color(19, 51, 0, 255, 8, 8)
+      bounds: 152 408 8 8
+    - image: solid-color(20, 51, 0, 255, 8, 8)
+      bounds: 160 408 8 8
+    - image: solid-color(21, 51, 0, 255, 8, 8)
+      bounds: 168 408 8 8
+    - image: solid-color(22, 51, 0, 255, 8, 8)
+      bounds: 176 408 8 8
+    - image: solid-color(23, 51, 0, 255, 8, 8)
+      bounds: 184 408 8 8
+    - image: solid-color(24, 51, 0, 255, 8, 8)
+      bounds: 192 408 8 8
+    - image: solid-color(25, 51, 0, 255, 8, 8)
+      bounds: 200 408 8 8
+    - image: solid-color(26, 51, 0, 255, 8, 8)
+      bounds: 208 408 8 8
+    - image: solid-color(27, 51, 0, 255, 8, 8)
+      bounds: 216 408 8 8
+    - image: solid-color(28, 51, 0, 255, 8, 8)
+      bounds: 224 408 8 8
+    - image: solid-color(29, 51, 0, 255, 8, 8)
+      bounds: 232 408 8 8
+    - image: solid-color(30, 51, 0, 255, 8, 8)
+      bounds: 240 408 8 8
+    - image: solid-color(31, 51, 0, 255, 8, 8)
+      bounds: 248 408 8 8
+    - image: solid-color(32, 51, 0, 255, 8, 8)
+      bounds: 256 408 8 8
+    - image: solid-color(33, 51, 0, 255, 8, 8)
+      bounds: 264 408 8 8
+    - image: solid-color(34, 51, 0, 255, 8, 8)
+      bounds: 272 408 8 8
+    - image: solid-color(35, 51, 0, 255, 8, 8)
+      bounds: 280 408 8 8
+    - image: solid-color(36, 51, 0, 255, 8, 8)
+      bounds: 288 408 8 8
+    - image: solid-color(37, 51, 0, 255, 8, 8)
+      bounds: 296 408 8 8
+    - image: solid-color(38, 51, 0, 255, 8, 8)
+      bounds: 304 408 8 8
+    - image: solid-color(39, 51, 0, 255, 8, 8)
+      bounds: 312 408 8 8
+    - image: solid-color(40, 51, 0, 255, 8, 8)
+      bounds: 320 408 8 8
+    - image: solid-color(41, 51, 0, 255, 8, 8)
+      bounds: 328 408 8 8
+    - image: solid-color(42, 51, 0, 255, 8, 8)
+      bounds: 336 408 8 8
+    - image: solid-color(43, 51, 0, 255, 8, 8)
+      bounds: 344 408 8 8
+    - image: solid-color(44, 51, 0, 255, 8, 8)
+      bounds: 352 408 8 8
+    - image: solid-color(45, 51, 0, 255, 8, 8)
+      bounds: 360 408 8 8
+    - image: solid-color(46, 51, 0, 255, 8, 8)
+      bounds: 368 408 8 8
+    - image: solid-color(47, 51, 0, 255, 8, 8)
+      bounds: 376 408 8 8
+    - image: solid-color(48, 51, 0, 255, 8, 8)
+      bounds: 384 408 8 8
+    - image: solid-color(49, 51, 0, 255, 8, 8)
+      bounds: 392 408 8 8
+    - image: solid-color(50, 51, 0, 255, 8, 8)
+      bounds: 400 408 8 8
+    - image: solid-color(51, 51, 0, 255, 8, 8)
+      bounds: 408 408 8 8
+    - image: solid-color(52, 51, 0, 255, 8, 8)
+      bounds: 416 408 8 8
+    - image: solid-color(53, 51, 0, 255, 8, 8)
+      bounds: 424 408 8 8
+    - image: solid-color(54, 51, 0, 255, 8, 8)
+      bounds: 432 408 8 8
+    - image: solid-color(55, 51, 0, 255, 8, 8)
+      bounds: 440 408 8 8
+    - image: solid-color(56, 51, 0, 255, 8, 8)
+      bounds: 448 408 8 8
+    - image: solid-color(57, 51, 0, 255, 8, 8)
+      bounds: 456 408 8 8
+    - image: solid-color(58, 51, 0, 255, 8, 8)
+      bounds: 464 408 8 8
+    - image: solid-color(59, 51, 0, 255, 8, 8)
+      bounds: 472 408 8 8
+    - image: solid-color(60, 51, 0, 255, 8, 8)
+      bounds: 480 408 8 8
+    - image: solid-color(61, 51, 0, 255, 8, 8)
+      bounds: 488 408 8 8
+    - image: solid-color(62, 51, 0, 255, 8, 8)
+      bounds: 496 408 8 8
+    - image: solid-color(63, 51, 0, 255, 8, 8)
+      bounds: 504 408 8 8
+    - image: solid-color(64, 51, 0, 255, 8, 8)
+      bounds: 512 408 8 8
+    - image: solid-color(65, 51, 0, 255, 8, 8)
+      bounds: 520 408 8 8
+    - image: solid-color(66, 51, 0, 255, 8, 8)
+      bounds: 528 408 8 8
+    - image: solid-color(67, 51, 0, 255, 8, 8)
+      bounds: 536 408 8 8
+    - image: solid-color(68, 51, 0, 255, 8, 8)
+      bounds: 544 408 8 8
+    - image: solid-color(69, 51, 0, 255, 8, 8)
+      bounds: 552 408 8 8
+    - image: solid-color(70, 51, 0, 255, 8, 8)
+      bounds: 560 408 8 8
+    - image: solid-color(71, 51, 0, 255, 8, 8)
+      bounds: 568 408 8 8
+    - image: solid-color(72, 51, 0, 255, 8, 8)
+      bounds: 576 408 8 8
+    - image: solid-color(73, 51, 0, 255, 8, 8)
+      bounds: 584 408 8 8
+    - image: solid-color(74, 51, 0, 255, 8, 8)
+      bounds: 592 408 8 8
+    - image: solid-color(75, 51, 0, 255, 8, 8)
+      bounds: 600 408 8 8
+    - image: solid-color(76, 51, 0, 255, 8, 8)
+      bounds: 608 408 8 8
+    - image: solid-color(77, 51, 0, 255, 8, 8)
+      bounds: 616 408 8 8
+    - image: solid-color(78, 51, 0, 255, 8, 8)
+      bounds: 624 408 8 8
+    - image: solid-color(79, 51, 0, 255, 8, 8)
+      bounds: 632 408 8 8
+    - image: solid-color(80, 51, 0, 255, 8, 8)
+      bounds: 640 408 8 8
+    - image: solid-color(81, 51, 0, 255, 8, 8)
+      bounds: 648 408 8 8
+    - image: solid-color(82, 51, 0, 255, 8, 8)
+      bounds: 656 408 8 8
+    - image: solid-color(83, 51, 0, 255, 8, 8)
+      bounds: 664 408 8 8
+    - image: solid-color(84, 51, 0, 255, 8, 8)
+      bounds: 672 408 8 8
+    - image: solid-color(85, 51, 0, 255, 8, 8)
+      bounds: 680 408 8 8
+    - image: solid-color(86, 51, 0, 255, 8, 8)
+      bounds: 688 408 8 8
+    - image: solid-color(87, 51, 0, 255, 8, 8)
+      bounds: 696 408 8 8
+    - image: solid-color(88, 51, 0, 255, 8, 8)
+      bounds: 704 408 8 8
+    - image: solid-color(89, 51, 0, 255, 8, 8)
+      bounds: 712 408 8 8
+    - image: solid-color(90, 51, 0, 255, 8, 8)
+      bounds: 720 408 8 8
+    - image: solid-color(91, 51, 0, 255, 8, 8)
+      bounds: 728 408 8 8
+    - image: solid-color(92, 51, 0, 255, 8, 8)
+      bounds: 736 408 8 8
+    - image: solid-color(93, 51, 0, 255, 8, 8)
+      bounds: 744 408 8 8
+    - image: solid-color(94, 51, 0, 255, 8, 8)
+      bounds: 752 408 8 8
+    - image: solid-color(95, 51, 0, 255, 8, 8)
+      bounds: 760 408 8 8
+    - image: solid-color(96, 51, 0, 255, 8, 8)
+      bounds: 768 408 8 8
+    - image: solid-color(97, 51, 0, 255, 8, 8)
+      bounds: 776 408 8 8
+    - image: solid-color(98, 51, 0, 255, 8, 8)
+      bounds: 784 408 8 8
+    - image: solid-color(99, 51, 0, 255, 8, 8)
+      bounds: 792 408 8 8
+    - image: solid-color(100, 51, 0, 255, 8, 8)
+      bounds: 800 408 8 8
+    - image: solid-color(101, 51, 0, 255, 8, 8)
+      bounds: 808 408 8 8
+    - image: solid-color(102, 51, 0, 255, 8, 8)
+      bounds: 816 408 8 8
+    - image: solid-color(103, 51, 0, 255, 8, 8)
+      bounds: 824 408 8 8
+    - image: solid-color(104, 51, 0, 255, 8, 8)
+      bounds: 832 408 8 8
+    - image: solid-color(105, 51, 0, 255, 8, 8)
+      bounds: 840 408 8 8
+    - image: solid-color(106, 51, 0, 255, 8, 8)
+      bounds: 848 408 8 8
+    - image: solid-color(107, 51, 0, 255, 8, 8)
+      bounds: 856 408 8 8
+    - image: solid-color(108, 51, 0, 255, 8, 8)
+      bounds: 864 408 8 8
+    - image: solid-color(109, 51, 0, 255, 8, 8)
+      bounds: 872 408 8 8
+    - image: solid-color(110, 51, 0, 255, 8, 8)
+      bounds: 880 408 8 8
+    - image: solid-color(111, 51, 0, 255, 8, 8)
+      bounds: 888 408 8 8
+    - image: solid-color(112, 51, 0, 255, 8, 8)
+      bounds: 896 408 8 8
+    - image: solid-color(113, 51, 0, 255, 8, 8)
+      bounds: 904 408 8 8
+    - image: solid-color(114, 51, 0, 255, 8, 8)
+      bounds: 912 408 8 8
+    - image: solid-color(115, 51, 0, 255, 8, 8)
+      bounds: 920 408 8 8
+    - image: solid-color(116, 51, 0, 255, 8, 8)
+      bounds: 928 408 8 8
+    - image: solid-color(117, 51, 0, 255, 8, 8)
+      bounds: 936 408 8 8
+    - image: solid-color(118, 51, 0, 255, 8, 8)
+      bounds: 944 408 8 8
+    - image: solid-color(119, 51, 0, 255, 8, 8)
+      bounds: 952 408 8 8
+    - image: solid-color(120, 51, 0, 255, 8, 8)
+      bounds: 960 408 8 8
+    - image: solid-color(121, 51, 0, 255, 8, 8)
+      bounds: 968 408 8 8
+    - image: solid-color(122, 51, 0, 255, 8, 8)
+      bounds: 976 408 8 8
+    - image: solid-color(123, 51, 0, 255, 8, 8)
+      bounds: 984 408 8 8
+    - image: solid-color(124, 51, 0, 255, 8, 8)
+      bounds: 992 408 8 8
+    - image: solid-color(125, 51, 0, 255, 8, 8)
+      bounds: 1000 408 8 8
+    - image: solid-color(126, 51, 0, 255, 8, 8)
+      bounds: 1008 408 8 8
+    - image: solid-color(127, 51, 0, 255, 8, 8)
+      bounds: 1016 408 8 8
+    - image: solid-color(0, 52, 0, 255, 8, 8)
+      bounds: 0 416 8 8
+    - image: solid-color(1, 52, 0, 255, 8, 8)
+      bounds: 8 416 8 8
+    - image: solid-color(2, 52, 0, 255, 8, 8)
+      bounds: 16 416 8 8
+    - image: solid-color(3, 52, 0, 255, 8, 8)
+      bounds: 24 416 8 8
+    - image: solid-color(4, 52, 0, 255, 8, 8)
+      bounds: 32 416 8 8
+    - image: solid-color(5, 52, 0, 255, 8, 8)
+      bounds: 40 416 8 8
+    - image: solid-color(6, 52, 0, 255, 8, 8)
+      bounds: 48 416 8 8
+    - image: solid-color(7, 52, 0, 255, 8, 8)
+      bounds: 56 416 8 8
+    - image: solid-color(8, 52, 0, 255, 8, 8)
+      bounds: 64 416 8 8
+    - image: solid-color(9, 52, 0, 255, 8, 8)
+      bounds: 72 416 8 8
+    - image: solid-color(10, 52, 0, 255, 8, 8)
+      bounds: 80 416 8 8
+    - image: solid-color(11, 52, 0, 255, 8, 8)
+      bounds: 88 416 8 8
+    - image: solid-color(12, 52, 0, 255, 8, 8)
+      bounds: 96 416 8 8
+    - image: solid-color(13, 52, 0, 255, 8, 8)
+      bounds: 104 416 8 8
+    - image: solid-color(14, 52, 0, 255, 8, 8)
+      bounds: 112 416 8 8
+    - image: solid-color(15, 52, 0, 255, 8, 8)
+      bounds: 120 416 8 8
+    - image: solid-color(16, 52, 0, 255, 8, 8)
+      bounds: 128 416 8 8
+    - image: solid-color(17, 52, 0, 255, 8, 8)
+      bounds: 136 416 8 8
+    - image: solid-color(18, 52, 0, 255, 8, 8)
+      bounds: 144 416 8 8
+    - image: solid-color(19, 52, 0, 255, 8, 8)
+      bounds: 152 416 8 8
+    - image: solid-color(20, 52, 0, 255, 8, 8)
+      bounds: 160 416 8 8
+    - image: solid-color(21, 52, 0, 255, 8, 8)
+      bounds: 168 416 8 8
+    - image: solid-color(22, 52, 0, 255, 8, 8)
+      bounds: 176 416 8 8
+    - image: solid-color(23, 52, 0, 255, 8, 8)
+      bounds: 184 416 8 8
+    - image: solid-color(24, 52, 0, 255, 8, 8)
+      bounds: 192 416 8 8
+    - image: solid-color(25, 52, 0, 255, 8, 8)
+      bounds: 200 416 8 8
+    - image: solid-color(26, 52, 0, 255, 8, 8)
+      bounds: 208 416 8 8
+    - image: solid-color(27, 52, 0, 255, 8, 8)
+      bounds: 216 416 8 8
+    - image: solid-color(28, 52, 0, 255, 8, 8)
+      bounds: 224 416 8 8
+    - image: solid-color(29, 52, 0, 255, 8, 8)
+      bounds: 232 416 8 8
+    - image: solid-color(30, 52, 0, 255, 8, 8)
+      bounds: 240 416 8 8
+    - image: solid-color(31, 52, 0, 255, 8, 8)
+      bounds: 248 416 8 8
+    - image: solid-color(32, 52, 0, 255, 8, 8)
+      bounds: 256 416 8 8
+    - image: solid-color(33, 52, 0, 255, 8, 8)
+      bounds: 264 416 8 8
+    - image: solid-color(34, 52, 0, 255, 8, 8)
+      bounds: 272 416 8 8
+    - image: solid-color(35, 52, 0, 255, 8, 8)
+      bounds: 280 416 8 8
+    - image: solid-color(36, 52, 0, 255, 8, 8)
+      bounds: 288 416 8 8
+    - image: solid-color(37, 52, 0, 255, 8, 8)
+      bounds: 296 416 8 8
+    - image: solid-color(38, 52, 0, 255, 8, 8)
+      bounds: 304 416 8 8
+    - image: solid-color(39, 52, 0, 255, 8, 8)
+      bounds: 312 416 8 8
+    - image: solid-color(40, 52, 0, 255, 8, 8)
+      bounds: 320 416 8 8
+    - image: solid-color(41, 52, 0, 255, 8, 8)
+      bounds: 328 416 8 8
+    - image: solid-color(42, 52, 0, 255, 8, 8)
+      bounds: 336 416 8 8
+    - image: solid-color(43, 52, 0, 255, 8, 8)
+      bounds: 344 416 8 8
+    - image: solid-color(44, 52, 0, 255, 8, 8)
+      bounds: 352 416 8 8
+    - image: solid-color(45, 52, 0, 255, 8, 8)
+      bounds: 360 416 8 8
+    - image: solid-color(46, 52, 0, 255, 8, 8)
+      bounds: 368 416 8 8
+    - image: solid-color(47, 52, 0, 255, 8, 8)
+      bounds: 376 416 8 8
+    - image: solid-color(48, 52, 0, 255, 8, 8)
+      bounds: 384 416 8 8
+    - image: solid-color(49, 52, 0, 255, 8, 8)
+      bounds: 392 416 8 8
+    - image: solid-color(50, 52, 0, 255, 8, 8)
+      bounds: 400 416 8 8
+    - image: solid-color(51, 52, 0, 255, 8, 8)
+      bounds: 408 416 8 8
+    - image: solid-color(52, 52, 0, 255, 8, 8)
+      bounds: 416 416 8 8
+    - image: solid-color(53, 52, 0, 255, 8, 8)
+      bounds: 424 416 8 8
+    - image: solid-color(54, 52, 0, 255, 8, 8)
+      bounds: 432 416 8 8
+    - image: solid-color(55, 52, 0, 255, 8, 8)
+      bounds: 440 416 8 8
+    - image: solid-color(56, 52, 0, 255, 8, 8)
+      bounds: 448 416 8 8
+    - image: solid-color(57, 52, 0, 255, 8, 8)
+      bounds: 456 416 8 8
+    - image: solid-color(58, 52, 0, 255, 8, 8)
+      bounds: 464 416 8 8
+    - image: solid-color(59, 52, 0, 255, 8, 8)
+      bounds: 472 416 8 8
+    - image: solid-color(60, 52, 0, 255, 8, 8)
+      bounds: 480 416 8 8
+    - image: solid-color(61, 52, 0, 255, 8, 8)
+      bounds: 488 416 8 8
+    - image: solid-color(62, 52, 0, 255, 8, 8)
+      bounds: 496 416 8 8
+    - image: solid-color(63, 52, 0, 255, 8, 8)
+      bounds: 504 416 8 8
+    - image: solid-color(64, 52, 0, 255, 8, 8)
+      bounds: 512 416 8 8
+    - image: solid-color(65, 52, 0, 255, 8, 8)
+      bounds: 520 416 8 8
+    - image: solid-color(66, 52, 0, 255, 8, 8)
+      bounds: 528 416 8 8
+    - image: solid-color(67, 52, 0, 255, 8, 8)
+      bounds: 536 416 8 8
+    - image: solid-color(68, 52, 0, 255, 8, 8)
+      bounds: 544 416 8 8
+    - image: solid-color(69, 52, 0, 255, 8, 8)
+      bounds: 552 416 8 8
+    - image: solid-color(70, 52, 0, 255, 8, 8)
+      bounds: 560 416 8 8
+    - image: solid-color(71, 52, 0, 255, 8, 8)
+      bounds: 568 416 8 8
+    - image: solid-color(72, 52, 0, 255, 8, 8)
+      bounds: 576 416 8 8
+    - image: solid-color(73, 52, 0, 255, 8, 8)
+      bounds: 584 416 8 8
+    - image: solid-color(74, 52, 0, 255, 8, 8)
+      bounds: 592 416 8 8
+    - image: solid-color(75, 52, 0, 255, 8, 8)
+      bounds: 600 416 8 8
+    - image: solid-color(76, 52, 0, 255, 8, 8)
+      bounds: 608 416 8 8
+    - image: solid-color(77, 52, 0, 255, 8, 8)
+      bounds: 616 416 8 8
+    - image: solid-color(78, 52, 0, 255, 8, 8)
+      bounds: 624 416 8 8
+    - image: solid-color(79, 52, 0, 255, 8, 8)
+      bounds: 632 416 8 8
+    - image: solid-color(80, 52, 0, 255, 8, 8)
+      bounds: 640 416 8 8
+    - image: solid-color(81, 52, 0, 255, 8, 8)
+      bounds: 648 416 8 8
+    - image: solid-color(82, 52, 0, 255, 8, 8)
+      bounds: 656 416 8 8
+    - image: solid-color(83, 52, 0, 255, 8, 8)
+      bounds: 664 416 8 8
+    - image: solid-color(84, 52, 0, 255, 8, 8)
+      bounds: 672 416 8 8
+    - image: solid-color(85, 52, 0, 255, 8, 8)
+      bounds: 680 416 8 8
+    - image: solid-color(86, 52, 0, 255, 8, 8)
+      bounds: 688 416 8 8
+    - image: solid-color(87, 52, 0, 255, 8, 8)
+      bounds: 696 416 8 8
+    - image: solid-color(88, 52, 0, 255, 8, 8)
+      bounds: 704 416 8 8
+    - image: solid-color(89, 52, 0, 255, 8, 8)
+      bounds: 712 416 8 8
+    - image: solid-color(90, 52, 0, 255, 8, 8)
+      bounds: 720 416 8 8
+    - image: solid-color(91, 52, 0, 255, 8, 8)
+      bounds: 728 416 8 8
+    - image: solid-color(92, 52, 0, 255, 8, 8)
+      bounds: 736 416 8 8
+    - image: solid-color(93, 52, 0, 255, 8, 8)
+      bounds: 744 416 8 8
+    - image: solid-color(94, 52, 0, 255, 8, 8)
+      bounds: 752 416 8 8
+    - image: solid-color(95, 52, 0, 255, 8, 8)
+      bounds: 760 416 8 8
+    - image: solid-color(96, 52, 0, 255, 8, 8)
+      bounds: 768 416 8 8
+    - image: solid-color(97, 52, 0, 255, 8, 8)
+      bounds: 776 416 8 8
+    - image: solid-color(98, 52, 0, 255, 8, 8)
+      bounds: 784 416 8 8
+    - image: solid-color(99, 52, 0, 255, 8, 8)
+      bounds: 792 416 8 8
+    - image: solid-color(100, 52, 0, 255, 8, 8)
+      bounds: 800 416 8 8
+    - image: solid-color(101, 52, 0, 255, 8, 8)
+      bounds: 808 416 8 8
+    - image: solid-color(102, 52, 0, 255, 8, 8)
+      bounds: 816 416 8 8
+    - image: solid-color(103, 52, 0, 255, 8, 8)
+      bounds: 824 416 8 8
+    - image: solid-color(104, 52, 0, 255, 8, 8)
+      bounds: 832 416 8 8
+    - image: solid-color(105, 52, 0, 255, 8, 8)
+      bounds: 840 416 8 8
+    - image: solid-color(106, 52, 0, 255, 8, 8)
+      bounds: 848 416 8 8
+    - image: solid-color(107, 52, 0, 255, 8, 8)
+      bounds: 856 416 8 8
+    - image: solid-color(108, 52, 0, 255, 8, 8)
+      bounds: 864 416 8 8
+    - image: solid-color(109, 52, 0, 255, 8, 8)
+      bounds: 872 416 8 8
+    - image: solid-color(110, 52, 0, 255, 8, 8)
+      bounds: 880 416 8 8
+    - image: solid-color(111, 52, 0, 255, 8, 8)
+      bounds: 888 416 8 8
+    - image: solid-color(112, 52, 0, 255, 8, 8)
+      bounds: 896 416 8 8
+    - image: solid-color(113, 52, 0, 255, 8, 8)
+      bounds: 904 416 8 8
+    - image: solid-color(114, 52, 0, 255, 8, 8)
+      bounds: 912 416 8 8
+    - image: solid-color(115, 52, 0, 255, 8, 8)
+      bounds: 920 416 8 8
+    - image: solid-color(116, 52, 0, 255, 8, 8)
+      bounds: 928 416 8 8
+    - image: solid-color(117, 52, 0, 255, 8, 8)
+      bounds: 936 416 8 8
+    - image: solid-color(118, 52, 0, 255, 8, 8)
+      bounds: 944 416 8 8
+    - image: solid-color(119, 52, 0, 255, 8, 8)
+      bounds: 952 416 8 8
+    - image: solid-color(120, 52, 0, 255, 8, 8)
+      bounds: 960 416 8 8
+    - image: solid-color(121, 52, 0, 255, 8, 8)
+      bounds: 968 416 8 8
+    - image: solid-color(122, 52, 0, 255, 8, 8)
+      bounds: 976 416 8 8
+    - image: solid-color(123, 52, 0, 255, 8, 8)
+      bounds: 984 416 8 8
+    - image: solid-color(124, 52, 0, 255, 8, 8)
+      bounds: 992 416 8 8
+    - image: solid-color(125, 52, 0, 255, 8, 8)
+      bounds: 1000 416 8 8
+    - image: solid-color(126, 52, 0, 255, 8, 8)
+      bounds: 1008 416 8 8
+    - image: solid-color(127, 52, 0, 255, 8, 8)
+      bounds: 1016 416 8 8
+    - image: solid-color(0, 53, 0, 255, 8, 8)
+      bounds: 0 424 8 8
+    - image: solid-color(1, 53, 0, 255, 8, 8)
+      bounds: 8 424 8 8
+    - image: solid-color(2, 53, 0, 255, 8, 8)
+      bounds: 16 424 8 8
+    - image: solid-color(3, 53, 0, 255, 8, 8)
+      bounds: 24 424 8 8
+    - image: solid-color(4, 53, 0, 255, 8, 8)
+      bounds: 32 424 8 8
+    - image: solid-color(5, 53, 0, 255, 8, 8)
+      bounds: 40 424 8 8
+    - image: solid-color(6, 53, 0, 255, 8, 8)
+      bounds: 48 424 8 8
+    - image: solid-color(7, 53, 0, 255, 8, 8)
+      bounds: 56 424 8 8
+    - image: solid-color(8, 53, 0, 255, 8, 8)
+      bounds: 64 424 8 8
+    - image: solid-color(9, 53, 0, 255, 8, 8)
+      bounds: 72 424 8 8
+    - image: solid-color(10, 53, 0, 255, 8, 8)
+      bounds: 80 424 8 8
+    - image: solid-color(11, 53, 0, 255, 8, 8)
+      bounds: 88 424 8 8
+    - image: solid-color(12, 53, 0, 255, 8, 8)
+      bounds: 96 424 8 8
+    - image: solid-color(13, 53, 0, 255, 8, 8)
+      bounds: 104 424 8 8
+    - image: solid-color(14, 53, 0, 255, 8, 8)
+      bounds: 112 424 8 8
+    - image: solid-color(15, 53, 0, 255, 8, 8)
+      bounds: 120 424 8 8
+    - image: solid-color(16, 53, 0, 255, 8, 8)
+      bounds: 128 424 8 8
+    - image: solid-color(17, 53, 0, 255, 8, 8)
+      bounds: 136 424 8 8
+    - image: solid-color(18, 53, 0, 255, 8, 8)
+      bounds: 144 424 8 8
+    - image: solid-color(19, 53, 0, 255, 8, 8)
+      bounds: 152 424 8 8
+    - image: solid-color(20, 53, 0, 255, 8, 8)
+      bounds: 160 424 8 8
+    - image: solid-color(21, 53, 0, 255, 8, 8)
+      bounds: 168 424 8 8
+    - image: solid-color(22, 53, 0, 255, 8, 8)
+      bounds: 176 424 8 8
+    - image: solid-color(23, 53, 0, 255, 8, 8)
+      bounds: 184 424 8 8
+    - image: solid-color(24, 53, 0, 255, 8, 8)
+      bounds: 192 424 8 8
+    - image: solid-color(25, 53, 0, 255, 8, 8)
+      bounds: 200 424 8 8
+    - image: solid-color(26, 53, 0, 255, 8, 8)
+      bounds: 208 424 8 8
+    - image: solid-color(27, 53, 0, 255, 8, 8)
+      bounds: 216 424 8 8
+    - image: solid-color(28, 53, 0, 255, 8, 8)
+      bounds: 224 424 8 8
+    - image: solid-color(29, 53, 0, 255, 8, 8)
+      bounds: 232 424 8 8
+    - image: solid-color(30, 53, 0, 255, 8, 8)
+      bounds: 240 424 8 8
+    - image: solid-color(31, 53, 0, 255, 8, 8)
+      bounds: 248 424 8 8
+    - image: solid-color(32, 53, 0, 255, 8, 8)
+      bounds: 256 424 8 8
+    - image: solid-color(33, 53, 0, 255, 8, 8)
+      bounds: 264 424 8 8
+    - image: solid-color(34, 53, 0, 255, 8, 8)
+      bounds: 272 424 8 8
+    - image: solid-color(35, 53, 0, 255, 8, 8)
+      bounds: 280 424 8 8
+    - image: solid-color(36, 53, 0, 255, 8, 8)
+      bounds: 288 424 8 8
+    - image: solid-color(37, 53, 0, 255, 8, 8)
+      bounds: 296 424 8 8
+    - image: solid-color(38, 53, 0, 255, 8, 8)
+      bounds: 304 424 8 8
+    - image: solid-color(39, 53, 0, 255, 8, 8)
+      bounds: 312 424 8 8
+    - image: solid-color(40, 53, 0, 255, 8, 8)
+      bounds: 320 424 8 8
+    - image: solid-color(41, 53, 0, 255, 8, 8)
+      bounds: 328 424 8 8
+    - image: solid-color(42, 53, 0, 255, 8, 8)
+      bounds: 336 424 8 8
+    - image: solid-color(43, 53, 0, 255, 8, 8)
+      bounds: 344 424 8 8
+    - image: solid-color(44, 53, 0, 255, 8, 8)
+      bounds: 352 424 8 8
+    - image: solid-color(45, 53, 0, 255, 8, 8)
+      bounds: 360 424 8 8
+    - image: solid-color(46, 53, 0, 255, 8, 8)
+      bounds: 368 424 8 8
+    - image: solid-color(47, 53, 0, 255, 8, 8)
+      bounds: 376 424 8 8
+    - image: solid-color(48, 53, 0, 255, 8, 8)
+      bounds: 384 424 8 8
+    - image: solid-color(49, 53, 0, 255, 8, 8)
+      bounds: 392 424 8 8
+    - image: solid-color(50, 53, 0, 255, 8, 8)
+      bounds: 400 424 8 8
+    - image: solid-color(51, 53, 0, 255, 8, 8)
+      bounds: 408 424 8 8
+    - image: solid-color(52, 53, 0, 255, 8, 8)
+      bounds: 416 424 8 8
+    - image: solid-color(53, 53, 0, 255, 8, 8)
+      bounds: 424 424 8 8
+    - image: solid-color(54, 53, 0, 255, 8, 8)
+      bounds: 432 424 8 8
+    - image: solid-color(55, 53, 0, 255, 8, 8)
+      bounds: 440 424 8 8
+    - image: solid-color(56, 53, 0, 255, 8, 8)
+      bounds: 448 424 8 8
+    - image: solid-color(57, 53, 0, 255, 8, 8)
+      bounds: 456 424 8 8
+    - image: solid-color(58, 53, 0, 255, 8, 8)
+      bounds: 464 424 8 8
+    - image: solid-color(59, 53, 0, 255, 8, 8)
+      bounds: 472 424 8 8
+    - image: solid-color(60, 53, 0, 255, 8, 8)
+      bounds: 480 424 8 8
+    - image: solid-color(61, 53, 0, 255, 8, 8)
+      bounds: 488 424 8 8
+    - image: solid-color(62, 53, 0, 255, 8, 8)
+      bounds: 496 424 8 8
+    - image: solid-color(63, 53, 0, 255, 8, 8)
+      bounds: 504 424 8 8
+    - image: solid-color(64, 53, 0, 255, 8, 8)
+      bounds: 512 424 8 8
+    - image: solid-color(65, 53, 0, 255, 8, 8)
+      bounds: 520 424 8 8
+    - image: solid-color(66, 53, 0, 255, 8, 8)
+      bounds: 528 424 8 8
+    - image: solid-color(67, 53, 0, 255, 8, 8)
+      bounds: 536 424 8 8
+    - image: solid-color(68, 53, 0, 255, 8, 8)
+      bounds: 544 424 8 8
+    - image: solid-color(69, 53, 0, 255, 8, 8)
+      bounds: 552 424 8 8
+    - image: solid-color(70, 53, 0, 255, 8, 8)
+      bounds: 560 424 8 8
+    - image: solid-color(71, 53, 0, 255, 8, 8)
+      bounds: 568 424 8 8
+    - image: solid-color(72, 53, 0, 255, 8, 8)
+      bounds: 576 424 8 8
+    - image: solid-color(73, 53, 0, 255, 8, 8)
+      bounds: 584 424 8 8
+    - image: solid-color(74, 53, 0, 255, 8, 8)
+      bounds: 592 424 8 8
+    - image: solid-color(75, 53, 0, 255, 8, 8)
+      bounds: 600 424 8 8
+    - image: solid-color(76, 53, 0, 255, 8, 8)
+      bounds: 608 424 8 8
+    - image: solid-color(77, 53, 0, 255, 8, 8)
+      bounds: 616 424 8 8
+    - image: solid-color(78, 53, 0, 255, 8, 8)
+      bounds: 624 424 8 8
+    - image: solid-color(79, 53, 0, 255, 8, 8)
+      bounds: 632 424 8 8
+    - image: solid-color(80, 53, 0, 255, 8, 8)
+      bounds: 640 424 8 8
+    - image: solid-color(81, 53, 0, 255, 8, 8)
+      bounds: 648 424 8 8
+    - image: solid-color(82, 53, 0, 255, 8, 8)
+      bounds: 656 424 8 8
+    - image: solid-color(83, 53, 0, 255, 8, 8)
+      bounds: 664 424 8 8
+    - image: solid-color(84, 53, 0, 255, 8, 8)
+      bounds: 672 424 8 8
+    - image: solid-color(85, 53, 0, 255, 8, 8)
+      bounds: 680 424 8 8
+    - image: solid-color(86, 53, 0, 255, 8, 8)
+      bounds: 688 424 8 8
+    - image: solid-color(87, 53, 0, 255, 8, 8)
+      bounds: 696 424 8 8
+    - image: solid-color(88, 53, 0, 255, 8, 8)
+      bounds: 704 424 8 8
+    - image: solid-color(89, 53, 0, 255, 8, 8)
+      bounds: 712 424 8 8
+    - image: solid-color(90, 53, 0, 255, 8, 8)
+      bounds: 720 424 8 8
+    - image: solid-color(91, 53, 0, 255, 8, 8)
+      bounds: 728 424 8 8
+    - image: solid-color(92, 53, 0, 255, 8, 8)
+      bounds: 736 424 8 8
+    - image: solid-color(93, 53, 0, 255, 8, 8)
+      bounds: 744 424 8 8
+    - image: solid-color(94, 53, 0, 255, 8, 8)
+      bounds: 752 424 8 8
+    - image: solid-color(95, 53, 0, 255, 8, 8)
+      bounds: 760 424 8 8
+    - image: solid-color(96, 53, 0, 255, 8, 8)
+      bounds: 768 424 8 8
+    - image: solid-color(97, 53, 0, 255, 8, 8)
+      bounds: 776 424 8 8
+    - image: solid-color(98, 53, 0, 255, 8, 8)
+      bounds: 784 424 8 8
+    - image: solid-color(99, 53, 0, 255, 8, 8)
+      bounds: 792 424 8 8
+    - image: solid-color(100, 53, 0, 255, 8, 8)
+      bounds: 800 424 8 8
+    - image: solid-color(101, 53, 0, 255, 8, 8)
+      bounds: 808 424 8 8
+    - image: solid-color(102, 53, 0, 255, 8, 8)
+      bounds: 816 424 8 8
+    - image: solid-color(103, 53, 0, 255, 8, 8)
+      bounds: 824 424 8 8
+    - image: solid-color(104, 53, 0, 255, 8, 8)
+      bounds: 832 424 8 8
+    - image: solid-color(105, 53, 0, 255, 8, 8)
+      bounds: 840 424 8 8
+    - image: solid-color(106, 53, 0, 255, 8, 8)
+      bounds: 848 424 8 8
+    - image: solid-color(107, 53, 0, 255, 8, 8)
+      bounds: 856 424 8 8
+    - image: solid-color(108, 53, 0, 255, 8, 8)
+      bounds: 864 424 8 8
+    - image: solid-color(109, 53, 0, 255, 8, 8)
+      bounds: 872 424 8 8
+    - image: solid-color(110, 53, 0, 255, 8, 8)
+      bounds: 880 424 8 8
+    - image: solid-color(111, 53, 0, 255, 8, 8)
+      bounds: 888 424 8 8
+    - image: solid-color(112, 53, 0, 255, 8, 8)
+      bounds: 896 424 8 8
+    - image: solid-color(113, 53, 0, 255, 8, 8)
+      bounds: 904 424 8 8
+    - image: solid-color(114, 53, 0, 255, 8, 8)
+      bounds: 912 424 8 8
+    - image: solid-color(115, 53, 0, 255, 8, 8)
+      bounds: 920 424 8 8
+    - image: solid-color(116, 53, 0, 255, 8, 8)
+      bounds: 928 424 8 8
+    - image: solid-color(117, 53, 0, 255, 8, 8)
+      bounds: 936 424 8 8
+    - image: solid-color(118, 53, 0, 255, 8, 8)
+      bounds: 944 424 8 8
+    - image: solid-color(119, 53, 0, 255, 8, 8)
+      bounds: 952 424 8 8
+    - image: solid-color(120, 53, 0, 255, 8, 8)
+      bounds: 960 424 8 8
+    - image: solid-color(121, 53, 0, 255, 8, 8)
+      bounds: 968 424 8 8
+    - image: solid-color(122, 53, 0, 255, 8, 8)
+      bounds: 976 424 8 8
+    - image: solid-color(123, 53, 0, 255, 8, 8)
+      bounds: 984 424 8 8
+    - image: solid-color(124, 53, 0, 255, 8, 8)
+      bounds: 992 424 8 8
+    - image: solid-color(125, 53, 0, 255, 8, 8)
+      bounds: 1000 424 8 8
+    - image: solid-color(126, 53, 0, 255, 8, 8)
+      bounds: 1008 424 8 8
+    - image: solid-color(127, 53, 0, 255, 8, 8)
+      bounds: 1016 424 8 8
+    - image: solid-color(0, 54, 0, 255, 8, 8)
+      bounds: 0 432 8 8
+    - image: solid-color(1, 54, 0, 255, 8, 8)
+      bounds: 8 432 8 8
+    - image: solid-color(2, 54, 0, 255, 8, 8)
+      bounds: 16 432 8 8
+    - image: solid-color(3, 54, 0, 255, 8, 8)
+      bounds: 24 432 8 8
+    - image: solid-color(4, 54, 0, 255, 8, 8)
+      bounds: 32 432 8 8
+    - image: solid-color(5, 54, 0, 255, 8, 8)
+      bounds: 40 432 8 8
+    - image: solid-color(6, 54, 0, 255, 8, 8)
+      bounds: 48 432 8 8
+    - image: solid-color(7, 54, 0, 255, 8, 8)
+      bounds: 56 432 8 8
+    - image: solid-color(8, 54, 0, 255, 8, 8)
+      bounds: 64 432 8 8
+    - image: solid-color(9, 54, 0, 255, 8, 8)
+      bounds: 72 432 8 8
+    - image: solid-color(10, 54, 0, 255, 8, 8)
+      bounds: 80 432 8 8
+    - image: solid-color(11, 54, 0, 255, 8, 8)
+      bounds: 88 432 8 8
+    - image: solid-color(12, 54, 0, 255, 8, 8)
+      bounds: 96 432 8 8
+    - image: solid-color(13, 54, 0, 255, 8, 8)
+      bounds: 104 432 8 8
+    - image: solid-color(14, 54, 0, 255, 8, 8)
+      bounds: 112 432 8 8
+    - image: solid-color(15, 54, 0, 255, 8, 8)
+      bounds: 120 432 8 8
+    - image: solid-color(16, 54, 0, 255, 8, 8)
+      bounds: 128 432 8 8
+    - image: solid-color(17, 54, 0, 255, 8, 8)
+      bounds: 136 432 8 8
+    - image: solid-color(18, 54, 0, 255, 8, 8)
+      bounds: 144 432 8 8
+    - image: solid-color(19, 54, 0, 255, 8, 8)
+      bounds: 152 432 8 8
+    - image: solid-color(20, 54, 0, 255, 8, 8)
+      bounds: 160 432 8 8
+    - image: solid-color(21, 54, 0, 255, 8, 8)
+      bounds: 168 432 8 8
+    - image: solid-color(22, 54, 0, 255, 8, 8)
+      bounds: 176 432 8 8
+    - image: solid-color(23, 54, 0, 255, 8, 8)
+      bounds: 184 432 8 8
+    - image: solid-color(24, 54, 0, 255, 8, 8)
+      bounds: 192 432 8 8
+    - image: solid-color(25, 54, 0, 255, 8, 8)
+      bounds: 200 432 8 8
+    - image: solid-color(26, 54, 0, 255, 8, 8)
+      bounds: 208 432 8 8
+    - image: solid-color(27, 54, 0, 255, 8, 8)
+      bounds: 216 432 8 8
+    - image: solid-color(28, 54, 0, 255, 8, 8)
+      bounds: 224 432 8 8
+    - image: solid-color(29, 54, 0, 255, 8, 8)
+      bounds: 232 432 8 8
+    - image: solid-color(30, 54, 0, 255, 8, 8)
+      bounds: 240 432 8 8
+    - image: solid-color(31, 54, 0, 255, 8, 8)
+      bounds: 248 432 8 8
+    - image: solid-color(32, 54, 0, 255, 8, 8)
+      bounds: 256 432 8 8
+    - image: solid-color(33, 54, 0, 255, 8, 8)
+      bounds: 264 432 8 8
+    - image: solid-color(34, 54, 0, 255, 8, 8)
+      bounds: 272 432 8 8
+    - image: solid-color(35, 54, 0, 255, 8, 8)
+      bounds: 280 432 8 8
+    - image: solid-color(36, 54, 0, 255, 8, 8)
+      bounds: 288 432 8 8
+    - image: solid-color(37, 54, 0, 255, 8, 8)
+      bounds: 296 432 8 8
+    - image: solid-color(38, 54, 0, 255, 8, 8)
+      bounds: 304 432 8 8
+    - image: solid-color(39, 54, 0, 255, 8, 8)
+      bounds: 312 432 8 8
+    - image: solid-color(40, 54, 0, 255, 8, 8)
+      bounds: 320 432 8 8
+    - image: solid-color(41, 54, 0, 255, 8, 8)
+      bounds: 328 432 8 8
+    - image: solid-color(42, 54, 0, 255, 8, 8)
+      bounds: 336 432 8 8
+    - image: solid-color(43, 54, 0, 255, 8, 8)
+      bounds: 344 432 8 8
+    - image: solid-color(44, 54, 0, 255, 8, 8)
+      bounds: 352 432 8 8
+    - image: solid-color(45, 54, 0, 255, 8, 8)
+      bounds: 360 432 8 8
+    - image: solid-color(46, 54, 0, 255, 8, 8)
+      bounds: 368 432 8 8
+    - image: solid-color(47, 54, 0, 255, 8, 8)
+      bounds: 376 432 8 8
+    - image: solid-color(48, 54, 0, 255, 8, 8)
+      bounds: 384 432 8 8
+    - image: solid-color(49, 54, 0, 255, 8, 8)
+      bounds: 392 432 8 8
+    - image: solid-color(50, 54, 0, 255, 8, 8)
+      bounds: 400 432 8 8
+    - image: solid-color(51, 54, 0, 255, 8, 8)
+      bounds: 408 432 8 8
+    - image: solid-color(52, 54, 0, 255, 8, 8)
+      bounds: 416 432 8 8
+    - image: solid-color(53, 54, 0, 255, 8, 8)
+      bounds: 424 432 8 8
+    - image: solid-color(54, 54, 0, 255, 8, 8)
+      bounds: 432 432 8 8
+    - image: solid-color(55, 54, 0, 255, 8, 8)
+      bounds: 440 432 8 8
+    - image: solid-color(56, 54, 0, 255, 8, 8)
+      bounds: 448 432 8 8
+    - image: solid-color(57, 54, 0, 255, 8, 8)
+      bounds: 456 432 8 8
+    - image: solid-color(58, 54, 0, 255, 8, 8)
+      bounds: 464 432 8 8
+    - image: solid-color(59, 54, 0, 255, 8, 8)
+      bounds: 472 432 8 8
+    - image: solid-color(60, 54, 0, 255, 8, 8)
+      bounds: 480 432 8 8
+    - image: solid-color(61, 54, 0, 255, 8, 8)
+      bounds: 488 432 8 8
+    - image: solid-color(62, 54, 0, 255, 8, 8)
+      bounds: 496 432 8 8
+    - image: solid-color(63, 54, 0, 255, 8, 8)
+      bounds: 504 432 8 8
+    - image: solid-color(64, 54, 0, 255, 8, 8)
+      bounds: 512 432 8 8
+    - image: solid-color(65, 54, 0, 255, 8, 8)
+      bounds: 520 432 8 8
+    - image: solid-color(66, 54, 0, 255, 8, 8)
+      bounds: 528 432 8 8
+    - image: solid-color(67, 54, 0, 255, 8, 8)
+      bounds: 536 432 8 8
+    - image: solid-color(68, 54, 0, 255, 8, 8)
+      bounds: 544 432 8 8
+    - image: solid-color(69, 54, 0, 255, 8, 8)
+      bounds: 552 432 8 8
+    - image: solid-color(70, 54, 0, 255, 8, 8)
+      bounds: 560 432 8 8
+    - image: solid-color(71, 54, 0, 255, 8, 8)
+      bounds: 568 432 8 8
+    - image: solid-color(72, 54, 0, 255, 8, 8)
+      bounds: 576 432 8 8
+    - image: solid-color(73, 54, 0, 255, 8, 8)
+      bounds: 584 432 8 8
+    - image: solid-color(74, 54, 0, 255, 8, 8)
+      bounds: 592 432 8 8
+    - image: solid-color(75, 54, 0, 255, 8, 8)
+      bounds: 600 432 8 8
+    - image: solid-color(76, 54, 0, 255, 8, 8)
+      bounds: 608 432 8 8
+    - image: solid-color(77, 54, 0, 255, 8, 8)
+      bounds: 616 432 8 8
+    - image: solid-color(78, 54, 0, 255, 8, 8)
+      bounds: 624 432 8 8
+    - image: solid-color(79, 54, 0, 255, 8, 8)
+      bounds: 632 432 8 8
+    - image: solid-color(80, 54, 0, 255, 8, 8)
+      bounds: 640 432 8 8
+    - image: solid-color(81, 54, 0, 255, 8, 8)
+      bounds: 648 432 8 8
+    - image: solid-color(82, 54, 0, 255, 8, 8)
+      bounds: 656 432 8 8
+    - image: solid-color(83, 54, 0, 255, 8, 8)
+      bounds: 664 432 8 8
+    - image: solid-color(84, 54, 0, 255, 8, 8)
+      bounds: 672 432 8 8
+    - image: solid-color(85, 54, 0, 255, 8, 8)
+      bounds: 680 432 8 8
+    - image: solid-color(86, 54, 0, 255, 8, 8)
+      bounds: 688 432 8 8
+    - image: solid-color(87, 54, 0, 255, 8, 8)
+      bounds: 696 432 8 8
+    - image: solid-color(88, 54, 0, 255, 8, 8)
+      bounds: 704 432 8 8
+    - image: solid-color(89, 54, 0, 255, 8, 8)
+      bounds: 712 432 8 8
+    - image: solid-color(90, 54, 0, 255, 8, 8)
+      bounds: 720 432 8 8
+    - image: solid-color(91, 54, 0, 255, 8, 8)
+      bounds: 728 432 8 8
+    - image: solid-color(92, 54, 0, 255, 8, 8)
+      bounds: 736 432 8 8
+    - image: solid-color(93, 54, 0, 255, 8, 8)
+      bounds: 744 432 8 8
+    - image: solid-color(94, 54, 0, 255, 8, 8)
+      bounds: 752 432 8 8
+    - image: solid-color(95, 54, 0, 255, 8, 8)
+      bounds: 760 432 8 8
+    - image: solid-color(96, 54, 0, 255, 8, 8)
+      bounds: 768 432 8 8
+    - image: solid-color(97, 54, 0, 255, 8, 8)
+      bounds: 776 432 8 8
+    - image: solid-color(98, 54, 0, 255, 8, 8)
+      bounds: 784 432 8 8
+    - image: solid-color(99, 54, 0, 255, 8, 8)
+      bounds: 792 432 8 8
+    - image: solid-color(100, 54, 0, 255, 8, 8)
+      bounds: 800 432 8 8
+    - image: solid-color(101, 54, 0, 255, 8, 8)
+      bounds: 808 432 8 8
+    - image: solid-color(102, 54, 0, 255, 8, 8)
+      bounds: 816 432 8 8
+    - image: solid-color(103, 54, 0, 255, 8, 8)
+      bounds: 824 432 8 8
+    - image: solid-color(104, 54, 0, 255, 8, 8)
+      bounds: 832 432 8 8
+    - image: solid-color(105, 54, 0, 255, 8, 8)
+      bounds: 840 432 8 8
+    - image: solid-color(106, 54, 0, 255, 8, 8)
+      bounds: 848 432 8 8
+    - image: solid-color(107, 54, 0, 255, 8, 8)
+      bounds: 856 432 8 8
+    - image: solid-color(108, 54, 0, 255, 8, 8)
+      bounds: 864 432 8 8
+    - image: solid-color(109, 54, 0, 255, 8, 8)
+      bounds: 872 432 8 8
+    - image: solid-color(110, 54, 0, 255, 8, 8)
+      bounds: 880 432 8 8
+    - image: solid-color(111, 54, 0, 255, 8, 8)
+      bounds: 888 432 8 8
+    - image: solid-color(112, 54, 0, 255, 8, 8)
+      bounds: 896 432 8 8
+    - image: solid-color(113, 54, 0, 255, 8, 8)
+      bounds: 904 432 8 8
+    - image: solid-color(114, 54, 0, 255, 8, 8)
+      bounds: 912 432 8 8
+    - image: solid-color(115, 54, 0, 255, 8, 8)
+      bounds: 920 432 8 8
+    - image: solid-color(116, 54, 0, 255, 8, 8)
+      bounds: 928 432 8 8
+    - image: solid-color(117, 54, 0, 255, 8, 8)
+      bounds: 936 432 8 8
+    - image: solid-color(118, 54, 0, 255, 8, 8)
+      bounds: 944 432 8 8
+    - image: solid-color(119, 54, 0, 255, 8, 8)
+      bounds: 952 432 8 8
+    - image: solid-color(120, 54, 0, 255, 8, 8)
+      bounds: 960 432 8 8
+    - image: solid-color(121, 54, 0, 255, 8, 8)
+      bounds: 968 432 8 8
+    - image: solid-color(122, 54, 0, 255, 8, 8)
+      bounds: 976 432 8 8
+    - image: solid-color(123, 54, 0, 255, 8, 8)
+      bounds: 984 432 8 8
+    - image: solid-color(124, 54, 0, 255, 8, 8)
+      bounds: 992 432 8 8
+    - image: solid-color(125, 54, 0, 255, 8, 8)
+      bounds: 1000 432 8 8
+    - image: solid-color(126, 54, 0, 255, 8, 8)
+      bounds: 1008 432 8 8
+    - image: solid-color(127, 54, 0, 255, 8, 8)
+      bounds: 1016 432 8 8
+    - image: solid-color(0, 55, 0, 255, 8, 8)
+      bounds: 0 440 8 8
+    - image: solid-color(1, 55, 0, 255, 8, 8)
+      bounds: 8 440 8 8
+    - image: solid-color(2, 55, 0, 255, 8, 8)
+      bounds: 16 440 8 8
+    - image: solid-color(3, 55, 0, 255, 8, 8)
+      bounds: 24 440 8 8
+    - image: solid-color(4, 55, 0, 255, 8, 8)
+      bounds: 32 440 8 8
+    - image: solid-color(5, 55, 0, 255, 8, 8)
+      bounds: 40 440 8 8
+    - image: solid-color(6, 55, 0, 255, 8, 8)
+      bounds: 48 440 8 8
+    - image: solid-color(7, 55, 0, 255, 8, 8)
+      bounds: 56 440 8 8
+    - image: solid-color(8, 55, 0, 255, 8, 8)
+      bounds: 64 440 8 8
+    - image: solid-color(9, 55, 0, 255, 8, 8)
+      bounds: 72 440 8 8
+    - image: solid-color(10, 55, 0, 255, 8, 8)
+      bounds: 80 440 8 8
+    - image: solid-color(11, 55, 0, 255, 8, 8)
+      bounds: 88 440 8 8
+    - image: solid-color(12, 55, 0, 255, 8, 8)
+      bounds: 96 440 8 8
+    - image: solid-color(13, 55, 0, 255, 8, 8)
+      bounds: 104 440 8 8
+    - image: solid-color(14, 55, 0, 255, 8, 8)
+      bounds: 112 440 8 8
+    - image: solid-color(15, 55, 0, 255, 8, 8)
+      bounds: 120 440 8 8
+    - image: solid-color(16, 55, 0, 255, 8, 8)
+      bounds: 128 440 8 8
+    - image: solid-color(17, 55, 0, 255, 8, 8)
+      bounds: 136 440 8 8
+    - image: solid-color(18, 55, 0, 255, 8, 8)
+      bounds: 144 440 8 8
+    - image: solid-color(19, 55, 0, 255, 8, 8)
+      bounds: 152 440 8 8
+    - image: solid-color(20, 55, 0, 255, 8, 8)
+      bounds: 160 440 8 8
+    - image: solid-color(21, 55, 0, 255, 8, 8)
+      bounds: 168 440 8 8
+    - image: solid-color(22, 55, 0, 255, 8, 8)
+      bounds: 176 440 8 8
+    - image: solid-color(23, 55, 0, 255, 8, 8)
+      bounds: 184 440 8 8
+    - image: solid-color(24, 55, 0, 255, 8, 8)
+      bounds: 192 440 8 8
+    - image: solid-color(25, 55, 0, 255, 8, 8)
+      bounds: 200 440 8 8
+    - image: solid-color(26, 55, 0, 255, 8, 8)
+      bounds: 208 440 8 8
+    - image: solid-color(27, 55, 0, 255, 8, 8)
+      bounds: 216 440 8 8
+    - image: solid-color(28, 55, 0, 255, 8, 8)
+      bounds: 224 440 8 8
+    - image: solid-color(29, 55, 0, 255, 8, 8)
+      bounds: 232 440 8 8
+    - image: solid-color(30, 55, 0, 255, 8, 8)
+      bounds: 240 440 8 8
+    - image: solid-color(31, 55, 0, 255, 8, 8)
+      bounds: 248 440 8 8
+    - image: solid-color(32, 55, 0, 255, 8, 8)
+      bounds: 256 440 8 8
+    - image: solid-color(33, 55, 0, 255, 8, 8)
+      bounds: 264 440 8 8
+    - image: solid-color(34, 55, 0, 255, 8, 8)
+      bounds: 272 440 8 8
+    - image: solid-color(35, 55, 0, 255, 8, 8)
+      bounds: 280 440 8 8
+    - image: solid-color(36, 55, 0, 255, 8, 8)
+      bounds: 288 440 8 8
+    - image: solid-color(37, 55, 0, 255, 8, 8)
+      bounds: 296 440 8 8
+    - image: solid-color(38, 55, 0, 255, 8, 8)
+      bounds: 304 440 8 8
+    - image: solid-color(39, 55, 0, 255, 8, 8)
+      bounds: 312 440 8 8
+    - image: solid-color(40, 55, 0, 255, 8, 8)
+      bounds: 320 440 8 8
+    - image: solid-color(41, 55, 0, 255, 8, 8)
+      bounds: 328 440 8 8
+    - image: solid-color(42, 55, 0, 255, 8, 8)
+      bounds: 336 440 8 8
+    - image: solid-color(43, 55, 0, 255, 8, 8)
+      bounds: 344 440 8 8
+    - image: solid-color(44, 55, 0, 255, 8, 8)
+      bounds: 352 440 8 8
+    - image: solid-color(45, 55, 0, 255, 8, 8)
+      bounds: 360 440 8 8
+    - image: solid-color(46, 55, 0, 255, 8, 8)
+      bounds: 368 440 8 8
+    - image: solid-color(47, 55, 0, 255, 8, 8)
+      bounds: 376 440 8 8
+    - image: solid-color(48, 55, 0, 255, 8, 8)
+      bounds: 384 440 8 8
+    - image: solid-color(49, 55, 0, 255, 8, 8)
+      bounds: 392 440 8 8
+    - image: solid-color(50, 55, 0, 255, 8, 8)
+      bounds: 400 440 8 8
+    - image: solid-color(51, 55, 0, 255, 8, 8)
+      bounds: 408 440 8 8
+    - image: solid-color(52, 55, 0, 255, 8, 8)
+      bounds: 416 440 8 8
+    - image: solid-color(53, 55, 0, 255, 8, 8)
+      bounds: 424 440 8 8
+    - image: solid-color(54, 55, 0, 255, 8, 8)
+      bounds: 432 440 8 8
+    - image: solid-color(55, 55, 0, 255, 8, 8)
+      bounds: 440 440 8 8
+    - image: solid-color(56, 55, 0, 255, 8, 8)
+      bounds: 448 440 8 8
+    - image: solid-color(57, 55, 0, 255, 8, 8)
+      bounds: 456 440 8 8
+    - image: solid-color(58, 55, 0, 255, 8, 8)
+      bounds: 464 440 8 8
+    - image: solid-color(59, 55, 0, 255, 8, 8)
+      bounds: 472 440 8 8
+    - image: solid-color(60, 55, 0, 255, 8, 8)
+      bounds: 480 440 8 8
+    - image: solid-color(61, 55, 0, 255, 8, 8)
+      bounds: 488 440 8 8
+    - image: solid-color(62, 55, 0, 255, 8, 8)
+      bounds: 496 440 8 8
+    - image: solid-color(63, 55, 0, 255, 8, 8)
+      bounds: 504 440 8 8
+    - image: solid-color(64, 55, 0, 255, 8, 8)
+      bounds: 512 440 8 8
+    - image: solid-color(65, 55, 0, 255, 8, 8)
+      bounds: 520 440 8 8
+    - image: solid-color(66, 55, 0, 255, 8, 8)
+      bounds: 528 440 8 8
+    - image: solid-color(67, 55, 0, 255, 8, 8)
+      bounds: 536 440 8 8
+    - image: solid-color(68, 55, 0, 255, 8, 8)
+      bounds: 544 440 8 8
+    - image: solid-color(69, 55, 0, 255, 8, 8)
+      bounds: 552 440 8 8
+    - image: solid-color(70, 55, 0, 255, 8, 8)
+      bounds: 560 440 8 8
+    - image: solid-color(71, 55, 0, 255, 8, 8)
+      bounds: 568 440 8 8
+    - image: solid-color(72, 55, 0, 255, 8, 8)
+      bounds: 576 440 8 8
+    - image: solid-color(73, 55, 0, 255, 8, 8)
+      bounds: 584 440 8 8
+    - image: solid-color(74, 55, 0, 255, 8, 8)
+      bounds: 592 440 8 8
+    - image: solid-color(75, 55, 0, 255, 8, 8)
+      bounds: 600 440 8 8
+    - image: solid-color(76, 55, 0, 255, 8, 8)
+      bounds: 608 440 8 8
+    - image: solid-color(77, 55, 0, 255, 8, 8)
+      bounds: 616 440 8 8
+    - image: solid-color(78, 55, 0, 255, 8, 8)
+      bounds: 624 440 8 8
+    - image: solid-color(79, 55, 0, 255, 8, 8)
+      bounds: 632 440 8 8
+    - image: solid-color(80, 55, 0, 255, 8, 8)
+      bounds: 640 440 8 8
+    - image: solid-color(81, 55, 0, 255, 8, 8)
+      bounds: 648 440 8 8
+    - image: solid-color(82, 55, 0, 255, 8, 8)
+      bounds: 656 440 8 8
+    - image: solid-color(83, 55, 0, 255, 8, 8)
+      bounds: 664 440 8 8
+    - image: solid-color(84, 55, 0, 255, 8, 8)
+      bounds: 672 440 8 8
+    - image: solid-color(85, 55, 0, 255, 8, 8)
+      bounds: 680 440 8 8
+    - image: solid-color(86, 55, 0, 255, 8, 8)
+      bounds: 688 440 8 8
+    - image: solid-color(87, 55, 0, 255, 8, 8)
+      bounds: 696 440 8 8
+    - image: solid-color(88, 55, 0, 255, 8, 8)
+      bounds: 704 440 8 8
+    - image: solid-color(89, 55, 0, 255, 8, 8)
+      bounds: 712 440 8 8
+    - image: solid-color(90, 55, 0, 255, 8, 8)
+      bounds: 720 440 8 8
+    - image: solid-color(91, 55, 0, 255, 8, 8)
+      bounds: 728 440 8 8
+    - image: solid-color(92, 55, 0, 255, 8, 8)
+      bounds: 736 440 8 8
+    - image: solid-color(93, 55, 0, 255, 8, 8)
+      bounds: 744 440 8 8
+    - image: solid-color(94, 55, 0, 255, 8, 8)
+      bounds: 752 440 8 8
+    - image: solid-color(95, 55, 0, 255, 8, 8)
+      bounds: 760 440 8 8
+    - image: solid-color(96, 55, 0, 255, 8, 8)
+      bounds: 768 440 8 8
+    - image: solid-color(97, 55, 0, 255, 8, 8)
+      bounds: 776 440 8 8
+    - image: solid-color(98, 55, 0, 255, 8, 8)
+      bounds: 784 440 8 8
+    - image: solid-color(99, 55, 0, 255, 8, 8)
+      bounds: 792 440 8 8
+    - image: solid-color(100, 55, 0, 255, 8, 8)
+      bounds: 800 440 8 8
+    - image: solid-color(101, 55, 0, 255, 8, 8)
+      bounds: 808 440 8 8
+    - image: solid-color(102, 55, 0, 255, 8, 8)
+      bounds: 816 440 8 8
+    - image: solid-color(103, 55, 0, 255, 8, 8)
+      bounds: 824 440 8 8
+    - image: solid-color(104, 55, 0, 255, 8, 8)
+      bounds: 832 440 8 8
+    - image: solid-color(105, 55, 0, 255, 8, 8)
+      bounds: 840 440 8 8
+    - image: solid-color(106, 55, 0, 255, 8, 8)
+      bounds: 848 440 8 8
+    - image: solid-color(107, 55, 0, 255, 8, 8)
+      bounds: 856 440 8 8
+    - image: solid-color(108, 55, 0, 255, 8, 8)
+      bounds: 864 440 8 8
+    - image: solid-color(109, 55, 0, 255, 8, 8)
+      bounds: 872 440 8 8
+    - image: solid-color(110, 55, 0, 255, 8, 8)
+      bounds: 880 440 8 8
+    - image: solid-color(111, 55, 0, 255, 8, 8)
+      bounds: 888 440 8 8
+    - image: solid-color(112, 55, 0, 255, 8, 8)
+      bounds: 896 440 8 8
+    - image: solid-color(113, 55, 0, 255, 8, 8)
+      bounds: 904 440 8 8
+    - image: solid-color(114, 55, 0, 255, 8, 8)
+      bounds: 912 440 8 8
+    - image: solid-color(115, 55, 0, 255, 8, 8)
+      bounds: 920 440 8 8
+    - image: solid-color(116, 55, 0, 255, 8, 8)
+      bounds: 928 440 8 8
+    - image: solid-color(117, 55, 0, 255, 8, 8)
+      bounds: 936 440 8 8
+    - image: solid-color(118, 55, 0, 255, 8, 8)
+      bounds: 944 440 8 8
+    - image: solid-color(119, 55, 0, 255, 8, 8)
+      bounds: 952 440 8 8
+    - image: solid-color(120, 55, 0, 255, 8, 8)
+      bounds: 960 440 8 8
+    - image: solid-color(121, 55, 0, 255, 8, 8)
+      bounds: 968 440 8 8
+    - image: solid-color(122, 55, 0, 255, 8, 8)
+      bounds: 976 440 8 8
+    - image: solid-color(123, 55, 0, 255, 8, 8)
+      bounds: 984 440 8 8
+    - image: solid-color(124, 55, 0, 255, 8, 8)
+      bounds: 992 440 8 8
+    - image: solid-color(125, 55, 0, 255, 8, 8)
+      bounds: 1000 440 8 8
+    - image: solid-color(126, 55, 0, 255, 8, 8)
+      bounds: 1008 440 8 8
+    - image: solid-color(127, 55, 0, 255, 8, 8)
+      bounds: 1016 440 8 8
+    - image: solid-color(0, 56, 0, 255, 8, 8)
+      bounds: 0 448 8 8
+    - image: solid-color(1, 56, 0, 255, 8, 8)
+      bounds: 8 448 8 8
+    - image: solid-color(2, 56, 0, 255, 8, 8)
+      bounds: 16 448 8 8
+    - image: solid-color(3, 56, 0, 255, 8, 8)
+      bounds: 24 448 8 8
+    - image: solid-color(4, 56, 0, 255, 8, 8)
+      bounds: 32 448 8 8
+    - image: solid-color(5, 56, 0, 255, 8, 8)
+      bounds: 40 448 8 8
+    - image: solid-color(6, 56, 0, 255, 8, 8)
+      bounds: 48 448 8 8
+    - image: solid-color(7, 56, 0, 255, 8, 8)
+      bounds: 56 448 8 8
+    - image: solid-color(8, 56, 0, 255, 8, 8)
+      bounds: 64 448 8 8
+    - image: solid-color(9, 56, 0, 255, 8, 8)
+      bounds: 72 448 8 8
+    - image: solid-color(10, 56, 0, 255, 8, 8)
+      bounds: 80 448 8 8
+    - image: solid-color(11, 56, 0, 255, 8, 8)
+      bounds: 88 448 8 8
+    - image: solid-color(12, 56, 0, 255, 8, 8)
+      bounds: 96 448 8 8
+    - image: solid-color(13, 56, 0, 255, 8, 8)
+      bounds: 104 448 8 8
+    - image: solid-color(14, 56, 0, 255, 8, 8)
+      bounds: 112 448 8 8
+    - image: solid-color(15, 56, 0, 255, 8, 8)
+      bounds: 120 448 8 8
+    - image: solid-color(16, 56, 0, 255, 8, 8)
+      bounds: 128 448 8 8
+    - image: solid-color(17, 56, 0, 255, 8, 8)
+      bounds: 136 448 8 8
+    - image: solid-color(18, 56, 0, 255, 8, 8)
+      bounds: 144 448 8 8
+    - image: solid-color(19, 56, 0, 255, 8, 8)
+      bounds: 152 448 8 8
+    - image: solid-color(20, 56, 0, 255, 8, 8)
+      bounds: 160 448 8 8
+    - image: solid-color(21, 56, 0, 255, 8, 8)
+      bounds: 168 448 8 8
+    - image: solid-color(22, 56, 0, 255, 8, 8)
+      bounds: 176 448 8 8
+    - image: solid-color(23, 56, 0, 255, 8, 8)
+      bounds: 184 448 8 8
+    - image: solid-color(24, 56, 0, 255, 8, 8)
+      bounds: 192 448 8 8
+    - image: solid-color(25, 56, 0, 255, 8, 8)
+      bounds: 200 448 8 8
+    - image: solid-color(26, 56, 0, 255, 8, 8)
+      bounds: 208 448 8 8
+    - image: solid-color(27, 56, 0, 255, 8, 8)
+      bounds: 216 448 8 8
+    - image: solid-color(28, 56, 0, 255, 8, 8)
+      bounds: 224 448 8 8
+    - image: solid-color(29, 56, 0, 255, 8, 8)
+      bounds: 232 448 8 8
+    - image: solid-color(30, 56, 0, 255, 8, 8)
+      bounds: 240 448 8 8
+    - image: solid-color(31, 56, 0, 255, 8, 8)
+      bounds: 248 448 8 8
+    - image: solid-color(32, 56, 0, 255, 8, 8)
+      bounds: 256 448 8 8
+    - image: solid-color(33, 56, 0, 255, 8, 8)
+      bounds: 264 448 8 8
+    - image: solid-color(34, 56, 0, 255, 8, 8)
+      bounds: 272 448 8 8
+    - image: solid-color(35, 56, 0, 255, 8, 8)
+      bounds: 280 448 8 8
+    - image: solid-color(36, 56, 0, 255, 8, 8)
+      bounds: 288 448 8 8
+    - image: solid-color(37, 56, 0, 255, 8, 8)
+      bounds: 296 448 8 8
+    - image: solid-color(38, 56, 0, 255, 8, 8)
+      bounds: 304 448 8 8
+    - image: solid-color(39, 56, 0, 255, 8, 8)
+      bounds: 312 448 8 8
+    - image: solid-color(40, 56, 0, 255, 8, 8)
+      bounds: 320 448 8 8
+    - image: solid-color(41, 56, 0, 255, 8, 8)
+      bounds: 328 448 8 8
+    - image: solid-color(42, 56, 0, 255, 8, 8)
+      bounds: 336 448 8 8
+    - image: solid-color(43, 56, 0, 255, 8, 8)
+      bounds: 344 448 8 8
+    - image: solid-color(44, 56, 0, 255, 8, 8)
+      bounds: 352 448 8 8
+    - image: solid-color(45, 56, 0, 255, 8, 8)
+      bounds: 360 448 8 8
+    - image: solid-color(46, 56, 0, 255, 8, 8)
+      bounds: 368 448 8 8
+    - image: solid-color(47, 56, 0, 255, 8, 8)
+      bounds: 376 448 8 8
+    - image: solid-color(48, 56, 0, 255, 8, 8)
+      bounds: 384 448 8 8
+    - image: solid-color(49, 56, 0, 255, 8, 8)
+      bounds: 392 448 8 8
+    - image: solid-color(50, 56, 0, 255, 8, 8)
+      bounds: 400 448 8 8
+    - image: solid-color(51, 56, 0, 255, 8, 8)
+      bounds: 408 448 8 8
+    - image: solid-color(52, 56, 0, 255, 8, 8)
+      bounds: 416 448 8 8
+    - image: solid-color(53, 56, 0, 255, 8, 8)
+      bounds: 424 448 8 8
+    - image: solid-color(54, 56, 0, 255, 8, 8)
+      bounds: 432 448 8 8
+    - image: solid-color(55, 56, 0, 255, 8, 8)
+      bounds: 440 448 8 8
+    - image: solid-color(56, 56, 0, 255, 8, 8)
+      bounds: 448 448 8 8
+    - image: solid-color(57, 56, 0, 255, 8, 8)
+      bounds: 456 448 8 8
+    - image: solid-color(58, 56, 0, 255, 8, 8)
+      bounds: 464 448 8 8
+    - image: solid-color(59, 56, 0, 255, 8, 8)
+      bounds: 472 448 8 8
+    - image: solid-color(60, 56, 0, 255, 8, 8)
+      bounds: 480 448 8 8
+    - image: solid-color(61, 56, 0, 255, 8, 8)
+      bounds: 488 448 8 8
+    - image: solid-color(62, 56, 0, 255, 8, 8)
+      bounds: 496 448 8 8
+    - image: solid-color(63, 56, 0, 255, 8, 8)
+      bounds: 504 448 8 8
+    - image: solid-color(64, 56, 0, 255, 8, 8)
+      bounds: 512 448 8 8
+    - image: solid-color(65, 56, 0, 255, 8, 8)
+      bounds: 520 448 8 8
+    - image: solid-color(66, 56, 0, 255, 8, 8)
+      bounds: 528 448 8 8
+    - image: solid-color(67, 56, 0, 255, 8, 8)
+      bounds: 536 448 8 8
+    - image: solid-color(68, 56, 0, 255, 8, 8)
+      bounds: 544 448 8 8
+    - image: solid-color(69, 56, 0, 255, 8, 8)
+      bounds: 552 448 8 8
+    - image: solid-color(70, 56, 0, 255, 8, 8)
+      bounds: 560 448 8 8
+    - image: solid-color(71, 56, 0, 255, 8, 8)
+      bounds: 568 448 8 8
+    - image: solid-color(72, 56, 0, 255, 8, 8)
+      bounds: 576 448 8 8
+    - image: solid-color(73, 56, 0, 255, 8, 8)
+      bounds: 584 448 8 8
+    - image: solid-color(74, 56, 0, 255, 8, 8)
+      bounds: 592 448 8 8
+    - image: solid-color(75, 56, 0, 255, 8, 8)
+      bounds: 600 448 8 8
+    - image: solid-color(76, 56, 0, 255, 8, 8)
+      bounds: 608 448 8 8
+    - image: solid-color(77, 56, 0, 255, 8, 8)
+      bounds: 616 448 8 8
+    - image: solid-color(78, 56, 0, 255, 8, 8)
+      bounds: 624 448 8 8
+    - image: solid-color(79, 56, 0, 255, 8, 8)
+      bounds: 632 448 8 8
+    - image: solid-color(80, 56, 0, 255, 8, 8)
+      bounds: 640 448 8 8
+    - image: solid-color(81, 56, 0, 255, 8, 8)
+      bounds: 648 448 8 8
+    - image: solid-color(82, 56, 0, 255, 8, 8)
+      bounds: 656 448 8 8
+    - image: solid-color(83, 56, 0, 255, 8, 8)
+      bounds: 664 448 8 8
+    - image: solid-color(84, 56, 0, 255, 8, 8)
+      bounds: 672 448 8 8
+    - image: solid-color(85, 56, 0, 255, 8, 8)
+      bounds: 680 448 8 8
+    - image: solid-color(86, 56, 0, 255, 8, 8)
+      bounds: 688 448 8 8
+    - image: solid-color(87, 56, 0, 255, 8, 8)
+      bounds: 696 448 8 8
+    - image: solid-color(88, 56, 0, 255, 8, 8)
+      bounds: 704 448 8 8
+    - image: solid-color(89, 56, 0, 255, 8, 8)
+      bounds: 712 448 8 8
+    - image: solid-color(90, 56, 0, 255, 8, 8)
+      bounds: 720 448 8 8
+    - image: solid-color(91, 56, 0, 255, 8, 8)
+      bounds: 728 448 8 8
+    - image: solid-color(92, 56, 0, 255, 8, 8)
+      bounds: 736 448 8 8
+    - image: solid-color(93, 56, 0, 255, 8, 8)
+      bounds: 744 448 8 8
+    - image: solid-color(94, 56, 0, 255, 8, 8)
+      bounds: 752 448 8 8
+    - image: solid-color(95, 56, 0, 255, 8, 8)
+      bounds: 760 448 8 8
+    - image: solid-color(96, 56, 0, 255, 8, 8)
+      bounds: 768 448 8 8
+    - image: solid-color(97, 56, 0, 255, 8, 8)
+      bounds: 776 448 8 8
+    - image: solid-color(98, 56, 0, 255, 8, 8)
+      bounds: 784 448 8 8
+    - image: solid-color(99, 56, 0, 255, 8, 8)
+      bounds: 792 448 8 8
+    - image: solid-color(100, 56, 0, 255, 8, 8)
+      bounds: 800 448 8 8
+    - image: solid-color(101, 56, 0, 255, 8, 8)
+      bounds: 808 448 8 8
+    - image: solid-color(102, 56, 0, 255, 8, 8)
+      bounds: 816 448 8 8
+    - image: solid-color(103, 56, 0, 255, 8, 8)
+      bounds: 824 448 8 8
+    - image: solid-color(104, 56, 0, 255, 8, 8)
+      bounds: 832 448 8 8
+    - image: solid-color(105, 56, 0, 255, 8, 8)
+      bounds: 840 448 8 8
+    - image: solid-color(106, 56, 0, 255, 8, 8)
+      bounds: 848 448 8 8
+    - image: solid-color(107, 56, 0, 255, 8, 8)
+      bounds: 856 448 8 8
+    - image: solid-color(108, 56, 0, 255, 8, 8)
+      bounds: 864 448 8 8
+    - image: solid-color(109, 56, 0, 255, 8, 8)
+      bounds: 872 448 8 8
+    - image: solid-color(110, 56, 0, 255, 8, 8)
+      bounds: 880 448 8 8
+    - image: solid-color(111, 56, 0, 255, 8, 8)
+      bounds: 888 448 8 8
+    - image: solid-color(112, 56, 0, 255, 8, 8)
+      bounds: 896 448 8 8
+    - image: solid-color(113, 56, 0, 255, 8, 8)
+      bounds: 904 448 8 8
+    - image: solid-color(114, 56, 0, 255, 8, 8)
+      bounds: 912 448 8 8
+    - image: solid-color(115, 56, 0, 255, 8, 8)
+      bounds: 920 448 8 8
+    - image: solid-color(116, 56, 0, 255, 8, 8)
+      bounds: 928 448 8 8
+    - image: solid-color(117, 56, 0, 255, 8, 8)
+      bounds: 936 448 8 8
+    - image: solid-color(118, 56, 0, 255, 8, 8)
+      bounds: 944 448 8 8
+    - image: solid-color(119, 56, 0, 255, 8, 8)
+      bounds: 952 448 8 8
+    - image: solid-color(120, 56, 0, 255, 8, 8)
+      bounds: 960 448 8 8
+    - image: solid-color(121, 56, 0, 255, 8, 8)
+      bounds: 968 448 8 8
+    - image: solid-color(122, 56, 0, 255, 8, 8)
+      bounds: 976 448 8 8
+    - image: solid-color(123, 56, 0, 255, 8, 8)
+      bounds: 984 448 8 8
+    - image: solid-color(124, 56, 0, 255, 8, 8)
+      bounds: 992 448 8 8
+    - image: solid-color(125, 56, 0, 255, 8, 8)
+      bounds: 1000 448 8 8
+    - image: solid-color(126, 56, 0, 255, 8, 8)
+      bounds: 1008 448 8 8
+    - image: solid-color(127, 56, 0, 255, 8, 8)
+      bounds: 1016 448 8 8
+    - image: solid-color(0, 57, 0, 255, 8, 8)
+      bounds: 0 456 8 8
+    - image: solid-color(1, 57, 0, 255, 8, 8)
+      bounds: 8 456 8 8
+    - image: solid-color(2, 57, 0, 255, 8, 8)
+      bounds: 16 456 8 8
+    - image: solid-color(3, 57, 0, 255, 8, 8)
+      bounds: 24 456 8 8
+    - image: solid-color(4, 57, 0, 255, 8, 8)
+      bounds: 32 456 8 8
+    - image: solid-color(5, 57, 0, 255, 8, 8)
+      bounds: 40 456 8 8
+    - image: solid-color(6, 57, 0, 255, 8, 8)
+      bounds: 48 456 8 8
+    - image: solid-color(7, 57, 0, 255, 8, 8)
+      bounds: 56 456 8 8
+    - image: solid-color(8, 57, 0, 255, 8, 8)
+      bounds: 64 456 8 8
+    - image: solid-color(9, 57, 0, 255, 8, 8)
+      bounds: 72 456 8 8
+    - image: solid-color(10, 57, 0, 255, 8, 8)
+      bounds: 80 456 8 8
+    - image: solid-color(11, 57, 0, 255, 8, 8)
+      bounds: 88 456 8 8
+    - image: solid-color(12, 57, 0, 255, 8, 8)
+      bounds: 96 456 8 8
+    - image: solid-color(13, 57, 0, 255, 8, 8)
+      bounds: 104 456 8 8
+    - image: solid-color(14, 57, 0, 255, 8, 8)
+      bounds: 112 456 8 8
+    - image: solid-color(15, 57, 0, 255, 8, 8)
+      bounds: 120 456 8 8
+    - image: solid-color(16, 57, 0, 255, 8, 8)
+      bounds: 128 456 8 8
+    - image: solid-color(17, 57, 0, 255, 8, 8)
+      bounds: 136 456 8 8
+    - image: solid-color(18, 57, 0, 255, 8, 8)
+      bounds: 144 456 8 8
+    - image: solid-color(19, 57, 0, 255, 8, 8)
+      bounds: 152 456 8 8
+    - image: solid-color(20, 57, 0, 255, 8, 8)
+      bounds: 160 456 8 8
+    - image: solid-color(21, 57, 0, 255, 8, 8)
+      bounds: 168 456 8 8
+    - image: solid-color(22, 57, 0, 255, 8, 8)
+      bounds: 176 456 8 8
+    - image: solid-color(23, 57, 0, 255, 8, 8)
+      bounds: 184 456 8 8
+    - image: solid-color(24, 57, 0, 255, 8, 8)
+      bounds: 192 456 8 8
+    - image: solid-color(25, 57, 0, 255, 8, 8)
+      bounds: 200 456 8 8
+    - image: solid-color(26, 57, 0, 255, 8, 8)
+      bounds: 208 456 8 8
+    - image: solid-color(27, 57, 0, 255, 8, 8)
+      bounds: 216 456 8 8
+    - image: solid-color(28, 57, 0, 255, 8, 8)
+      bounds: 224 456 8 8
+    - image: solid-color(29, 57, 0, 255, 8, 8)
+      bounds: 232 456 8 8
+    - image: solid-color(30, 57, 0, 255, 8, 8)
+      bounds: 240 456 8 8
+    - image: solid-color(31, 57, 0, 255, 8, 8)
+      bounds: 248 456 8 8
+    - image: solid-color(32, 57, 0, 255, 8, 8)
+      bounds: 256 456 8 8
+    - image: solid-color(33, 57, 0, 255, 8, 8)
+      bounds: 264 456 8 8
+    - image: solid-color(34, 57, 0, 255, 8, 8)
+      bounds: 272 456 8 8
+    - image: solid-color(35, 57, 0, 255, 8, 8)
+      bounds: 280 456 8 8
+    - image: solid-color(36, 57, 0, 255, 8, 8)
+      bounds: 288 456 8 8
+    - image: solid-color(37, 57, 0, 255, 8, 8)
+      bounds: 296 456 8 8
+    - image: solid-color(38, 57, 0, 255, 8, 8)
+      bounds: 304 456 8 8
+    - image: solid-color(39, 57, 0, 255, 8, 8)
+      bounds: 312 456 8 8
+    - image: solid-color(40, 57, 0, 255, 8, 8)
+      bounds: 320 456 8 8
+    - image: solid-color(41, 57, 0, 255, 8, 8)
+      bounds: 328 456 8 8
+    - image: solid-color(42, 57, 0, 255, 8, 8)
+      bounds: 336 456 8 8
+    - image: solid-color(43, 57, 0, 255, 8, 8)
+      bounds: 344 456 8 8
+    - image: solid-color(44, 57, 0, 255, 8, 8)
+      bounds: 352 456 8 8
+    - image: solid-color(45, 57, 0, 255, 8, 8)
+      bounds: 360 456 8 8
+    - image: solid-color(46, 57, 0, 255, 8, 8)
+      bounds: 368 456 8 8
+    - image: solid-color(47, 57, 0, 255, 8, 8)
+      bounds: 376 456 8 8
+    - image: solid-color(48, 57, 0, 255, 8, 8)
+      bounds: 384 456 8 8
+    - image: solid-color(49, 57, 0, 255, 8, 8)
+      bounds: 392 456 8 8
+    - image: solid-color(50, 57, 0, 255, 8, 8)
+      bounds: 400 456 8 8
+    - image: solid-color(51, 57, 0, 255, 8, 8)
+      bounds: 408 456 8 8
+    - image: solid-color(52, 57, 0, 255, 8, 8)
+      bounds: 416 456 8 8
+    - image: solid-color(53, 57, 0, 255, 8, 8)
+      bounds: 424 456 8 8
+    - image: solid-color(54, 57, 0, 255, 8, 8)
+      bounds: 432 456 8 8
+    - image: solid-color(55, 57, 0, 255, 8, 8)
+      bounds: 440 456 8 8
+    - image: solid-color(56, 57, 0, 255, 8, 8)
+      bounds: 448 456 8 8
+    - image: solid-color(57, 57, 0, 255, 8, 8)
+      bounds: 456 456 8 8
+    - image: solid-color(58, 57, 0, 255, 8, 8)
+      bounds: 464 456 8 8
+    - image: solid-color(59, 57, 0, 255, 8, 8)
+      bounds: 472 456 8 8
+    - image: solid-color(60, 57, 0, 255, 8, 8)
+      bounds: 480 456 8 8
+    - image: solid-color(61, 57, 0, 255, 8, 8)
+      bounds: 488 456 8 8
+    - image: solid-color(62, 57, 0, 255, 8, 8)
+      bounds: 496 456 8 8
+    - image: solid-color(63, 57, 0, 255, 8, 8)
+      bounds: 504 456 8 8
+    - image: solid-color(64, 57, 0, 255, 8, 8)
+      bounds: 512 456 8 8
+    - image: solid-color(65, 57, 0, 255, 8, 8)
+      bounds: 520 456 8 8
+    - image: solid-color(66, 57, 0, 255, 8, 8)
+      bounds: 528 456 8 8
+    - image: solid-color(67, 57, 0, 255, 8, 8)
+      bounds: 536 456 8 8
+    - image: solid-color(68, 57, 0, 255, 8, 8)
+      bounds: 544 456 8 8
+    - image: solid-color(69, 57, 0, 255, 8, 8)
+      bounds: 552 456 8 8
+    - image: solid-color(70, 57, 0, 255, 8, 8)
+      bounds: 560 456 8 8
+    - image: solid-color(71, 57, 0, 255, 8, 8)
+      bounds: 568 456 8 8
+    - image: solid-color(72, 57, 0, 255, 8, 8)
+      bounds: 576 456 8 8
+    - image: solid-color(73, 57, 0, 255, 8, 8)
+      bounds: 584 456 8 8
+    - image: solid-color(74, 57, 0, 255, 8, 8)
+      bounds: 592 456 8 8
+    - image: solid-color(75, 57, 0, 255, 8, 8)
+      bounds: 600 456 8 8
+    - image: solid-color(76, 57, 0, 255, 8, 8)
+      bounds: 608 456 8 8
+    - image: solid-color(77, 57, 0, 255, 8, 8)
+      bounds: 616 456 8 8
+    - image: solid-color(78, 57, 0, 255, 8, 8)
+      bounds: 624 456 8 8
+    - image: solid-color(79, 57, 0, 255, 8, 8)
+      bounds: 632 456 8 8
+    - image: solid-color(80, 57, 0, 255, 8, 8)
+      bounds: 640 456 8 8
+    - image: solid-color(81, 57, 0, 255, 8, 8)
+      bounds: 648 456 8 8
+    - image: solid-color(82, 57, 0, 255, 8, 8)
+      bounds: 656 456 8 8
+    - image: solid-color(83, 57, 0, 255, 8, 8)
+      bounds: 664 456 8 8
+    - image: solid-color(84, 57, 0, 255, 8, 8)
+      bounds: 672 456 8 8
+    - image: solid-color(85, 57, 0, 255, 8, 8)
+      bounds: 680 456 8 8
+    - image: solid-color(86, 57, 0, 255, 8, 8)
+      bounds: 688 456 8 8
+    - image: solid-color(87, 57, 0, 255, 8, 8)
+      bounds: 696 456 8 8
+    - image: solid-color(88, 57, 0, 255, 8, 8)
+      bounds: 704 456 8 8
+    - image: solid-color(89, 57, 0, 255, 8, 8)
+      bounds: 712 456 8 8
+    - image: solid-color(90, 57, 0, 255, 8, 8)
+      bounds: 720 456 8 8
+    - image: solid-color(91, 57, 0, 255, 8, 8)
+      bounds: 728 456 8 8
+    - image: solid-color(92, 57, 0, 255, 8, 8)
+      bounds: 736 456 8 8
+    - image: solid-color(93, 57, 0, 255, 8, 8)
+      bounds: 744 456 8 8
+    - image: solid-color(94, 57, 0, 255, 8, 8)
+      bounds: 752 456 8 8
+    - image: solid-color(95, 57, 0, 255, 8, 8)
+      bounds: 760 456 8 8
+    - image: solid-color(96, 57, 0, 255, 8, 8)
+      bounds: 768 456 8 8
+    - image: solid-color(97, 57, 0, 255, 8, 8)
+      bounds: 776 456 8 8
+    - image: solid-color(98, 57, 0, 255, 8, 8)
+      bounds: 784 456 8 8
+    - image: solid-color(99, 57, 0, 255, 8, 8)
+      bounds: 792 456 8 8
+    - image: solid-color(100, 57, 0, 255, 8, 8)
+      bounds: 800 456 8 8
+    - image: solid-color(101, 57, 0, 255, 8, 8)
+      bounds: 808 456 8 8
+    - image: solid-color(102, 57, 0, 255, 8, 8)
+      bounds: 816 456 8 8
+    - image: solid-color(103, 57, 0, 255, 8, 8)
+      bounds: 824 456 8 8
+    - image: solid-color(104, 57, 0, 255, 8, 8)
+      bounds: 832 456 8 8
+    - image: solid-color(105, 57, 0, 255, 8, 8)
+      bounds: 840 456 8 8
+    - image: solid-color(106, 57, 0, 255, 8, 8)
+      bounds: 848 456 8 8
+    - image: solid-color(107, 57, 0, 255, 8, 8)
+      bounds: 856 456 8 8
+    - image: solid-color(108, 57, 0, 255, 8, 8)
+      bounds: 864 456 8 8
+    - image: solid-color(109, 57, 0, 255, 8, 8)
+      bounds: 872 456 8 8
+    - image: solid-color(110, 57, 0, 255, 8, 8)
+      bounds: 880 456 8 8
+    - image: solid-color(111, 57, 0, 255, 8, 8)
+      bounds: 888 456 8 8
+    - image: solid-color(112, 57, 0, 255, 8, 8)
+      bounds: 896 456 8 8
+    - image: solid-color(113, 57, 0, 255, 8, 8)
+      bounds: 904 456 8 8
+    - image: solid-color(114, 57, 0, 255, 8, 8)
+      bounds: 912 456 8 8
+    - image: solid-color(115, 57, 0, 255, 8, 8)
+      bounds: 920 456 8 8
+    - image: solid-color(116, 57, 0, 255, 8, 8)
+      bounds: 928 456 8 8
+    - image: solid-color(117, 57, 0, 255, 8, 8)
+      bounds: 936 456 8 8
+    - image: solid-color(118, 57, 0, 255, 8, 8)
+      bounds: 944 456 8 8
+    - image: solid-color(119, 57, 0, 255, 8, 8)
+      bounds: 952 456 8 8
+    - image: solid-color(120, 57, 0, 255, 8, 8)
+      bounds: 960 456 8 8
+    - image: solid-color(121, 57, 0, 255, 8, 8)
+      bounds: 968 456 8 8
+    - image: solid-color(122, 57, 0, 255, 8, 8)
+      bounds: 976 456 8 8
+    - image: solid-color(123, 57, 0, 255, 8, 8)
+      bounds: 984 456 8 8
+    - image: solid-color(124, 57, 0, 255, 8, 8)
+      bounds: 992 456 8 8
+    - image: solid-color(125, 57, 0, 255, 8, 8)
+      bounds: 1000 456 8 8
+    - image: solid-color(126, 57, 0, 255, 8, 8)
+      bounds: 1008 456 8 8
+    - image: solid-color(127, 57, 0, 255, 8, 8)
+      bounds: 1016 456 8 8
+    - image: solid-color(0, 58, 0, 255, 8, 8)
+      bounds: 0 464 8 8
+    - image: solid-color(1, 58, 0, 255, 8, 8)
+      bounds: 8 464 8 8
+    - image: solid-color(2, 58, 0, 255, 8, 8)
+      bounds: 16 464 8 8
+    - image: solid-color(3, 58, 0, 255, 8, 8)
+      bounds: 24 464 8 8
+    - image: solid-color(4, 58, 0, 255, 8, 8)
+      bounds: 32 464 8 8
+    - image: solid-color(5, 58, 0, 255, 8, 8)
+      bounds: 40 464 8 8
+    - image: solid-color(6, 58, 0, 255, 8, 8)
+      bounds: 48 464 8 8
+    - image: solid-color(7, 58, 0, 255, 8, 8)
+      bounds: 56 464 8 8
+    - image: solid-color(8, 58, 0, 255, 8, 8)
+      bounds: 64 464 8 8
+    - image: solid-color(9, 58, 0, 255, 8, 8)
+      bounds: 72 464 8 8
+    - image: solid-color(10, 58, 0, 255, 8, 8)
+      bounds: 80 464 8 8
+    - image: solid-color(11, 58, 0, 255, 8, 8)
+      bounds: 88 464 8 8
+    - image: solid-color(12, 58, 0, 255, 8, 8)
+      bounds: 96 464 8 8
+    - image: solid-color(13, 58, 0, 255, 8, 8)
+      bounds: 104 464 8 8
+    - image: solid-color(14, 58, 0, 255, 8, 8)
+      bounds: 112 464 8 8
+    - image: solid-color(15, 58, 0, 255, 8, 8)
+      bounds: 120 464 8 8
+    - image: solid-color(16, 58, 0, 255, 8, 8)
+      bounds: 128 464 8 8
+    - image: solid-color(17, 58, 0, 255, 8, 8)
+      bounds: 136 464 8 8
+    - image: solid-color(18, 58, 0, 255, 8, 8)
+      bounds: 144 464 8 8
+    - image: solid-color(19, 58, 0, 255, 8, 8)
+      bounds: 152 464 8 8
+    - image: solid-color(20, 58, 0, 255, 8, 8)
+      bounds: 160 464 8 8
+    - image: solid-color(21, 58, 0, 255, 8, 8)
+      bounds: 168 464 8 8
+    - image: solid-color(22, 58, 0, 255, 8, 8)
+      bounds: 176 464 8 8
+    - image: solid-color(23, 58, 0, 255, 8, 8)
+      bounds: 184 464 8 8
+    - image: solid-color(24, 58, 0, 255, 8, 8)
+      bounds: 192 464 8 8
+    - image: solid-color(25, 58, 0, 255, 8, 8)
+      bounds: 200 464 8 8
+    - image: solid-color(26, 58, 0, 255, 8, 8)
+      bounds: 208 464 8 8
+    - image: solid-color(27, 58, 0, 255, 8, 8)
+      bounds: 216 464 8 8
+    - image: solid-color(28, 58, 0, 255, 8, 8)
+      bounds: 224 464 8 8
+    - image: solid-color(29, 58, 0, 255, 8, 8)
+      bounds: 232 464 8 8
+    - image: solid-color(30, 58, 0, 255, 8, 8)
+      bounds: 240 464 8 8
+    - image: solid-color(31, 58, 0, 255, 8, 8)
+      bounds: 248 464 8 8
+    - image: solid-color(32, 58, 0, 255, 8, 8)
+      bounds: 256 464 8 8
+    - image: solid-color(33, 58, 0, 255, 8, 8)
+      bounds: 264 464 8 8
+    - image: solid-color(34, 58, 0, 255, 8, 8)
+      bounds: 272 464 8 8
+    - image: solid-color(35, 58, 0, 255, 8, 8)
+      bounds: 280 464 8 8
+    - image: solid-color(36, 58, 0, 255, 8, 8)
+      bounds: 288 464 8 8
+    - image: solid-color(37, 58, 0, 255, 8, 8)
+      bounds: 296 464 8 8
+    - image: solid-color(38, 58, 0, 255, 8, 8)
+      bounds: 304 464 8 8
+    - image: solid-color(39, 58, 0, 255, 8, 8)
+      bounds: 312 464 8 8
+    - image: solid-color(40, 58, 0, 255, 8, 8)
+      bounds: 320 464 8 8
+    - image: solid-color(41, 58, 0, 255, 8, 8)
+      bounds: 328 464 8 8
+    - image: solid-color(42, 58, 0, 255, 8, 8)
+      bounds: 336 464 8 8
+    - image: solid-color(43, 58, 0, 255, 8, 8)
+      bounds: 344 464 8 8
+    - image: solid-color(44, 58, 0, 255, 8, 8)
+      bounds: 352 464 8 8
+    - image: solid-color(45, 58, 0, 255, 8, 8)
+      bounds: 360 464 8 8
+    - image: solid-color(46, 58, 0, 255, 8, 8)
+      bounds: 368 464 8 8
+    - image: solid-color(47, 58, 0, 255, 8, 8)
+      bounds: 376 464 8 8
+    - image: solid-color(48, 58, 0, 255, 8, 8)
+      bounds: 384 464 8 8
+    - image: solid-color(49, 58, 0, 255, 8, 8)
+      bounds: 392 464 8 8
+    - image: solid-color(50, 58, 0, 255, 8, 8)
+      bounds: 400 464 8 8
+    - image: solid-color(51, 58, 0, 255, 8, 8)
+      bounds: 408 464 8 8
+    - image: solid-color(52, 58, 0, 255, 8, 8)
+      bounds: 416 464 8 8
+    - image: solid-color(53, 58, 0, 255, 8, 8)
+      bounds: 424 464 8 8
+    - image: solid-color(54, 58, 0, 255, 8, 8)
+      bounds: 432 464 8 8
+    - image: solid-color(55, 58, 0, 255, 8, 8)
+      bounds: 440 464 8 8
+    - image: solid-color(56, 58, 0, 255, 8, 8)
+      bounds: 448 464 8 8
+    - image: solid-color(57, 58, 0, 255, 8, 8)
+      bounds: 456 464 8 8
+    - image: solid-color(58, 58, 0, 255, 8, 8)
+      bounds: 464 464 8 8
+    - image: solid-color(59, 58, 0, 255, 8, 8)
+      bounds: 472 464 8 8
+    - image: solid-color(60, 58, 0, 255, 8, 8)
+      bounds: 480 464 8 8
+    - image: solid-color(61, 58, 0, 255, 8, 8)
+      bounds: 488 464 8 8
+    - image: solid-color(62, 58, 0, 255, 8, 8)
+      bounds: 496 464 8 8
+    - image: solid-color(63, 58, 0, 255, 8, 8)
+      bounds: 504 464 8 8
+    - image: solid-color(64, 58, 0, 255, 8, 8)
+      bounds: 512 464 8 8
+    - image: solid-color(65, 58, 0, 255, 8, 8)
+      bounds: 520 464 8 8
+    - image: solid-color(66, 58, 0, 255, 8, 8)
+      bounds: 528 464 8 8
+    - image: solid-color(67, 58, 0, 255, 8, 8)
+      bounds: 536 464 8 8
+    - image: solid-color(68, 58, 0, 255, 8, 8)
+      bounds: 544 464 8 8
+    - image: solid-color(69, 58, 0, 255, 8, 8)
+      bounds: 552 464 8 8
+    - image: solid-color(70, 58, 0, 255, 8, 8)
+      bounds: 560 464 8 8
+    - image: solid-color(71, 58, 0, 255, 8, 8)
+      bounds: 568 464 8 8
+    - image: solid-color(72, 58, 0, 255, 8, 8)
+      bounds: 576 464 8 8
+    - image: solid-color(73, 58, 0, 255, 8, 8)
+      bounds: 584 464 8 8
+    - image: solid-color(74, 58, 0, 255, 8, 8)
+      bounds: 592 464 8 8
+    - image: solid-color(75, 58, 0, 255, 8, 8)
+      bounds: 600 464 8 8
+    - image: solid-color(76, 58, 0, 255, 8, 8)
+      bounds: 608 464 8 8
+    - image: solid-color(77, 58, 0, 255, 8, 8)
+      bounds: 616 464 8 8
+    - image: solid-color(78, 58, 0, 255, 8, 8)
+      bounds: 624 464 8 8
+    - image: solid-color(79, 58, 0, 255, 8, 8)
+      bounds: 632 464 8 8
+    - image: solid-color(80, 58, 0, 255, 8, 8)
+      bounds: 640 464 8 8
+    - image: solid-color(81, 58, 0, 255, 8, 8)
+      bounds: 648 464 8 8
+    - image: solid-color(82, 58, 0, 255, 8, 8)
+      bounds: 656 464 8 8
+    - image: solid-color(83, 58, 0, 255, 8, 8)
+      bounds: 664 464 8 8
+    - image: solid-color(84, 58, 0, 255, 8, 8)
+      bounds: 672 464 8 8
+    - image: solid-color(85, 58, 0, 255, 8, 8)
+      bounds: 680 464 8 8
+    - image: solid-color(86, 58, 0, 255, 8, 8)
+      bounds: 688 464 8 8
+    - image: solid-color(87, 58, 0, 255, 8, 8)
+      bounds: 696 464 8 8
+    - image: solid-color(88, 58, 0, 255, 8, 8)
+      bounds: 704 464 8 8
+    - image: solid-color(89, 58, 0, 255, 8, 8)
+      bounds: 712 464 8 8
+    - image: solid-color(90, 58, 0, 255, 8, 8)
+      bounds: 720 464 8 8
+    - image: solid-color(91, 58, 0, 255, 8, 8)
+      bounds: 728 464 8 8
+    - image: solid-color(92, 58, 0, 255, 8, 8)
+      bounds: 736 464 8 8
+    - image: solid-color(93, 58, 0, 255, 8, 8)
+      bounds: 744 464 8 8
+    - image: solid-color(94, 58, 0, 255, 8, 8)
+      bounds: 752 464 8 8
+    - image: solid-color(95, 58, 0, 255, 8, 8)
+      bounds: 760 464 8 8
+    - image: solid-color(96, 58, 0, 255, 8, 8)
+      bounds: 768 464 8 8
+    - image: solid-color(97, 58, 0, 255, 8, 8)
+      bounds: 776 464 8 8
+    - image: solid-color(98, 58, 0, 255, 8, 8)
+      bounds: 784 464 8 8
+    - image: solid-color(99, 58, 0, 255, 8, 8)
+      bounds: 792 464 8 8
+    - image: solid-color(100, 58, 0, 255, 8, 8)
+      bounds: 800 464 8 8
+    - image: solid-color(101, 58, 0, 255, 8, 8)
+      bounds: 808 464 8 8
+    - image: solid-color(102, 58, 0, 255, 8, 8)
+      bounds: 816 464 8 8
+    - image: solid-color(103, 58, 0, 255, 8, 8)
+      bounds: 824 464 8 8
+    - image: solid-color(104, 58, 0, 255, 8, 8)
+      bounds: 832 464 8 8
+    - image: solid-color(105, 58, 0, 255, 8, 8)
+      bounds: 840 464 8 8
+    - image: solid-color(106, 58, 0, 255, 8, 8)
+      bounds: 848 464 8 8
+    - image: solid-color(107, 58, 0, 255, 8, 8)
+      bounds: 856 464 8 8
+    - image: solid-color(108, 58, 0, 255, 8, 8)
+      bounds: 864 464 8 8
+    - image: solid-color(109, 58, 0, 255, 8, 8)
+      bounds: 872 464 8 8
+    - image: solid-color(110, 58, 0, 255, 8, 8)
+      bounds: 880 464 8 8
+    - image: solid-color(111, 58, 0, 255, 8, 8)
+      bounds: 888 464 8 8
+    - image: solid-color(112, 58, 0, 255, 8, 8)
+      bounds: 896 464 8 8
+    - image: solid-color(113, 58, 0, 255, 8, 8)
+      bounds: 904 464 8 8
+    - image: solid-color(114, 58, 0, 255, 8, 8)
+      bounds: 912 464 8 8
+    - image: solid-color(115, 58, 0, 255, 8, 8)
+      bounds: 920 464 8 8
+    - image: solid-color(116, 58, 0, 255, 8, 8)
+      bounds: 928 464 8 8
+    - image: solid-color(117, 58, 0, 255, 8, 8)
+      bounds: 936 464 8 8
+    - image: solid-color(118, 58, 0, 255, 8, 8)
+      bounds: 944 464 8 8
+    - image: solid-color(119, 58, 0, 255, 8, 8)
+      bounds: 952 464 8 8
+    - image: solid-color(120, 58, 0, 255, 8, 8)
+      bounds: 960 464 8 8
+    - image: solid-color(121, 58, 0, 255, 8, 8)
+      bounds: 968 464 8 8
+    - image: solid-color(122, 58, 0, 255, 8, 8)
+      bounds: 976 464 8 8
+    - image: solid-color(123, 58, 0, 255, 8, 8)
+      bounds: 984 464 8 8
+    - image: solid-color(124, 58, 0, 255, 8, 8)
+      bounds: 992 464 8 8
+    - image: solid-color(125, 58, 0, 255, 8, 8)
+      bounds: 1000 464 8 8
+    - image: solid-color(126, 58, 0, 255, 8, 8)
+      bounds: 1008 464 8 8
+    - image: solid-color(127, 58, 0, 255, 8, 8)
+      bounds: 1016 464 8 8
+    - image: solid-color(0, 59, 0, 255, 8, 8)
+      bounds: 0 472 8 8
+    - image: solid-color(1, 59, 0, 255, 8, 8)
+      bounds: 8 472 8 8
+    - image: solid-color(2, 59, 0, 255, 8, 8)
+      bounds: 16 472 8 8
+    - image: solid-color(3, 59, 0, 255, 8, 8)
+      bounds: 24 472 8 8
+    - image: solid-color(4, 59, 0, 255, 8, 8)
+      bounds: 32 472 8 8
+    - image: solid-color(5, 59, 0, 255, 8, 8)
+      bounds: 40 472 8 8
+    - image: solid-color(6, 59, 0, 255, 8, 8)
+      bounds: 48 472 8 8
+    - image: solid-color(7, 59, 0, 255, 8, 8)
+      bounds: 56 472 8 8
+    - image: solid-color(8, 59, 0, 255, 8, 8)
+      bounds: 64 472 8 8
+    - image: solid-color(9, 59, 0, 255, 8, 8)
+      bounds: 72 472 8 8
+    - image: solid-color(10, 59, 0, 255, 8, 8)
+      bounds: 80 472 8 8
+    - image: solid-color(11, 59, 0, 255, 8, 8)
+      bounds: 88 472 8 8
+    - image: solid-color(12, 59, 0, 255, 8, 8)
+      bounds: 96 472 8 8
+    - image: solid-color(13, 59, 0, 255, 8, 8)
+      bounds: 104 472 8 8
+    - image: solid-color(14, 59, 0, 255, 8, 8)
+      bounds: 112 472 8 8
+    - image: solid-color(15, 59, 0, 255, 8, 8)
+      bounds: 120 472 8 8
+    - image: solid-color(16, 59, 0, 255, 8, 8)
+      bounds: 128 472 8 8
+    - image: solid-color(17, 59, 0, 255, 8, 8)
+      bounds: 136 472 8 8
+    - image: solid-color(18, 59, 0, 255, 8, 8)
+      bounds: 144 472 8 8
+    - image: solid-color(19, 59, 0, 255, 8, 8)
+      bounds: 152 472 8 8
+    - image: solid-color(20, 59, 0, 255, 8, 8)
+      bounds: 160 472 8 8
+    - image: solid-color(21, 59, 0, 255, 8, 8)
+      bounds: 168 472 8 8
+    - image: solid-color(22, 59, 0, 255, 8, 8)
+      bounds: 176 472 8 8
+    - image: solid-color(23, 59, 0, 255, 8, 8)
+      bounds: 184 472 8 8
+    - image: solid-color(24, 59, 0, 255, 8, 8)
+      bounds: 192 472 8 8
+    - image: solid-color(25, 59, 0, 255, 8, 8)
+      bounds: 200 472 8 8
+    - image: solid-color(26, 59, 0, 255, 8, 8)
+      bounds: 208 472 8 8
+    - image: solid-color(27, 59, 0, 255, 8, 8)
+      bounds: 216 472 8 8
+    - image: solid-color(28, 59, 0, 255, 8, 8)
+      bounds: 224 472 8 8
+    - image: solid-color(29, 59, 0, 255, 8, 8)
+      bounds: 232 472 8 8
+    - image: solid-color(30, 59, 0, 255, 8, 8)
+      bounds: 240 472 8 8
+    - image: solid-color(31, 59, 0, 255, 8, 8)
+      bounds: 248 472 8 8
+    - image: solid-color(32, 59, 0, 255, 8, 8)
+      bounds: 256 472 8 8
+    - image: solid-color(33, 59, 0, 255, 8, 8)
+      bounds: 264 472 8 8
+    - image: solid-color(34, 59, 0, 255, 8, 8)
+      bounds: 272 472 8 8
+    - image: solid-color(35, 59, 0, 255, 8, 8)
+      bounds: 280 472 8 8
+    - image: solid-color(36, 59, 0, 255, 8, 8)
+      bounds: 288 472 8 8
+    - image: solid-color(37, 59, 0, 255, 8, 8)
+      bounds: 296 472 8 8
+    - image: solid-color(38, 59, 0, 255, 8, 8)
+      bounds: 304 472 8 8
+    - image: solid-color(39, 59, 0, 255, 8, 8)
+      bounds: 312 472 8 8
+    - image: solid-color(40, 59, 0, 255, 8, 8)
+      bounds: 320 472 8 8
+    - image: solid-color(41, 59, 0, 255, 8, 8)
+      bounds: 328 472 8 8
+    - image: solid-color(42, 59, 0, 255, 8, 8)
+      bounds: 336 472 8 8
+    - image: solid-color(43, 59, 0, 255, 8, 8)
+      bounds: 344 472 8 8
+    - image: solid-color(44, 59, 0, 255, 8, 8)
+      bounds: 352 472 8 8
+    - image: solid-color(45, 59, 0, 255, 8, 8)
+      bounds: 360 472 8 8
+    - image: solid-color(46, 59, 0, 255, 8, 8)
+      bounds: 368 472 8 8
+    - image: solid-color(47, 59, 0, 255, 8, 8)
+      bounds: 376 472 8 8
+    - image: solid-color(48, 59, 0, 255, 8, 8)
+      bounds: 384 472 8 8
+    - image: solid-color(49, 59, 0, 255, 8, 8)
+      bounds: 392 472 8 8
+    - image: solid-color(50, 59, 0, 255, 8, 8)
+      bounds: 400 472 8 8
+    - image: solid-color(51, 59, 0, 255, 8, 8)
+      bounds: 408 472 8 8
+    - image: solid-color(52, 59, 0, 255, 8, 8)
+      bounds: 416 472 8 8
+    - image: solid-color(53, 59, 0, 255, 8, 8)
+      bounds: 424 472 8 8
+    - image: solid-color(54, 59, 0, 255, 8, 8)
+      bounds: 432 472 8 8
+    - image: solid-color(55, 59, 0, 255, 8, 8)
+      bounds: 440 472 8 8
+    - image: solid-color(56, 59, 0, 255, 8, 8)
+      bounds: 448 472 8 8
+    - image: solid-color(57, 59, 0, 255, 8, 8)
+      bounds: 456 472 8 8
+    - image: solid-color(58, 59, 0, 255, 8, 8)
+      bounds: 464 472 8 8
+    - image: solid-color(59, 59, 0, 255, 8, 8)
+      bounds: 472 472 8 8
+    - image: solid-color(60, 59, 0, 255, 8, 8)
+      bounds: 480 472 8 8
+    - image: solid-color(61, 59, 0, 255, 8, 8)
+      bounds: 488 472 8 8
+    - image: solid-color(62, 59, 0, 255, 8, 8)
+      bounds: 496 472 8 8
+    - image: solid-color(63, 59, 0, 255, 8, 8)
+      bounds: 504 472 8 8
+    - image: solid-color(64, 59, 0, 255, 8, 8)
+      bounds: 512 472 8 8
+    - image: solid-color(65, 59, 0, 255, 8, 8)
+      bounds: 520 472 8 8
+    - image: solid-color(66, 59, 0, 255, 8, 8)
+      bounds: 528 472 8 8
+    - image: solid-color(67, 59, 0, 255, 8, 8)
+      bounds: 536 472 8 8
+    - image: solid-color(68, 59, 0, 255, 8, 8)
+      bounds: 544 472 8 8
+    - image: solid-color(69, 59, 0, 255, 8, 8)
+      bounds: 552 472 8 8
+    - image: solid-color(70, 59, 0, 255, 8, 8)
+      bounds: 560 472 8 8
+    - image: solid-color(71, 59, 0, 255, 8, 8)
+      bounds: 568 472 8 8
+    - image: solid-color(72, 59, 0, 255, 8, 8)
+      bounds: 576 472 8 8
+    - image: solid-color(73, 59, 0, 255, 8, 8)
+      bounds: 584 472 8 8
+    - image: solid-color(74, 59, 0, 255, 8, 8)
+      bounds: 592 472 8 8
+    - image: solid-color(75, 59, 0, 255, 8, 8)
+      bounds: 600 472 8 8
+    - image: solid-color(76, 59, 0, 255, 8, 8)
+      bounds: 608 472 8 8
+    - image: solid-color(77, 59, 0, 255, 8, 8)
+      bounds: 616 472 8 8
+    - image: solid-color(78, 59, 0, 255, 8, 8)
+      bounds: 624 472 8 8
+    - image: solid-color(79, 59, 0, 255, 8, 8)
+      bounds: 632 472 8 8
+    - image: solid-color(80, 59, 0, 255, 8, 8)
+      bounds: 640 472 8 8
+    - image: solid-color(81, 59, 0, 255, 8, 8)
+      bounds: 648 472 8 8
+    - image: solid-color(82, 59, 0, 255, 8, 8)
+      bounds: 656 472 8 8
+    - image: solid-color(83, 59, 0, 255, 8, 8)
+      bounds: 664 472 8 8
+    - image: solid-color(84, 59, 0, 255, 8, 8)
+      bounds: 672 472 8 8
+    - image: solid-color(85, 59, 0, 255, 8, 8)
+      bounds: 680 472 8 8
+    - image: solid-color(86, 59, 0, 255, 8, 8)
+      bounds: 688 472 8 8
+    - image: solid-color(87, 59, 0, 255, 8, 8)
+      bounds: 696 472 8 8
+    - image: solid-color(88, 59, 0, 255, 8, 8)
+      bounds: 704 472 8 8
+    - image: solid-color(89, 59, 0, 255, 8, 8)
+      bounds: 712 472 8 8
+    - image: solid-color(90, 59, 0, 255, 8, 8)
+      bounds: 720 472 8 8
+    - image: solid-color(91, 59, 0, 255, 8, 8)
+      bounds: 728 472 8 8
+    - image: solid-color(92, 59, 0, 255, 8, 8)
+      bounds: 736 472 8 8
+    - image: solid-color(93, 59, 0, 255, 8, 8)
+      bounds: 744 472 8 8
+    - image: solid-color(94, 59, 0, 255, 8, 8)
+      bounds: 752 472 8 8
+    - image: solid-color(95, 59, 0, 255, 8, 8)
+      bounds: 760 472 8 8
+    - image: solid-color(96, 59, 0, 255, 8, 8)
+      bounds: 768 472 8 8
+    - image: solid-color(97, 59, 0, 255, 8, 8)
+      bounds: 776 472 8 8
+    - image: solid-color(98, 59, 0, 255, 8, 8)
+      bounds: 784 472 8 8
+    - image: solid-color(99, 59, 0, 255, 8, 8)
+      bounds: 792 472 8 8
+    - image: solid-color(100, 59, 0, 255, 8, 8)
+      bounds: 800 472 8 8
+    - image: solid-color(101, 59, 0, 255, 8, 8)
+      bounds: 808 472 8 8
+    - image: solid-color(102, 59, 0, 255, 8, 8)
+      bounds: 816 472 8 8
+    - image: solid-color(103, 59, 0, 255, 8, 8)
+      bounds: 824 472 8 8
+    - image: solid-color(104, 59, 0, 255, 8, 8)
+      bounds: 832 472 8 8
+    - image: solid-color(105, 59, 0, 255, 8, 8)
+      bounds: 840 472 8 8
+    - image: solid-color(106, 59, 0, 255, 8, 8)
+      bounds: 848 472 8 8
+    - image: solid-color(107, 59, 0, 255, 8, 8)
+      bounds: 856 472 8 8
+    - image: solid-color(108, 59, 0, 255, 8, 8)
+      bounds: 864 472 8 8
+    - image: solid-color(109, 59, 0, 255, 8, 8)
+      bounds: 872 472 8 8
+    - image: solid-color(110, 59, 0, 255, 8, 8)
+      bounds: 880 472 8 8
+    - image: solid-color(111, 59, 0, 255, 8, 8)
+      bounds: 888 472 8 8
+    - image: solid-color(112, 59, 0, 255, 8, 8)
+      bounds: 896 472 8 8
+    - image: solid-color(113, 59, 0, 255, 8, 8)
+      bounds: 904 472 8 8
+    - image: solid-color(114, 59, 0, 255, 8, 8)
+      bounds: 912 472 8 8
+    - image: solid-color(115, 59, 0, 255, 8, 8)
+      bounds: 920 472 8 8
+    - image: solid-color(116, 59, 0, 255, 8, 8)
+      bounds: 928 472 8 8
+    - image: solid-color(117, 59, 0, 255, 8, 8)
+      bounds: 936 472 8 8
+    - image: solid-color(118, 59, 0, 255, 8, 8)
+      bounds: 944 472 8 8
+    - image: solid-color(119, 59, 0, 255, 8, 8)
+      bounds: 952 472 8 8
+    - image: solid-color(120, 59, 0, 255, 8, 8)
+      bounds: 960 472 8 8
+    - image: solid-color(121, 59, 0, 255, 8, 8)
+      bounds: 968 472 8 8
+    - image: solid-color(122, 59, 0, 255, 8, 8)
+      bounds: 976 472 8 8
+    - image: solid-color(123, 59, 0, 255, 8, 8)
+      bounds: 984 472 8 8
+    - image: solid-color(124, 59, 0, 255, 8, 8)
+      bounds: 992 472 8 8
+    - image: solid-color(125, 59, 0, 255, 8, 8)
+      bounds: 1000 472 8 8
+    - image: solid-color(126, 59, 0, 255, 8, 8)
+      bounds: 1008 472 8 8
+    - image: solid-color(127, 59, 0, 255, 8, 8)
+      bounds: 1016 472 8 8
+    - image: solid-color(0, 60, 0, 255, 8, 8)
+      bounds: 0 480 8 8
+    - image: solid-color(1, 60, 0, 255, 8, 8)
+      bounds: 8 480 8 8
+    - image: solid-color(2, 60, 0, 255, 8, 8)
+      bounds: 16 480 8 8
+    - image: solid-color(3, 60, 0, 255, 8, 8)
+      bounds: 24 480 8 8
+    - image: solid-color(4, 60, 0, 255, 8, 8)
+      bounds: 32 480 8 8
+    - image: solid-color(5, 60, 0, 255, 8, 8)
+      bounds: 40 480 8 8
+    - image: solid-color(6, 60, 0, 255, 8, 8)
+      bounds: 48 480 8 8
+    - image: solid-color(7, 60, 0, 255, 8, 8)
+      bounds: 56 480 8 8
+    - image: solid-color(8, 60, 0, 255, 8, 8)
+      bounds: 64 480 8 8
+    - image: solid-color(9, 60, 0, 255, 8, 8)
+      bounds: 72 480 8 8
+    - image: solid-color(10, 60, 0, 255, 8, 8)
+      bounds: 80 480 8 8
+    - image: solid-color(11, 60, 0, 255, 8, 8)
+      bounds: 88 480 8 8
+    - image: solid-color(12, 60, 0, 255, 8, 8)
+      bounds: 96 480 8 8
+    - image: solid-color(13, 60, 0, 255, 8, 8)
+      bounds: 104 480 8 8
+    - image: solid-color(14, 60, 0, 255, 8, 8)
+      bounds: 112 480 8 8
+    - image: solid-color(15, 60, 0, 255, 8, 8)
+      bounds: 120 480 8 8
+    - image: solid-color(16, 60, 0, 255, 8, 8)
+      bounds: 128 480 8 8
+    - image: solid-color(17, 60, 0, 255, 8, 8)
+      bounds: 136 480 8 8
+    - image: solid-color(18, 60, 0, 255, 8, 8)
+      bounds: 144 480 8 8
+    - image: solid-color(19, 60, 0, 255, 8, 8)
+      bounds: 152 480 8 8
+    - image: solid-color(20, 60, 0, 255, 8, 8)
+      bounds: 160 480 8 8
+    - image: solid-color(21, 60, 0, 255, 8, 8)
+      bounds: 168 480 8 8
+    - image: solid-color(22, 60, 0, 255, 8, 8)
+      bounds: 176 480 8 8
+    - image: solid-color(23, 60, 0, 255, 8, 8)
+      bounds: 184 480 8 8
+    - image: solid-color(24, 60, 0, 255, 8, 8)
+      bounds: 192 480 8 8
+    - image: solid-color(25, 60, 0, 255, 8, 8)
+      bounds: 200 480 8 8
+    - image: solid-color(26, 60, 0, 255, 8, 8)
+      bounds: 208 480 8 8
+    - image: solid-color(27, 60, 0, 255, 8, 8)
+      bounds: 216 480 8 8
+    - image: solid-color(28, 60, 0, 255, 8, 8)
+      bounds: 224 480 8 8
+    - image: solid-color(29, 60, 0, 255, 8, 8)
+      bounds: 232 480 8 8
+    - image: solid-color(30, 60, 0, 255, 8, 8)
+      bounds: 240 480 8 8
+    - image: solid-color(31, 60, 0, 255, 8, 8)
+      bounds: 248 480 8 8
+    - image: solid-color(32, 60, 0, 255, 8, 8)
+      bounds: 256 480 8 8
+    - image: solid-color(33, 60, 0, 255, 8, 8)
+      bounds: 264 480 8 8
+    - image: solid-color(34, 60, 0, 255, 8, 8)
+      bounds: 272 480 8 8
+    - image: solid-color(35, 60, 0, 255, 8, 8)
+      bounds: 280 480 8 8
+    - image: solid-color(36, 60, 0, 255, 8, 8)
+      bounds: 288 480 8 8
+    - image: solid-color(37, 60, 0, 255, 8, 8)
+      bounds: 296 480 8 8
+    - image: solid-color(38, 60, 0, 255, 8, 8)
+      bounds: 304 480 8 8
+    - image: solid-color(39, 60, 0, 255, 8, 8)
+      bounds: 312 480 8 8
+    - image: solid-color(40, 60, 0, 255, 8, 8)
+      bounds: 320 480 8 8
+    - image: solid-color(41, 60, 0, 255, 8, 8)
+      bounds: 328 480 8 8
+    - image: solid-color(42, 60, 0, 255, 8, 8)
+      bounds: 336 480 8 8
+    - image: solid-color(43, 60, 0, 255, 8, 8)
+      bounds: 344 480 8 8
+    - image: solid-color(44, 60, 0, 255, 8, 8)
+      bounds: 352 480 8 8
+    - image: solid-color(45, 60, 0, 255, 8, 8)
+      bounds: 360 480 8 8
+    - image: solid-color(46, 60, 0, 255, 8, 8)
+      bounds: 368 480 8 8
+    - image: solid-color(47, 60, 0, 255, 8, 8)
+      bounds: 376 480 8 8
+    - image: solid-color(48, 60, 0, 255, 8, 8)
+      bounds: 384 480 8 8
+    - image: solid-color(49, 60, 0, 255, 8, 8)
+      bounds: 392 480 8 8
+    - image: solid-color(50, 60, 0, 255, 8, 8)
+      bounds: 400 480 8 8
+    - image: solid-color(51, 60, 0, 255, 8, 8)
+      bounds: 408 480 8 8
+    - image: solid-color(52, 60, 0, 255, 8, 8)
+      bounds: 416 480 8 8
+    - image: solid-color(53, 60, 0, 255, 8, 8)
+      bounds: 424 480 8 8
+    - image: solid-color(54, 60, 0, 255, 8, 8)
+      bounds: 432 480 8 8
+    - image: solid-color(55, 60, 0, 255, 8, 8)
+      bounds: 440 480 8 8
+    - image: solid-color(56, 60, 0, 255, 8, 8)
+      bounds: 448 480 8 8
+    - image: solid-color(57, 60, 0, 255, 8, 8)
+      bounds: 456 480 8 8
+    - image: solid-color(58, 60, 0, 255, 8, 8)
+      bounds: 464 480 8 8
+    - image: solid-color(59, 60, 0, 255, 8, 8)
+      bounds: 472 480 8 8
+    - image: solid-color(60, 60, 0, 255, 8, 8)
+      bounds: 480 480 8 8
+    - image: solid-color(61, 60, 0, 255, 8, 8)
+      bounds: 488 480 8 8
+    - image: solid-color(62, 60, 0, 255, 8, 8)
+      bounds: 496 480 8 8
+    - image: solid-color(63, 60, 0, 255, 8, 8)
+      bounds: 504 480 8 8
+    - image: solid-color(64, 60, 0, 255, 8, 8)
+      bounds: 512 480 8 8
+    - image: solid-color(65, 60, 0, 255, 8, 8)
+      bounds: 520 480 8 8
+    - image: solid-color(66, 60, 0, 255, 8, 8)
+      bounds: 528 480 8 8
+    - image: solid-color(67, 60, 0, 255, 8, 8)
+      bounds: 536 480 8 8
+    - image: solid-color(68, 60, 0, 255, 8, 8)
+      bounds: 544 480 8 8
+    - image: solid-color(69, 60, 0, 255, 8, 8)
+      bounds: 552 480 8 8
+    - image: solid-color(70, 60, 0, 255, 8, 8)
+      bounds: 560 480 8 8
+    - image: solid-color(71, 60, 0, 255, 8, 8)
+      bounds: 568 480 8 8
+    - image: solid-color(72, 60, 0, 255, 8, 8)
+      bounds: 576 480 8 8
+    - image: solid-color(73, 60, 0, 255, 8, 8)
+      bounds: 584 480 8 8
+    - image: solid-color(74, 60, 0, 255, 8, 8)
+      bounds: 592 480 8 8
+    - image: solid-color(75, 60, 0, 255, 8, 8)
+      bounds: 600 480 8 8
+    - image: solid-color(76, 60, 0, 255, 8, 8)
+      bounds: 608 480 8 8
+    - image: solid-color(77, 60, 0, 255, 8, 8)
+      bounds: 616 480 8 8
+    - image: solid-color(78, 60, 0, 255, 8, 8)
+      bounds: 624 480 8 8
+    - image: solid-color(79, 60, 0, 255, 8, 8)
+      bounds: 632 480 8 8
+    - image: solid-color(80, 60, 0, 255, 8, 8)
+      bounds: 640 480 8 8
+    - image: solid-color(81, 60, 0, 255, 8, 8)
+      bounds: 648 480 8 8
+    - image: solid-color(82, 60, 0, 255, 8, 8)
+      bounds: 656 480 8 8
+    - image: solid-color(83, 60, 0, 255, 8, 8)
+      bounds: 664 480 8 8
+    - image: solid-color(84, 60, 0, 255, 8, 8)
+      bounds: 672 480 8 8
+    - image: solid-color(85, 60, 0, 255, 8, 8)
+      bounds: 680 480 8 8
+    - image: solid-color(86, 60, 0, 255, 8, 8)
+      bounds: 688 480 8 8
+    - image: solid-color(87, 60, 0, 255, 8, 8)
+      bounds: 696 480 8 8
+    - image: solid-color(88, 60, 0, 255, 8, 8)
+      bounds: 704 480 8 8
+    - image: solid-color(89, 60, 0, 255, 8, 8)
+      bounds: 712 480 8 8
+    - image: solid-color(90, 60, 0, 255, 8, 8)
+      bounds: 720 480 8 8
+    - image: solid-color(91, 60, 0, 255, 8, 8)
+      bounds: 728 480 8 8
+    - image: solid-color(92, 60, 0, 255, 8, 8)
+      bounds: 736 480 8 8
+    - image: solid-color(93, 60, 0, 255, 8, 8)
+      bounds: 744 480 8 8
+    - image: solid-color(94, 60, 0, 255, 8, 8)
+      bounds: 752 480 8 8
+    - image: solid-color(95, 60, 0, 255, 8, 8)
+      bounds: 760 480 8 8
+    - image: solid-color(96, 60, 0, 255, 8, 8)
+      bounds: 768 480 8 8
+    - image: solid-color(97, 60, 0, 255, 8, 8)
+      bounds: 776 480 8 8
+    - image: solid-color(98, 60, 0, 255, 8, 8)
+      bounds: 784 480 8 8
+    - image: solid-color(99, 60, 0, 255, 8, 8)
+      bounds: 792 480 8 8
+    - image: solid-color(100, 60, 0, 255, 8, 8)
+      bounds: 800 480 8 8
+    - image: solid-color(101, 60, 0, 255, 8, 8)
+      bounds: 808 480 8 8
+    - image: solid-color(102, 60, 0, 255, 8, 8)
+      bounds: 816 480 8 8
+    - image: solid-color(103, 60, 0, 255, 8, 8)
+      bounds: 824 480 8 8
+    - image: solid-color(104, 60, 0, 255, 8, 8)
+      bounds: 832 480 8 8
+    - image: solid-color(105, 60, 0, 255, 8, 8)
+      bounds: 840 480 8 8
+    - image: solid-color(106, 60, 0, 255, 8, 8)
+      bounds: 848 480 8 8
+    - image: solid-color(107, 60, 0, 255, 8, 8)
+      bounds: 856 480 8 8
+    - image: solid-color(108, 60, 0, 255, 8, 8)
+      bounds: 864 480 8 8
+    - image: solid-color(109, 60, 0, 255, 8, 8)
+      bounds: 872 480 8 8
+    - image: solid-color(110, 60, 0, 255, 8, 8)
+      bounds: 880 480 8 8
+    - image: solid-color(111, 60, 0, 255, 8, 8)
+      bounds: 888 480 8 8
+    - image: solid-color(112, 60, 0, 255, 8, 8)
+      bounds: 896 480 8 8
+    - image: solid-color(113, 60, 0, 255, 8, 8)
+      bounds: 904 480 8 8
+    - image: solid-color(114, 60, 0, 255, 8, 8)
+      bounds: 912 480 8 8
+    - image: solid-color(115, 60, 0, 255, 8, 8)
+      bounds: 920 480 8 8
+    - image: solid-color(116, 60, 0, 255, 8, 8)
+      bounds: 928 480 8 8
+    - image: solid-color(117, 60, 0, 255, 8, 8)
+      bounds: 936 480 8 8
+    - image: solid-color(118, 60, 0, 255, 8, 8)
+      bounds: 944 480 8 8
+    - image: solid-color(119, 60, 0, 255, 8, 8)
+      bounds: 952 480 8 8
+    - image: solid-color(120, 60, 0, 255, 8, 8)
+      bounds: 960 480 8 8
+    - image: solid-color(121, 60, 0, 255, 8, 8)
+      bounds: 968 480 8 8
+    - image: solid-color(122, 60, 0, 255, 8, 8)
+      bounds: 976 480 8 8
+    - image: solid-color(123, 60, 0, 255, 8, 8)
+      bounds: 984 480 8 8
+    - image: solid-color(124, 60, 0, 255, 8, 8)
+      bounds: 992 480 8 8
+    - image: solid-color(125, 60, 0, 255, 8, 8)
+      bounds: 1000 480 8 8
+    - image: solid-color(126, 60, 0, 255, 8, 8)
+      bounds: 1008 480 8 8
+    - image: solid-color(127, 60, 0, 255, 8, 8)
+      bounds: 1016 480 8 8
+    - image: solid-color(0, 61, 0, 255, 8, 8)
+      bounds: 0 488 8 8
+    - image: solid-color(1, 61, 0, 255, 8, 8)
+      bounds: 8 488 8 8
+    - image: solid-color(2, 61, 0, 255, 8, 8)
+      bounds: 16 488 8 8
+    - image: solid-color(3, 61, 0, 255, 8, 8)
+      bounds: 24 488 8 8
+    - image: solid-color(4, 61, 0, 255, 8, 8)
+      bounds: 32 488 8 8
+    - image: solid-color(5, 61, 0, 255, 8, 8)
+      bounds: 40 488 8 8
+    - image: solid-color(6, 61, 0, 255, 8, 8)
+      bounds: 48 488 8 8
+    - image: solid-color(7, 61, 0, 255, 8, 8)
+      bounds: 56 488 8 8
+    - image: solid-color(8, 61, 0, 255, 8, 8)
+      bounds: 64 488 8 8
+    - image: solid-color(9, 61, 0, 255, 8, 8)
+      bounds: 72 488 8 8
+    - image: solid-color(10, 61, 0, 255, 8, 8)
+      bounds: 80 488 8 8
+    - image: solid-color(11, 61, 0, 255, 8, 8)
+      bounds: 88 488 8 8
+    - image: solid-color(12, 61, 0, 255, 8, 8)
+      bounds: 96 488 8 8
+    - image: solid-color(13, 61, 0, 255, 8, 8)
+      bounds: 104 488 8 8
+    - image: solid-color(14, 61, 0, 255, 8, 8)
+      bounds: 112 488 8 8
+    - image: solid-color(15, 61, 0, 255, 8, 8)
+      bounds: 120 488 8 8
+    - image: solid-color(16, 61, 0, 255, 8, 8)
+      bounds: 128 488 8 8
+    - image: solid-color(17, 61, 0, 255, 8, 8)
+      bounds: 136 488 8 8
+    - image: solid-color(18, 61, 0, 255, 8, 8)
+      bounds: 144 488 8 8
+    - image: solid-color(19, 61, 0, 255, 8, 8)
+      bounds: 152 488 8 8
+    - image: solid-color(20, 61, 0, 255, 8, 8)
+      bounds: 160 488 8 8
+    - image: solid-color(21, 61, 0, 255, 8, 8)
+      bounds: 168 488 8 8
+    - image: solid-color(22, 61, 0, 255, 8, 8)
+      bounds: 176 488 8 8
+    - image: solid-color(23, 61, 0, 255, 8, 8)
+      bounds: 184 488 8 8
+    - image: solid-color(24, 61, 0, 255, 8, 8)
+      bounds: 192 488 8 8
+    - image: solid-color(25, 61, 0, 255, 8, 8)
+      bounds: 200 488 8 8
+    - image: solid-color(26, 61, 0, 255, 8, 8)
+      bounds: 208 488 8 8
+    - image: solid-color(27, 61, 0, 255, 8, 8)
+      bounds: 216 488 8 8
+    - image: solid-color(28, 61, 0, 255, 8, 8)
+      bounds: 224 488 8 8
+    - image: solid-color(29, 61, 0, 255, 8, 8)
+      bounds: 232 488 8 8
+    - image: solid-color(30, 61, 0, 255, 8, 8)
+      bounds: 240 488 8 8
+    - image: solid-color(31, 61, 0, 255, 8, 8)
+      bounds: 248 488 8 8
+    - image: solid-color(32, 61, 0, 255, 8, 8)
+      bounds: 256 488 8 8
+    - image: solid-color(33, 61, 0, 255, 8, 8)
+      bounds: 264 488 8 8
+    - image: solid-color(34, 61, 0, 255, 8, 8)
+      bounds: 272 488 8 8
+    - image: solid-color(35, 61, 0, 255, 8, 8)
+      bounds: 280 488 8 8
+    - image: solid-color(36, 61, 0, 255, 8, 8)
+      bounds: 288 488 8 8
+    - image: solid-color(37, 61, 0, 255, 8, 8)
+      bounds: 296 488 8 8
+    - image: solid-color(38, 61, 0, 255, 8, 8)
+      bounds: 304 488 8 8
+    - image: solid-color(39, 61, 0, 255, 8, 8)
+      bounds: 312 488 8 8
+    - image: solid-color(40, 61, 0, 255, 8, 8)
+      bounds: 320 488 8 8
+    - image: solid-color(41, 61, 0, 255, 8, 8)
+      bounds: 328 488 8 8
+    - image: solid-color(42, 61, 0, 255, 8, 8)
+      bounds: 336 488 8 8
+    - image: solid-color(43, 61, 0, 255, 8, 8)
+      bounds: 344 488 8 8
+    - image: solid-color(44, 61, 0, 255, 8, 8)
+      bounds: 352 488 8 8
+    - image: solid-color(45, 61, 0, 255, 8, 8)
+      bounds: 360 488 8 8
+    - image: solid-color(46, 61, 0, 255, 8, 8)
+      bounds: 368 488 8 8
+    - image: solid-color(47, 61, 0, 255, 8, 8)
+      bounds: 376 488 8 8
+    - image: solid-color(48, 61, 0, 255, 8, 8)
+      bounds: 384 488 8 8
+    - image: solid-color(49, 61, 0, 255, 8, 8)
+      bounds: 392 488 8 8
+    - image: solid-color(50, 61, 0, 255, 8, 8)
+      bounds: 400 488 8 8
+    - image: solid-color(51, 61, 0, 255, 8, 8)
+      bounds: 408 488 8 8
+    - image: solid-color(52, 61, 0, 255, 8, 8)
+      bounds: 416 488 8 8
+    - image: solid-color(53, 61, 0, 255, 8, 8)
+      bounds: 424 488 8 8
+    - image: solid-color(54, 61, 0, 255, 8, 8)
+      bounds: 432 488 8 8
+    - image: solid-color(55, 61, 0, 255, 8, 8)
+      bounds: 440 488 8 8
+    - image: solid-color(56, 61, 0, 255, 8, 8)
+      bounds: 448 488 8 8
+    - image: solid-color(57, 61, 0, 255, 8, 8)
+      bounds: 456 488 8 8
+    - image: solid-color(58, 61, 0, 255, 8, 8)
+      bounds: 464 488 8 8
+    - image: solid-color(59, 61, 0, 255, 8, 8)
+      bounds: 472 488 8 8
+    - image: solid-color(60, 61, 0, 255, 8, 8)
+      bounds: 480 488 8 8
+    - image: solid-color(61, 61, 0, 255, 8, 8)
+      bounds: 488 488 8 8
+    - image: solid-color(62, 61, 0, 255, 8, 8)
+      bounds: 496 488 8 8
+    - image: solid-color(63, 61, 0, 255, 8, 8)
+      bounds: 504 488 8 8
+    - image: solid-color(64, 61, 0, 255, 8, 8)
+      bounds: 512 488 8 8
+    - image: solid-color(65, 61, 0, 255, 8, 8)
+      bounds: 520 488 8 8
+    - image: solid-color(66, 61, 0, 255, 8, 8)
+      bounds: 528 488 8 8
+    - image: solid-color(67, 61, 0, 255, 8, 8)
+      bounds: 536 488 8 8
+    - image: solid-color(68, 61, 0, 255, 8, 8)
+      bounds: 544 488 8 8
+    - image: solid-color(69, 61, 0, 255, 8, 8)
+      bounds: 552 488 8 8
+    - image: solid-color(70, 61, 0, 255, 8, 8)
+      bounds: 560 488 8 8
+    - image: solid-color(71, 61, 0, 255, 8, 8)
+      bounds: 568 488 8 8
+    - image: solid-color(72, 61, 0, 255, 8, 8)
+      bounds: 576 488 8 8
+    - image: solid-color(73, 61, 0, 255, 8, 8)
+      bounds: 584 488 8 8
+    - image: solid-color(74, 61, 0, 255, 8, 8)
+      bounds: 592 488 8 8
+    - image: solid-color(75, 61, 0, 255, 8, 8)
+      bounds: 600 488 8 8
+    - image: solid-color(76, 61, 0, 255, 8, 8)
+      bounds: 608 488 8 8
+    - image: solid-color(77, 61, 0, 255, 8, 8)
+      bounds: 616 488 8 8
+    - image: solid-color(78, 61, 0, 255, 8, 8)
+      bounds: 624 488 8 8
+    - image: solid-color(79, 61, 0, 255, 8, 8)
+      bounds: 632 488 8 8
+    - image: solid-color(80, 61, 0, 255, 8, 8)
+      bounds: 640 488 8 8
+    - image: solid-color(81, 61, 0, 255, 8, 8)
+      bounds: 648 488 8 8
+    - image: solid-color(82, 61, 0, 255, 8, 8)
+      bounds: 656 488 8 8
+    - image: solid-color(83, 61, 0, 255, 8, 8)
+      bounds: 664 488 8 8
+    - image: solid-color(84, 61, 0, 255, 8, 8)
+      bounds: 672 488 8 8
+    - image: solid-color(85, 61, 0, 255, 8, 8)
+      bounds: 680 488 8 8
+    - image: solid-color(86, 61, 0, 255, 8, 8)
+      bounds: 688 488 8 8
+    - image: solid-color(87, 61, 0, 255, 8, 8)
+      bounds: 696 488 8 8
+    - image: solid-color(88, 61, 0, 255, 8, 8)
+      bounds: 704 488 8 8
+    - image: solid-color(89, 61, 0, 255, 8, 8)
+      bounds: 712 488 8 8
+    - image: solid-color(90, 61, 0, 255, 8, 8)
+      bounds: 720 488 8 8
+    - image: solid-color(91, 61, 0, 255, 8, 8)
+      bounds: 728 488 8 8
+    - image: solid-color(92, 61, 0, 255, 8, 8)
+      bounds: 736 488 8 8
+    - image: solid-color(93, 61, 0, 255, 8, 8)
+      bounds: 744 488 8 8
+    - image: solid-color(94, 61, 0, 255, 8, 8)
+      bounds: 752 488 8 8
+    - image: solid-color(95, 61, 0, 255, 8, 8)
+      bounds: 760 488 8 8
+    - image: solid-color(96, 61, 0, 255, 8, 8)
+      bounds: 768 488 8 8
+    - image: solid-color(97, 61, 0, 255, 8, 8)
+      bounds: 776 488 8 8
+    - image: solid-color(98, 61, 0, 255, 8, 8)
+      bounds: 784 488 8 8
+    - image: solid-color(99, 61, 0, 255, 8, 8)
+      bounds: 792 488 8 8
+    - image: solid-color(100, 61, 0, 255, 8, 8)
+      bounds: 800 488 8 8
+    - image: solid-color(101, 61, 0, 255, 8, 8)
+      bounds: 808 488 8 8
+    - image: solid-color(102, 61, 0, 255, 8, 8)
+      bounds: 816 488 8 8
+    - image: solid-color(103, 61, 0, 255, 8, 8)
+      bounds: 824 488 8 8
+    - image: solid-color(104, 61, 0, 255, 8, 8)
+      bounds: 832 488 8 8
+    - image: solid-color(105, 61, 0, 255, 8, 8)
+      bounds: 840 488 8 8
+    - image: solid-color(106, 61, 0, 255, 8, 8)
+      bounds: 848 488 8 8
+    - image: solid-color(107, 61, 0, 255, 8, 8)
+      bounds: 856 488 8 8
+    - image: solid-color(108, 61, 0, 255, 8, 8)
+      bounds: 864 488 8 8
+    - image: solid-color(109, 61, 0, 255, 8, 8)
+      bounds: 872 488 8 8
+    - image: solid-color(110, 61, 0, 255, 8, 8)
+      bounds: 880 488 8 8
+    - image: solid-color(111, 61, 0, 255, 8, 8)
+      bounds: 888 488 8 8
+    - image: solid-color(112, 61, 0, 255, 8, 8)
+      bounds: 896 488 8 8
+    - image: solid-color(113, 61, 0, 255, 8, 8)
+      bounds: 904 488 8 8
+    - image: solid-color(114, 61, 0, 255, 8, 8)
+      bounds: 912 488 8 8
+    - image: solid-color(115, 61, 0, 255, 8, 8)
+      bounds: 920 488 8 8
+    - image: solid-color(116, 61, 0, 255, 8, 8)
+      bounds: 928 488 8 8
+    - image: solid-color(117, 61, 0, 255, 8, 8)
+      bounds: 936 488 8 8
+    - image: solid-color(118, 61, 0, 255, 8, 8)
+      bounds: 944 488 8 8
+    - image: solid-color(119, 61, 0, 255, 8, 8)
+      bounds: 952 488 8 8
+    - image: solid-color(120, 61, 0, 255, 8, 8)
+      bounds: 960 488 8 8
+    - image: solid-color(121, 61, 0, 255, 8, 8)
+      bounds: 968 488 8 8
+    - image: solid-color(122, 61, 0, 255, 8, 8)
+      bounds: 976 488 8 8
+    - image: solid-color(123, 61, 0, 255, 8, 8)
+      bounds: 984 488 8 8
+    - image: solid-color(124, 61, 0, 255, 8, 8)
+      bounds: 992 488 8 8
+    - image: solid-color(125, 61, 0, 255, 8, 8)
+      bounds: 1000 488 8 8
+    - image: solid-color(126, 61, 0, 255, 8, 8)
+      bounds: 1008 488 8 8
+    - image: solid-color(127, 61, 0, 255, 8, 8)
+      bounds: 1016 488 8 8
+    - image: solid-color(0, 62, 0, 255, 8, 8)
+      bounds: 0 496 8 8
+    - image: solid-color(1, 62, 0, 255, 8, 8)
+      bounds: 8 496 8 8
+    - image: solid-color(2, 62, 0, 255, 8, 8)
+      bounds: 16 496 8 8
+    - image: solid-color(3, 62, 0, 255, 8, 8)
+      bounds: 24 496 8 8
+    - image: solid-color(4, 62, 0, 255, 8, 8)
+      bounds: 32 496 8 8
+    - image: solid-color(5, 62, 0, 255, 8, 8)
+      bounds: 40 496 8 8
+    - image: solid-color(6, 62, 0, 255, 8, 8)
+      bounds: 48 496 8 8
+    - image: solid-color(7, 62, 0, 255, 8, 8)
+      bounds: 56 496 8 8
+    - image: solid-color(8, 62, 0, 255, 8, 8)
+      bounds: 64 496 8 8
+    - image: solid-color(9, 62, 0, 255, 8, 8)
+      bounds: 72 496 8 8
+    - image: solid-color(10, 62, 0, 255, 8, 8)
+      bounds: 80 496 8 8
+    - image: solid-color(11, 62, 0, 255, 8, 8)
+      bounds: 88 496 8 8
+    - image: solid-color(12, 62, 0, 255, 8, 8)
+      bounds: 96 496 8 8
+    - image: solid-color(13, 62, 0, 255, 8, 8)
+      bounds: 104 496 8 8
+    - image: solid-color(14, 62, 0, 255, 8, 8)
+      bounds: 112 496 8 8
+    - image: solid-color(15, 62, 0, 255, 8, 8)
+      bounds: 120 496 8 8
+    - image: solid-color(16, 62, 0, 255, 8, 8)
+      bounds: 128 496 8 8
+    - image: solid-color(17, 62, 0, 255, 8, 8)
+      bounds: 136 496 8 8
+    - image: solid-color(18, 62, 0, 255, 8, 8)
+      bounds: 144 496 8 8
+    - image: solid-color(19, 62, 0, 255, 8, 8)
+      bounds: 152 496 8 8
+    - image: solid-color(20, 62, 0, 255, 8, 8)
+      bounds: 160 496 8 8
+    - image: solid-color(21, 62, 0, 255, 8, 8)
+      bounds: 168 496 8 8
+    - image: solid-color(22, 62, 0, 255, 8, 8)
+      bounds: 176 496 8 8
+    - image: solid-color(23, 62, 0, 255, 8, 8)
+      bounds: 184 496 8 8
+    - image: solid-color(24, 62, 0, 255, 8, 8)
+      bounds: 192 496 8 8
+    - image: solid-color(25, 62, 0, 255, 8, 8)
+      bounds: 200 496 8 8
+    - image: solid-color(26, 62, 0, 255, 8, 8)
+      bounds: 208 496 8 8
+    - image: solid-color(27, 62, 0, 255, 8, 8)
+      bounds: 216 496 8 8
+    - image: solid-color(28, 62, 0, 255, 8, 8)
+      bounds: 224 496 8 8
+    - image: solid-color(29, 62, 0, 255, 8, 8)
+      bounds: 232 496 8 8
+    - image: solid-color(30, 62, 0, 255, 8, 8)
+      bounds: 240 496 8 8
+    - image: solid-color(31, 62, 0, 255, 8, 8)
+      bounds: 248 496 8 8
+    - image: solid-color(32, 62, 0, 255, 8, 8)
+      bounds: 256 496 8 8
+    - image: solid-color(33, 62, 0, 255, 8, 8)
+      bounds: 264 496 8 8
+    - image: solid-color(34, 62, 0, 255, 8, 8)
+      bounds: 272 496 8 8
+    - image: solid-color(35, 62, 0, 255, 8, 8)
+      bounds: 280 496 8 8
+    - image: solid-color(36, 62, 0, 255, 8, 8)
+      bounds: 288 496 8 8
+    - image: solid-color(37, 62, 0, 255, 8, 8)
+      bounds: 296 496 8 8
+    - image: solid-color(38, 62, 0, 255, 8, 8)
+      bounds: 304 496 8 8
+    - image: solid-color(39, 62, 0, 255, 8, 8)
+      bounds: 312 496 8 8
+    - image: solid-color(40, 62, 0, 255, 8, 8)
+      bounds: 320 496 8 8
+    - image: solid-color(41, 62, 0, 255, 8, 8)
+      bounds: 328 496 8 8
+    - image: solid-color(42, 62, 0, 255, 8, 8)
+      bounds: 336 496 8 8
+    - image: solid-color(43, 62, 0, 255, 8, 8)
+      bounds: 344 496 8 8
+    - image: solid-color(44, 62, 0, 255, 8, 8)
+      bounds: 352 496 8 8
+    - image: solid-color(45, 62, 0, 255, 8, 8)
+      bounds: 360 496 8 8
+    - image: solid-color(46, 62, 0, 255, 8, 8)
+      bounds: 368 496 8 8
+    - image: solid-color(47, 62, 0, 255, 8, 8)
+      bounds: 376 496 8 8
+    - image: solid-color(48, 62, 0, 255, 8, 8)
+      bounds: 384 496 8 8
+    - image: solid-color(49, 62, 0, 255, 8, 8)
+      bounds: 392 496 8 8
+    - image: solid-color(50, 62, 0, 255, 8, 8)
+      bounds: 400 496 8 8
+    - image: solid-color(51, 62, 0, 255, 8, 8)
+      bounds: 408 496 8 8
+    - image: solid-color(52, 62, 0, 255, 8, 8)
+      bounds: 416 496 8 8
+    - image: solid-color(53, 62, 0, 255, 8, 8)
+      bounds: 424 496 8 8
+    - image: solid-color(54, 62, 0, 255, 8, 8)
+      bounds: 432 496 8 8
+    - image: solid-color(55, 62, 0, 255, 8, 8)
+      bounds: 440 496 8 8
+    - image: solid-color(56, 62, 0, 255, 8, 8)
+      bounds: 448 496 8 8
+    - image: solid-color(57, 62, 0, 255, 8, 8)
+      bounds: 456 496 8 8
+    - image: solid-color(58, 62, 0, 255, 8, 8)
+      bounds: 464 496 8 8
+    - image: solid-color(59, 62, 0, 255, 8, 8)
+      bounds: 472 496 8 8
+    - image: solid-color(60, 62, 0, 255, 8, 8)
+      bounds: 480 496 8 8
+    - image: solid-color(61, 62, 0, 255, 8, 8)
+      bounds: 488 496 8 8
+    - image: solid-color(62, 62, 0, 255, 8, 8)
+      bounds: 496 496 8 8
+    - image: solid-color(63, 62, 0, 255, 8, 8)
+      bounds: 504 496 8 8
+    - image: solid-color(64, 62, 0, 255, 8, 8)
+      bounds: 512 496 8 8
+    - image: solid-color(65, 62, 0, 255, 8, 8)
+      bounds: 520 496 8 8
+    - image: solid-color(66, 62, 0, 255, 8, 8)
+      bounds: 528 496 8 8
+    - image: solid-color(67, 62, 0, 255, 8, 8)
+      bounds: 536 496 8 8
+    - image: solid-color(68, 62, 0, 255, 8, 8)
+      bounds: 544 496 8 8
+    - image: solid-color(69, 62, 0, 255, 8, 8)
+      bounds: 552 496 8 8
+    - image: solid-color(70, 62, 0, 255, 8, 8)
+      bounds: 560 496 8 8
+    - image: solid-color(71, 62, 0, 255, 8, 8)
+      bounds: 568 496 8 8
+    - image: solid-color(72, 62, 0, 255, 8, 8)
+      bounds: 576 496 8 8
+    - image: solid-color(73, 62, 0, 255, 8, 8)
+      bounds: 584 496 8 8
+    - image: solid-color(74, 62, 0, 255, 8, 8)
+      bounds: 592 496 8 8
+    - image: solid-color(75, 62, 0, 255, 8, 8)
+      bounds: 600 496 8 8
+    - image: solid-color(76, 62, 0, 255, 8, 8)
+      bounds: 608 496 8 8
+    - image: solid-color(77, 62, 0, 255, 8, 8)
+      bounds: 616 496 8 8
+    - image: solid-color(78, 62, 0, 255, 8, 8)
+      bounds: 624 496 8 8
+    - image: solid-color(79, 62, 0, 255, 8, 8)
+      bounds: 632 496 8 8
+    - image: solid-color(80, 62, 0, 255, 8, 8)
+      bounds: 640 496 8 8
+    - image: solid-color(81, 62, 0, 255, 8, 8)
+      bounds: 648 496 8 8
+    - image: solid-color(82, 62, 0, 255, 8, 8)
+      bounds: 656 496 8 8
+    - image: solid-color(83, 62, 0, 255, 8, 8)
+      bounds: 664 496 8 8
+    - image: solid-color(84, 62, 0, 255, 8, 8)
+      bounds: 672 496 8 8
+    - image: solid-color(85, 62, 0, 255, 8, 8)
+      bounds: 680 496 8 8
+    - image: solid-color(86, 62, 0, 255, 8, 8)
+      bounds: 688 496 8 8
+    - image: solid-color(87, 62, 0, 255, 8, 8)
+      bounds: 696 496 8 8
+    - image: solid-color(88, 62, 0, 255, 8, 8)
+      bounds: 704 496 8 8
+    - image: solid-color(89, 62, 0, 255, 8, 8)
+      bounds: 712 496 8 8
+    - image: solid-color(90, 62, 0, 255, 8, 8)
+      bounds: 720 496 8 8
+    - image: solid-color(91, 62, 0, 255, 8, 8)
+      bounds: 728 496 8 8
+    - image: solid-color(92, 62, 0, 255, 8, 8)
+      bounds: 736 496 8 8
+    - image: solid-color(93, 62, 0, 255, 8, 8)
+      bounds: 744 496 8 8
+    - image: solid-color(94, 62, 0, 255, 8, 8)
+      bounds: 752 496 8 8
+    - image: solid-color(95, 62, 0, 255, 8, 8)
+      bounds: 760 496 8 8
+    - image: solid-color(96, 62, 0, 255, 8, 8)
+      bounds: 768 496 8 8
+    - image: solid-color(97, 62, 0, 255, 8, 8)
+      bounds: 776 496 8 8
+    - image: solid-color(98, 62, 0, 255, 8, 8)
+      bounds: 784 496 8 8
+    - image: solid-color(99, 62, 0, 255, 8, 8)
+      bounds: 792 496 8 8
+    - image: solid-color(100, 62, 0, 255, 8, 8)
+      bounds: 800 496 8 8
+    - image: solid-color(101, 62, 0, 255, 8, 8)
+      bounds: 808 496 8 8
+    - image: solid-color(102, 62, 0, 255, 8, 8)
+      bounds: 816 496 8 8
+    - image: solid-color(103, 62, 0, 255, 8, 8)
+      bounds: 824 496 8 8
+    - image: solid-color(104, 62, 0, 255, 8, 8)
+      bounds: 832 496 8 8
+    - image: solid-color(105, 62, 0, 255, 8, 8)
+      bounds: 840 496 8 8
+    - image: solid-color(106, 62, 0, 255, 8, 8)
+      bounds: 848 496 8 8
+    - image: solid-color(107, 62, 0, 255, 8, 8)
+      bounds: 856 496 8 8
+    - image: solid-color(108, 62, 0, 255, 8, 8)
+      bounds: 864 496 8 8
+    - image: solid-color(109, 62, 0, 255, 8, 8)
+      bounds: 872 496 8 8
+    - image: solid-color(110, 62, 0, 255, 8, 8)
+      bounds: 880 496 8 8
+    - image: solid-color(111, 62, 0, 255, 8, 8)
+      bounds: 888 496 8 8
+    - image: solid-color(112, 62, 0, 255, 8, 8)
+      bounds: 896 496 8 8
+    - image: solid-color(113, 62, 0, 255, 8, 8)
+      bounds: 904 496 8 8
+    - image: solid-color(114, 62, 0, 255, 8, 8)
+      bounds: 912 496 8 8
+    - image: solid-color(115, 62, 0, 255, 8, 8)
+      bounds: 920 496 8 8
+    - image: solid-color(116, 62, 0, 255, 8, 8)
+      bounds: 928 496 8 8
+    - image: solid-color(117, 62, 0, 255, 8, 8)
+      bounds: 936 496 8 8
+    - image: solid-color(118, 62, 0, 255, 8, 8)
+      bounds: 944 496 8 8
+    - image: solid-color(119, 62, 0, 255, 8, 8)
+      bounds: 952 496 8 8
+    - image: solid-color(120, 62, 0, 255, 8, 8)
+      bounds: 960 496 8 8
+    - image: solid-color(121, 62, 0, 255, 8, 8)
+      bounds: 968 496 8 8
+    - image: solid-color(122, 62, 0, 255, 8, 8)
+      bounds: 976 496 8 8
+    - image: solid-color(123, 62, 0, 255, 8, 8)
+      bounds: 984 496 8 8
+    - image: solid-color(124, 62, 0, 255, 8, 8)
+      bounds: 992 496 8 8
+    - image: solid-color(125, 62, 0, 255, 8, 8)
+      bounds: 1000 496 8 8
+    - image: solid-color(126, 62, 0, 255, 8, 8)
+      bounds: 1008 496 8 8
+    - image: solid-color(127, 62, 0, 255, 8, 8)
+      bounds: 1016 496 8 8
+    - image: solid-color(0, 63, 0, 255, 8, 8)
+      bounds: 0 504 8 8
+    - image: solid-color(1, 63, 0, 255, 8, 8)
+      bounds: 8 504 8 8
+    - image: solid-color(2, 63, 0, 255, 8, 8)
+      bounds: 16 504 8 8
+    - image: solid-color(3, 63, 0, 255, 8, 8)
+      bounds: 24 504 8 8
+    - image: solid-color(4, 63, 0, 255, 8, 8)
+      bounds: 32 504 8 8
+    - image: solid-color(5, 63, 0, 255, 8, 8)
+      bounds: 40 504 8 8
+    - image: solid-color(6, 63, 0, 255, 8, 8)
+      bounds: 48 504 8 8
+    - image: solid-color(7, 63, 0, 255, 8, 8)
+      bounds: 56 504 8 8
+    - image: solid-color(8, 63, 0, 255, 8, 8)
+      bounds: 64 504 8 8
+    - image: solid-color(9, 63, 0, 255, 8, 8)
+      bounds: 72 504 8 8
+    - image: solid-color(10, 63, 0, 255, 8, 8)
+      bounds: 80 504 8 8
+    - image: solid-color(11, 63, 0, 255, 8, 8)
+      bounds: 88 504 8 8
+    - image: solid-color(12, 63, 0, 255, 8, 8)
+      bounds: 96 504 8 8
+    - image: solid-color(13, 63, 0, 255, 8, 8)
+      bounds: 104 504 8 8
+    - image: solid-color(14, 63, 0, 255, 8, 8)
+      bounds: 112 504 8 8
+    - image: solid-color(15, 63, 0, 255, 8, 8)
+      bounds: 120 504 8 8
+    - image: solid-color(16, 63, 0, 255, 8, 8)
+      bounds: 128 504 8 8
+    - image: solid-color(17, 63, 0, 255, 8, 8)
+      bounds: 136 504 8 8
+    - image: solid-color(18, 63, 0, 255, 8, 8)
+      bounds: 144 504 8 8
+    - image: solid-color(19, 63, 0, 255, 8, 8)
+      bounds: 152 504 8 8
+    - image: solid-color(20, 63, 0, 255, 8, 8)
+      bounds: 160 504 8 8
+    - image: solid-color(21, 63, 0, 255, 8, 8)
+      bounds: 168 504 8 8
+    - image: solid-color(22, 63, 0, 255, 8, 8)
+      bounds: 176 504 8 8
+    - image: solid-color(23, 63, 0, 255, 8, 8)
+      bounds: 184 504 8 8
+    - image: solid-color(24, 63, 0, 255, 8, 8)
+      bounds: 192 504 8 8
+    - image: solid-color(25, 63, 0, 255, 8, 8)
+      bounds: 200 504 8 8
+    - image: solid-color(26, 63, 0, 255, 8, 8)
+      bounds: 208 504 8 8
+    - image: solid-color(27, 63, 0, 255, 8, 8)
+      bounds: 216 504 8 8
+    - image: solid-color(28, 63, 0, 255, 8, 8)
+      bounds: 224 504 8 8
+    - image: solid-color(29, 63, 0, 255, 8, 8)
+      bounds: 232 504 8 8
+    - image: solid-color(30, 63, 0, 255, 8, 8)
+      bounds: 240 504 8 8
+    - image: solid-color(31, 63, 0, 255, 8, 8)
+      bounds: 248 504 8 8
+    - image: solid-color(32, 63, 0, 255, 8, 8)
+      bounds: 256 504 8 8
+    - image: solid-color(33, 63, 0, 255, 8, 8)
+      bounds: 264 504 8 8
+    - image: solid-color(34, 63, 0, 255, 8, 8)
+      bounds: 272 504 8 8
+    - image: solid-color(35, 63, 0, 255, 8, 8)
+      bounds: 280 504 8 8
+    - image: solid-color(36, 63, 0, 255, 8, 8)
+      bounds: 288 504 8 8
+    - image: solid-color(37, 63, 0, 255, 8, 8)
+      bounds: 296 504 8 8
+    - image: solid-color(38, 63, 0, 255, 8, 8)
+      bounds: 304 504 8 8
+    - image: solid-color(39, 63, 0, 255, 8, 8)
+      bounds: 312 504 8 8
+    - image: solid-color(40, 63, 0, 255, 8, 8)
+      bounds: 320 504 8 8
+    - image: solid-color(41, 63, 0, 255, 8, 8)
+      bounds: 328 504 8 8
+    - image: solid-color(42, 63, 0, 255, 8, 8)
+      bounds: 336 504 8 8
+    - image: solid-color(43, 63, 0, 255, 8, 8)
+      bounds: 344 504 8 8
+    - image: solid-color(44, 63, 0, 255, 8, 8)
+      bounds: 352 504 8 8
+    - image: solid-color(45, 63, 0, 255, 8, 8)
+      bounds: 360 504 8 8
+    - image: solid-color(46, 63, 0, 255, 8, 8)
+      bounds: 368 504 8 8
+    - image: solid-color(47, 63, 0, 255, 8, 8)
+      bounds: 376 504 8 8
+    - image: solid-color(48, 63, 0, 255, 8, 8)
+      bounds: 384 504 8 8
+    - image: solid-color(49, 63, 0, 255, 8, 8)
+      bounds: 392 504 8 8
+    - image: solid-color(50, 63, 0, 255, 8, 8)
+      bounds: 400 504 8 8
+    - image: solid-color(51, 63, 0, 255, 8, 8)
+      bounds: 408 504 8 8
+    - image: solid-color(52, 63, 0, 255, 8, 8)
+      bounds: 416 504 8 8
+    - image: solid-color(53, 63, 0, 255, 8, 8)
+      bounds: 424 504 8 8
+    - image: solid-color(54, 63, 0, 255, 8, 8)
+      bounds: 432 504 8 8
+    - image: solid-color(55, 63, 0, 255, 8, 8)
+      bounds: 440 504 8 8
+    - image: solid-color(56, 63, 0, 255, 8, 8)
+      bounds: 448 504 8 8
+    - image: solid-color(57, 63, 0, 255, 8, 8)
+      bounds: 456 504 8 8
+    - image: solid-color(58, 63, 0, 255, 8, 8)
+      bounds: 464 504 8 8
+    - image: solid-color(59, 63, 0, 255, 8, 8)
+      bounds: 472 504 8 8
+    - image: solid-color(60, 63, 0, 255, 8, 8)
+      bounds: 480 504 8 8
+    - image: solid-color(61, 63, 0, 255, 8, 8)
+      bounds: 488 504 8 8
+    - image: solid-color(62, 63, 0, 255, 8, 8)
+      bounds: 496 504 8 8
+    - image: solid-color(63, 63, 0, 255, 8, 8)
+      bounds: 504 504 8 8
+    - image: solid-color(64, 63, 0, 255, 8, 8)
+      bounds: 512 504 8 8
+    - image: solid-color(65, 63, 0, 255, 8, 8)
+      bounds: 520 504 8 8
+    - image: solid-color(66, 63, 0, 255, 8, 8)
+      bounds: 528 504 8 8
+    - image: solid-color(67, 63, 0, 255, 8, 8)
+      bounds: 536 504 8 8
+    - image: solid-color(68, 63, 0, 255, 8, 8)
+      bounds: 544 504 8 8
+    - image: solid-color(69, 63, 0, 255, 8, 8)
+      bounds: 552 504 8 8
+    - image: solid-color(70, 63, 0, 255, 8, 8)
+      bounds: 560 504 8 8
+    - image: solid-color(71, 63, 0, 255, 8, 8)
+      bounds: 568 504 8 8
+    - image: solid-color(72, 63, 0, 255, 8, 8)
+      bounds: 576 504 8 8
+    - image: solid-color(73, 63, 0, 255, 8, 8)
+      bounds: 584 504 8 8
+    - image: solid-color(74, 63, 0, 255, 8, 8)
+      bounds: 592 504 8 8
+    - image: solid-color(75, 63, 0, 255, 8, 8)
+      bounds: 600 504 8 8
+    - image: solid-color(76, 63, 0, 255, 8, 8)
+      bounds: 608 504 8 8
+    - image: solid-color(77, 63, 0, 255, 8, 8)
+      bounds: 616 504 8 8
+    - image: solid-color(78, 63, 0, 255, 8, 8)
+      bounds: 624 504 8 8
+    - image: solid-color(79, 63, 0, 255, 8, 8)
+      bounds: 632 504 8 8
+    - image: solid-color(80, 63, 0, 255, 8, 8)
+      bounds: 640 504 8 8
+    - image: solid-color(81, 63, 0, 255, 8, 8)
+      bounds: 648 504 8 8
+    - image: solid-color(82, 63, 0, 255, 8, 8)
+      bounds: 656 504 8 8
+    - image: solid-color(83, 63, 0, 255, 8, 8)
+      bounds: 664 504 8 8
+    - image: solid-color(84, 63, 0, 255, 8, 8)
+      bounds: 672 504 8 8
+    - image: solid-color(85, 63, 0, 255, 8, 8)
+      bounds: 680 504 8 8
+    - image: solid-color(86, 63, 0, 255, 8, 8)
+      bounds: 688 504 8 8
+    - image: solid-color(87, 63, 0, 255, 8, 8)
+      bounds: 696 504 8 8
+    - image: solid-color(88, 63, 0, 255, 8, 8)
+      bounds: 704 504 8 8
+    - image: solid-color(89, 63, 0, 255, 8, 8)
+      bounds: 712 504 8 8
+    - image: solid-color(90, 63, 0, 255, 8, 8)
+      bounds: 720 504 8 8
+    - image: solid-color(91, 63, 0, 255, 8, 8)
+      bounds: 728 504 8 8
+    - image: solid-color(92, 63, 0, 255, 8, 8)
+      bounds: 736 504 8 8
+    - image: solid-color(93, 63, 0, 255, 8, 8)
+      bounds: 744 504 8 8
+    - image: solid-color(94, 63, 0, 255, 8, 8)
+      bounds: 752 504 8 8
+    - image: solid-color(95, 63, 0, 255, 8, 8)
+      bounds: 760 504 8 8
+    - image: solid-color(96, 63, 0, 255, 8, 8)
+      bounds: 768 504 8 8
+    - image: solid-color(97, 63, 0, 255, 8, 8)
+      bounds: 776 504 8 8
+    - image: solid-color(98, 63, 0, 255, 8, 8)
+      bounds: 784 504 8 8
+    - image: solid-color(99, 63, 0, 255, 8, 8)
+      bounds: 792 504 8 8
+    - image: solid-color(100, 63, 0, 255, 8, 8)
+      bounds: 800 504 8 8
+    - image: solid-color(101, 63, 0, 255, 8, 8)
+      bounds: 808 504 8 8
+    - image: solid-color(102, 63, 0, 255, 8, 8)
+      bounds: 816 504 8 8
+    - image: solid-color(103, 63, 0, 255, 8, 8)
+      bounds: 824 504 8 8
+    - image: solid-color(104, 63, 0, 255, 8, 8)
+      bounds: 832 504 8 8
+    - image: solid-color(105, 63, 0, 255, 8, 8)
+      bounds: 840 504 8 8
+    - image: solid-color(106, 63, 0, 255, 8, 8)
+      bounds: 848 504 8 8
+    - image: solid-color(107, 63, 0, 255, 8, 8)
+      bounds: 856 504 8 8
+    - image: solid-color(108, 63, 0, 255, 8, 8)
+      bounds: 864 504 8 8
+    - image: solid-color(109, 63, 0, 255, 8, 8)
+      bounds: 872 504 8 8
+    - image: solid-color(110, 63, 0, 255, 8, 8)
+      bounds: 880 504 8 8
+    - image: solid-color(111, 63, 0, 255, 8, 8)
+      bounds: 888 504 8 8
+    - image: solid-color(112, 63, 0, 255, 8, 8)
+      bounds: 896 504 8 8
+    - image: solid-color(113, 63, 0, 255, 8, 8)
+      bounds: 904 504 8 8
+    - image: solid-color(114, 63, 0, 255, 8, 8)
+      bounds: 912 504 8 8
+    - image: solid-color(115, 63, 0, 255, 8, 8)
+      bounds: 920 504 8 8
+    - image: solid-color(116, 63, 0, 255, 8, 8)
+      bounds: 928 504 8 8
+    - image: solid-color(117, 63, 0, 255, 8, 8)
+      bounds: 936 504 8 8
+    - image: solid-color(118, 63, 0, 255, 8, 8)
+      bounds: 944 504 8 8
+    - image: solid-color(119, 63, 0, 255, 8, 8)
+      bounds: 952 504 8 8
+    - image: solid-color(120, 63, 0, 255, 8, 8)
+      bounds: 960 504 8 8
+    - image: solid-color(121, 63, 0, 255, 8, 8)
+      bounds: 968 504 8 8
+    - image: solid-color(122, 63, 0, 255, 8, 8)
+      bounds: 976 504 8 8
+    - image: solid-color(123, 63, 0, 255, 8, 8)
+      bounds: 984 504 8 8
+    - image: solid-color(124, 63, 0, 255, 8, 8)
+      bounds: 992 504 8 8
+    - image: solid-color(125, 63, 0, 255, 8, 8)
+      bounds: 1000 504 8 8
+    - image: solid-color(126, 63, 0, 255, 8, 8)
+      bounds: 1008 504 8 8
+    - image: solid-color(127, 63, 0, 255, 8, 8)
+      bounds: 1016 504 8 8


### PR DESCRIPTION
This is a good test case for resource cache / hashing performance.