### PR TITLE
Remove the requested_images and requested_glyphs hash sets.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -18,7 +18,6 @@ use mask_cache::ClipRegion;
 use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{ResourceCache, TiledImageMap};
 use scene::{Scene, SceneProperties};
-use std::cmp;
 use tiling::{CompositeOps, DisplayListMap, PrimitiveFlags};
 use util::{ComplexClipRegionHelpers, subtract_rect};
 
@@ -1166,10 +1165,6 @@ impl Frame {
                                      device_pixel_ratio,
                                      texture_cache_profile,
                                      gpu_cache_profile);
-        // Expire any resources that haven't been used for `cache_expiry_frames`.
-        let num_frames_back = self.frame_builder_config.cache_expiry_frames;
-        let expiry_frame = FrameId(cmp::max(num_frames_back, self.id.0) - num_frames_back);
-        resource_cache.expire_old_resources(expiry_frame);
         frame
     }
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -213,7 +213,10 @@ impl RenderBackend {
         enable_render_on_scroll: bool,
     ) -> RenderBackend {
 
-        let resource_cache = ResourceCache::new(texture_cache, workers, blob_image_renderer);
+        let resource_cache = ResourceCache::new(texture_cache,
+                                                workers,
+                                                blob_image_renderer,
+                                                frame_config.cache_expiry_frames);
 
         register_thread_with_profiler("Backend".to_string());
 


### PR DESCRIPTION
These were used to work out which texture cache items to add
to the GPU cache for this frame.

However, we already run through the cache items to expire old
resources, so we can just check if the resource was accessed
during this frame while doing that, and push those items to
the GPU cache.

This results in some very good performance wins:

many-images benchmark:
 Before: 6.66 ms
 After:  5.32 ms

text-rendering benchmark:
 Before: 0.41 ms
 After:  0.36 ms