### PR TITLE
Remove shaders hashmap from device. Also add shader deinit path.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -173,4 +173,6 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
         renderer.render(DeviceUintSize::new(width, height));
         window.swap_buffers().ok();
     }
+
+    renderer.deinit();
 }

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -554,4 +554,6 @@ fn main() {
 
         save_flipped("screenshot.png", &pixels, size);
     }
+
+    wrench.renderer.deinit();
 }


### PR DESCRIPTION
Lots of the surrounding code (particularly in renderer.rs) are
still far from ideal. However, this does remove the hash lookups
when switching shaders, and also ensures all shaders are correctly
deleted when shutting down a renderer.

We can work on incremental improvements to the code in renderer.rs.