### PR TITLE
Update the max texture size assertion to help understanding where the error comes from.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -685,9 +685,18 @@ impl TextureCache {
             ImageFormat::Invalid | ImageFormat::RGBAF32 => unreachable!(),
         };
 
+
         // TODO(gw): Handle this sensibly (support failing to render items that can't fit?)
-        assert!(requested_size.width <= self.max_texture_size);
-        assert!(requested_size.height <= self.max_texture_size);
+        assert!(
+            requested_size.width <= self.max_texture_size,
+            "Width {:?} > max texture size (format: {:?}).",
+            requested_size.width, format
+        );
+        assert!(
+            requested_size.height <= self.max_texture_size,
+            "Height {:?} > max texture size (format: {:?}).",
+            requested_size.height, format
+        );
 
         let mut page_id = None; //using ID here to please the borrow checker
         for (i, page) in page_list.iter_mut().enumerate() {


### PR DESCRIPTION
We are hitting this assertion in places where we expect tiling to have avoided this situation, *except* if the image is used as a mask or a yuv plane.

I'd like to verify that we are indeed only running into this with a8 images which should be mostly used for masks and yuv surfaces.