### PR TITLE
React to memory pressure.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -164,6 +164,10 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
                     flags.toggle(TEXTURE_CACHE_DBG);
                     renderer.set_debug_flags(flags);
                 },
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
+                                             _, Some(glutin::VirtualKeyCode::M)) => {
+                    api.notify_memory_pressure();
+                },
 
                 _ => event_handler(&event, document_id, &api),
             }

--- a/webrender/src/glyph_cache.rs
+++ b/webrender/src/glyph_cache.rs
@@ -89,6 +89,15 @@ impl GlyphCache {
         }
     }
 
+    pub fn clear(&mut self, texture_cache: &mut TextureCache) {
+        for (_, glyph_key_cache) in &mut self.glyph_key_caches {
+            glyph_key_cache.clear(texture_cache)
+        }
+        // We use this in on_memory_pressure where retaining memory allocations
+        // isn't desirable, so we completely remove the hash map instead of clearing it.
+        self.glyph_key_caches = FastHashMap::default();
+    }
+
     pub fn clear_fonts<F>(&mut self, texture_cache: &mut TextureCache, key_fun: F)
     where for<'r> F: Fn(&'r &FontInstanceKey) -> bool
     {

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -268,6 +268,7 @@ impl RendererFrame {
 pub enum ResultMsg {
     RefreshShader(PathBuf),
     NewFrame(DocumentId, RendererFrame, TextureUpdateList, BackendProfileCounters),
+    UpdateResources { updates: TextureUpdateList, cancel_rendering: bool },
 }
 
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use frame::Frame;
+use frame::{Frame, FrameId};
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
 use internal_types::{FastHashMap, SourceTexture, ResultMsg, RendererFrame};
@@ -12,6 +12,7 @@ use resource_cache::ResourceCache;
 use scene::Scene;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
+use std::u32;
 use texture_cache::TextureCache;
 use time::precise_time_ns;
 use thread_profiler::register_thread_with_profiler;
@@ -583,6 +584,17 @@ impl RenderBackend {
                     for document in document_ids {
                         self.documents.remove(&document);
                     }
+                }
+                ApiMsg::MemoryPressure => {
+                    self.resource_cache.on_memory_pressure();
+
+                    let pending_update = self.resource_cache.pending_updates();
+                    let msg = ResultMsg::UpdateResources { updates: pending_update, cancel_rendering: true };
+                    self.result_tx.send(msg).unwrap();
+                    // We use new_frame_ready to wake up the renderer and get the
+                    // resource updates processed, but the UpdateResources message
+                    // will cancel rendering the frame.
+                    self.notifier.lock().unwrap().as_mut().unwrap().new_frame_ready();
                 }
                 ApiMsg::ShutDown => {
                     let notifier = self.notifier.lock();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1332,6 +1332,17 @@ impl Renderer {
 
                     self.current_frame = Some(frame);
                 }
+                ResultMsg::UpdateResources { updates, cancel_rendering } => {
+                    self.pending_texture_updates.push(updates);
+                    self.update_texture_cache();
+                    // If we receive a NewFrame message followed by this one within
+                    // the same update we need ot cancel the frame because we might
+                    // have deleted the resources in use in the frame dut to a memory
+                    // pressure event.
+                    if cancel_rendering {
+                        self.current_frame = None;
+                    }
+                }
                 ResultMsg::RefreshShader(path) => {
                     self.pending_shader_updates.push(path);
                 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -799,6 +799,19 @@ impl ResourceCache {
         self.state = State::Idle;
     }
 
+    pub fn on_memory_pressure(&mut self) {
+        // This is drastic. It will basically flush everything out of the cache,
+        // and the next frame will have to rebuild all of its resources.
+        // We may want to look into something less extreme, but on the other hand this
+        // should only be used in situations where are running low enough on memory
+        // that we risk crashing if we don't do something about it.
+        // The advantage of clearing the cache completely is that it gets rid of any
+        // remaining fragmentation that could have persisted if we kept around the most
+        // recently used resources.
+        self.cached_images.clear(&mut self.texture_cache);
+        self.cached_glyphs.clear(&mut self.texture_cache);
+    }
+
     pub fn clear_namespace(&mut self, namespace: IdNamespace) {
         //TODO: use `retain` when we are on Rust-1.18
         let image_keys: Vec<_> = self.resources.image_templates.images.keys()

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -170,6 +170,8 @@ pub enum ApiMsg {
     ExternalEvent(ExternalEvent),
     /// Removes all resources associated with a namespace.
     ClearNamespace(IdNamespace),
+    /// Flush from the caches anything that isn't necessary, to free some memory.
+    MemoryPressure,
     ShutDown,
 }
 
@@ -189,6 +191,7 @@ impl fmt::Debug for ApiMsg {
             ApiMsg::VRCompositorCommand(..) => "ApiMsg::VRCompositorCommand",
             ApiMsg::ExternalEvent(..) => "ApiMsg::ExternalEvent",
             ApiMsg::ClearNamespace(..) => "ApiMsg::ClearNamespace",
+            ApiMsg::MemoryPressure => "ApiMsg::MemoryPressure",
             ApiMsg::ShutDown => "ApiMsg::ShutDown",
         })
     }
@@ -397,6 +400,10 @@ impl RenderApi {
     pub fn send_external_event(&self, evt: ExternalEvent) {
         let msg = ApiMsg::ExternalEvent(evt);
         self.api_sender.send(msg).unwrap();
+    }
+
+    pub fn notify_memory_pressure(&self) {
+        self.api_sender.send(ApiMsg::MemoryPressure).unwrap();
     }
 
     pub fn shut_down(&self) {

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -527,6 +527,9 @@ fn main() {
                         flags.toggle(TEXTURE_CACHE_DBG);
                         wrench.renderer.set_debug_flags(flags);
                     },
+                    VirtualKeyCode::M => {
+                        wrench.api.notify_memory_pressure();
+                    },
                     VirtualKeyCode::L => {
                         do_loop = !do_loop;
                     },

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -449,7 +449,10 @@ impl Wrench {
             "Esc, Q - Quit",
             "H - Toggle help",
             "R - Toggle recreating display items each frame",
-            "P - Toggle profiler"
+            "P - Toggle profiler",
+            "O - Toggle showing intermediate targets",
+            "I - Toggle showing texture caches",
+            "M - Trigger memory pressure event",
         ];
 
         let color_and_offset = [ (*BLACK_COLOR, 2.0), (*WHITE_COLOR, 0.0) ];


### PR DESCRIPTION
Memory pressure events are sent when the amount of available memory is so low that we risk crashing very soon if we don't do anything about it. When this happens we don't really care about frame budgets and smoothness anymore, we can only do a best effort at freeing memory and hope to not crash.

This PR adds memory pressure notifications to the API and reacts to it by completely clearing the texture cache and clearing some of the allocations that we try to recycle for performance purposes.