### PR TITLE
Expose the namespace id from RenderApi

### DIFF
--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -239,6 +239,10 @@ pub struct RenderApi {
 }
 
 impl RenderApi {
+    pub fn get_namespace_id(&self) -> IdNamespace {
+        self.namespace_id
+    }
+
     pub fn clone_sender(&self) -> RenderApiSender {
         RenderApiSender::new(self.api_sender.clone(), self.payload_sender.clone())
     }


### PR DESCRIPTION
As a result of the multi-document changes in #1509, it is necessary for
Gecko to stop just inventing its own namespace ids and instead use ones
that match what WR is using internally. Therefore it is necessary for
the RenderApi to expose the namespace id.