### PR TITLE
Remove images from the texture cache when deleting the template.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -380,6 +380,8 @@ impl ResourceCache {
     pub fn delete_image_template(&mut self, image_key: ImageKey) {
         let value = self.resources.image_templates.remove(image_key);
 
+        self.cached_images.clear_keys(&mut self.texture_cache, |request| request.key == image_key);
+
         match value {
             Some(image) => {
                 if image.data.is_blob() {


### PR DESCRIPTION
This is perhaps a bit too simple/naive in that it will go through all cached images to find out the ones to remove from the texture cache each time an image template is deleted, but it is certainly better than keeping the allocation around for the next 600 frames.