### PR TITLE
Add debug flag to see the texture cache.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::path::PathBuf;
 use webrender;
 use webrender::api::*;
+use webrender::renderer::{PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
 
 struct Notifier {
     window_proxy: glutin::WindowProxy,
@@ -143,10 +144,22 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
 
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::P)) => {
-                    let enable_profiler = !renderer.get_profiler_enabled();
-                    renderer.set_profiler_enabled(enable_profiler);
-                    api.generate_frame(document_id, None);
-                }
+                    let mut flags = renderer.get_debug_flags();
+                    flags.toggle(PROFILER_DBG);
+                    renderer.set_debug_flags(flags);
+                },
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
+                                             _, Some(glutin::VirtualKeyCode::O)) => {
+                    let mut flags = renderer.get_debug_flags();
+                    flags.toggle(RENDER_TARGET_DBG);
+                    renderer.set_debug_flags(flags);
+                },
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
+                                             _, Some(glutin::VirtualKeyCode::I)) => {
+                    let mut flags = renderer.get_debug_flags();
+                    flags.toggle(TEXTURE_CACHE_DBG);
+                    renderer.set_debug_flags(flags);
+                },
 
                 _ => event_handler(&event, document_id, &api),
             }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -82,6 +82,15 @@ const GPU_TAG_PRIM_BORDER_EDGE: GpuProfileTag = GpuProfileTag { label: "BorderEd
 const GPU_TAG_PRIM_CACHE_IMAGE: GpuProfileTag = GpuProfileTag { label: "CacheImage", color: debug_colors::SILVER };
 const GPU_TAG_BLUR: GpuProfileTag = GpuProfileTag { label: "Blur", color: debug_colors::VIOLET };
 
+bitflags! {
+    #[derive(Default)]
+    pub struct DebugFlags: u32 {
+        const PROFILER_DBG      = 1 << 0;
+        const RENDER_TARGET_DBG = 1 << 1;
+        const TEXTURE_CACHE_DBG = 1 << 2;
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum GraphicsApi {
     OpenGL,
@@ -656,14 +665,12 @@ pub struct Renderer {
 
     max_texture_size: u32,
 
-    enable_profiler: bool,
     max_recorded_profiles: usize,
     clear_framebuffer: bool,
     clear_color: ColorF,
     enable_clear_scissor: bool,
     debug: DebugRenderer,
-    render_target_debug: bool,
-    texture_cache_debug: bool,
+    debug_flags: DebugFlags,
     enable_batcher: bool,
     backend_profile_counters: BackendProfileCounters,
     profile_counters: RendererProfileCounters,
@@ -750,7 +757,6 @@ impl Renderer {
     ///    device_pixel_ratio: 1.0,
     ///    resource_override_path: None,
     ///    enable_aa: false,
-    ///    enable_profiler: false,
     /// };
     /// let (renderer, sender) = Renderer::new(opts);
     /// ```
@@ -1139,8 +1145,7 @@ impl Renderer {
         };
 
         let device_pixel_ratio = options.device_pixel_ratio;
-        let render_target_debug = options.render_target_debug;
-        let texture_cache_debug = options.texture_cache_debug;
+        let debug_flags = options.debug_flags;
         let payload_tx_for_backend = payload_tx.clone();
         let recorder = options.recorder;
         let worker_config = ThreadPoolConfig::new()
@@ -1209,14 +1214,12 @@ impl Renderer {
             ps_line,
             notifier,
             debug: debug_renderer,
-            render_target_debug,
-            texture_cache_debug,
+            debug_flags,
             enable_batcher: options.enable_batcher,
             backend_profile_counters: BackendProfileCounters::new(),
             profile_counters: RendererProfileCounters::new(),
             profiler: Profiler::new(),
             max_texture_size: max_texture_size,
-            enable_profiler: options.enable_profiler,
             max_recorded_profiles: options.max_recorded_profiles,
             clear_framebuffer: options.clear_framebuffer,
             clear_color: options.clear_color,
@@ -1437,7 +1440,7 @@ impl Renderer {
                     self.cpu_profiles.push_back(cpu_profile);
                 }
 
-                if self.enable_profiler {
+                if self.debug_flags.contains(PROFILER_DBG) {
                     self.profiler.draw_profile(&mut self.device,
                                                &frame.profile_counters,
                                                &self.backend_profile_counters,
@@ -2295,12 +2298,12 @@ impl Renderer {
         &mut self.debug
     }
 
-    pub fn get_profiler_enabled(&mut self) -> bool {
-        self.enable_profiler
+    pub fn get_debug_flags(&self) -> DebugFlags {
+        self.debug_flags
     }
 
-    pub fn set_profiler_enabled(&mut self, enabled: bool) {
-        self.enable_profiler = enabled;
+    pub fn set_debug_flags(&mut self, flags: DebugFlags) {
+        self.debug_flags = flags;
     }
 
     pub fn save_cpu_profile(&self, filename: &str) {
@@ -2309,7 +2312,7 @@ impl Renderer {
 
     fn draw_render_target_debug(&mut self,
                                 framebuffer_size: &DeviceUintSize) {
-        if self.render_target_debug {
+        if self.debug_flags.contains(RENDER_TARGET_DBG) {
             // TODO(gw): Make the layout of the render targets a bit more sophisticated.
             // Right now, it just draws them in one row at the bottom of the screen,
             // with a fixed size.
@@ -2343,7 +2346,7 @@ impl Renderer {
     }
 
     fn draw_texture_cache_debug(&mut self, framebuffer_size: &DeviceUintSize) {
-        if self.texture_cache_debug {
+        if self.debug_flags.contains(TEXTURE_CACHE_DBG) {
             let x_offset = 16;
             let y_offset = 16;
             let spacing = 16;
@@ -2351,7 +2354,7 @@ impl Renderer {
 
             for (i, texture_id) in self.cache_texture_id_map.iter().enumerate() {
                 let x = x_offset + (spacing + size) * i as i32;
-                let y = y_offset + if self.render_target_debug { 528 } else { 0 };
+                let y = y_offset + if self.debug_flags.contains(RENDER_TARGET_DBG) { 528 } else { 0 };
 
                 // If we have more targets than fit on one row in screen, just early exit.
                 if x > framebuffer_size.width as i32 {
@@ -2441,7 +2444,6 @@ pub struct RendererOptions {
     pub resource_override_path: Option<PathBuf>,
     pub enable_aa: bool,
     pub enable_dithering: bool,
-    pub enable_profiler: bool,
     pub max_recorded_profiles: usize,
     pub debug: bool,
     pub enable_scrollbars: bool,
@@ -2452,14 +2454,13 @@ pub struct RendererOptions {
     pub clear_color: ColorF,
     pub enable_clear_scissor: bool,
     pub enable_batcher: bool,
-    pub render_target_debug: bool,
-    pub texture_cache_debug: bool,
     pub max_texture_size: Option<u32>,
     pub cache_expiry_frames: u32,
     pub workers: Option<Arc<ThreadPool>>,
     pub blob_image_renderer: Option<Box<BlobImageRenderer>>,
     pub recorder: Option<Box<ApiRecordingReceiver>>,
     pub enable_render_on_scroll: bool,
+    pub debug_flags: DebugFlags,
 }
 
 impl Default for RendererOptions {
@@ -2469,7 +2470,7 @@ impl Default for RendererOptions {
             resource_override_path: None,
             enable_aa: true,
             enable_dithering: true,
-            enable_profiler: false,
+            debug_flags: DebugFlags::empty(),
             max_recorded_profiles: 0,
             debug: false,
             enable_scrollbars: false,
@@ -2480,8 +2481,6 @@ impl Default for RendererOptions {
             clear_color: ColorF::new(1.0, 1.0, 1.0, 1.0),
             enable_clear_scissor: true,
             enable_batcher: true,
-            render_target_debug: false,
-            texture_cache_debug: false,
             max_texture_size: None,
             cache_expiry_frames: 600, // roughly, 10 seconds
             workers: None,

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -59,6 +59,7 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 use std::rc::Rc;
 use webrender::api::*;
+use webrender::renderer::{PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
@@ -366,7 +367,6 @@ fn main() {
         };
 
     let mut show_help = false;
-    let mut profiler = false;
     let mut do_loop = false;
 
     let queue_frames = thing.queue_frames();
@@ -513,8 +513,19 @@ fn main() {
                         break 'outer;
                     },
                     VirtualKeyCode::P => {
-                        profiler = !profiler;
-                        wrench.renderer.set_profiler_enabled(profiler);
+                        let mut flags = wrench.renderer.get_debug_flags();
+                        flags.toggle(PROFILER_DBG);
+                        wrench.renderer.set_debug_flags(flags);
+                    },
+                    VirtualKeyCode::O => {
+                        let mut flags = wrench.renderer.get_debug_flags();
+                        flags.toggle(RENDER_TARGET_DBG);
+                        wrench.renderer.set_debug_flags(flags);
+                    },
+                    VirtualKeyCode::I => {
+                        let mut flags = wrench.renderer.get_debug_flags();
+                        flags.toggle(TEXTURE_CACHE_DBG);
+                        wrench.renderer.set_debug_flags(flags);
                     },
                     VirtualKeyCode::L => {
                         do_loop = !do_loop;


### PR DESCRIPTION
This PR adds a way to see what's in the texture cache for debugging purposes. In the process of doing this I merged the three debugging options (profiler, render target and texture cache) into a single bitflags and exposed it (previously only the profiler could be toggled after initialization).
In wrench and the sample programs, use "i" to toggle showing the texture cache, "o" to toggle the intermediate render targets, and "p" for the profiler.
Textures are justified to the right of the screen (less likely to overlap with the profiler output) and their sizes are adjusted to fit the width of the screen if they overflow.