### PR TITLE
Refactor freelist and fix texture updates.

### DIFF
--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate gleam;
+extern crate glutin;
+extern crate webrender;
+
+#[path="common/boilerplate.rs"]
+mod boilerplate;
+
+use boilerplate::HandyDandyRectBuilder;
+use webrender::api::*;
+
+static IMAGE_KEY: ImageKey = ImageKey(IdNamespace(0), 0);
+
+fn body(_api: &RenderApi,
+        _document_id: &DocumentId,
+        builder: &mut DisplayListBuilder,
+        resources: &mut ResourceUpdates,
+        _pipeline_id: &PipelineId,
+        _layout_size: &LayoutSize) {
+
+    let mut image_data = Vec::new();
+    for y in 0..32 {
+        for x in 0..32 {
+            let lum = 255 * (((x & 8) == 0) ^ ((y & 8) == 0)) as u8;
+            image_data.extend_from_slice(&[lum, lum, lum, 0xff]);
+        }
+    }
+
+    resources.add_image(
+        IMAGE_KEY,
+        ImageDescriptor::new(32, 32, ImageFormat::BGRA8, true),
+        ImageData::new(image_data),
+        None,
+    );
+
+    let bounds = (0,0).to(512, 512);
+    builder.push_stacking_context(ScrollPolicy::Scrollable,
+                                  bounds,
+                                  None,
+                                  TransformStyle::Flat,
+                                  None,
+                                  MixBlendMode::Normal,
+                                  Vec::new());
+
+    let image_size = LayoutSize::new(100.0, 100.0);
+
+    builder.push_image(
+        LayoutRect::new(LayoutPoint::new(100.0, 100.0), image_size),
+        Some(LocalClip::from(bounds)),
+        image_size,
+        LayoutSize::zero(),
+        ImageRendering::Auto,
+        IMAGE_KEY
+    );
+
+    builder.push_image(
+        LayoutRect::new(LayoutPoint::new(250.0, 100.0), image_size),
+        Some(LocalClip::from(bounds)),
+        image_size,
+        LayoutSize::zero(),
+        ImageRendering::Pixelated,
+        IMAGE_KEY
+    );
+
+    builder.pop_stacking_context();
+}
+
+fn event_handler(event: &glutin::Event,
+                 document_id: DocumentId,
+                 api: &RenderApi) {
+    match *event {
+        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+            match key {
+                 glutin::VirtualKeyCode::Space => {
+                    let mut image_data = Vec::new();
+                    for y in 0..64 {
+                        for x in 0..64 {
+                            let r = 255 * ((y & 32) == 0) as u8;
+                            let g = 255 * ((x & 32) == 0) as u8;
+                            image_data.extend_from_slice(&[0, g, r, 0xff]);
+                        }
+                    }
+
+                    let mut updates = ResourceUpdates::new();
+                    updates.update_image(IMAGE_KEY,
+                                         ImageDescriptor::new(64, 64, ImageFormat::BGRA8, true),
+                                         ImageData::new(image_data),
+                                         None);
+                    api.update_resources(updates);
+                    api.generate_frame(document_id, None);
+                 }
+                 _ => {}
+             }
+         }
+         _ => {}
+     }
+}
+
+fn main() {
+    boilerplate::main_wrapper(body, event_handler, None);
+}

--- a/webrender/src/glyph_cache.rs
+++ b/webrender/src/glyph_cache.rs
@@ -15,7 +15,7 @@ pub struct CachedGlyphInfo {
 }
 
 impl Resource for CachedGlyphInfo {
-    fn free(&self, texture_cache: &mut TextureCache) {
+    fn free(self, texture_cache: &mut TextureCache) {
         if let Some(id) = self.texture_cache_id {
             texture_cache.free(id);
         }
@@ -29,7 +29,7 @@ impl Resource for CachedGlyphInfo {
     fn add_to_gpu_cache(&self,
                         texture_cache: &mut TextureCache,
                         gpu_cache: &mut GpuCache) {
-        if let Some(texture_cache_id) = self.texture_cache_id {
+        if let Some(texture_cache_id) = self.texture_cache_id.as_ref() {
             let item = texture_cache.get_mut(texture_cache_id);
             if let Some(mut request) = gpu_cache.request(&mut item.uv_rect_handle) {
                 request.push(item.uv_rect);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -553,7 +553,9 @@ impl ResourceCache {
 
         for (loop_index, key) in glyph_keys.iter().enumerate() {
             let glyph = glyph_key_cache.get(key, self.current_frame_id);
-            let cache_item = glyph.texture_cache_id.map(|image_id| self.texture_cache.get(image_id));
+            let cache_item = glyph.texture_cache_id
+                                  .as_ref()
+                                  .map(|image_id| self.texture_cache.get(image_id));
             if let Some(cache_item) = cache_item {
                 f(loop_index, &cache_item.uv_rect_handle);
                 debug_assert!(texture_id == None ||
@@ -594,7 +596,7 @@ impl ResourceCache {
             tile,
         };
         let image_info = &self.cached_images.get(&key, self.current_frame_id);
-        let item = self.texture_cache.get(image_info.texture_cache_id);
+        let item = self.texture_cache.get(&image_info.texture_cache_id);
         CacheItem {
             texture_id: SourceTexture::TextureCache(item.texture_id),
             uv_rect_handle: item.uv_rect_handle,
@@ -756,25 +758,21 @@ impl ResourceCache {
             };
 
             match self.cached_images.entry(request, self.current_frame_id) {
-                Occupied(entry) => {
-                    let image_id = entry.get().texture_cache_id;
+                Occupied(mut entry) => {
+                    let entry = entry.get_mut();
 
                     // We should only get to this code path if the image
                     // definitely needs to be updated.
-                    debug_assert!(entry.get().epoch != image_template.epoch);
-                    self.texture_cache.update(image_id,
+                    debug_assert!(entry.epoch != image_template.epoch);
+                    self.texture_cache.update(&entry.texture_cache_id,
                                               descriptor,
                                               filter,
                                               image_data,
                                               image_template.dirty_rect);
 
                     // Update the cached epoch
-                    debug_assert_eq!(self.current_frame_id, entry.get().last_access);
-                    *entry.into_mut() = CachedImageInfo {
-                        texture_cache_id: image_id,
-                        epoch: image_template.epoch,
-                        last_access: self.current_frame_id,
-                    };
+                    debug_assert_eq!(self.current_frame_id, entry.last_access);
+                    entry.epoch = image_template.epoch;
                     image_template.dirty_rect = None;
                 }
                 Vacant(entry) => {
@@ -823,7 +821,7 @@ impl ResourceCache {
 }
 
 pub trait Resource {
-    fn free(&self, texture_cache: &mut TextureCache);
+    fn free(self, texture_cache: &mut TextureCache);
     fn get_last_access_time(&self) -> FrameId;
     fn set_last_access_time(&mut self, frame_id: FrameId);
     fn add_to_gpu_cache(&self,
@@ -832,7 +830,7 @@ pub trait Resource {
 }
 
 impl Resource for CachedImageInfo {
-    fn free(&self, texture_cache: &mut TextureCache) {
+    fn free(self, texture_cache: &mut TextureCache) {
         texture_cache.free(self.texture_cache_id);
     }
     fn get_last_access_time(&self) -> FrameId {
@@ -844,7 +842,7 @@ impl Resource for CachedImageInfo {
     fn add_to_gpu_cache(&self,
                         texture_cache: &mut TextureCache,
                         gpu_cache: &mut GpuCache) {
-        let item = texture_cache.get_mut(self.texture_cache_id);
+        let item = texture_cache.get_mut(&self.texture_cache_id);
         if let Some(mut request) = gpu_cache.request(&mut item.uv_rect_handle) {
             request.push(item.uv_rect);
         }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use device::TextureFilter;
-use freelist::{FreeList, FreeListItem, FreeListItemId};
+use freelist::{FreeList, FreeListHandle};
 use gpu_cache::GpuCacheHandle;
 use internal_types::{FastHashMap, TextureUpdate, TextureUpdateOp, UvRect};
 use internal_types::{CacheTextureId, RenderTargetMode, TextureUpdateList};
@@ -46,7 +46,7 @@ const COALESCING_TIMEOUT: u64 = 100;
 /// the timeout.
 const COALESCING_TIMEOUT_CHECKING_INTERVAL: usize = 256;
 
-pub type TextureCacheItemId = FreeListItemId;
+pub type TextureCacheItemId = FreeListHandle<TextureCacheItem>;
 
 enum CoalescingStatus {
     Changed,
@@ -457,38 +457,6 @@ pub struct TextureCacheItem {
     pub user_data: [f32; 2],
 }
 
-// Structure squat the width/height fields to maintain the free list information :)
-impl FreeListItem for TextureCacheItem {
-    fn take(&mut self) -> Self {
-        let data = self.clone();
-        self.texture_id = CacheTextureId(0);
-        data
-    }
-
-    fn next_free_id(&self) -> Option<FreeListItemId> {
-        if self.allocated_rect.size.width == 0 {
-            debug_assert_eq!(self.allocated_rect.size.height, 0);
-            None
-        } else {
-            debug_assert_eq!(self.allocated_rect.size.width, 1);
-            Some(FreeListItemId::new(self.allocated_rect.size.height))
-        }
-    }
-
-    fn set_next_free_id(&mut self, id: Option<FreeListItemId>) {
-        match id {
-            Some(id) => {
-                self.allocated_rect.size.width = 1;
-                self.allocated_rect.size.height = id.value();
-            }
-            None => {
-                self.allocated_rect.size.width = 0;
-                self.allocated_rect.size.height = 0;
-            }
-        }
-    }
-}
-
 impl TextureCacheItem {
     fn new(texture_id: CacheTextureId,
            rect: DeviceUintRect,
@@ -587,7 +555,7 @@ pub enum AllocationKind {
 
 #[derive(Debug)]
 pub struct AllocationResult {
-    image_id: TextureCacheItemId,
+    new_image_id: Option<TextureCacheItemId>,
     kind: AllocationKind,
     item: TextureCacheItem,
 }
@@ -636,7 +604,7 @@ impl TextureCache {
         )
     }
 
-    // If item_id is None, create a new id, otherwise reuse it.
+    // If existing_item_id is None, create a new id, otherwise reuse it.
     fn allocate_impl(
         &mut self,
         requested_width: u32,
@@ -645,7 +613,7 @@ impl TextureCache {
         filter: TextureFilter,
         user_data: [f32; 2],
         profile: &mut TextureCacheProfileCounters,
-        item_id: Option<TextureCacheItemId>
+        existing_item_id: Option<&TextureCacheItemId>
     ) -> AllocationResult {
         let requested_size = DeviceUintSize::new(requested_width, requested_height);
 
@@ -657,6 +625,17 @@ impl TextureCache {
         if filter == TextureFilter::Nearest {
             // Fall back to standalone texture allocation.
             let texture_id = self.cache_id_list.allocate();
+
+            let update_op = TextureUpdate {
+                id: texture_id,
+                op: texture_create_op(DeviceUintSize::new(requested_width,
+                                                          requested_height),
+                                      format,
+                                      RenderTargetMode::None,
+                                      filter),
+            };
+            self.pending_updates.push(update_op);
+
             let cache_item = TextureCacheItem::new(
                 texture_id,
                 DeviceUintRect::new(DeviceUintPoint::zero(), requested_size),
@@ -664,15 +643,21 @@ impl TextureCache {
                 user_data
             );
 
-            let image_id = match item_id {
-                Some(id) => id,
-                None => self.items.insert(cache_item.clone()),
+            let new_image_id = match existing_item_id {
+                Some(id) => {
+                    *self.items.get_mut(id) = cache_item.clone();
+                    None
+                }
+                None => {
+                    let id = self.items.insert(cache_item.clone());
+                    Some(id)
+                }
             };
 
             return AllocationResult {
-                item: self.items.get(image_id).clone(),
+                item: cache_item,
                 kind: AllocationKind::Standalone,
-                image_id,
+                new_image_id,
             }
         }
 
@@ -751,7 +736,10 @@ impl TextureCache {
 
                     let update_op = TextureUpdate {
                         id: texture_id,
-                        op: texture_create_op(texture_size, format, mode),
+                        op: texture_create_op(texture_size,
+                                              format,
+                                              mode,
+                                              filter),
                     };
                     self.pending_updates.push(update_op);
 
@@ -777,21 +765,27 @@ impl TextureCache {
             user_data
         );
 
-        let image_id = match item_id {
-            Some(id) => id,
-            None => self.items.insert(cache_item.clone()),
+        let new_image_id = match existing_item_id {
+            Some(id) => {
+                *self.items.get_mut(id) = cache_item.clone();
+                None
+            }
+            None => {
+                let id = self.items.insert(cache_item.clone());
+                Some(id)
+            }
         };
 
         AllocationResult {
             item: cache_item,
             kind: AllocationKind::TexturePage,
-            image_id,
+            new_image_id,
         }
     }
 
     pub fn update(
         &mut self,
-        image_id: TextureCacheItemId,
+        image_id: &TextureCacheItemId,
         descriptor: ImageDescriptor,
         filter: TextureFilter,
         data: ImageData,
@@ -1002,14 +996,14 @@ impl TextureCache {
             }
         }
 
-        result.image_id
+        result.new_image_id.unwrap()
     }
 
-    pub fn get(&self, id: TextureCacheItemId) -> &TextureCacheItem {
+    pub fn get(&self, id: &TextureCacheItemId) -> &TextureCacheItem {
         self.items.get(id)
     }
 
-    pub fn get_mut(&mut self, id: TextureCacheItemId) -> &mut TextureCacheItem {
+    pub fn get_mut(&mut self, id: &TextureCacheItemId) -> &mut TextureCacheItem {
         self.items.get_mut(id)
     }
 
@@ -1034,13 +1028,16 @@ impl TextureCache {
     }
 }
 
-fn texture_create_op(texture_size: DeviceUintSize, format: ImageFormat, mode: RenderTargetMode)
+fn texture_create_op(texture_size: DeviceUintSize,
+                     format: ImageFormat,
+                     mode: RenderTargetMode,
+                     filter: TextureFilter)
                      -> TextureUpdateOp {
     TextureUpdateOp::Create {
         width: texture_size.width,
         height: texture_size.height,
         format,
-        filter: TextureFilter::Linear,
+        filter,
         mode,
         data: None,
     }


### PR DESCRIPTION
Refactor the freelist implementation to be simpler. Specifically,
the handles returned from the freelist are strong handles, that
cannot be cloned or copied. This is prep work for some upcoming
refactoring of the texture cache allocator and implementation.

While doing this, I found some bugs in the texture update APIs
that are now fixed. There were two issues:
 * When reusing an existing texture ID, the texture cache info
   was not being updated in the item cache. This meant the old
   dimensions were being used.
 * When a standalone texture was updated, it wasn't getting
   initialized in the code path where the dimensions are different.

It's a bit difficult to reftest this right now (until we get
raw tests), so I've added an example that checks both texture
update code paths. Neither of those code paths were working
correctly before this change.