### PR TITLE
Fix push_nested_display_list's glyph cache handling (and also the glyph cache parser)

### DIFF
--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -216,9 +216,11 @@ impl GlyphKey {
     }
 }
 
+pub type GlyphIndex = u32;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GlyphInstance {
-    pub index: u32,
+    pub index: GlyphIndex,
     pub point: LayoutPoint,
 }


### PR DESCRIPTION
* Cache stores indices, not full GlyphInstances
* push_nested needs to split off the cache and data and handle them seperately