### PR TITLE
Refactor the boilerplate code and update examples.

### DIFF
--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -6,76 +6,83 @@ extern crate gleam;
 extern crate glutin;
 extern crate webrender;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[path="common/boilerplate.rs"]
 mod boilerplate;
 
-use boilerplate::HandyDandyRectBuilder;
-use std::sync::Mutex;
+use boilerplate::{Example, HandyDandyRectBuilder};
 use webrender::api::*;
 
 // This example creates a 100x100 white rect and allows the user to move it
 // around by using the arrow keys. It does this by using the animation API.
 
-fn body(_api: &RenderApi,
-        _document_id: &DocumentId,
-        builder: &mut DisplayListBuilder,
-        _resouces: &mut ResourceUpdates,
-        _pipeline_id: &PipelineId,
-        _layout_size: &LayoutSize) {
-    // Create a 100x100 stacking context with an animatable transform property.
-    // Note the magic "42" we use as the animation key. That is used to update
-    // the transform in the keyboard event handler code.
-    let bounds = (0,0).to(100, 100);
-    builder.push_stacking_context(ScrollPolicy::Scrollable,
-                                  bounds,
-                                  Some(PropertyBinding::Binding(PropertyBindingKey::new(42))),
-                                  TransformStyle::Flat,
-                                  None,
-                                  MixBlendMode::Normal,
-                                  Vec::new());
-
-    // Fill it with a white rect
-    builder.push_rect(bounds, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
-
-    builder.pop_stacking_context();
+struct App {
+    transform: LayoutTransform,
 }
 
-lazy_static! {
-    static ref TRANSFORM: Mutex<LayoutTransform> = Mutex::new(LayoutTransform::identity());
-}
+impl Example for App {
+    fn render(&mut self,
+              _api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              _resources: &mut ResourceUpdates,
+              _layout_size: LayoutSize,
+              _pipeline_id: PipelineId,
+              _document_id: DocumentId) {
+        // Create a 100x100 stacking context with an animatable transform property.
+        // Note the magic "42" we use as the animation key. That is used to update
+        // the transform in the keyboard event handler code.
+        let bounds = (0,0).to(100, 100);
+        builder.push_stacking_context(ScrollPolicy::Scrollable,
+                                      bounds,
+                                      Some(PropertyBinding::Binding(PropertyBindingKey::new(42))),
+                                      TransformStyle::Flat,
+                                      None,
+                                      MixBlendMode::Normal,
+                                      Vec::new());
 
-fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
-    match *event {
-        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
-            let offset = match key {
-                 glutin::VirtualKeyCode::Down => (0.0, 10.0),
-                 glutin::VirtualKeyCode::Up => (0.0, -10.0),
-                 glutin::VirtualKeyCode::Right => (10.0, 0.0),
-                 glutin::VirtualKeyCode::Left => (-10.0, 0.0),
-                 _ => return,
-            };
-            // Update the transform based on the keyboard input and push it to
-            // webrender using the generate_frame API. This will recomposite with
-            // the updated transform.
-            let new_transform = TRANSFORM.lock().unwrap().post_translate(LayoutVector3D::new(offset.0, offset.1, 0.0));
-            api.generate_frame(document_id, Some(DynamicProperties {
-                transforms: vec![
-                  PropertyValue {
-                    key: PropertyBindingKey::new(42),
-                    value: new_transform,
-                  },
-                ],
-                floats: vec![],
-            }));
-            *TRANSFORM.lock().unwrap() = new_transform;
+        // Fill it with a white rect
+        builder.push_rect(bounds, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
+
+        builder.pop_stacking_context();
+    }
+
+    fn on_event(&mut self,
+                event: glutin::Event,
+                api: &RenderApi,
+                document_id: DocumentId) -> bool {
+        match event {
+            glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+                let offset = match key {
+                     glutin::VirtualKeyCode::Down => (0.0, 10.0),
+                     glutin::VirtualKeyCode::Up => (0.0, -10.0),
+                     glutin::VirtualKeyCode::Right => (10.0, 0.0),
+                     glutin::VirtualKeyCode::Left => (-10.0, 0.0),
+                     _ => return false,
+                };
+                // Update the transform based on the keyboard input and push it to
+                // webrender using the generate_frame API. This will recomposite with
+                // the updated transform.
+                let new_transform = self.transform.post_translate(LayoutVector3D::new(offset.0, offset.1, 0.0));
+                api.generate_frame(document_id, Some(DynamicProperties {
+                    transforms: vec![
+                      PropertyValue {
+                        key: PropertyBindingKey::new(42),
+                        value: new_transform,
+                      },
+                    ],
+                    floats: vec![],
+                }));
+                self.transform = new_transform;
+            }
+            _ => ()
         }
-        _ => ()
+
+        false
     }
 }
 
 fn main() {
-    boilerplate::main_wrapper(body, event_handler, None);
+    let mut app = App {
+        transform: LayoutTransform::identity(),
+    };
+    boilerplate::main_wrapper(&mut app, None);
 }

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -52,15 +52,21 @@ impl HandyDandyRectBuilder for (i32, i32) {
     }
 }
 
-pub fn main_wrapper(builder_callback: fn(&RenderApi,
-                                         &DocumentId,
-                                         &mut DisplayListBuilder,
-                                         &mut ResourceUpdates,
-                                         &PipelineId,
-                                         &LayoutSize) -> (),
-                    event_handler: fn(&glutin::Event,
-                                      DocumentId,
-                                      &RenderApi) -> (),
+pub trait Example {
+    fn render(&mut self,
+              api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              resources: &mut ResourceUpdates,
+              layout_size: LayoutSize,
+              pipeline_id: PipelineId,
+              document_id: DocumentId);
+    fn on_event(&mut self,
+                event: glutin::Event,
+                api: &RenderApi,
+                document_id: DocumentId) -> bool;
+}
+
+pub fn main_wrapper(example: &mut Example,
                     options: Option<webrender::RendererOptions>)
 {
     let args: Vec<String> = env::args().collect();
@@ -118,8 +124,7 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
     let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
     let mut resources = ResourceUpdates::new();
 
-    builder_callback(&api, &document_id, &mut builder, &mut resources, &pipeline_id, &layout_size);
-
+    example.render(&api, &mut builder, &mut resources, layout_size, pipeline_id, document_id);
     api.set_display_list(
         document_id,
         epoch,
@@ -151,25 +156,41 @@ pub fn main_wrapper(builder_callback: fn(&RenderApi,
                     let mut flags = renderer.get_debug_flags();
                     flags.toggle(PROFILER_DBG);
                     renderer.set_debug_flags(flags);
-                },
+                }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::O)) => {
                     let mut flags = renderer.get_debug_flags();
                     flags.toggle(RENDER_TARGET_DBG);
                     renderer.set_debug_flags(flags);
-                },
+                }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::I)) => {
                     let mut flags = renderer.get_debug_flags();
                     flags.toggle(TEXTURE_CACHE_DBG);
                     renderer.set_debug_flags(flags);
-                },
+                }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::M)) => {
                     api.notify_memory_pressure();
-                },
+                }
+                _ => {
+                    if example.on_event(event, &api, document_id) {
+                        let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
+                        let mut resources = ResourceUpdates::new();
 
-                _ => event_handler(&event, document_id, &api),
+                        example.render(&api, &mut builder, &mut resources, layout_size, pipeline_id, document_id);
+                        api.set_display_list(
+                            document_id,
+                            epoch,
+                            Some(root_background_color),
+                            LayoutSize::new(width as f32, height as f32),
+                            builder.finalize(),
+                            true,
+                            resources
+                        );
+                        api.generate_frame(document_id, None);
+                    }
+                }
             }
         }
 

--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -9,96 +9,106 @@ extern crate webrender;
 #[path="common/boilerplate.rs"]
 mod boilerplate;
 
-use boilerplate::HandyDandyRectBuilder;
+use boilerplate::{Example, HandyDandyRectBuilder};
 use webrender::api::*;
 
-static IMAGE_KEY: ImageKey = ImageKey(IdNamespace(0), 0);
-
-fn body(_api: &RenderApi,
-        _document_id: &DocumentId,
-        builder: &mut DisplayListBuilder,
-        resources: &mut ResourceUpdates,
-        _pipeline_id: &PipelineId,
-        _layout_size: &LayoutSize) {
-
-    let mut image_data = Vec::new();
-    for y in 0..32 {
-        for x in 0..32 {
-            let lum = 255 * (((x & 8) == 0) ^ ((y & 8) == 0)) as u8;
-            image_data.extend_from_slice(&[lum, lum, lum, 0xff]);
-        }
-    }
-
-    resources.add_image(
-        IMAGE_KEY,
-        ImageDescriptor::new(32, 32, ImageFormat::BGRA8, true),
-        ImageData::new(image_data),
-        None,
-    );
-
-    let bounds = (0,0).to(512, 512);
-    builder.push_stacking_context(ScrollPolicy::Scrollable,
-                                  bounds,
-                                  None,
-                                  TransformStyle::Flat,
-                                  None,
-                                  MixBlendMode::Normal,
-                                  Vec::new());
-
-    let image_size = LayoutSize::new(100.0, 100.0);
-
-    builder.push_image(
-        LayoutRect::new(LayoutPoint::new(100.0, 100.0), image_size),
-        Some(LocalClip::from(bounds)),
-        image_size,
-        LayoutSize::zero(),
-        ImageRendering::Auto,
-        IMAGE_KEY
-    );
-
-    builder.push_image(
-        LayoutRect::new(LayoutPoint::new(250.0, 100.0), image_size),
-        Some(LocalClip::from(bounds)),
-        image_size,
-        LayoutSize::zero(),
-        ImageRendering::Pixelated,
-        IMAGE_KEY
-    );
-
-    builder.pop_stacking_context();
+struct App {
+    image_key: ImageKey,
 }
 
-fn event_handler(event: &glutin::Event,
-                 document_id: DocumentId,
-                 api: &RenderApi) {
-    match *event {
-        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
-            match key {
-                 glutin::VirtualKeyCode::Space => {
-                    let mut image_data = Vec::new();
-                    for y in 0..64 {
-                        for x in 0..64 {
-                            let r = 255 * ((y & 32) == 0) as u8;
-                            let g = 255 * ((x & 32) == 0) as u8;
-                            image_data.extend_from_slice(&[0, g, r, 0xff]);
-                        }
-                    }
+impl Example for App {
+    fn render(&mut self,
+              _api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              resources: &mut ResourceUpdates,
+              _layout_size: LayoutSize,
+              _pipeline_id: PipelineId,
+              _document_id: DocumentId) {
+        let mut image_data = Vec::new();
+        for y in 0..32 {
+            for x in 0..32 {
+                let lum = 255 * (((x & 8) == 0) ^ ((y & 8) == 0)) as u8;
+                image_data.extend_from_slice(&[lum, lum, lum, 0xff]);
+            }
+        }
 
-                    let mut updates = ResourceUpdates::new();
-                    updates.update_image(IMAGE_KEY,
-                                         ImageDescriptor::new(64, 64, ImageFormat::BGRA8, true),
-                                         ImageData::new(image_data),
-                                         None);
-                    api.update_resources(updates);
-                    api.generate_frame(document_id, None);
+        resources.add_image(
+            self.image_key,
+            ImageDescriptor::new(32, 32, ImageFormat::BGRA8, true),
+            ImageData::new(image_data),
+            None,
+        );
+
+        let bounds = (0,0).to(512, 512);
+        builder.push_stacking_context(ScrollPolicy::Scrollable,
+                                      bounds,
+                                      None,
+                                      TransformStyle::Flat,
+                                      None,
+                                      MixBlendMode::Normal,
+                                      Vec::new());
+
+        let image_size = LayoutSize::new(100.0, 100.0);
+
+        builder.push_image(
+            LayoutRect::new(LayoutPoint::new(100.0, 100.0), image_size),
+            Some(LocalClip::from(bounds)),
+            image_size,
+            LayoutSize::zero(),
+            ImageRendering::Auto,
+            self.image_key
+        );
+
+        builder.push_image(
+            LayoutRect::new(LayoutPoint::new(250.0, 100.0), image_size),
+            Some(LocalClip::from(bounds)),
+            image_size,
+            LayoutSize::zero(),
+            ImageRendering::Pixelated,
+            self.image_key
+        );
+
+        builder.pop_stacking_context();
+    }
+
+    fn on_event(&mut self,
+                event: glutin::Event,
+                api: &RenderApi,
+                document_id: DocumentId) -> bool {
+        match event {
+            glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+                match key {
+                     glutin::VirtualKeyCode::Space => {
+                        let mut image_data = Vec::new();
+                        for y in 0..64 {
+                            for x in 0..64 {
+                                let r = 255 * ((y & 32) == 0) as u8;
+                                let g = 255 * ((x & 32) == 0) as u8;
+                                image_data.extend_from_slice(&[0, g, r, 0xff]);
+                            }
+                        }
+
+                        let mut updates = ResourceUpdates::new();
+                        updates.update_image(self.image_key,
+                                             ImageDescriptor::new(64, 64, ImageFormat::BGRA8, true),
+                                             ImageData::new(image_data),
+                                             None);
+                        api.update_resources(updates);
+                        api.generate_frame(document_id, None);
+                     }
+                     _ => {}
                  }
-                 _ => {}
              }
-         }
-         _ => {}
-     }
+             _ => {}
+        }
+
+        false
+    }
 }
 
 fn main() {
-    boilerplate::main_wrapper(body, event_handler, None);
+    let mut app = App {
+        image_key: ImageKey(IdNamespace(0), 0),
+    };
+    boilerplate::main_wrapper(&mut app, None);
 }

--- a/webrender/examples/nested_display_list.rs
+++ b/webrender/examples/nested_display_list.rs
@@ -6,131 +6,138 @@ extern crate gleam;
 extern crate glutin;
 extern crate webrender;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[path="common/boilerplate.rs"]
 mod boilerplate;
 
-use boilerplate::HandyDandyRectBuilder;
-use std::sync::Mutex;
+use boilerplate::{Example, HandyDandyRectBuilder};
 use webrender::api::*;
 
-fn body(_api: &RenderApi,
-        _document_id: &DocumentId,
-        builder: &mut DisplayListBuilder,
-        _resources: &mut ResourceUpdates,
-        pipeline_id: &PipelineId,
-        layout_size: &LayoutSize) {
-    let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);
-    builder.push_stacking_context(ScrollPolicy::Scrollable,
-                                  bounds,
-                                  None,
-                                  TransformStyle::Flat,
-                                  None,
-                                  MixBlendMode::Normal,
-                                  Vec::new());
-
-    let outer_scroll_frame_rect = (100, 100).to(600, 400);
-    builder.push_rect(outer_scroll_frame_rect, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
-
-    let nested_clip_id = builder.define_scroll_frame(None,
-                                                     (100, 100).to(1000, 1000),
-                                                     outer_scroll_frame_rect,
-                                                     vec![],
-                                                     None,
-                                                     ScrollSensitivity::ScriptAndInputEvents);
-    builder.push_clip_id(nested_clip_id);
-
-    let mut builder2 = DisplayListBuilder::new(*pipeline_id, *layout_size);
-    let mut builder3 = DisplayListBuilder::new(*pipeline_id, *layout_size);
-
-    let rect = (110, 110).to(210, 210);
-    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
-
-    // A fixed position rectangle should be fixed to the reference frame that starts
-    // in the outer display list.
-    builder3.push_stacking_context(ScrollPolicy::Fixed,
-                                  (220, 110).to(320, 210),
-                                  None,
-                                  TransformStyle::Flat,
-                                  None,
-                                  MixBlendMode::Normal,
-                                  Vec::new());
-    let rect = (0, 0).to(100, 100);
-    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
-    builder3.pop_stacking_context();
-
-    // Now we push an inner scroll frame that should have the same id as the outer one,
-    // but the WebRender nested display list replacement code should convert it into
-    // a unique ClipId.
-    let inner_scroll_frame_rect = (330, 110).to(530, 360);
-    builder3.push_rect(inner_scroll_frame_rect, None, ColorF::new(1.0, 0.0, 1.0, 0.5));
-    let inner_nested_clip_id =
-        builder3.define_scroll_frame(None,
-                                     (330, 110).to(2000, 2000),
-                                     inner_scroll_frame_rect,
-                                     vec![],
-                                     None,
-                                     ScrollSensitivity::ScriptAndInputEvents);
-    builder3.push_clip_id(inner_nested_clip_id);
-    let rect = (340, 120).to(440, 220);
-    builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
-    builder3.pop_clip_id();
-
-    let (_, _, built_list) = builder3.finalize();
-    builder2.push_nested_display_list(&built_list);
-    let (_, _, built_list) = builder2.finalize();
-    builder.push_nested_display_list(&built_list);
-
-    builder.pop_clip_id();
-
-    builder.pop_stacking_context();
+struct App {
+    cursor_position: WorldPoint,
 }
 
-lazy_static! {
-    static ref CURSOR_POSITION: Mutex<WorldPoint> = Mutex::new(WorldPoint::zero());
-}
+impl Example for App {
+    fn render(&mut self,
+              _api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              _resources: &mut ResourceUpdates,
+              layout_size: LayoutSize,
+              pipeline_id: PipelineId,
+              _document_id: DocumentId) {
+        let bounds = LayoutRect::new(LayoutPoint::zero(), layout_size);
+        builder.push_stacking_context(ScrollPolicy::Scrollable,
+                                      bounds,
+                                      None,
+                                      TransformStyle::Flat,
+                                      None,
+                                      MixBlendMode::Normal,
+                                      Vec::new());
 
-fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
-    match *event {
-        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
-            let offset = match key {
-                 glutin::VirtualKeyCode::Down => (0.0, -10.0),
-                 glutin::VirtualKeyCode::Up => (0.0, 10.0),
-                 glutin::VirtualKeyCode::Right => (-10.0, 0.0),
-                 glutin::VirtualKeyCode::Left => (10.0, 0.0),
-                 _ => return,
-            };
+        let outer_scroll_frame_rect = (100, 100).to(600, 400);
+        builder.push_rect(outer_scroll_frame_rect, None, ColorF::new(1.0, 1.0, 1.0, 1.0));
 
-            api.scroll(document_id,
-                       ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
-                       *CURSOR_POSITION.lock().unwrap(),
-                       ScrollEventPhase::Start);
-        }
-        glutin::Event::MouseMoved(x, y) => {
-            *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
-        }
-        glutin::Event::MouseWheel(delta, _, event_cursor_position) => {
-            if let Some((x, y)) = event_cursor_position {
-                *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
+        let nested_clip_id = builder.define_scroll_frame(None,
+                                                         (100, 100).to(1000, 1000),
+                                                         outer_scroll_frame_rect,
+                                                         vec![],
+                                                         None,
+                                                         ScrollSensitivity::ScriptAndInputEvents);
+        builder.push_clip_id(nested_clip_id);
+
+        let mut builder2 = DisplayListBuilder::new(pipeline_id, layout_size);
+        let mut builder3 = DisplayListBuilder::new(pipeline_id, layout_size);
+
+        let rect = (110, 110).to(210, 210);
+        builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
+
+        // A fixed position rectangle should be fixed to the reference frame that starts
+        // in the outer display list.
+        builder3.push_stacking_context(ScrollPolicy::Fixed,
+                                      (220, 110).to(320, 210),
+                                      None,
+                                      TransformStyle::Flat,
+                                      None,
+                                      MixBlendMode::Normal,
+                                      Vec::new());
+        let rect = (0, 0).to(100, 100);
+        builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
+        builder3.pop_stacking_context();
+
+        // Now we push an inner scroll frame that should have the same id as the outer one,
+        // but the WebRender nested display list replacement code should convert it into
+        // a unique ClipId.
+        let inner_scroll_frame_rect = (330, 110).to(530, 360);
+        builder3.push_rect(inner_scroll_frame_rect, None, ColorF::new(1.0, 0.0, 1.0, 0.5));
+        let inner_nested_clip_id =
+            builder3.define_scroll_frame(None,
+                                         (330, 110).to(2000, 2000),
+                                         inner_scroll_frame_rect,
+                                         vec![],
+                                         None,
+                                         ScrollSensitivity::ScriptAndInputEvents);
+        builder3.push_clip_id(inner_nested_clip_id);
+        let rect = (340, 120).to(440, 220);
+        builder3.push_rect(rect, None, ColorF::new(0.0, 1.0, 0.0, 1.0));
+        builder3.pop_clip_id();
+
+        let (_, _, built_list) = builder3.finalize();
+        builder2.push_nested_display_list(&built_list);
+        let (_, _, built_list) = builder2.finalize();
+        builder.push_nested_display_list(&built_list);
+
+        builder.pop_clip_id();
+
+        builder.pop_stacking_context();
+    }
+
+    fn on_event(&mut self,
+                event: glutin::Event,
+                api: &RenderApi,
+                document_id: DocumentId) -> bool {
+        match event {
+            glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+                let offset = match key {
+                     glutin::VirtualKeyCode::Down => (0.0, -10.0),
+                     glutin::VirtualKeyCode::Up => (0.0, 10.0),
+                     glutin::VirtualKeyCode::Right => (-10.0, 0.0),
+                     glutin::VirtualKeyCode::Left => (10.0, 0.0),
+                     _ => return false,
+                };
+
+                api.scroll(document_id,
+                           ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
+                           self.cursor_position,
+                           ScrollEventPhase::Start);
             }
+            glutin::Event::MouseMoved(x, y) => {
+                self.cursor_position = WorldPoint::new(x as f32, y as f32);
+            }
+            glutin::Event::MouseWheel(delta, _, event_cursor_position) => {
+                if let Some((x, y)) = event_cursor_position {
+                    self.cursor_position = WorldPoint::new(x as f32, y as f32);
+                }
 
-            const LINE_HEIGHT: f32 = 38.0;
-            let (dx, dy) = match delta {
-                glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
-                glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
-            };
+                const LINE_HEIGHT: f32 = 38.0;
+                let (dx, dy) = match delta {
+                    glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
+                    glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
+                };
 
-            api.scroll(document_id,
-                       ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
-                       *CURSOR_POSITION.lock().unwrap(),
-                       ScrollEventPhase::Start);
+                api.scroll(document_id,
+                           ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
+                           self.cursor_position,
+                           ScrollEventPhase::Start);
+            }
+            _ => ()
         }
-        _ => ()
+
+        false
     }
 }
 
 fn main() {
-    boilerplate::main_wrapper(body, event_handler, None);
+    let mut app = App {
+        cursor_position: WorldPoint::zero(),
+    };
+    boilerplate::main_wrapper(&mut app, None);
 }

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -6,140 +6,147 @@ extern crate gleam;
 extern crate glutin;
 extern crate webrender;
 
-#[macro_use]
-extern crate lazy_static;
-
 #[path="common/boilerplate.rs"]
 mod boilerplate;
 
-use boilerplate::HandyDandyRectBuilder;
-use std::sync::Mutex;
+use boilerplate::{Example, HandyDandyRectBuilder};
 use webrender::api::*;
 
-fn body(_api: &RenderApi,
-        _document_id: &DocumentId,
-        builder: &mut DisplayListBuilder,
-        _resources: &mut ResourceUpdates,
-        _pipeline_id: &PipelineId,
-        layout_size: &LayoutSize) {
-    let bounds = LayoutRect::new(LayoutPoint::zero(), *layout_size);
-    builder.push_stacking_context(ScrollPolicy::Scrollable,
-                                  bounds,
-                                  None,
-                                  TransformStyle::Flat,
-                                  None,
-                                  MixBlendMode::Normal,
-                                  Vec::new());
+struct App {
+    cursor_position: WorldPoint,
+}
 
-    if true {   // scrolling and clips stuff
-        // let's make a scrollbox
-        let scrollbox = (0, 0).to(300, 400);
+impl Example for App {
+    fn render(&mut self,
+              _api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              _resources: &mut ResourceUpdates,
+              layout_size: LayoutSize,
+              _pipeline_id: PipelineId,
+              _document_id: DocumentId) {
+        let bounds = LayoutRect::new(LayoutPoint::zero(), layout_size);
         builder.push_stacking_context(ScrollPolicy::Scrollable,
-                                      LayoutRect::new(LayoutPoint::new(10.0, 10.0),
-                                                      LayoutSize::zero()),
+                                      bounds,
                                       None,
                                       TransformStyle::Flat,
                                       None,
                                       MixBlendMode::Normal,
                                       Vec::new());
-        // set the scrolling clip
-        let clip_id = builder.define_scroll_frame(None,
-                                                  (0, 0).by(1000, 1000),
-                                                  scrollbox,
-                                                  vec![],
-                                                  None,
-                                                  ScrollSensitivity::ScriptAndInputEvents);
-        builder.push_clip_id(clip_id);
 
-        // now put some content into it.
-        // start with a white background
-        builder.push_rect((0, 0).to(1000, 1000), None, ColorF::new(1.0, 1.0, 1.0, 1.0));
+        if true {   // scrolling and clips stuff
+            // let's make a scrollbox
+            let scrollbox = (0, 0).to(300, 400);
+            builder.push_stacking_context(ScrollPolicy::Scrollable,
+                                          LayoutRect::new(LayoutPoint::new(10.0, 10.0),
+                                                          LayoutSize::zero()),
+                                          None,
+                                          TransformStyle::Flat,
+                                          None,
+                                          MixBlendMode::Normal,
+                                          Vec::new());
+            // set the scrolling clip
+            let clip_id = builder.define_scroll_frame(None,
+                                                      (0, 0).by(1000, 1000),
+                                                      scrollbox,
+                                                      vec![],
+                                                      None,
+                                                      ScrollSensitivity::ScriptAndInputEvents);
+            builder.push_clip_id(clip_id);
 
-        // let's make a 50x50 blue square as a visual reference
-        builder.push_rect((0, 0).to(50, 50), None, ColorF::new(0.0, 0.0, 1.0, 1.0));
+            // now put some content into it.
+            // start with a white background
+            builder.push_rect((0, 0).to(1000, 1000), None, ColorF::new(1.0, 1.0, 1.0, 1.0));
 
-        // and a 50x50 green square next to it with an offset clip
-        // to see what that looks like
-        builder.push_rect((50, 0).to(100, 50),
-                          Some(LocalClip::from((60, 10).to(110, 60))),
-                          ColorF::new(0.0, 1.0, 0.0, 1.0));
+            // let's make a 50x50 blue square as a visual reference
+            builder.push_rect((0, 0).to(50, 50), None, ColorF::new(0.0, 0.0, 1.0, 1.0));
 
-        // Below the above rectangles, set up a nested scrollbox. It's still in
-        // the same stacking context, so note that the rects passed in need to
-        // be relative to the stacking context.
-        let nested_clip_id = builder.define_scroll_frame(None,
-                                                         (0, 100).to(300, 400),
-                                                         (0, 100).to(200, 300),
-                                                         vec![],
-                                                         None,
-                                                         ScrollSensitivity::ScriptAndInputEvents);
-        builder.push_clip_id(nested_clip_id);
+            // and a 50x50 green square next to it with an offset clip
+            // to see what that looks like
+            builder.push_rect((50, 0).to(100, 50),
+                              Some(LocalClip::from((60, 10).to(110, 60))),
+                              ColorF::new(0.0, 1.0, 0.0, 1.0));
 
-        // give it a giant gray background just to distinguish it and to easily
-        // visually identify the nested scrollbox
-        builder.push_rect((-1000, -1000).to(5000, 5000), None, ColorF::new(0.5, 0.5, 0.5, 1.0));
+            // Below the above rectangles, set up a nested scrollbox. It's still in
+            // the same stacking context, so note that the rects passed in need to
+            // be relative to the stacking context.
+            let nested_clip_id = builder.define_scroll_frame(None,
+                                                             (0, 100).to(300, 400),
+                                                             (0, 100).to(200, 300),
+                                                             vec![],
+                                                             None,
+                                                             ScrollSensitivity::ScriptAndInputEvents);
+            builder.push_clip_id(nested_clip_id);
 
-        // add a teal square to visualize the scrolling/clipping behaviour
-        // as you scroll the nested scrollbox with WASD keys
-        builder.push_rect((0, 100).to(50, 150), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
+            // give it a giant gray background just to distinguish it and to easily
+            // visually identify the nested scrollbox
+            builder.push_rect((-1000, -1000).to(5000, 5000), None, ColorF::new(0.5, 0.5, 0.5, 1.0));
 
-        // just for good measure add another teal square in the bottom-right
-        // corner of the nested scrollframe content, which can be scrolled into
-        // view by the user
-        builder.push_rect((250, 350).to(300, 400), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
+            // add a teal square to visualize the scrolling/clipping behaviour
+            // as you scroll the nested scrollbox with WASD keys
+            builder.push_rect((0, 100).to(50, 150), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
 
-        builder.pop_clip_id(); // nested_clip_id
+            // just for good measure add another teal square in the bottom-right
+            // corner of the nested scrollframe content, which can be scrolled into
+            // view by the user
+            builder.push_rect((250, 350).to(300, 400), None, ColorF::new(0.0, 1.0, 1.0, 1.0));
 
-        builder.pop_clip_id(); // clip_id
+            builder.pop_clip_id(); // nested_clip_id
+
+            builder.pop_clip_id(); // clip_id
+            builder.pop_stacking_context();
+        }
+
         builder.pop_stacking_context();
     }
 
-    builder.pop_stacking_context();
-}
+    fn on_event(&mut self,
+                event: glutin::Event,
+                api: &RenderApi,
+                document_id: DocumentId) -> bool {
+        match event {
+            glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
+                let offset = match key {
+                     glutin::VirtualKeyCode::Down => (0.0, -10.0),
+                     glutin::VirtualKeyCode::Up => (0.0, 10.0),
+                     glutin::VirtualKeyCode::Right => (-10.0, 0.0),
+                     glutin::VirtualKeyCode::Left => (10.0, 0.0),
+                     _ => return false,
+                };
 
-lazy_static! {
-    static ref CURSOR_POSITION: Mutex<WorldPoint> = Mutex::new(WorldPoint::zero());
-}
-
-fn event_handler(event: &glutin::Event, document_id: DocumentId, api: &RenderApi) {
-    match *event {
-        glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(key)) => {
-            let offset = match key {
-                 glutin::VirtualKeyCode::Down => (0.0, -10.0),
-                 glutin::VirtualKeyCode::Up => (0.0, 10.0),
-                 glutin::VirtualKeyCode::Right => (-10.0, 0.0),
-                 glutin::VirtualKeyCode::Left => (10.0, 0.0),
-                 _ => return,
-            };
-
-            api.scroll(document_id,
-                       ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
-                       *CURSOR_POSITION.lock().unwrap(),
-                       ScrollEventPhase::Start);
-        }
-        glutin::Event::MouseMoved(x, y) => {
-            *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
-        }
-        glutin::Event::MouseWheel(delta, _, event_cursor_position) => {
-            if let Some((x, y)) = event_cursor_position {
-                *CURSOR_POSITION.lock().unwrap() = WorldPoint::new(x as f32, y as f32);
+                api.scroll(document_id,
+                           ScrollLocation::Delta(LayoutVector2D::new(offset.0, offset.1)),
+                           self.cursor_position,
+                           ScrollEventPhase::Start);
             }
+            glutin::Event::MouseMoved(x, y) => {
+                self.cursor_position = WorldPoint::new(x as f32, y as f32);
+            }
+            glutin::Event::MouseWheel(delta, _, event_cursor_position) => {
+                if let Some((x, y)) = event_cursor_position {
+                    self.cursor_position = WorldPoint::new(x as f32, y as f32);
+                }
 
-            const LINE_HEIGHT: f32 = 38.0;
-            let (dx, dy) = match delta {
-                glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
-                glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
-            };
+                const LINE_HEIGHT: f32 = 38.0;
+                let (dx, dy) = match delta {
+                    glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
+                    glutin::MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
+                };
 
-            api.scroll(document_id,
-                       ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
-                       *CURSOR_POSITION.lock().unwrap(),
-                       ScrollEventPhase::Start);
+                api.scroll(document_id,
+                           ScrollLocation::Delta(LayoutVector2D::new(dx, dy)),
+                           self.cursor_position,
+                           ScrollEventPhase::Start);
+            }
+            _ => ()
         }
-        _ => ()
+
+        false
     }
 }
 
 fn main() {
-    boilerplate::main_wrapper(body, event_handler, None);
+    let mut app = App {
+        cursor_position: WorldPoint::zero(),
+    };
+    boilerplate::main_wrapper(&mut app, None);
 }


### PR DESCRIPTION
Instead of free functions, there is now an Example trait that
each example must implement. This allows examples to store
state without resorting to globals, mutexes and such things.

The trait has two methods:

 * render - the example must create a display list and resource
            transaction update matching the current application state.

 * on_event - called when a glutin event is received. This can return
              true if the example wants render() to be called again
              after the event is handled.

Previously, it was not possible to modify or rebuild the display list
after the initial display list was created. Now, examples can choose
to rebuild a display list as required.