### PR TITLE
Fail initialization if the max texture size is insufficient.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -810,6 +810,7 @@ pub struct Renderer {
 pub enum InitError {
     Shader(ShaderError),
     Thread(std::io::Error),
+    MaxTextureSize,
 }
 
 impl From<ShaderError> for InitError {
@@ -839,12 +840,11 @@ impl Renderer {
     /// ```
     /// [rendereroptions]: struct.RendererOptions.html
     pub fn new(gl: Rc<gl::Gl>, mut options: RendererOptions) -> Result<(Renderer, RenderApiSender), InitError> {
+
         let (api_tx, api_rx) = try!{ channel::msg_channel() };
         let (payload_tx, payload_rx) = try!{ channel::payload_channel() };
         let (result_tx, result_rx) = channel();
         let gl_type = gl.get_type();
-
-        register_thread_with_profiler("Compositor".to_owned());
 
         let notifier = Arc::new(Mutex::new(None));
 
@@ -853,9 +853,28 @@ impl Renderer {
             notifier: Arc::clone(&notifier),
         };
 
-        let mut device = Device::new(gl,
-                                     options.resource_override_path.clone(),
-                                     Box::new(file_watch_handler));
+        let mut device = Device::new(
+            gl,
+            options.resource_override_path.clone(),
+            Box::new(file_watch_handler)
+        );
+
+        let device_max_size = device.max_texture_size();
+        // 512 is the minimum that the texture cache can work with.
+        // Broken GL contexts can return a max texture size of zero (See #1260). Better to
+        // gracefully fail now than panic as soon as a texture is allocated.
+        let min_texture_size = 512;
+        if device_max_size < min_texture_size {
+            println!("Device reporting insufficient max texture size ({})", device_max_size);
+            return Err(InitError::MaxTextureSize);
+        }
+        let max_texture_size = cmp::max(
+            cmp::min(device_max_size, options.max_texture_size.unwrap_or(device_max_size)),
+            min_texture_size
+        );
+
+        register_thread_with_profiler("Compositor".to_owned());
+
         // device-pixel ratio doesn't matter here - we are just creating resources.
         device.begin_frame(1.0);
 
@@ -1111,9 +1130,6 @@ impl Renderer {
                                      &mut device,
                                      options.precache_shaders)
         };
-
-        let device_max_size = device.max_texture_size();
-        let max_texture_size = cmp::min(device_max_size, options.max_texture_size.unwrap_or(device_max_size));
 
         let texture_cache = TextureCache::new(max_texture_size);
         let backend_profile_counters = BackendProfileCounters::new();


### PR DESCRIPTION
This works around #1260 ([driver issues entry](https://github.com/servo/webrender/wiki/Driver-issues#1260---broken-gl-context-reports-max-texture-size-equal-to-zero)) by gracefully failing the initialization instead of panicking the first time we try to allocate a texture cache page.
This should let us fallback to another compositor backend and more easily identify the issue when it happens.