### PR TITLE
Export texture cache size limit

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -16,7 +16,7 @@ use core_text;
 use internal_types::FastHashMap;
 use std::collections::hash_map::Entry;
 use api::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
-use api::{GlyphKey, SubpixelDirection};
+use api::{GlyphKey};
 use api::{FontInstanceKey, NativeFontHandle};
 use gamma_lut::{GammaLut, Color as ColorLut};
 use std::ptr;

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -868,7 +868,7 @@ impl Renderer {
             println!("Device reporting insufficient max texture size ({})", device_max_size);
             return Err(InitError::MaxTextureSize);
         }
-        let max_texture_size = cmp::max(
+        let max_device_size = cmp::max(
             cmp::min(device_max_size, options.max_texture_size.unwrap_or(device_max_size)),
             min_texture_size
         );
@@ -1131,7 +1131,9 @@ impl Renderer {
                                      options.precache_shaders)
         };
 
-        let texture_cache = TextureCache::new(max_texture_size);
+        let texture_cache = TextureCache::new(max_device_size);
+        let max_texture_size = texture_cache.max_texture_size();
+
         let backend_profile_counters = BackendProfileCounters::new();
 
         let dummy_cache_texture_id = device.create_texture_ids(1, TextureTarget::Array)[0];


### PR DESCRIPTION
In TextureCache, there is another formula to calculate the max texture size. So, we should use that value instead of the device max texture size.