### PR TITLE
Add support for position:sticky

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -410,11 +410,9 @@ impl Frame {
             let transform = context.scene.properties.resolve_layout_transform(transform);
             let perspective =
                 stacking_context.perspective.unwrap_or_else(LayoutTransform::identity);
+            let origin = reference_frame_relative_offset + bounds.origin.to_vector();
             let transform =
-                LayerToScrollTransform::create_translation(reference_frame_relative_offset.x,
-                                                           reference_frame_relative_offset.y,
-                                                           0.0)
-                                        .pre_translate(bounds.origin.to_vector().to_3d())
+                LayerToScrollTransform::create_translation(origin.x, origin.y, 0.0)
                                         .pre_mul(&transform)
                                         .pre_mul(&perspective);
 
@@ -424,6 +422,7 @@ impl Frame {
                                                            pipeline_id,
                                                            &reference_frame_bounds,
                                                            &transform,
+                                                           origin,
                                                            &mut self.clip_scroll_tree);
             context.replacements.push((context_scroll_node_id, clip_id));
             reference_frame_relative_offset = LayerVector2D::zero();
@@ -485,16 +484,14 @@ impl Frame {
         self.pipeline_epoch_map.insert(pipeline_id, pipeline.epoch);
 
         let iframe_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
-        let transform = LayerToScrollTransform::create_translation(
-            reference_frame_relative_offset.x + bounds.origin.x,
-            reference_frame_relative_offset.y + bounds.origin.y,
-            0.0);
-
+        let origin = reference_frame_relative_offset + bounds.origin.to_vector();
+        let transform = LayerToScrollTransform::create_translation(origin.x, origin.y, 0.0);
         let iframe_reference_frame_id =
             context.builder.push_reference_frame(Some(clip_id),
                                                  pipeline_id,
                                                  &iframe_rect,
                                                  &transform,
+                                                 origin,
                                                  &mut self.clip_scroll_tree);
 
         context.builder.add_scroll_frame(
@@ -693,8 +690,9 @@ impl Frame {
                 clip_region.origin += reference_frame_relative_offset;
 
                 // Just use clip rectangle as the frame rect for this scroll frame.
-                // This is only interesting when calculating scroll extents for the
-                // ClipScrollNode::scroll(..) API
+                // This is useful when calculating scroll extents for the
+                // ClipScrollNode::scroll(..) API as well as for properly setting sticky
+                // positioning offsets.
                 let frame_rect = item.local_clip()
                                      .clip_rect()
                                      .translate(&reference_frame_relative_offset);
@@ -707,6 +705,16 @@ impl Frame {
                                           &content_rect,
                                           clip_region,
                                           info.scroll_sensitivity);
+            }
+            SpecificDisplayItem::StickyFrame(ref info) => {
+                let frame_rect = item.rect().translate(&reference_frame_relative_offset);
+                let new_clip_id = context.convert_new_id_to_nested(&info.id);
+                self.clip_scroll_tree.add_sticky_frame(
+                    new_clip_id,
+                    clip_and_scroll.scroll_node_id, /* parent id */
+                    frame_rect,
+                    info.sticky_frame_info);
+
             }
             SpecificDisplayItem::PushNestedDisplayList => {
                 // Using the clip and scroll already processed for nesting here

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -5,10 +5,10 @@
 use api::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipAndScrollInfo, ClipId, ColorF};
 use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect, DeviceUintSize};
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
-use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, SubpixelDirection};
+use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
 use api::{LayerToScrollTransform, LayerVector2D, LayoutVector2D, LineOrientation, LineStyle};
-use api::{LocalClip, PipelineId, RepeatMode, ScrollSensitivity, TextShadow, TileOffset};
-use api::{TransformStyle, WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
+use api::{LocalClip, PipelineId, RepeatMode, ScrollSensitivity, SubpixelDirection, TextShadow};
+use api::{TileOffset, TransformStyle, WebGLContextId, WorldPixel, YuvColorSpace, YuvData};
 use app_units::Au;
 use frame::FrameId;
 use gpu_cache::GpuCache;
@@ -323,9 +323,14 @@ impl FrameBuilder {
                                 pipeline_id: PipelineId,
                                 rect: &LayerRect,
                                 transform: &LayerToScrollTransform,
+                                origin_in_parent_reference_frame: LayerVector2D,
                                 clip_scroll_tree: &mut ClipScrollTree)
                                 -> ClipId {
-        let new_id = clip_scroll_tree.add_reference_frame(rect, transform, pipeline_id, parent_id);
+        let new_id = clip_scroll_tree.add_reference_frame(rect,
+                                                          transform,
+                                                          origin_in_parent_reference_frame,
+                                                          pipeline_id,
+                                                          parent_id);
         self.reference_frame_stack.push(new_id);
         new_id
     }
@@ -353,10 +358,10 @@ impl FrameBuilder {
 
         let root_id = clip_scroll_tree.root_reference_frame_id();
         if let Some(root_node) = clip_scroll_tree.nodes.get_mut(&root_id) {
-            if let NodeType::ReferenceFrame(ref mut transform) = root_node.node_type {
-                *transform = LayerToScrollTransform::create_translation(viewport_offset.x,
-                                                                        viewport_offset.y,
-                                                                        0.0);
+            if let NodeType::ReferenceFrame(ref mut info) = root_node.node_type {
+                info.transform = LayerToScrollTransform::create_translation(viewport_offset.x,
+                                                                            viewport_offset.y,
+                                                                            0.0);
             }
             root_node.local_clip_rect = viewport_clip;
         }
@@ -375,7 +380,12 @@ impl FrameBuilder {
                      -> ClipId {
         let viewport_rect = LayerRect::new(LayerPoint::zero(), *viewport_size);
         let identity = &LayerToScrollTransform::identity();
-        self.push_reference_frame(None, pipeline_id, &viewport_rect, identity, clip_scroll_tree);
+        self.push_reference_frame(None,
+                                  pipeline_id,
+                                  &viewport_rect,
+                                  identity,
+                                  LayerVector2D::zero(),
+                                  clip_scroll_tree);
 
         let topmost_scrolling_node_id = ClipId::root_scroll_node(pipeline_id);
         clip_scroll_tree.topmost_scrolling_node_id = topmost_scrolling_node_id;
@@ -1879,9 +1889,9 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             current_id = node.parent;
 
             let clip = match node.node_type {
-                NodeType::ReferenceFrame(transform) => {
+                NodeType::ReferenceFrame(ref info) => {
                     // if the transform is non-aligned, bake the next LCCR into the clip mask
-                    next_node_needs_region_mask |= !transform.preserves_2d_axis_alignment();
+                    next_node_needs_region_mask |= !info.transform.preserves_2d_axis_alignment();
                     continue
                 },
                 NodeType::Clip(ref clip) if clip.mask_cache_info.is_masking() => clip,

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use euclid::SideOffsets2D;
+use euclid::{SideOffsets2D, TypedSideOffsets2D};
 use {ColorF, FontKey, ImageKey, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
 use {GlyphOptions, LayoutVector2D, PipelineId, PropertyBinding, WebGLContextId};
 
@@ -50,6 +50,7 @@ pub struct DisplayItem {
 pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),
     ScrollFrame(ScrollFrameDisplayItem),
+    StickyFrame(StickyFrameDisplayItem),
     Rectangle(RectangleDisplayItem),
     Line(LineDisplayItem),
     Text(TextDisplayItem),
@@ -75,6 +76,20 @@ pub struct ClipDisplayItem {
     pub id: ClipId,
     pub parent_id: ClipId,
     pub image_mask: Option<ImageMask>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StickyFrameDisplayItem {
+    pub id: ClipId,
+    pub sticky_frame_info: StickyFrameInfo,
+}
+
+pub type StickyFrameInfo = TypedSideOffsets2D<Option<StickySideConstraint>, LayoutPoint>;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct StickySideConstraint {
+    pub margin: f32,
+    pub max_offset: f32,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
@@ -663,11 +678,12 @@ macro_rules! define_empty_heap_size_of {
     }
 }
 
-define_empty_heap_size_of!(ClipId);
-define_empty_heap_size_of!(RepeatMode);
-define_empty_heap_size_of!(ImageKey);
-define_empty_heap_size_of!(MixBlendMode);
-define_empty_heap_size_of!(TransformStyle);
-define_empty_heap_size_of!(LocalClip);
-define_empty_heap_size_of!(ScrollSensitivity);
 define_empty_heap_size_of!(ClipAndScrollInfo);
+define_empty_heap_size_of!(ClipId);
+define_empty_heap_size_of!(ImageKey);
+define_empty_heap_size_of!(LocalClip);
+define_empty_heap_size_of!(MixBlendMode);
+define_empty_heap_size_of!(RepeatMode);
+define_empty_heap_size_of!(ScrollSensitivity);
+define_empty_heap_size_of!(StickySideConstraint);
+define_empty_heap_size_of!(TransformStyle);

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -9,15 +9,15 @@ use serde::ser::{SerializeSeq, SerializeMap};
 use time::precise_time_ns;
 use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShadowDisplayItem};
 use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion, DisplayItem};
-use {ExtendMode, FilterOp, FontKey, GlyphIndex, GlyphInstance, GlyphOptions, Gradient};
-use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
-use {ImageRendering, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
-use {LineDisplayItem, LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId};
-use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
-use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity};
-use {SpecificDisplayItem, StackingContext, TextDisplayItem, TextShadow, TransformStyle};
-use {WebGLContextId, WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
-use {FastHashMap, FastHashSet};
+use {ExtendMode, FastHashMap, FastHashSet, FilterOp, FontKey, GlyphIndex, GlyphInstance};
+use {GlyphOptions, Gradient, GradientDisplayItem, GradientStop, IframeDisplayItem};
+use {ImageDisplayItem, ImageKey, ImageMask, ImageRendering, LayoutPoint, LayoutRect, LayoutSize};
+use {LayoutTransform, LayoutVector2D, LineDisplayItem, LineOrientation, LineStyle, LocalClip};
+use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
+use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy};
+use {ScrollSensitivity, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem};
+use {StickyFrameInfo, TextDisplayItem, TextShadow, TransformStyle, WebGLContextId};
+use {WebGLDisplayItem, YuvColorSpace, YuvData, YuvImageDisplayItem};
 use std::marker::PhantomData;
 
 #[repr(C)]
@@ -965,6 +965,21 @@ impl DisplayListBuilder {
 
         self.push_item(item, clip_rect, Some(LocalClip::from(clip_rect)));
         self.push_iter(complex_clips);
+        id
+    }
+
+    pub fn define_sticky_frame(&mut self,
+                               id: Option<ClipId>,
+                               frame_rect: LayoutRect,
+                               sticky_frame_info: StickyFrameInfo)
+                               -> ClipId {
+        let id = self.generate_clip_id(id);
+        let item = SpecificDisplayItem::StickyFrame(StickyFrameDisplayItem {
+            id,
+            sticky_frame_info,
+        });
+
+        self.push_item(item, frame_rect, None);
         id
     }
 

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -9,3 +9,4 @@
 == simple.yaml simple-ref.yaml
 == clip-and-scroll-property.yaml clip-and-scroll-property-ref.yaml
 == translate-nested.yaml translate-nested-ref.yaml
+== sticky.yaml sticky-ref.yaml

--- a/wrench/reftests/scrolling/sticky-ref.yaml
+++ b/wrench/reftests/scrolling/sticky-ref.yaml
@@ -1,0 +1,40 @@
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 50, 50]
+      color: green
+    - type: rect
+      bounds: [10, 70, 50, 50]
+      color: green
+    - type: rect
+      bounds: [70, 10, 50, 50]
+      color: green
+    - type: rect
+      bounds: [70, 70, 50, 50]
+      color: green
+
+    - type: rect
+      bounds: [130, 10, 50, 40]
+      color: green
+    - type: rect
+      bounds: [130, 70, 40, 50]
+      color: green
+    - type: rect
+      bounds: [190, 20, 50, 40]
+      color: green
+    - type: rect
+      bounds: [200, 70, 40, 50]
+      color: green
+
+    - type: rect
+      bounds: [250, 35, 50, 25]
+      color: green
+    - type: rect
+      bounds: [275, 70, 25, 50]
+      color: green
+    - type: rect
+      bounds: [310, 10, 50, 25]
+      color: green
+    - type: rect
+      bounds: [310, 70, 25, 50]
+      color: green

--- a/wrench/reftests/scrolling/sticky.yaml
+++ b/wrench/reftests/scrolling/sticky.yaml
@@ -1,0 +1,167 @@
+root:
+  items:
+    # This is a scroll frame with an out-of-viewport rect that should be pushed into the
+    # viewport by its "bottom" sticky constraint.
+    - type: scroll-frame
+      bounds: [10, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [10, 60, 50, 50]
+        sticky-info:
+          bottom: [0, -500]
+        items:
+        - type: rect
+          bounds: [10, 60, 50, 50]
+          color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [70, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [70, 10, 50, 50]
+        sticky-info:
+          top: [0, 500]
+        items:
+        - type: rect
+          bounds: [70, 10, 50, 50]
+          color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [10, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [60, 70, 50, 50]
+        sticky-info:
+          right: [0, -500]
+        items:
+        - type: rect
+          bounds: [60, 70, 50, 50]
+          color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [70, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [70, 70, 50, 50]
+        sticky-info:
+          left: [0, 500]
+        items:
+        - type: rect
+          bounds: [70, 70, 50, 50]
+          color: green
+
+    # The same tests, but this time with a margin.
+    - type: scroll-frame
+      bounds: [130, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [130, 60, 50, 50]
+        sticky-info:
+          bottom: [10, -500]
+        items:
+        - type: rect
+          bounds: [130, 60, 50, 50]
+          color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [190, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [190, 10, 50, 50]
+        sticky-info:
+          top: [10, 500]
+        items:
+        - type: rect
+          bounds: [190, 10, 50, 50]
+          color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [130, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [180, 70, 50, 50]
+        sticky-info:
+          right: [10, -500]
+        items:
+        - type: rect
+          bounds: [180, 70, 50, 50]
+          color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [190, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [190, 70, 50, 50]
+        sticky-info:
+          left: [10, 500]
+        items:
+        - type: rect
+          bounds: [190, 70, 50, 50]
+          color: green
+
+    # The same tests, but this time with a limit.
+    - type: scroll-frame
+      bounds: [250, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [250, 60, 50, 50]
+        sticky-info:
+          bottom: [0, -25]
+        items:
+        - type: rect
+          bounds: [250, 60, 50, 50]
+          color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [310, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [310, 10, 50, 50]
+        sticky-info:
+          top: [0, 25]
+        items:
+        - type: rect
+          bounds: [310, 10, 50, 50]
+          color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [250, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [300, 70, 50, 50]
+        sticky-info:
+          right: [0, -25]
+        items:
+        - type: rect
+          bounds: [300, 70, 50, 50]
+          color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [310, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [310, 70, 50, 50]
+        sticky-info:
+          left: [0, 25]
+        items:
+        - type: rect
+          bounds: [310, 70, 50, 50]
+          color: green

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -164,7 +164,20 @@ impl YamlFrameReader {
                 vec![]
             }
         }
+    }
 
+    fn to_sticky_info(&mut self, item: &Yaml) -> Option<StickySideConstraint> {
+        match item.as_vec_f32() {
+            Some(v) => Some(StickySideConstraint { margin: v[0], max_offset: v[1] }),
+            None => None,
+        }
+    }
+
+    fn to_sticky_frame_info(&mut self, item: &Yaml) -> StickyFrameInfo {
+        StickyFrameInfo::new(self.to_sticky_info(&item["top"]),
+                             self.to_sticky_info(&item["right"]),
+                             self.to_sticky_info(&item["bottom"]),
+                             self.to_sticky_info(&item["left"]))
     }
 
     fn get_or_create_font(&mut self, desc: FontDescriptor, wrench: &mut Wrench) -> FontKey {
@@ -601,6 +614,7 @@ impl YamlFrameReader {
                 "image" => self.handle_image(dl, wrench, item, local_clip),
                 "text" | "glyphs" => self.handle_text(dl, wrench, item, local_clip),
                 "scroll-frame" => self.handle_scroll_frame(dl, wrench, item),
+                "sticky-frame" => self.handle_sticky_frame(dl, wrench, item),
                 "clip" => self.handle_clip(dl, wrench, item),
                 "border" => self.handle_border(dl, wrench, item, local_clip),
                 "gradient" => self.handle_gradient(dl, item, local_clip),
@@ -620,7 +634,7 @@ impl YamlFrameReader {
     }
 
     pub fn handle_scroll_frame(&mut self, dl: &mut DisplayListBuilder, wrench: &mut Wrench, yaml: &Yaml) {
-        let clip_rect = yaml["bounds"].as_rect().expect("clip must have a bounds");
+        let clip_rect = yaml["bounds"].as_rect().expect("scroll frame must have a bounds");
         let content_size = yaml["content-size"].as_size().unwrap_or(clip_rect.size);
         let content_rect = LayerRect::new(clip_rect.origin, content_size);
 
@@ -638,6 +652,19 @@ impl YamlFrameReader {
         if let Some(size) = yaml["scroll-offset"].as_point() {
             self.scroll_offsets.insert(id, LayerPoint::new(size.x, size.y));
         }
+
+        dl.push_clip_id(id);
+        if !yaml["items"].is_badvalue() {
+            self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);
+        }
+        dl.pop_clip_id();
+    }
+
+    pub fn handle_sticky_frame(&mut self, dl: &mut DisplayListBuilder, wrench: &mut Wrench, yaml: &Yaml) {
+        let bounds = yaml["bounds"].as_rect().expect("sticky frame must have a bounds");
+        let id = yaml["id"].as_i64().map(|id| ClipId::new(id as u64, dl.pipeline_id));
+        let sticky_frame_info = self.to_sticky_frame_info(&yaml["sticky-info"]);
+        let id = dl.define_sticky_frame(id, bounds, sticky_frame_info);
 
         dl.push_clip_id(id);
         if !yaml["items"].is_badvalue() {


### PR DESCRIPTION
We add a new clip scroll tree node type which is a sticky frame. The
StickyFrame doesn't do any clipping, but will adjust the position of its
contents to satisfy a given set of sticky constraints. The constraints
consist of a margin (distance from the particular edge of the viewport)
and a max_offset, which determines how far the sticky frame can move
from its original (scrolled) position. The design of these  constraints
can be modified if they are particularly unpleasant for Gecko to
implement.

Fixes #1277.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1573)
<!-- Reviewable:end -->
