### PR TITLE
Avoid Sending an empty message if there is no resource to update.

### DIFF
--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -371,6 +371,9 @@ impl RenderApi {
 
     /// Adds an image identified by the `ImageKey`.
     pub fn update_resources(&self, resources: ResourceUpdates) {
+        if resources.updates.is_empty() {
+            return;
+        }
         self.api_sender.send(ApiMsg::UpdateResources(resources)).unwrap();
     }
 


### PR DESCRIPTION
I tiny detail, but it is more convenient to check here and always call `update_resources` in gecko/servo than check whether the update list isn't empty before calling `update_resources`. Typically (in particular in gecko), the `ResourceUpdates` is passed around and the code that adds updates is different from the one that sends the transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1579)
<!-- Reviewable:end -->
