### PR TITLE
Rename FontInstanceKey to FontInstance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.48.0",
+ "webrender 0.48.1",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1030,7 +1030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1056,12 +1056,12 @@ dependencies = [
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.48.0",
+ "webrender_api 0.48.1",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.48.0"
+version = "0.48.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/src/glyph_cache.rs
+++ b/webrender/src/glyph_cache.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DevicePoint, DeviceUintSize, FontInstanceKey, GlyphKey};
+use api::{DevicePoint, DeviceUintSize, FontInstance, GlyphKey};
 use internal_types::FastHashMap;
 use resource_cache::ResourceClassCache;
 use std::sync::Arc;
@@ -18,7 +18,7 @@ pub struct CachedGlyphInfo {
 pub type GlyphKeyCache = ResourceClassCache<GlyphKey, Option<CachedGlyphInfo>>;
 
 pub struct GlyphCache {
-    pub glyph_key_caches: FastHashMap<FontInstanceKey, GlyphKeyCache>,
+    pub glyph_key_caches: FastHashMap<FontInstance, GlyphKeyCache>,
 }
 
 impl GlyphCache {
@@ -29,14 +29,14 @@ impl GlyphCache {
     }
 
     pub fn get_glyph_key_cache_for_font_mut(&mut self,
-                                            font: FontInstanceKey) -> &mut GlyphKeyCache {
+                                            font: FontInstance) -> &mut GlyphKeyCache {
         self.glyph_key_caches
             .entry(font)
             .or_insert(ResourceClassCache::new())
     }
 
     pub fn get_glyph_key_cache_for_font(&self,
-                                        font: &FontInstanceKey) -> &GlyphKeyCache {
+                                        font: &FontInstance) -> &GlyphKeyCache {
         self.glyph_key_caches
             .get(font)
             .expect("BUG: Unable to find glyph key cache!")
@@ -52,7 +52,7 @@ impl GlyphCache {
     }
 
     pub fn clear_fonts<F>(&mut self, key_fun: F)
-    where for<'r> F: Fn(&'r &FontInstanceKey) -> bool
+    where for<'r> F: Fn(&'r &FontInstance) -> bool
     {
         let caches_to_destroy = self.glyph_key_caches.keys()
             .filter(&key_fun)

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -19,7 +19,7 @@ use std::mem;
 use texture_cache::{TextureCache, TextureCacheHandle};
 #[cfg(test)]
 use api::{ColorF, LayoutPoint, FontRenderMode, IdNamespace, SubpixelDirection};
-use api::{DevicePoint, DeviceUintSize, FontInstanceKey};
+use api::{DevicePoint, DeviceUintSize, FontInstance};
 use api::{FontKey, FontTemplate};
 use api::{ImageData, ImageDescriptor, ImageFormat};
 use api::{GlyphKey, GlyphDimensions};
@@ -145,7 +145,7 @@ impl GlyphRasterizer {
     pub fn request_glyphs(
         &mut self,
         glyph_cache: &mut GlyphCache,
-        font: FontInstanceKey,
+        font: FontInstance,
         glyph_keys: &[GlyphKey],
         texture_cache: &mut TextureCache,
         gpu_cache: &mut GpuCache) {
@@ -222,7 +222,7 @@ impl GlyphRasterizer {
     }
 
     pub fn get_glyph_dimensions(&mut self,
-                                font: &FontInstanceKey,
+                                font: &FontInstance,
                                 glyph_key: &GlyphKey) -> Option<GlyphDimensions> {
         self.font_contexts.lock_shared_context().get_glyph_dimensions(font, glyph_key)
     }
@@ -339,11 +339,11 @@ impl FontContext {
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 pub struct GlyphRequest {
     pub key: GlyphKey,
-    pub font: FontInstanceKey,
+    pub font: FontInstance,
 }
 
 impl GlyphRequest {
-    pub fn new(font: &FontInstanceKey, key: &GlyphKey) -> Self {
+    pub fn new(font: &FontInstance, key: &GlyphKey) -> Self {
         GlyphRequest {
             key: key.clone(),
             font: font.clone(),
@@ -378,7 +378,7 @@ fn raterize_200_glyphs() {
     let font_key = FontKey::new(IdNamespace(0), 0);
     glyph_rasterizer.add_font(font_key, FontTemplate::Raw(Arc::new(font_data), 0));
 
-    let font = FontInstanceKey {
+    let font = FontInstance {
         font_key,
         color: ColorF::new(0.0, 0.0, 0.0, 1.0).into(),
         size: Au::from_px(32),

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -17,7 +17,7 @@ use internal_types::FastHashMap;
 use std::collections::hash_map::Entry;
 use api::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
 use api::{GlyphKey};
-use api::{FontInstanceKey, NativeFontHandle};
+use api::{FontInstance, NativeFontHandle};
 use gamma_lut::{GammaLut, Color as ColorLut};
 use std::ptr;
 use std::sync::Arc;
@@ -238,7 +238,7 @@ impl FontContext {
     }
 
     pub fn get_glyph_dimensions(&mut self,
-                                font: &FontInstanceKey,
+                                font: &FontInstance,
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         self.get_ct_font(font.font_key, font.size).and_then(|ref ct_font| {
             let glyph = key.index as CGGlyph;
@@ -298,7 +298,7 @@ impl FontContext {
     }
 
     pub fn rasterize_glyph(&mut self,
-                           font: &FontInstanceKey,
+                           font: &FontInstance,
                            key: &GlyphKey)
                            -> Option<RasterizedGlyph> {
 

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{FontInstanceKey, FontKey, FontRenderMode, GlyphDimensions};
+use api::{FontInstance, FontKey, FontRenderMode, GlyphDimensions};
 use api::{NativeFontHandle, SubpixelDirection};
 use api::{GlyphKey};
 use internal_types::FastHashMap;
@@ -123,7 +123,7 @@ impl FontContext {
     }
 
     fn load_glyph(&self,
-                  font: &FontInstanceKey,
+                  font: &FontInstance,
                   glyph: &GlyphKey) -> Option<FT_GlyphSlot> {
 
         debug_assert!(self.faces.contains_key(&font.font_key));
@@ -166,7 +166,7 @@ impl FontContext {
     // Get the bounding box for a glyph, accounting for sub-pixel positioning.
     fn get_bounding_box(&self,
                         slot: FT_GlyphSlot,
-                        font: &FontInstanceKey,
+                        font: &FontInstance,
                         glyph: &GlyphKey) -> FT_BBox {
         let mut cbox: FT_BBox = unsafe { mem::uninitialized() };
 
@@ -213,7 +213,7 @@ impl FontContext {
 
     fn get_glyph_dimensions_impl(&self,
                                  slot: FT_GlyphSlot,
-                                 font: &FontInstanceKey,
+                                 font: &FontInstance,
                                  glyph: &GlyphKey) -> Option<GlyphDimensions> {
         let metrics = unsafe { &(*slot).metrics };
 
@@ -249,7 +249,7 @@ impl FontContext {
     }
 
     pub fn get_glyph_dimensions(&mut self,
-                                font: &FontInstanceKey,
+                                font: &FontInstance,
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         let slot = self.load_glyph(font, key);
         slot.and_then(|slot| {
@@ -258,7 +258,7 @@ impl FontContext {
     }
 
     pub fn rasterize_glyph(&mut self,
-                           font: &FontInstanceKey,
+                           font: &FontInstance,
                            key: &GlyphKey)
                            -> Option<RasterizedGlyph> {
 

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{FontKey, FontRenderMode, GlyphDimensions};
-use api::{FontInstanceKey, GlyphKey, GlyphOptions, SubpixelDirection};
+use api::{FontInstance, GlyphKey, GlyphOptions, SubpixelDirection};
 use gamma_lut::{GammaLut, Color as ColorLut};
 use internal_types::FastHashMap;
 
@@ -155,7 +155,7 @@ impl FontContext {
     }
 
     fn create_glyph_analysis(&self,
-                             font: &FontInstanceKey,
+                             font: &FontInstance,
                              key: &GlyphKey) ->
                             dwrote::GlyphRunAnalysis {
         let face = self.fonts.get(&font.font_key).unwrap();
@@ -202,7 +202,7 @@ impl FontContext {
 
     // TODO: Pipe GlyphOptions into glyph_dimensions too
     pub fn get_glyph_dimensions(&self,
-                                font: &FontInstanceKey,
+                                font: &FontInstance,
                                 key: &GlyphKey)
                                 -> Option<GlyphDimensions> {
         // Probably have to default to something else here.
@@ -283,7 +283,7 @@ impl FontContext {
     }
 
     pub fn rasterize_glyph(&mut self,
-                           font: &FontInstanceKey,
+                           font: &FontInstance,
                            key: &GlyphKey)
                            -> Option<RasterizedGlyph> {
         let analysis = self.create_glyph_analysis(font, key);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntS
 use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, TextShadow};
 use api::{GlyphKey, LayerToWorldTransform, TileOffset, WebGLContextId, YuvColorSpace, YuvFormat};
-use api::{device_length, FontInstanceKey, LayerVector2D, LineOrientation, LineStyle, SubpixelDirection};
+use api::{device_length, FontInstance, LayerVector2D, LineOrientation, LineStyle, SubpixelDirection};
 use app_units::Au;
 use border::BorderCornerInstance;
 use euclid::{Size2D};
@@ -546,12 +546,12 @@ impl TextRunPrimitiveCpu {
             TextRunMode::Shadow => self.shadow_render_mode,
         };
 
-        let font = FontInstanceKey::new(self.font_key,
-                                        font_size_dp,
-                                        self.color,
-                                        render_mode,
-                                        self.glyph_options,
-                                        self.subpx_dir);
+        let font = FontInstance::new(self.font_key,
+                                     font_size_dp,
+                                     self.color,
+                                     render_mode,
+                                     self.glyph_options,
+                                     self.subpx_dir);
 
         // Cache the glyph positions, if not in the cache already.
         // TODO(gw): In the future, remove `glyph_instances`

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -17,7 +17,7 @@ use texture_cache::{TextureCache, TextureCacheHandle};
 use api::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest};
 use api::{BlobImageResources, BlobImageData, ResourceUpdates, ResourceUpdate, AddFont};
 use api::{DevicePoint, DeviceIntSize, DeviceUintRect, DeviceUintSize};
-use api::{Epoch, FontInstanceKey, FontKey, FontTemplate};
+use api::{Epoch, FontInstance, FontKey, FontTemplate};
 use api::{GlyphDimensions, GlyphKey, IdNamespace};
 use api::{ImageData, ImageDescriptor, ImageKey, ImageRendering};
 use api::{TileOffset, TileSize};
@@ -496,7 +496,7 @@ impl ResourceCache {
     }
 
     pub fn request_glyphs(&mut self,
-                          font: FontInstanceKey,
+                          font: FontInstance,
                           glyph_keys: &[GlyphKey],
                           gpu_cache: &mut GpuCache) {
         debug_assert_eq!(self.state, State::AddResources);
@@ -515,7 +515,7 @@ impl ResourceCache {
     }
 
     pub fn get_glyphs<F>(&self,
-                         font: FontInstanceKey,
+                         font: FontInstance,
                          glyph_keys: &[GlyphKey],
                          mut f: F) -> SourceTexture where F: FnMut(usize, &GpuCacheHandle) {
         debug_assert_eq!(self.state, State::QueryResources);
@@ -538,7 +538,7 @@ impl ResourceCache {
     }
 
     pub fn get_glyph_dimensions(&mut self,
-                                font: &FontInstanceKey,
+                                font: &FontInstance,
                                 key: &GlyphKey) -> Option<GlyphDimensions> {
         let key = GlyphRequest::new(font, key);
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -21,7 +21,7 @@ use std::{f32, i32, mem, usize};
 use texture_allocator::GuillotineAllocator;
 use util::{TransformedRect, TransformedRectKind};
 use api::{BuiltDisplayList, ClipAndScrollInfo, ClipId, ColorF, DeviceIntPoint, ImageKey};
-use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize, FontInstanceKey};
+use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize, FontInstance};
 use api::{ExternalImageType, FilterOp, FontRenderMode, ImageRendering, LayerRect};
 use api::{LayerToWorldTransform, MixBlendMode, PipelineId, PropertyBinding, TransformStyle};
 use api::{TileOffset, WorldToLayerTransform, YuvColorSpace, YuvFormat, LayerVector2D};
@@ -488,12 +488,12 @@ impl AlphaRenderItem {
                         // TODO(gw): avoid / recycle this allocation in the future.
                         let mut instances = Vec::new();
 
-                        let font = FontInstanceKey::new(text_cpu.font_key,
-                                                        font_size_dp,
-                                                        text_cpu.color,
-                                                        text_cpu.normal_render_mode,
-                                                        text_cpu.glyph_options,
-                                                        text_cpu.subpx_dir);
+                        let font = FontInstance::new(text_cpu.font_key,
+                                                     font_size_dp,
+                                                     text_cpu.color,
+                                                     text_cpu.normal_render_mode,
+                                                     text_cpu.glyph_options,
+                                                     text_cpu.subpx_dir);
 
                         let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                        &text_cpu.glyph_keys,
@@ -1067,12 +1067,12 @@ impl RenderTarget for ColorRenderTarget {
                                     let text = &ctx.prim_store.cpu_text_runs[sub_metadata.cpu_prim_index.0];
                                     let font_size_dp = text.logical_font_size.scale_by(ctx.device_pixel_ratio);
 
-                                    let font = FontInstanceKey::new(text.font_key,
-                                                                    font_size_dp,
-                                                                    text.color,
-                                                                    text.shadow_render_mode,
-                                                                    text.glyph_options,
-                                                                    text.subpx_dir);
+                                    let font = FontInstance::new(text.font_key,
+                                                                 font_size_dp,
+                                                                 text.color,
+                                                                 text.shadow_render_mode,
+                                                                 text.glyph_options,
+                                                                 text.subpx_dir);
 
                                     let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                                    &text.glyph_keys,

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.48.0"
+version = "0.48.1"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint, DeviceIntSize};
 use {DeviceUintRect, DeviceUintSize, FontKey, GlyphDimensions, GlyphKey};
 use {ImageData, ImageDescriptor, ImageKey, LayoutPoint, LayoutVector2D, LayoutSize, LayoutTransform};
-use {FontInstanceKey, NativeFontHandle, WorldPoint};
+use {FontInstance, NativeFontHandle, WorldPoint};
 #[cfg(feature = "webgl")]
 use {WebGLCommand, WebGLContextId};
 
@@ -148,7 +148,7 @@ pub enum ApiMsg {
     /// Add/remove/update images and fonts.
     UpdateResources(ResourceUpdates),
     /// Gets the glyph dimensions
-    GetGlyphDimensions(FontInstanceKey, Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
+    GetGlyphDimensions(FontInstance, Vec<GlyphKey>, MsgSender<Vec<Option<GlyphDimensions>>>),
     /// Gets the glyph indices from a string
     GetGlyphIndices(FontKey, String, MsgSender<Vec<Option<u32>>>),
     /// Adds a new document namespace.
@@ -343,7 +343,7 @@ impl RenderApi {
     /// 'empty' textures (height or width = 0)
     /// This means that glyph dimensions e.g. for spaces (' ') will mostly be None.
     pub fn get_glyph_dimensions(&self,
-                                font: FontInstanceKey,
+                                font: FontInstance,
                                 glyph_keys: Vec<GlyphKey>)
                                 -> Vec<Option<GlyphDimensions>> {
         let (tx, rx) = channel::msg_channel().unwrap();

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -145,7 +145,7 @@ pub struct GlyphOptions {
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
-pub struct FontInstanceKey {
+pub struct FontInstance {
     pub font_key: FontKey,
     // The font size is in *device* pixels, not logical pixels.
     // It is stored as an Au since we need sub-pixel sizes, but
@@ -159,13 +159,13 @@ pub struct FontInstanceKey {
     pub subpx_dir: SubpixelDirection,
 }
 
-impl FontInstanceKey {
+impl FontInstance {
     pub fn new(font_key: FontKey,
                size: Au,
                mut color: ColorF,
                render_mode: FontRenderMode,
                glyph_options: Option<GlyphOptions>,
-               subpx_dir: SubpixelDirection) -> FontInstanceKey {
+               subpx_dir: SubpixelDirection) -> FontInstance {
         // In alpha/mono mode, the color of the font is irrelevant.
         // Forcing it to black in those cases saves rasterizing glyphs
         // of different colors when not needed.
@@ -173,7 +173,7 @@ impl FontInstanceKey {
             color = ColorF::new(0.0, 0.0, 0.0, 1.0);
         }
 
-        FontInstanceKey {
+        FontInstance {
             font_key,
             size,
             color: color.into(),

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -224,12 +224,12 @@ impl Wrench {
                                     .collect();
 
         // Retrieve the metrics for each glyph.
-        let font = FontInstanceKey::new(font_key,
-                                        size,
-                                        ColorF::new(0.0, 0.0, 0.0, 1.0),
-                                        FontRenderMode::Alpha,
-                                        None,
-                                        SubpixelDirection::Horizontal);
+        let font = FontInstance::new(font_key,
+                                     size,
+                                     ColorF::new(0.0, 0.0, 0.0, 1.0),
+                                     FontRenderMode::Alpha,
+                                     None,
+                                     SubpixelDirection::Horizontal);
         let mut keys = Vec::new();
         for glyph_index in &indices {
             keys.push(GlyphKey::new(*glyph_index,


### PR DESCRIPTION
In preparation for some API changes that will introduce a different sort of "FontInstanceKey", Glenn and I discussed that it would make more sense for what is now currently called "FontInstanceKey" to actually just be "FontInstance", whereas "FontInstanceKey" will now be something of an identifier for that thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1580)
<!-- Reviewable:end -->
