### PR TITLE
Add external image support for both 2D and 2D_ARRAY samplers.

### DIFF
--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -14,7 +14,7 @@
 // The textureLod() doesn't support sampler2DRect for WR_FEATURE_TEXTURE_RECT, too.
 //
 // Use texture() instead.
-#if defined(WR_FEATURE_TEXTURE_EXTERNAL) || defined(WR_FEATURE_TEXTURE_RECT)
+#if defined(WR_FEATURE_TEXTURE_EXTERNAL) || defined(WR_FEATURE_TEXTURE_RECT) || defined(WR_FEATURE_TEXTURE_2D)
 #define TEX_SAMPLE(sampler, tex_coord) texture(sampler, tex_coord.xy)
 #else
 // In normal case, we use textureLod(). We haven't used the lod yet. So, we always pass 0.0 now.
@@ -71,7 +71,11 @@
     #define HIGHP_SAMPLER_FLOAT
 #endif
 
-#ifdef WR_FEATURE_TEXTURE_RECT
+#ifdef WR_FEATURE_TEXTURE_2D
+uniform sampler2D sColor0;
+uniform sampler2D sColor1;
+uniform sampler2D sColor2;
+#elif defined WR_FEATURE_TEXTURE_RECT
 uniform sampler2DRect sColor0;
 uniform sampler2DRect sColor1;
 uniform sampler2DRect sColor2;

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -155,18 +155,21 @@ pub enum ImageBufferKind {
     Texture2D = 0,
     TextureRect = 1,
     TextureExternal = 2,
+    Texture2DArray = 3,
 }
 
-pub const IMAGE_BUFFER_KINDS: [ImageBufferKind; 3] = [
+pub const IMAGE_BUFFER_KINDS: [ImageBufferKind; 4] = [
     ImageBufferKind::Texture2D,
     ImageBufferKind::TextureRect,
-    ImageBufferKind::TextureExternal
+    ImageBufferKind::TextureExternal,
+    ImageBufferKind::Texture2DArray,
 ];
 
 impl ImageBufferKind {
     pub fn get_feature_string(&self) -> &'static str {
         match *self {
-            ImageBufferKind::Texture2D => "",
+            ImageBufferKind::Texture2D => "TEXTURE_2D",
+            ImageBufferKind::Texture2DArray => "",
             ImageBufferKind::TextureRect => "TEXTURE_RECT",
             ImageBufferKind::TextureExternal => "TEXTURE_EXTERNAL",
         }
@@ -177,6 +180,7 @@ impl ImageBufferKind {
             gl::GlType::Gles => {
                 match *self {
                     ImageBufferKind::Texture2D => true,
+                    ImageBufferKind::Texture2DArray => true,
                     ImageBufferKind::TextureRect => true,
                     ImageBufferKind::TextureExternal => true,
                 }
@@ -184,6 +188,7 @@ impl ImageBufferKind {
             gl::GlType::Gl => {
                 match *self {
                     ImageBufferKind::Texture2D => true,
+                    ImageBufferKind::Texture2DArray => true,
                     ImageBufferKind::TextureRect => true,
                     ImageBufferKind::TextureExternal => false,
                 }
@@ -2157,6 +2162,7 @@ impl Renderer {
                 let image = handler.lock(ext_image.id, ext_image.channel_index);
                 let texture_target = match ext_image.image_type {
                     ExternalImageType::Texture2DHandle => TextureTarget::Default,
+                    ExternalImageType::Texture2DArrayHandle => TextureTarget::Array,
                     ExternalImageType::TextureRectHandle => TextureTarget::Rect,
                     ExternalImageType::TextureExternalHandle => TextureTarget::External,
                     ExternalImageType::ExternalBuffer => {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -577,6 +577,7 @@ impl ResourceCache {
                 ImageData::External(ext_image) => {
                     match ext_image.image_type {
                         ExternalImageType::Texture2DHandle |
+                        ExternalImageType::Texture2DArrayHandle |
                         ExternalImageType::TextureRectHandle |
                         ExternalImageType::TextureExternalHandle => {
                             Some(ext_image)

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -942,6 +942,7 @@ impl TextureUpdate {
             ImageData::External(ext_image) => {
                 match ext_image.image_type {
                     ExternalImageType::Texture2DHandle |
+                    ExternalImageType::Texture2DArrayHandle |
                     ExternalImageType::TextureRectHandle |
                     ExternalImageType::TextureExternalHandle => {
                         panic!("External texture handle should not go through texture_cache.");

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -459,6 +459,7 @@ impl AlphaRenderItem {
                             SourceTexture::External(ext_image) => {
                                 match ext_image.image_type {
                                     ExternalImageType::Texture2DHandle => AlphaBatchKind::Image(ImageBufferKind::Texture2D),
+                                    ExternalImageType::Texture2DArrayHandle => AlphaBatchKind::Image(ImageBufferKind::Texture2DArray),
                                     ExternalImageType::TextureRectHandle => AlphaBatchKind::Image(ImageBufferKind::TextureRect),
                                     ExternalImageType::TextureExternalHandle => AlphaBatchKind::Image(ImageBufferKind::TextureExternal),
                                     ExternalImageType::ExternalBuffer => {
@@ -469,7 +470,7 @@ impl AlphaRenderItem {
                                 }
                             }
                             _ => {
-                                AlphaBatchKind::Image(ImageBufferKind::Texture2D)
+                                AlphaBatchKind::Image(ImageBufferKind::Texture2DArray)
                             }
                         };
 
@@ -570,6 +571,7 @@ impl AlphaRenderItem {
                                 SourceTexture::External(ext_image) => {
                                     match ext_image.image_type {
                                         ExternalImageType::Texture2DHandle => ImageBufferKind::Texture2D,
+                                        ExternalImageType::Texture2DArrayHandle => ImageBufferKind::Texture2DArray,
                                         ExternalImageType::TextureRectHandle => ImageBufferKind::TextureRect,
                                         ExternalImageType::TextureExternalHandle => ImageBufferKind::TextureExternal,
                                         ExternalImageType::ExternalBuffer => {
@@ -580,7 +582,7 @@ impl AlphaRenderItem {
                                     }
                                 }
                                 _ => {
-                                    ImageBufferKind::Texture2D
+                                    ImageBufferKind::Texture2DArray
                                 }
                             }
                         };

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -33,6 +33,7 @@ pub struct ExternalImageId(pub u64);
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum ExternalImageType {
     Texture2DHandle,        // gl TEXTURE_2D handle
+    Texture2DArrayHandle,   // gl TEXTURE_2D_ARRAY handle
     TextureRectHandle,      // gl TEXTURE_RECT handle
     TextureExternalHandle,  // gl TEXTURE_EXTERNAL handle
     ExternalBuffer,
@@ -131,6 +132,7 @@ impl ImageData {
             &ImageData::External(ext_data) => {
                 match ext_data.image_type {
                     ExternalImageType::Texture2DHandle => false,
+                    ExternalImageType::Texture2DArrayHandle => false,
                     ExternalImageType::TextureRectHandle => false,
                     ExternalImageType::TextureExternalHandle => false,
                     ExternalImageType::ExternalBuffer => true,


### PR DESCRIPTION
This fixes an oversight on my part when adding the new texture
cache implementation. The webgl / offscreen rendering code has
not been updated to create array textures.

Add explicit external image support for both 2D and 2D_ARRAY
samplers. In the future, we may deprecate / remove the 2D
image buffer kind, once we have switched everything over to
use array textures, but this is a good interim fix for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1581)
<!-- Reviewable:end -->
