### PR TITLE
Switch clip code and shaders to use typed GpuCacheAddress directly.

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -13,16 +13,15 @@
 
 in int aClipRenderTaskIndex;
 in int aClipLayerIndex;
-in int aClipDataIndex;
-in int aClipSegmentIndex;
-in int aClipResourceAddress;
+in int aClipSegment;
+in ivec4 aClipDataResourceAddress;
 
 struct CacheClipInstance {
     int render_task_index;
     int layer_index;
-    int data_index;
-    int segment_index;
-    int resource_address;
+    int segment;
+    ivec2 clip_data_address;
+    ivec2 resource_address;
 };
 
 CacheClipInstance fetch_clip_item(int index) {
@@ -30,9 +29,9 @@ CacheClipInstance fetch_clip_item(int index) {
 
     cci.render_task_index = aClipRenderTaskIndex;
     cci.layer_index = aClipLayerIndex;
-    cci.data_index = aClipDataIndex;
-    cci.segment_index = aClipSegmentIndex;
-    cci.resource_address = aClipResourceAddress;
+    cci.segment = aClipSegment;
+    cci.clip_data_address = aClipDataResourceAddress.xy;
+    cci.resource_address = aClipDataResourceAddress.zw;
 
     return cci;
 }
@@ -48,7 +47,7 @@ struct ClipVertexInfo {
 ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
                                       Layer layer,
                                       ClipArea area,
-                                      int segment_index) {
+                                      int segment) {
 
     RectWithSize clipped_local_rect = intersect_rect(local_clip_rect,
                                                      layer.local_clip_rect);
@@ -59,7 +58,7 @@ ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
     vec2 inner_p1 = area.inner_rect.zw;
 
     vec2 p0, p1;
-    switch (segment_index) {
+    switch (segment) {
         case SEGMENT_ALL:
             p0 = outer_p0;
             p1 = outer_p1;

--- a/webrender/res/cs_clip_image.vs.glsl
+++ b/webrender/res/cs_clip_image.vs.glsl
@@ -7,8 +7,8 @@ struct ImageMaskData {
     RectWithSize local_rect;
 };
 
-ImageMaskData fetch_mask_data(int index) {
-    vec4 data = fetch_from_resource_cache_1(index);
+ImageMaskData fetch_mask_data(ivec2 address) {
+    vec4 data = fetch_from_resource_cache_1_direct(address);
     return ImageMaskData(RectWithSize(data.xy, data.zw));
 }
 
@@ -16,14 +16,14 @@ void main(void) {
     CacheClipInstance cci = fetch_clip_item(gl_InstanceID);
     ClipArea area = fetch_clip_area(cci.render_task_index);
     Layer layer = fetch_layer(cci.layer_index);
-    ImageMaskData mask = fetch_mask_data(cci.data_index);
+    ImageMaskData mask = fetch_mask_data(cci.clip_data_address);
     RectWithSize local_rect = mask.local_rect;
-    ImageResource res = fetch_image_resource(cci.resource_address);
+    ImageResource res = fetch_image_resource_direct(cci.resource_address);
 
     ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
                                                layer,
                                                area,
-                                               cci.segment_index);
+                                               cci.segment);
 
     vPos = vi.local_pos;
     vLayer = res.layer;

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -110,6 +110,13 @@ ivec2 get_resource_cache_uv(int address) {
 
 uniform HIGHP_SAMPLER_FLOAT sampler2D sResourceCache;
 
+vec4[2] fetch_from_resource_cache_2_direct(ivec2 address) {
+    return vec4[2](
+        texelFetchOffset(sResourceCache, address, 0, ivec2(0, 0)),
+        texelFetchOffset(sResourceCache, address, 0, ivec2(1, 0))
+    );
+}
+
 vec4[2] fetch_from_resource_cache_2(int address) {
     ivec2 uv = get_resource_cache_uv(address);
     return vec4[2](
@@ -172,6 +179,10 @@ vec4[4] fetch_from_resource_cache_4(int address) {
         texelFetchOffset(sResourceCache, uv, 0, ivec2(2, 0)),
         texelFetchOffset(sResourceCache, uv, 0, ivec2(3, 0))
     );
+}
+
+vec4 fetch_from_resource_cache_1_direct(ivec2 address) {
+    return texelFetch(sResourceCache, address, 0);
 }
 
 vec4 fetch_from_resource_cache_1(int address) {
@@ -768,6 +779,11 @@ struct ImageResource {
 
 ImageResource fetch_image_resource(int address) {
     vec4 data[2] = fetch_from_resource_cache_2(address);
+    return ImageResource(data[0], data[1].x);
+}
+
+ImageResource fetch_image_resource_direct(ivec2 address) {
+    vec4 data[2] = fetch_from_resource_cache_2_direct(address);
     return ImageResource(data[0], data[1].x);
 }
 

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -89,6 +89,7 @@ pub enum VertexAttributeKind {
     F32,
     U8Norm,
     I32,
+    U16,
 }
 
 #[derive(Debug)]
@@ -159,6 +160,7 @@ impl VertexAttributeKind {
             VertexAttributeKind::F32 => 4,
             VertexAttributeKind::U8Norm => 1,
             VertexAttributeKind::I32 => 4,
+            VertexAttributeKind::U16 => 2,
         }
     }
 }
@@ -198,6 +200,13 @@ impl VertexAttribute {
                 gl.vertex_attrib_i_pointer(attr_index,
                                            self.count as gl::GLint,
                                            gl::INT,
+                                           stride,
+                                           offset);
+            }
+            VertexAttributeKind::U16 => {
+                gl.vertex_attrib_i_pointer(attr_index,
+                                           self.count as gl::GLint,
+                                           gl::UNSIGNED_SHORT,
                                            stride,
                                            offset);
             }

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -28,7 +28,8 @@ use device::FrameId;
 use internal_types::UvRect;
 use profiler::GpuCacheProfileCounters;
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
-use std::{mem, u32};
+use std::{mem, u16, u32};
+use std::ops::Add;
 use api::{ColorF, LayerRect};
 
 pub const GPU_CACHE_INITIAL_HEIGHT: u32 = 512;
@@ -138,6 +139,24 @@ impl GpuCacheAddress {
         GpuCacheAddress {
             u: u as u16,
             v: v as u16,
+        }
+    }
+
+    pub fn invalid() -> GpuCacheAddress {
+        GpuCacheAddress {
+            u: u16::MAX,
+            v: u16::MAX,
+        }
+    }
+}
+
+impl Add<usize> for GpuCacheAddress {
+    type Output = GpuCacheAddress;
+
+    fn add(self, other: usize) -> GpuCacheAddress {
+        GpuCacheAddress {
+            u: self.u + other as u16,
+            v: self.v,
         }
     }
 }

--- a/webrender/src/mask_cache.rs
+++ b/webrender/src/mask_cache.rs
@@ -120,6 +120,10 @@ impl ClipAddressRange {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.item_count == 0
+    }
+
     pub fn get_count(&self) -> usize {
         self.item_count
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -125,9 +125,8 @@ const DESC_CLIP: VertexDescriptor = VertexDescriptor {
     instance_attributes: &[
         VertexAttribute { name: "aClipRenderTaskIndex", count: 1, kind: VertexAttributeKind::I32 },
         VertexAttribute { name: "aClipLayerIndex", count: 1, kind: VertexAttributeKind::I32 },
-        VertexAttribute { name: "aClipDataIndex", count: 1, kind: VertexAttributeKind::I32 },
-        VertexAttribute { name: "aClipSegmentIndex", count: 1, kind: VertexAttributeKind::I32 },
-        VertexAttribute { name: "aClipResourceAddress", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aClipSegment", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aClipDataResourceAddress", count: 4, kind: VertexAttributeKind::U16 },
     ]
 };
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -4,7 +4,7 @@
 
 use border::{BorderCornerInstance, BorderCornerSide};
 use device::TextureId;
-use gpu_cache::{GpuCache, GpuCacheHandle, GpuCacheUpdateList};
+use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle, GpuCacheUpdateList};
 use internal_types::BatchTextures;
 use internal_types::{FastHashMap, SourceTexture};
 use mask_cache::MaskCacheInfo;
@@ -711,82 +711,88 @@ impl ClipBatcher {
 
         for &(packed_layer_index, ref info) in clips.iter() {
             let instance = CacheClipInstance {
-                task_id: task_index.0 as i32,
+                render_task_index: task_index.0 as i32,
                 layer_index: packed_layer_index.0 as i32,
-                address: 0,
                 segment: 0,
-                resource_address: 0,
+                clip_data_address: GpuCacheAddress::invalid(),
+                resource_address: GpuCacheAddress::invalid(),
             };
 
-            for clip_index in 0 .. info.complex_clip_range.get_count() {
-                let gpu_address = info.complex_clip_range.location.as_int(gpu_cache) +
-                                  (CLIP_DATA_GPU_BLOCKS * clip_index) as i32;
-                match geometry_kind {
-                    MaskGeometryKind::Default => {
-                        self.rectangles.push(CacheClipInstance {
-                            address: gpu_address,
-                            segment: MaskSegment::All as i32,
-                            ..instance
-                        });
-                    }
-                    MaskGeometryKind::CornersOnly => {
-                        self.rectangles.extend_from_slice(&[
-                            CacheClipInstance {
-                                address: gpu_address,
-                                segment: MaskSegment::TopLeftCorner as i32,
+            if !info.complex_clip_range.is_empty() {
+                let base_gpu_address = gpu_cache.get_address(&info.complex_clip_range.location);
+
+                for clip_index in 0 .. info.complex_clip_range.get_count() {
+                    let gpu_address = base_gpu_address + CLIP_DATA_GPU_BLOCKS * clip_index;
+                    match geometry_kind {
+                        MaskGeometryKind::Default => {
+                            self.rectangles.push(CacheClipInstance {
+                                clip_data_address: gpu_address,
+                                segment: MaskSegment::All as i32,
                                 ..instance
-                            },
-                            CacheClipInstance {
-                                address: gpu_address,
-                                segment: MaskSegment::TopRightCorner as i32,
-                                ..instance
-                            },
-                            CacheClipInstance {
-                                address: gpu_address,
-                                segment: MaskSegment::BottomLeftCorner as i32,
-                                ..instance
-                            },
-                            CacheClipInstance {
-                                address: gpu_address,
-                                segment: MaskSegment::BottomRightCorner as i32,
-                                ..instance
-                            },
-                        ]);
+                            });
+                        }
+                        MaskGeometryKind::CornersOnly => {
+                            self.rectangles.extend_from_slice(&[
+                                CacheClipInstance {
+                                    clip_data_address: gpu_address,
+                                    segment: MaskSegment::TopLeftCorner as i32,
+                                    ..instance
+                                },
+                                CacheClipInstance {
+                                    clip_data_address: gpu_address,
+                                    segment: MaskSegment::TopRightCorner as i32,
+                                    ..instance
+                                },
+                                CacheClipInstance {
+                                    clip_data_address: gpu_address,
+                                    segment: MaskSegment::BottomLeftCorner as i32,
+                                    ..instance
+                                },
+                                CacheClipInstance {
+                                    clip_data_address: gpu_address,
+                                    segment: MaskSegment::BottomRightCorner as i32,
+                                    ..instance
+                                },
+                            ]);
+                        }
                     }
                 }
             }
 
-            for clip_index in 0 .. info.layer_clip_range.get_count() {
-                let gpu_address = info.layer_clip_range.location.as_int(gpu_cache) +
-                                  (CLIP_DATA_GPU_BLOCKS * clip_index) as i32;
-                self.rectangles.push(CacheClipInstance {
-                    address: gpu_address,
-                    segment: MaskSegment::All as i32,
-                    ..instance
-                });
+            if !info.layer_clip_range.is_empty() {
+                let base_gpu_address = gpu_cache.get_address(&info.layer_clip_range.location);
+
+                for clip_index in 0 .. info.layer_clip_range.get_count() {
+                    let gpu_address = base_gpu_address + CLIP_DATA_GPU_BLOCKS * clip_index;
+                    self.rectangles.push(CacheClipInstance {
+                        clip_data_address: gpu_address,
+                        segment: MaskSegment::All as i32,
+                        ..instance
+                    });
+                }
             }
 
-            if let Some((ref mask, gpu_location)) = info.image {
+            if let Some((ref mask, ref gpu_location)) = info.image {
                 let cache_item = resource_cache.get_cached_image(mask.image, ImageRendering::Auto, None);
                 self.images.entry(cache_item.texture_id)
                            .or_insert(Vec::new())
                            .push(CacheClipInstance {
-                    address: gpu_location.as_int(gpu_cache),
-                    resource_address: cache_item.uv_rect_handle.as_int(gpu_cache),
+                    clip_data_address: gpu_cache.get_address(gpu_location),
+                    resource_address: gpu_cache.get_address(&cache_item.uv_rect_handle),
                     ..instance
                 })
             }
 
-            for &(ref source, gpu_location) in &info.border_corners {
-                let gpu_address = gpu_location.as_int(gpu_cache);
+            for &(ref source, ref gpu_location) in &info.border_corners {
+                let gpu_address = gpu_cache.get_address(gpu_location);
                 self.border_clears.push(CacheClipInstance {
-                    address: gpu_address,
+                    clip_data_address: gpu_address,
                     segment: 0,
                     ..instance
                 });
                 for clip_index in 0..source.actual_clip_count {
                     self.borders.push(CacheClipInstance {
-                        address: gpu_address,
+                        clip_data_address: gpu_address,
                         segment: 1 + clip_index as i32,
                         ..instance
                     })
@@ -1384,12 +1390,13 @@ pub struct BlurCommand {
 /// Could be an image or a rectangle, which defines the
 /// way `address` is treated.
 #[derive(Clone, Copy, Debug)]
+#[repr(C)]
 pub struct CacheClipInstance {
-    task_id: i32,
+    render_task_index: i32,
     layer_index: i32,
-    address: i32,
     segment: i32,
-    resource_address: i32,
+    clip_data_address: GpuCacheAddress,
+    resource_address: GpuCacheAddress,
 }
 
 // 32 bytes per instance should be enough for anyone!


### PR DESCRIPTION
This saves a bit of work converting address types in both CPU and
vertex shader code.

It also makes the vertex types use the correct type for cache
addresses, instead of casting to an i32.

The intent is to incrementally move all vertex formats over to
using the 2D style addresses directly, and then remove the
duplicated code from prim_shared.glsl which allows fetching via
an i32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1584)
<!-- Reviewable:end -->
