### PR TITLE
Use the proper window dimension when setting up wrench.

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -315,11 +315,13 @@ fn main() {
                                  args.is_present("vsync"),
                                  is_headless);
     let dp_ratio = dp_ratio.unwrap_or(window.hidpi_factor());
+    let (width, height) = window.get_inner_size_pixels();
+    let dim = DeviceUintSize::new(width, height);
     let mut wrench = Wrench::new(&mut window,
                                  res_path,
                                  dp_ratio,
                                  save_type,
-                                 size,
+                                 dim,
                                  args.is_present("rebuild"),
                                  args.is_present("no_subpixel_aa"),
                                  args.is_present("debug"),


### PR DESCRIPTION
This makes sure we use the same dimensions for the first frame
as for subsequent ones. It also fixes the offset of things
when on hidpi on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1586)
<!-- Reviewable:end -->
