### PR TITLE
Renderer coverage profiling

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -8,8 +8,6 @@ use std::env;
 use std::path::PathBuf;
 use webrender;
 use webrender::api::*;
-use webrender::renderer::{PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
-use webrender::renderer::ExternalImageHandler;
 
 struct Notifier {
     window_proxy: glutin::WindowProxy,
@@ -65,7 +63,7 @@ pub trait Example {
                 event: glutin::Event,
                 api: &RenderApi,
                 document_id: DocumentId) -> bool;
-    fn get_external_image_handler(&self) -> Option<Box<ExternalImageHandler>> {
+    fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
         None
     }
 }
@@ -113,7 +111,7 @@ pub fn main_wrapper(example: &mut Example,
     };
 
     let size = DeviceUintSize::new(width, height);
-    let (mut renderer, sender) = webrender::renderer::Renderer::new(gl, opts).unwrap();
+    let (mut renderer, sender) = webrender::Renderer::new(gl, opts).unwrap();
     let api = sender.create_api();
     let document_id = api.add_document(size);
 
@@ -162,19 +160,19 @@ pub fn main_wrapper(example: &mut Example,
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::P)) => {
                     let mut flags = renderer.get_debug_flags();
-                    flags.toggle(PROFILER_DBG);
+                    flags.toggle(webrender::PROFILER_DBG);
                     renderer.set_debug_flags(flags);
                 }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::O)) => {
                     let mut flags = renderer.get_debug_flags();
-                    flags.toggle(RENDER_TARGET_DBG);
+                    flags.toggle(webrender::RENDER_TARGET_DBG);
                     renderer.set_debug_flags(flags);
                 }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::I)) => {
                     let mut flags = renderer.get_debug_flags();
-                    flags.toggle(TEXTURE_CACHE_DBG);
+                    flags.toggle(webrender::TEXTURE_CACHE_DBG);
                     renderer.set_debug_flags(flags);
                 }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -12,7 +12,6 @@ mod boilerplate;
 use boilerplate::{Example, HandyDandyRectBuilder};
 use std::mem;
 use webrender::api::*;
-use webrender::renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 
 struct ImageGenerator {
     patterns: [[u8; 3]; 6],
@@ -57,15 +56,15 @@ impl ImageGenerator {
     }
 }
 
-impl ExternalImageHandler for ImageGenerator {
-    fn lock(&mut self, _key: ExternalImageId, channel_index: u8) -> ExternalImage {
+impl webrender::ExternalImageHandler for ImageGenerator {
+    fn lock(&mut self, _key: ExternalImageId, channel_index: u8) -> webrender::ExternalImage {
         self.generate_image(channel_index as u32);
-        ExternalImage {
+        webrender::ExternalImage {
             u0: 0.0,
             v0: 0.0,
             u1: 1.0,
             v1: 1.0,
-            source: ExternalImageSource::RawData(&self.current_image)
+            source: webrender::ExternalImageSource::RawData(&self.current_image)
         }
     }
     fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {
@@ -270,7 +269,7 @@ impl Example for App {
         false
     }
 
-    fn get_external_image_handler(&self) -> Option<Box<ExternalImageHandler>> {
+    fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
         Some(Box::new(ImageGenerator::new()))
     }
 }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -443,7 +443,8 @@ struct IBOId(gl::GLuint);
 #[derive(PartialEq, Eq, Hash, Debug, Copy, Clone)]
 pub struct PBOId(gl::GLuint);
 
-const MAX_EVENTS_PER_FRAME: usize = 256;
+const MAX_TIMERS_PER_FRAME: usize = 256;
+const MAX_SAMPLERS_PER_FRAME: usize = 16;
 const MAX_PROFILE_FRAMES: usize = 4;
 
 pub trait NamedTag {
@@ -451,142 +452,148 @@ pub trait NamedTag {
 }
 
 #[derive(Debug, Clone)]
-pub struct GpuSample<T> {
+pub struct GpuTimer<T> {
     pub tag: T,
     pub time_ns: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct GpuSampler<T> {
+    pub tag: T,
+    pub count: u64,
+}
+
+pub struct QuerySet<T> {
+    set: Vec<gl::GLuint>,
+    data: Vec<T>,
+    pending: gl::GLuint,
+}
+
+impl<T> QuerySet<T> {
+    fn new(set: Vec<gl::GLuint>) -> Self {
+        QuerySet {
+            set,
+            data: Vec::new(),
+            pending: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.data.clear();
+        self.pending = 0;
+    }
+
+    fn add(&mut self, value: T) -> Option<gl::GLuint> {
+        assert_eq!(self.pending, 0);
+        self.set.get(self.data.len())
+            .cloned()
+            .map(|query_id| {
+                self.data.push(value);
+                self.pending = query_id;
+                query_id
+            })
+    }
+
+    fn take<F: Fn(&mut T, gl::GLuint)>(&mut self, fun: F) -> Vec<T> {
+        let mut data = mem::replace(&mut self.data, Vec::new());
+        for (value, &query) in data.iter_mut().zip(self.set.iter()) {
+            fun(value, query)
+        }
+        data
+    }
+}
+
 pub struct GpuFrameProfile<T> {
     gl: Rc<gl::Gl>,
-    queries: Vec<gl::GLuint>,
-    samples: Vec<GpuSample<T>>,
-    next_query: usize,
-    pending_query: gl::GLuint,
+    timers: QuerySet<GpuTimer<T>>,
+    samplers: QuerySet<GpuSampler<T>>,
     frame_id: FrameId,
     inside_frame: bool,
 }
 
 impl<T> GpuFrameProfile<T> {
     fn new(gl: Rc<gl::Gl>) -> Self {
-        match gl.get_type() {
-            gl::GlType::Gl => {
-                let queries = gl.gen_queries(MAX_EVENTS_PER_FRAME as gl::GLint);
-                GpuFrameProfile {
-                    gl,
-                    queries,
-                    samples: Vec::new(),
-                    next_query: 0,
-                    pending_query: 0,
-                    frame_id: FrameId(0),
-                    inside_frame: false,
-                }
-            }
-            gl::GlType::Gles => {
-                GpuFrameProfile {
-                    gl,
-                    queries: Vec::new(),
-                    samples: Vec::new(),
-                    next_query: 0,
-                    pending_query: 0,
-                    frame_id: FrameId(0),
-                    inside_frame: false,
-                }
-            }
+        let (time_queries, sample_queries) = match gl.get_type() {
+            gl::GlType::Gl => (
+                gl.gen_queries(MAX_TIMERS_PER_FRAME as gl::GLint),
+                gl.gen_queries(MAX_SAMPLERS_PER_FRAME as gl::GLint),
+            ),
+            gl::GlType::Gles => (Vec::new(), Vec::new()),
+        };
+
+        GpuFrameProfile {
+            gl,
+            timers: QuerySet::new(time_queries),
+            samplers: QuerySet::new(sample_queries),
+            frame_id: FrameId(0),
+            inside_frame: false,
         }
     }
 
     fn begin_frame(&mut self, frame_id: FrameId) {
         self.frame_id = frame_id;
-        self.next_query = 0;
-        self.pending_query = 0;
-        self.samples.clear();
+        self.timers.reset();
+        self.samplers.reset();
         self.inside_frame = true;
     }
 
     fn end_frame(&mut self) {
+        self.done_marker();
+        self.done_sampler();
         self.inside_frame = false;
-        match self.gl.get_type() {
-            gl::GlType::Gl => {
-                if self.pending_query != 0 {
-                    self.gl.end_query(gl::TIME_ELAPSED);
-                }
-            }
-            gl::GlType::Gles => {},
-        }
     }
 
-    fn add_marker(&mut self, tag: T) -> GpuMarker
-    where T: NamedTag {
+    fn done_marker(&mut self) {
         debug_assert!(self.inside_frame);
-        match self.gl.get_type() {
-            gl::GlType::Gl => {
-                self.add_marker_gl(tag)
-            }
-            gl::GlType::Gles => {
-                self.add_marker_gles(tag)
-            }
-        }
-    }
-
-    fn add_marker_gl(&mut self, tag: T) -> GpuMarker
-    where T: NamedTag {
-        if self.pending_query != 0 {
+        if self.timers.pending != 0 {
             self.gl.end_query(gl::TIME_ELAPSED);
+            self.timers.pending = 0;
         }
+    }
+
+    fn add_marker(&mut self, tag: T) -> GpuMarker where T: NamedTag {
+        self.done_marker();
 
         let marker = GpuMarker::new(&self.gl, tag.get_label());
 
-        if self.next_query < MAX_EVENTS_PER_FRAME {
-            self.pending_query = self.queries[self.next_query];
-            self.gl.begin_query(gl::TIME_ELAPSED, self.pending_query);
-            self.samples.push(GpuSample {
-                tag,
-                time_ns: 0,
-            });
-        } else {
-            self.pending_query = 0;
+        if let Some(query) = self.timers.add(GpuTimer { tag, time_ns: 0 }) {
+            self.gl.begin_query(gl::TIME_ELAPSED, query);
         }
 
-        self.next_query += 1;
         marker
     }
 
-    fn add_marker_gles(&mut self, tag: T) -> GpuMarker
-    where T: NamedTag {
-        let marker = GpuMarker::new(&self.gl, tag.get_label());
-        self.samples.push(GpuSample {
-            tag,
-            time_ns: 0,
-        });
-        marker
+    fn done_sampler(&mut self) {
+        debug_assert!(self.inside_frame);
+        if self.samplers.pending != 0 {
+            self.gl.end_query(gl::SAMPLES_PASSED);
+            self.samplers.pending = 0;
+        }
+    }
+
+    fn add_sampler(&mut self, tag: T) where T: NamedTag {
+        self.done_sampler();
+
+        if let Some(query) = self.samplers.add(GpuSampler { tag, count: 0 }) {
+            self.gl.begin_query(gl::SAMPLES_PASSED, query);
+        }
     }
 
     fn is_valid(&self) -> bool {
-        self.next_query > 0 && self.next_query <= MAX_EVENTS_PER_FRAME
+        !self.timers.set.is_empty() || !self.samplers.set.is_empty()
     }
 
-    fn build_samples(&mut self) -> Vec<GpuSample<T>> {
+    fn build_samples(&mut self) -> (Vec<GpuTimer<T>>, Vec<GpuSampler<T>>) {
         debug_assert!(!self.inside_frame);
-        match self.gl.get_type() {
-            gl::GlType::Gl => {
-                self.build_samples_gl()
-            }
-            gl::GlType::Gles => {
-                self.build_samples_gles()
-            }
-        }
-    }
+        let gl = &self.gl;
 
-    fn build_samples_gl(&mut self) -> Vec<GpuSample<T>> {
-        for (index, sample) in self.samples.iter_mut().enumerate() {
-            sample.time_ns = self.gl.get_query_object_ui64v(self.queries[index], gl::QUERY_RESULT)
-        }
-
-        mem::replace(&mut self.samples, Vec::new())
-    }
-
-    fn build_samples_gles(&mut self) -> Vec<GpuSample<T>> {
-        mem::replace(&mut self.samples, Vec::new())
+        (self.timers.take(|timer, query| {
+            timer.time_ns = gl.get_query_object_ui64v(query, gl::QUERY_RESULT)
+         }),
+         self.samplers.take(|sampler, query| {
+            sampler.count = gl.get_query_object_ui64v(query, gl::QUERY_RESULT)
+         }),
+        )
     }
 }
 
@@ -594,7 +601,8 @@ impl<T> Drop for GpuFrameProfile<T> {
     fn drop(&mut self) {
         match self.gl.get_type() {
             gl::GlType::Gl =>  {
-                self.gl.delete_queries(&self.queries);
+                self.gl.delete_queries(&self.timers.set);
+                self.gl.delete_queries(&self.samplers.set);
             }
             gl::GlType::Gles => {},
         }
@@ -611,18 +619,19 @@ impl<T> GpuProfiler<T> {
         GpuProfiler {
             next_frame: 0,
             frames: [
-                      GpuFrameProfile::new(Rc::clone(gl)),
-                      GpuFrameProfile::new(Rc::clone(gl)),
-                      GpuFrameProfile::new(Rc::clone(gl)),
-                      GpuFrameProfile::new(Rc::clone(gl)),
-                    ],
+                GpuFrameProfile::new(Rc::clone(gl)),
+                GpuFrameProfile::new(Rc::clone(gl)),
+                GpuFrameProfile::new(Rc::clone(gl)),
+                GpuFrameProfile::new(Rc::clone(gl)),
+            ],
         }
     }
 
-    pub fn build_samples(&mut self) -> Option<(FrameId, Vec<GpuSample<T>>)> {
+    pub fn build_samples(&mut self) -> Option<(FrameId, Vec<GpuTimer<T>>, Vec<GpuSampler<T>>)> {
         let frame = &mut self.frames[self.next_frame];
         if frame.is_valid() {
-            Some((frame.frame_id, frame.build_samples()))
+            let (timers, samplers) = frame.build_samples();
+            Some((frame.frame_id, timers, samplers))
         } else {
             None
         }
@@ -642,6 +651,15 @@ impl<T> GpuProfiler<T> {
     pub fn add_marker(&mut self, tag: T) -> GpuMarker
     where T: NamedTag {
         self.frames[self.next_frame].add_marker(tag)
+    }
+
+    pub fn add_sampler(&mut self, tag: T)
+    where T: NamedTag {
+        self.frames[self.next_frame].add_sampler(tag)
+    }
+
+    pub fn done_sampler(&mut self) {
+        self.frames[self.next_frame].done_sampler()
     }
 }
 
@@ -688,6 +706,7 @@ impl Drop for GpuMarker {
         }
     }
 }
+
 
 #[derive(Debug, Copy, Clone)]
 pub enum VertexUsageHint {

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -12,7 +12,7 @@ but it can also be used as such in a standalone application.
 WebRender currently depends on [FreeType](https://www.freetype.org/)
 
 # Api Structure
-The main entry point to WebRender is the `webrender::renderer::Renderer`.
+The main entry point to WebRender is the `webrender::Renderer`.
 
 By calling `Renderer::new(...)` you get a `Renderer`, as well as a `RenderApiSender`.
 Your `Renderer` is responsible to render the previously processed frames onto the screen.
@@ -72,6 +72,7 @@ mod profiler;
 mod record;
 mod render_backend;
 mod render_task;
+mod renderer;
 mod resource_cache;
 mod scene;
 mod spring;
@@ -108,8 +109,6 @@ mod platform {
     }
 }
 
-pub mod renderer;
-
 #[cfg(target_os="macos")]
 extern crate core_graphics;
 #[cfg(target_os="macos")]
@@ -139,6 +138,8 @@ extern crate gamma_lut;
 
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, ReadPixelsFormat, Renderer, RendererOptions};
+pub use renderer::{CpuProfile, GpuProfile, DebugFlags};
+pub use renderer::{MAX_VERTEX_TEXTURE_WIDTH, PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
 
 pub use webrender_api as api;
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -419,7 +419,7 @@ impl RenderApi {
     /// Supplies a new frame to WebRender.
     ///
     /// Non-blocking, it notifies a worker process which processes the display list.
-    /// When it's done and a RenderNotifier has been set in `webrender::renderer::Renderer`,
+    /// When it's done and a RenderNotifier has been set in `webrender::Renderer`,
     /// [new_frame_ready()][notifier] gets called.
     ///
     /// Note: Scrolling doesn't require an own Frame.

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -62,7 +62,6 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 use std::rc::Rc;
 use webrender::api::*;
-use webrender::renderer::{PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
@@ -526,17 +525,17 @@ fn main() {
                     },
                     VirtualKeyCode::P => {
                         let mut flags = wrench.renderer.get_debug_flags();
-                        flags.toggle(PROFILER_DBG);
+                        flags.toggle(webrender::PROFILER_DBG);
                         wrench.renderer.set_debug_flags(flags);
                     },
                     VirtualKeyCode::O => {
                         let mut flags = wrench.renderer.get_debug_flags();
-                        flags.toggle(RENDER_TARGET_DBG);
+                        flags.toggle(webrender::RENDER_TARGET_DBG);
                         wrench.renderer.set_debug_flags(flags);
                     },
                     VirtualKeyCode::I => {
                         let mut flags = wrench.renderer.get_debug_flags();
-                        flags.toggle(TEXTURE_CACHE_DBG);
+                        flags.toggle(webrender::TEXTURE_CACHE_DBG);
                         wrench.renderer.set_debug_flags(flags);
                     },
                     VirtualKeyCode::M => {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -21,7 +21,6 @@ use std::path::{Path, PathBuf};
 use time;
 use webrender;
 use webrender::api::*;
-use webrender::renderer::{CpuProfile, GpuProfile, GraphicsApiInfo};
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use {WHITE_COLOR, BLACK_COLOR, WindowWrapper};
 
@@ -113,7 +112,7 @@ pub struct Wrench {
     window_size: DeviceUintSize,
     device_pixel_ratio: f32,
 
-    pub renderer: webrender::renderer::Renderer,
+    pub renderer: webrender::Renderer,
     pub api: RenderApi,
     pub document_id: DocumentId,
     pub root_pipeline_id: PipelineId,
@@ -122,7 +121,7 @@ pub struct Wrench {
 
     image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
-    graphics_api: GraphicsApiInfo,
+    graphics_api: webrender::GraphicsApiInfo,
 
     pub rebuild_display_lists: bool,
     pub verbose: bool,
@@ -173,7 +172,7 @@ impl Wrench {
             .. Default::default()
         };
 
-        let (renderer, sender) = webrender::renderer::Renderer::new(window.clone_gl(), opts).unwrap();
+        let (renderer, sender) = webrender::Renderer::new(window.clone_gl(), opts).unwrap();
         let api = sender.create_api();
         let document_id = api.add_document(size);
 
@@ -432,7 +431,7 @@ impl Wrench {
         self.api.generate_frame(self.document_id, None);
     }
 
-    pub fn get_frame_profiles(&mut self) -> (Vec<CpuProfile>, Vec<GpuProfile>) {
+    pub fn get_frame_profiles(&mut self) -> (Vec<webrender::CpuProfile>, Vec<webrender::GpuProfile>) {
         self.renderer.get_frame_profiles()
     }
 


### PR DESCRIPTION
Computes the fraction of screen getting covered by the opaque/transparent passes.
Also hides `renderer` module from the public eyes (breaking change).
r? @glennw

~~WIP until the FF patch is ready~~
[wr-profile.diff.zip](https://github.com/servo/webrender/files/1240226/wr-profile.diff.zip)

<!-- Reviewable:start -->


---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1594)
<!-- Reviewable:end -->
