### PR TITLE
Refactor and optimize the render task tree.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -21,8 +21,8 @@ use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu, TextRunMode};
 use prim_store::{RectanglePrimitive, TextRunPrimitiveCpu, TextShadowPrimitiveCpu};
 use prim_store::{BoxShadowPrimitiveCpu, TexelRect, YuvImagePrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_task::{AlphaRenderItem, ClipWorkItem, MaskCacheKey, RenderTask, RenderTaskIndex};
-use render_task::{RenderTaskId, RenderTaskLocation};
+use render_task::{AlphaRenderItem, ClipWorkItem, RenderTask};
+use render_task::{RenderTaskTree, RenderTaskId, RenderTaskLocation};
 use resource_cache::ResourceCache;
 use clip_scroll_node::{ClipInfo, ClipScrollNode, NodeType};
 use clip_scroll_tree::ClipScrollTree;
@@ -31,7 +31,7 @@ use euclid::{SideOffsets2D, vec2, vec3};
 use tiling::{ContextIsolation, StackingContextIndex};
 use tiling::{ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, DisplayListMap, Frame};
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
-use tiling::{RenderTargetContext, RenderTaskCollection, ScrollbarPrimitive, StackingContext};
+use tiling::{RenderTargetContext, ScrollbarPrimitive, StackingContext};
 use util::{self, pack_as_float, subtract_rect, recycle_vec};
 use util::{MatrixHelpers, RectHelpers};
 
@@ -1276,6 +1276,7 @@ impl FrameBuilder {
                                                 display_lists: &DisplayListMap,
                                                 resource_cache: &mut ResourceCache,
                                                 gpu_cache: &mut GpuCache,
+                                                render_tasks: &mut RenderTaskTree,
                                                 profile_counters: &mut FrameProfileCounters,
                                                 device_pixel_ratio: f32) {
         profile_scope!("cull");
@@ -1285,6 +1286,7 @@ impl FrameBuilder {
                                                            display_lists,
                                                            resource_cache,
                                                            gpu_cache,
+                                                           render_tasks,
                                                            profile_counters,
                                                            device_pixel_ratio);
     }
@@ -1338,18 +1340,15 @@ impl FrameBuilder {
 
     fn build_render_task(&mut self,
                          clip_scroll_tree: &ClipScrollTree,
-                         gpu_cache: &mut GpuCache)
-                         -> (RenderTask, usize) {
+                         gpu_cache: &mut GpuCache,
+                         render_tasks: &mut RenderTaskTree)
+                         -> RenderTaskId {
         profile_scope!("build_render_task");
 
         let mut next_z = 0;
-        let mut next_task_index = RenderTaskIndex(0);
-
         let mut sc_stack: Vec<StackingContextIndex> = Vec::new();
-        let mut current_task = RenderTask::new_alpha_batch(next_task_index,
-                                                           DeviceIntPoint::zero(),
+        let mut current_task = RenderTask::new_alpha_batch(DeviceIntPoint::zero(),
                                                            RenderTaskLocation::Fixed);
-        next_task_index.0 += 1;
         // A stack of the alpha batcher tasks. We create them on the way down,
         // and then actually populate with items and dependencies on the way up.
         let mut alpha_task_stack = Vec::new();
@@ -1358,7 +1357,7 @@ impl FrameBuilder {
         // The stacking contexts that fall into this category are
         //  - ones with `ContextIsolation::Items`, for their actual items to be backed
         //  - immediate children of `ContextIsolation::Items`
-        let mut preserve_3d_map: FastHashMap<StackingContextIndex, RenderTask> = FastHashMap::default();
+        let mut preserve_3d_map: FastHashMap<StackingContextIndex, RenderTaskId> = FastHashMap::default();
         // The plane splitter stack, using a simple BSP tree.
         let mut splitter_stack = Vec::new();
 
@@ -1383,8 +1382,7 @@ impl FrameBuilder {
 
                     if stacking_context.isolation == ContextIsolation::Full && composite_count == 0 {
                         alpha_task_stack.push(current_task);
-                        current_task = RenderTask::new_dynamic_alpha_batch(next_task_index, stacking_context_rect);
-                        next_task_index.0 += 1;
+                        current_task = RenderTask::new_dynamic_alpha_batch(stacking_context_rect);
                     }
 
                     if parent_isolation == Some(ContextIsolation::Items) ||
@@ -1393,8 +1391,7 @@ impl FrameBuilder {
                             splitter_stack.push(BspSplitter::new());
                         }
                         alpha_task_stack.push(current_task);
-                        current_task = RenderTask::new_dynamic_alpha_batch(next_task_index, stacking_context_rect);
-                        next_task_index.0 += 1;
+                        current_task = RenderTask::new_dynamic_alpha_batch(stacking_context_rect);
                         //Note: technically, we shouldn't make a new alpha task for "preserve-3d" contexts
                         // that have no child items (only other stacking contexts). However, we don't know if
                         // there are any items at this time (in `PushStackingContext`).
@@ -1409,8 +1406,7 @@ impl FrameBuilder {
 
                     for _ in 0..composite_count {
                         alpha_task_stack.push(current_task);
-                        current_task = RenderTask::new_dynamic_alpha_batch(next_task_index, stacking_context_rect);
-                        next_task_index.0 += 1;
+                        current_task = RenderTask::new_dynamic_alpha_batch(stacking_context_rect);
                     }
                 }
                 PrimitiveRunCmd::PopStackingContext => {
@@ -1428,43 +1424,46 @@ impl FrameBuilder {
 
                     if stacking_context.isolation == ContextIsolation::Full && composite_count == 0 {
                         let mut prev_task = alpha_task_stack.pop().unwrap();
+                        let current_task_id = render_tasks.add(current_task);
                         let item = AlphaRenderItem::HardwareComposite(stacking_context_index,
-                                                                      current_task.id,
+                                                                      current_task_id,
                                                                       HardwareCompositeOp::PremultipliedAlpha,
                                                                       next_z);
                         next_z += 1;
-                        prev_task.as_alpha_batch().items.push(item);
-                        prev_task.children.push(current_task);
+                        prev_task.as_alpha_batch_mut().items.push(item);
+                        prev_task.children.push(current_task_id);
                         current_task = prev_task;
                     }
 
                     for filter in &stacking_context.composite_ops.filters {
                         let mut prev_task = alpha_task_stack.pop().unwrap();
+                        let current_task_id = render_tasks.add(current_task);
                         let item = AlphaRenderItem::Blend(stacking_context_index,
-                                                          current_task.id,
+                                                          current_task_id,
                                                           *filter,
                                                           next_z);
                         next_z += 1;
-                        prev_task.as_alpha_batch().items.push(item);
-                        prev_task.children.push(current_task);
+                        prev_task.as_alpha_batch_mut().items.push(item);
+                        prev_task.children.push(current_task_id);
                         current_task = prev_task;
                     }
 
                     if let Some(mix_blend_mode) = stacking_context.composite_ops.mix_blend_mode {
                         let readback_task =
-                            RenderTask::new_readback(stacking_context_index,
-                                                     stacking_context.screen_bounds);
+                            RenderTask::new_readback(stacking_context.screen_bounds);
+                        let current_task_id = render_tasks.add(current_task);
+                        let readback_task_id = render_tasks.add(readback_task);
 
                         let mut prev_task = alpha_task_stack.pop().unwrap();
                         let item = AlphaRenderItem::Composite(stacking_context_index,
-                                                              readback_task.id,
-                                                              current_task.id,
+                                                              readback_task_id,
+                                                              current_task_id,
                                                               mix_blend_mode,
                                                               next_z);
                         next_z += 1;
-                        prev_task.as_alpha_batch().items.push(item);
-                        prev_task.children.push(current_task);
-                        prev_task.children.push(readback_task);
+                        prev_task.as_alpha_batch_mut().items.push(item);
+                        prev_task.children.push(current_task_id);
+                        prev_task.children.push(readback_task_id);
                         current_task = prev_task;
                     }
 
@@ -1473,13 +1472,14 @@ impl FrameBuilder {
                         //Note: we don't register the dependent tasks here. It's only done
                         // when we are out of the `preserve-3d` branch (see the code below),
                         // since this is only where the parent task is known.
-                        preserve_3d_map.insert(stacking_context_index, current_task);
+                        let current_task_id = render_tasks.add(current_task);
+                        preserve_3d_map.insert(stacking_context_index, current_task_id);
                         current_task = alpha_task_stack.pop().unwrap();
                     }
 
                     if parent_isolation != Some(ContextIsolation::Items) &&
                        stacking_context.isolation == ContextIsolation::Items {
-                        debug!("\tsplitter[{}]: flush {:?}", splitter_stack.len(), current_task.id);
+                        debug!("\tsplitter[{}]: flush", splitter_stack.len());
                         let mut splitter = splitter_stack.pop().unwrap();
                         // Flush the accumulated plane splits onto the task tree.
                         // Notice how this is done before splitting in order to avoid duplicate tasks.
@@ -1487,7 +1487,7 @@ impl FrameBuilder {
                         // Z axis is directed at the screen, `sort` is ascending, and we need back-to-front order.
                         for poly in splitter.sort(vec3(0.0, 0.0, 1.0)) {
                             let sc_index = StackingContextIndex(poly.anchor);
-                            let task_id = preserve_3d_map[&sc_index].id;
+                            let task_id = preserve_3d_map[&sc_index];
                             debug!("\t\tproduce {:?} -> {:?} for {:?}", sc_index, poly, task_id);
                             let pp = &poly.points;
                             let gpu_blocks = [
@@ -1497,7 +1497,7 @@ impl FrameBuilder {
                             ];
                             let handle = gpu_cache.push_per_frame_blocks(&gpu_blocks);
                             let item = AlphaRenderItem::SplitComposite(sc_index, task_id, handle, next_z);
-                            current_task.as_alpha_batch().items.push(item);
+                            current_task.as_alpha_batch_mut().items.push(item);
                         }
                         preserve_3d_map.clear();
                         next_z += 1;
@@ -1515,7 +1515,7 @@ impl FrameBuilder {
                         continue
                     }
 
-                    debug!("\trun of {} items into {:?}", prim_count, current_task.id);
+                    debug!("\trun of {} items", prim_count);
 
                     for i in 0..prim_count {
                         let prim_index = PrimitiveIndex(first_prim_index.0 + i);
@@ -1524,15 +1524,15 @@ impl FrameBuilder {
                             let prim_metadata = self.prim_store.get_metadata(prim_index);
 
                             // Add any dynamic render tasks needed to render this primitive
-                            if let Some(ref render_task) = prim_metadata.render_task {
-                                current_task.children.push(render_task.clone());
+                            if let Some(render_task_id) = prim_metadata.render_task_id {
+                                current_task.children.push(render_task_id);
                             }
-                            if let Some(ref clip_task) = prim_metadata.clip_task {
-                                current_task.children.push(clip_task.clone());
+                            if let Some(clip_task_id) = prim_metadata.clip_task_id {
+                                current_task.children.push(clip_task_id);
                             }
 
                             let item = AlphaRenderItem::Primitive(Some(group_index), prim_index, next_z);
-                            current_task.as_alpha_batch().items.push(item);
+                            current_task.as_alpha_batch_mut().items.push(item);
                             next_z += 1;
                         }
                     }
@@ -1542,8 +1542,7 @@ impl FrameBuilder {
 
         debug_assert!(alpha_task_stack.is_empty());
         debug_assert!(preserve_3d_map.is_empty());
-        debug_assert_eq!(current_task.id, RenderTaskId::Static(RenderTaskIndex(0)));
-        (current_task, next_task_index.0)
+        render_tasks.add(current_task)
     }
 
     pub fn build(&mut self,
@@ -1578,19 +1577,21 @@ impl FrameBuilder {
 
         self.update_scroll_bars(clip_scroll_tree, gpu_cache);
 
+        let mut render_tasks = RenderTaskTree::new();
+
         self.build_layer_screen_rects_and_cull_layers(&screen_rect,
                                                       clip_scroll_tree,
                                                       display_lists,
                                                       resource_cache,
                                                       gpu_cache,
+                                                      &mut render_tasks,
                                                       &mut profile_counters,
                                                       device_pixel_ratio);
 
-        let (main_render_task, static_render_task_count) = self.build_render_task(clip_scroll_tree, gpu_cache);
-        let mut render_tasks = RenderTaskCollection::new(static_render_task_count);
+        let main_render_task_id = self.build_render_task(clip_scroll_tree, gpu_cache, &mut render_tasks);
 
         let mut required_pass_count = 0;
-        main_render_task.max_depth(0, &mut required_pass_count);
+        render_tasks.max_depth(main_render_task_id, 0, &mut required_pass_count);
 
         resource_cache.block_until_all_resources_added(gpu_cache, texture_cache_profile);
 
@@ -1601,12 +1602,11 @@ impl FrameBuilder {
         // Do the allocations now, assigning each tile's tasks to a render
         // pass and target as required.
         for index in 0..required_pass_count {
-            passes.push(RenderPass::new(index as isize,
-                                        index == required_pass_count-1,
+            passes.push(RenderPass::new(index == required_pass_count-1,
                                         cache_size));
         }
 
-        main_render_task.assign_to_passes(passes.len() - 1, &mut passes);
+        render_tasks.assign_to_passes(main_render_task_id, passes.len() - 1, &mut passes);
 
         for pass in &mut passes {
             let ctx = RenderTargetContext {
@@ -1626,6 +1626,8 @@ impl FrameBuilder {
 
         let gpu_cache_updates = gpu_cache.end_frame(gpu_cache_profile);
 
+        render_tasks.build();
+
         resource_cache.end_frame();
 
         Frame {
@@ -1636,7 +1638,7 @@ impl FrameBuilder {
             passes,
             cache_size,
             layer_texture_data: self.packed_layers.clone(),
-            render_task_data: render_tasks.render_task_data,
+            render_tasks,
             deferred_resolves,
             gpu_cache_updates: Some(gpu_cache_updates),
         }
@@ -1660,6 +1662,7 @@ struct LayerRectCalculationAndCullingPass<'a> {
     profile_counters: &'a mut FrameProfileCounters,
     device_pixel_ratio: f32,
     stacking_context_stack: Vec<StackingContextIndex>,
+    render_tasks: &'a mut RenderTaskTree,
 
     /// A cached clip info stack, which should handle the most common situation,
     /// which is that we are using the same clip info stack that we were using
@@ -1678,6 +1681,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                       display_lists: &'a DisplayListMap,
                       resource_cache: &'a mut ResourceCache,
                       gpu_cache: &'a mut GpuCache,
+                      render_tasks: &'a mut RenderTaskTree,
                       profile_counters: &'a mut FrameProfileCounters,
                       device_pixel_ratio: f32) {
 
@@ -1693,6 +1697,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
             stacking_context_stack: Vec::new(),
             current_clip_stack: Vec::new(),
             current_clip_info: None,
+            render_tasks,
         };
         pass.run();
     }
@@ -1977,7 +1982,8 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                                                                    &packed_layer.transform,
                                                                    self.device_pixel_ratio,
                                                                    display_list,
-                                                                   TextRunMode::Normal);
+                                                                   TextRunMode::Normal,
+                                                                   &mut self.render_tasks);
 
             stacking_context.screen_bounds = stacking_context.screen_bounds.union(&prim_screen_rect);
             stacking_context.isolated_items_bounds = stacking_context.isolated_items_bounds.union(&prim_local_rect);
@@ -1988,7 +1994,7 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 // stacking context. This means that two primitives which are only clipped
                 // by the stacking context stack can share clip masks during render task
                 // assignment to targets.
-                let (mask_key, mask_rect, extra) = match prim_metadata.clip_cache_info {
+                let (cache_key, mask_rect, extra) = match prim_metadata.clip_cache_info {
                     Some(ref info) => {
                         // Take into account the actual clip info of the primitive, and
                         // mutate the current bounds accordingly.
@@ -2001,22 +2007,24 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                             }
                             _ => prim_screen_rect,
                         };
-                        (MaskCacheKey::Primitive(prim_index),
+                        (None,
                          mask_rect,
                          Some((packed_layer_index, info.strip_aligned())))
                     }
                     None => {
-                        //Note: can't use `prim_bounding_rect` since
-                        // the primitive ID is not a part of the task key
-                        (MaskCacheKey::ClipNode(clip_and_scroll.clip_node_id()),
+                        (Some(clip_and_scroll.clip_node_id()),
                          clip_bounds,
                          None)
                     }
                 };
-                prim_metadata.clip_task = RenderTask::new_mask(mask_rect,
-                                                               mask_key,
-                                                               &self.current_clip_stack,
-                                                               extra)
+                let clip_task = RenderTask::new_mask(cache_key,
+                                                     mask_rect,
+                                                     &self.current_clip_stack,
+                                                     extra);
+                let render_tasks = &mut self.render_tasks;
+                prim_metadata.clip_task_id = clip_task.map(|clip_task| {
+                    render_tasks.add(clip_task)
+                });
             }
 
             self.profile_counters.visible_primitives.inc();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -26,7 +26,7 @@ use profiler::{Profiler, BackendProfileCounters};
 use profiler::{GpuProfileTag, RendererProfileTimers, RendererProfileCounters};
 use record::ApiRecordingReceiver;
 use render_backend::RenderBackend;
-use render_task::RenderTaskData;
+use render_task::RenderTaskTree;
 use std;
 use std::cmp;
 use std::collections::VecDeque;
@@ -41,7 +41,7 @@ use std::thread;
 use texture_cache::TextureCache;
 use rayon::ThreadPool;
 use rayon::Configuration as ThreadPoolConfig;
-use tiling::{AlphaBatchKind, BlurCommand, CompositePrimitiveInstance, Frame, PrimitiveBatch, RenderTarget};
+use tiling::{AlphaBatchKind, BlurCommand, Frame, PrimitiveBatch, RenderTarget};
 use tiling::{AlphaRenderTarget, CacheClipInstance, PrimitiveInstance, ColorRenderTarget, RenderTargetKind};
 use time::precise_time_ns;
 use thread_profiler::{register_thread_with_profiler, write_profile};
@@ -763,7 +763,7 @@ impl GpuDataTextures {
 
     fn init_frame(&mut self, device: &mut Device, frame: &mut Frame) {
         self.layer_texture.init(device, &mut frame.layer_texture_data);
-        self.render_task_texture.init(device, &mut frame.render_task_data);
+        self.render_task_texture.init(device, &mut frame.render_tasks.task_data);
 
         device.bind_texture(TextureSampler::Layers, self.layer_texture.id);
         device.bind_texture(TextureSampler::RenderTasks, self.render_task_texture.id);
@@ -1723,7 +1723,7 @@ impl Renderer {
     fn submit_batch(&mut self,
                     batch: &PrimitiveBatch,
                     projection: &Transform3D<f32>,
-                    render_task_data: &[RenderTaskData],
+                    render_tasks: &RenderTaskTree,
                     render_target: Option<(TextureId, i32)>,
                     target_dimensions: DeviceUintSize) {
         let transform_kind = batch.key.flags.transform_kind();
@@ -1737,7 +1737,7 @@ impl Renderer {
                       });
 
         let marker = match batch.key.kind {
-            AlphaBatchKind::Composite => {
+            AlphaBatchKind::Composite { .. } => {
                 self.ps_composite.bind(&mut self.device, projection);
                 GPU_TAG_PRIM_COMPOSITE
             }
@@ -1826,63 +1826,64 @@ impl Renderer {
         };
 
         // Handle special case readback for composites.
-        if batch.key.kind == AlphaBatchKind::Composite {
-            // composites can't be grouped together because
-            // they may overlap and affect each other.
-            debug_assert!(batch.instances.len() == 1);
-            let instance = CompositePrimitiveInstance::from(&batch.instances[0]);
-            let cache_texture = self.texture_resolver.resolve(&SourceTexture::CacheRGBA8);
+        match batch.key.kind {
+            AlphaBatchKind::Composite { task_id, readback_id, backdrop_id } => {
+                // composites can't be grouped together because
+                // they may overlap and affect each other.
+                debug_assert!(batch.instances.len() == 1);
+                let cache_texture = self.texture_resolver.resolve(&SourceTexture::CacheRGBA8);
 
-            // TODO(gw): This code branch is all a bit hacky. We rely
-            // on pulling specific values from the render target data
-            // and also cloning the single primitive instance to be
-            // able to pass to draw_instanced_batch(). We should
-            // think about a cleaner way to achieve this!
+                // Before submitting the composite batch, do the
+                // framebuffer readbacks that are needed for each
+                // composite operation in this batch.
+                let cache_texture_dimensions = self.device.get_texture_dimensions(cache_texture);
 
-            // Before submitting the composite batch, do the
-            // framebuffer readbacks that are needed for each
-            // composite operation in this batch.
-            let cache_texture_dimensions = self.device.get_texture_dimensions(cache_texture);
+                let source = render_tasks.get(task_id);
+                let backdrop = render_tasks.get(backdrop_id);
+                let readback = render_tasks.get(readback_id);
 
-            let backdrop = &render_task_data[instance.task_index.0 as usize];
-            let readback = &render_task_data[instance.backdrop_task_index.0 as usize];
-            let source = &render_task_data[instance.src_task_index.0 as usize];
+                let (readback_rect, readback_layer) = readback.get_target_rect();
+                let (backdrop_rect, _) = backdrop.get_target_rect();
+                let backdrop_screen_origin = backdrop.as_alpha_batch().screen_origin;
+                let source_screen_origin = source.as_alpha_batch().screen_origin;
 
-            // Bind the FBO to blit the backdrop to.
-            // Called per-instance in case the layer (and therefore FBO)
-            // changes. The device will skip the GL call if the requested
-            // target is already bound.
-            let cache_draw_target = (cache_texture, readback.data[4] as i32);
-            self.device.bind_draw_target(Some(cache_draw_target), Some(cache_texture_dimensions));
+                // Bind the FBO to blit the backdrop to.
+                // Called per-instance in case the layer (and therefore FBO)
+                // changes. The device will skip the GL call if the requested
+                // target is already bound.
+                let cache_draw_target = (cache_texture, readback_layer.0 as i32);
+                self.device.bind_draw_target(Some(cache_draw_target), Some(cache_texture_dimensions));
 
-            let src_x = backdrop.data[0] - backdrop.data[4] + source.data[4];
-            let src_y = backdrop.data[1] - backdrop.data[5] + source.data[5];
+                let src_x = backdrop_rect.origin.x + backdrop_screen_origin.x - source_screen_origin.x;
+                let src_y = backdrop_rect.origin.y + backdrop_screen_origin.y - source_screen_origin.y;
 
-            let dest_x = readback.data[0];
-            let dest_y = readback.data[1];
+                let dest_x = readback_rect.origin.x;
+                let dest_y = readback_rect.origin.y;
 
-            let width = readback.data[2];
-            let height = readback.data[3];
+                let width = readback_rect.size.width;
+                let height = readback_rect.size.height;
 
-            let mut src = DeviceIntRect::new(DeviceIntPoint::new(src_x as i32, src_y as i32),
-                                             DeviceIntSize::new(width as i32, height as i32));
-            let mut dest = DeviceIntRect::new(DeviceIntPoint::new(dest_x as i32, dest_y as i32),
-                                              DeviceIntSize::new(width as i32, height as i32));
+                let mut src = DeviceIntRect::new(DeviceIntPoint::new(src_x as i32, src_y as i32),
+                                                 DeviceIntSize::new(width as i32, height as i32));
+                let mut dest = DeviceIntRect::new(DeviceIntPoint::new(dest_x as i32, dest_y as i32),
+                                                  DeviceIntSize::new(width as i32, height as i32));
 
-            // Need to invert the y coordinates and flip the image vertically when
-            // reading back from the framebuffer.
-            if render_target.is_none() {
-                src.origin.y = target_dimensions.height as i32 - src.size.height - src.origin.y;
-                dest.origin.y += dest.size.height;
-                dest.size.height = -dest.size.height;
+                // Need to invert the y coordinates and flip the image vertically when
+                // reading back from the framebuffer.
+                if render_target.is_none() {
+                    src.origin.y = target_dimensions.height as i32 - src.size.height - src.origin.y;
+                    dest.origin.y += dest.size.height;
+                    dest.size.height = -dest.size.height;
+                }
+
+                self.device.blit_render_target(render_target,
+                                               Some(src),
+                                               dest);
+
+                // Restore draw target to current pass render target + layer.
+                self.device.bind_draw_target(render_target, Some(target_dimensions));
             }
-
-            self.device.blit_render_target(render_target,
-                                           Some(src),
-                                           dest);
-
-            // Restore draw target to current pass render target + layer.
-            self.device.bind_draw_target(render_target, Some(target_dimensions));
+            _ => {}
         }
 
         let _gm = self.gpu_profile.add_marker(marker);
@@ -1896,7 +1897,7 @@ impl Renderer {
                          target: &ColorRenderTarget,
                          target_size: DeviceUintSize,
                          clear_color: Option<[f32; 4]>,
-                         render_task_data: &[RenderTaskData],
+                         render_tasks: &RenderTaskTree,
                          projection: &Transform3D<f32>) {
         {
             let _gm = self.gpu_profile.add_marker(GPU_TAG_SETUP_TARGET);
@@ -2007,7 +2008,7 @@ impl Renderer {
                                .rev() {
                 self.submit_batch(batch,
                                   &projection,
-                                  render_task_data,
+                                  render_tasks,
                                   render_target,
                                   target_size);
             }
@@ -2038,7 +2039,7 @@ impl Renderer {
 
                 self.submit_batch(batch,
                                   &projection,
-                                  render_task_data,
+                                  render_tasks,
                                   render_target,
                                   target_size);
             }
@@ -2325,7 +2326,7 @@ impl Renderer {
                                            target,
                                            *size,
                                            clear_color,
-                                           &frame.render_task_data,
+                                           &frame.render_tasks,
                                            &projection);
 
                 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -8,16 +8,16 @@ use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle, GpuCacheUpdateList};
 use internal_types::BatchTextures;
 use internal_types::{FastHashMap, SourceTexture};
 use mask_cache::MaskCacheInfo;
-use prim_store::{CLIP_DATA_GPU_BLOCKS, DeferredResolve, PrimitiveCacheKey};
+use prim_store::{CLIP_DATA_GPU_BLOCKS, DeferredResolve};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
 use profiler::FrameProfileCounters;
-use render_task::{AlphaRenderItem, MaskGeometryKind, MaskSegment, RenderTask, RenderTaskData};
-use render_task::{RenderTaskId, RenderTaskIndex, RenderTaskKey, RenderTaskKind};
-use render_task::RenderTaskLocation;
+use render_task::{AlphaRenderItem, MaskGeometryKind, MaskSegment};
+use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKey, RenderTaskKind};
+use render_task::{RenderTaskLocation, RenderTaskTree};
 use renderer::BlendMode;
 use renderer::ImageBufferKind;
 use resource_cache::ResourceCache;
-use std::{f32, i32, mem, usize};
+use std::{f32, i32, usize};
 use texture_allocator::GuillotineAllocator;
 use util::{TransformedRect, TransformedRectKind};
 use api::{BuiltDisplayList, ClipAndScrollInfo, ClipId, ColorF, DeviceIntPoint, ImageKey};
@@ -28,8 +28,7 @@ use api::{TileOffset, WorldToLayerTransform, YuvColorSpace, YuvFormat, LayerVect
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.
-const OPAQUE_TASK_INDEX: RenderTaskIndex = RenderTaskIndex(i32::MAX as usize);
-
+const OPAQUE_TASK_ADDRESS: RenderTaskAddress = RenderTaskAddress(i32::MAX as u32);
 
 pub type DisplayListMap = FastHashMap<PipelineId, BuiltDisplayList>;
 
@@ -98,74 +97,8 @@ pub struct RenderPassIndex(isize);
 
 #[derive(Debug)]
 struct DynamicTaskInfo {
-    index: RenderTaskIndex,
-    rect: DeviceIntRect,
-}
-
-#[derive(Debug)]
-pub struct RenderTaskCollection {
-    pub render_task_data: Vec<RenderTaskData>,
-    dynamic_tasks: FastHashMap<(RenderTaskKey, RenderPassIndex), DynamicTaskInfo>,
-}
-
-impl RenderTaskCollection {
-    pub fn new(static_render_task_count: usize) -> RenderTaskCollection {
-        RenderTaskCollection {
-            render_task_data: vec![RenderTaskData::empty(); static_render_task_count],
-            dynamic_tasks: FastHashMap::default(),
-        }
-    }
-
-    fn add(&mut self, task: &RenderTask, pass: RenderPassIndex) -> RenderTaskIndex {
-        match task.id {
-            RenderTaskId::Static(index) => {
-                self.render_task_data[index.0] = task.write_task_data();
-                index
-            }
-            RenderTaskId::Dynamic(key) => {
-                let index = RenderTaskIndex(self.render_task_data.len());
-                let key = (key, pass);
-                debug_assert!(!self.dynamic_tasks.contains_key(&key));
-                self.dynamic_tasks.insert(key, DynamicTaskInfo {
-                    index,
-                    rect: match task.location {
-                        RenderTaskLocation::Fixed => panic!("Dynamic tasks should not have fixed locations!"),
-                        RenderTaskLocation::Dynamic(Some((origin, _)), size) => DeviceIntRect::new(origin, size),
-                        RenderTaskLocation::Dynamic(None, _) => panic!("Expect the task to be already allocated here"),
-                    },
-                });
-                self.render_task_data.push(task.write_task_data());
-                index
-            }
-        }
-    }
-
-    fn get_dynamic_allocation(&self, pass_index: RenderPassIndex, key: RenderTaskKey) -> Option<&DeviceIntRect> {
-        let key = (key, pass_index);
-        self.dynamic_tasks.get(&key)
-                          .map(|task| &task.rect)
-    }
-
-    fn get_static_task_index(&self, id: &RenderTaskId) -> RenderTaskIndex {
-        match id {
-            &RenderTaskId::Static(index) => index,
-            &RenderTaskId::Dynamic(..) => panic!("This is a bug - expected a static render task!"),
-        }
-    }
-
-    fn get_task_index(&self, id: &RenderTaskId, pass_index: RenderPassIndex) -> RenderTaskIndex {
-        match id {
-            &RenderTaskId::Static(index) => index,
-            &RenderTaskId::Dynamic(key) => {
-                self.dynamic_tasks[&(key, pass_index)].index
-            }
-        }
-    }
-}
-
-struct AlphaBatchTask {
     task_id: RenderTaskId,
-    items: Vec<AlphaRenderItem>,
+    rect: DeviceIntRect,
 }
 
 pub struct BatchList {
@@ -207,21 +140,24 @@ impl BatchList {
         // This is because the result of a composite can affect
         // the input to the next composite. Perhaps we can
         // optimize this in the future.
-        if key.kind != AlphaBatchKind::Composite {
-            'outer: for (batch_index, batch) in batches.iter()
-                                                       .enumerate()
-                                                       .rev()
-                                                       .take(10) {
-                if batch.key.is_compatible_with(key) {
-                    selected_batch_index = Some(batch_index);
-                    break;
-                }
+        match key.kind {
+            AlphaBatchKind::Composite { .. } => {}
+            _ => {
+                'outer: for (batch_index, batch) in batches.iter()
+                                                           .enumerate()
+                                                           .rev()
+                                                           .take(10) {
+                    if batch.key.is_compatible_with(key) {
+                        selected_batch_index = Some(batch_index);
+                        break;
+                    }
 
-                // check for intersections
-                if check_intersections {
-                    for item_rect in &batch.item_rects {
-                        if item_rect.intersects(item_bounding_rect) {
-                            break 'outer;
+                    // check for intersections
+                    if check_intersections {
+                        for item_rect in &batch.item_rects {
+                            if item_rect.intersects(item_bounding_rect) {
+                                break 'outer;
+                            }
                         }
                     }
                 }
@@ -256,7 +192,7 @@ impl BatchList {
 /// Encapsulates the logic of building batches for items that are blended.
 pub struct AlphaBatcher {
     pub batch_list: BatchList,
-    tasks: Vec<AlphaBatchTask>,
+    tasks: Vec<RenderTaskId>,
 }
 
 impl AlphaRenderItem {
@@ -264,9 +200,9 @@ impl AlphaRenderItem {
                     batch_list: &mut BatchList,
                     ctx: &RenderTargetContext,
                     gpu_cache: &mut GpuCache,
-                    render_tasks: &RenderTaskCollection,
-                    child_pass_index: RenderPassIndex,
-                    task_index: RenderTaskIndex,
+                    render_tasks: &RenderTaskTree,
+                    task_id: RenderTaskId,
+                    task_address: RenderTaskAddress,
                     deferred_resolves: &mut Vec<DeferredResolve>) {
         match *self {
             AlphaRenderItem::Blend(stacking_context_index, src_id, filter, z) => {
@@ -275,7 +211,7 @@ impl AlphaRenderItem {
                                              AlphaBatchKeyFlags::empty(),
                                              BlendMode::PremultipliedAlpha,
                                              BatchTextures::no_texture());
-                let src_task_index = render_tasks.get_static_task_index(&src_id);
+                let src_task_address = render_tasks.get_task_address(src_id);
 
                 let (filter_mode, amount) = match filter {
                     // TODO: Implement blur filter #1351
@@ -294,9 +230,9 @@ impl AlphaRenderItem {
                 let amount = (amount * 65535.0).round() as i32;
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
 
-                let instance = CompositePrimitiveInstance::new(task_index,
-                                                               src_task_index,
-                                                               RenderTaskIndex(0),
+                let instance = CompositePrimitiveInstance::new(task_address,
+                                                               src_task_address,
+                                                               RenderTaskAddress(0),
                                                                filter_mode,
                                                                amount,
                                                                z);
@@ -305,16 +241,16 @@ impl AlphaRenderItem {
             }
             AlphaRenderItem::HardwareComposite(stacking_context_index, src_id, composite_op, z) => {
                 let stacking_context = &ctx.stacking_context_store[stacking_context_index.0];
-                let src_task_index = render_tasks.get_static_task_index(&src_id);
+                let src_task_address = render_tasks.get_task_address(src_id);
                 let key = AlphaBatchKey::new(AlphaBatchKind::HardwareComposite,
                                              AlphaBatchKeyFlags::empty(),
                                              composite_op.to_blend_mode(),
                                              BatchTextures::no_texture());
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
 
-                let instance = CompositePrimitiveInstance::new(task_index,
-                                                               src_task_index,
-                                                               RenderTaskIndex(0),
+                let instance = CompositePrimitiveInstance::new(task_address,
+                                                               src_task_address,
+                                                               RenderTaskAddress(0),
                                                                0,
                                                                0,
                                                                z);
@@ -322,22 +258,22 @@ impl AlphaRenderItem {
                 batch.add_instance(PrimitiveInstance::from(instance));
             }
             AlphaRenderItem::Composite(stacking_context_index,
+                                       readback_id,
                                        backdrop_id,
-                                       src_id,
                                        mode,
                                        z) => {
                 let stacking_context = &ctx.stacking_context_store[stacking_context_index.0];
-                let key = AlphaBatchKey::new(AlphaBatchKind::Composite,
+                let key = AlphaBatchKey::new(AlphaBatchKind::Composite { task_id, readback_id, backdrop_id },
                                              AlphaBatchKeyFlags::empty(),
                                              BlendMode::Alpha,
                                              BatchTextures::no_texture());
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
-                let backdrop_task = render_tasks.get_task_index(&backdrop_id, child_pass_index);
-                let src_task_index = render_tasks.get_static_task_index(&src_id);
+                let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
+                let readback_task_address = render_tasks.get_task_address(readback_id);
 
-                let instance = CompositePrimitiveInstance::new(task_index,
-                                                               src_task_index,
-                                                               backdrop_task,
+                let instance = CompositePrimitiveInstance::new(task_address,
+                                                               backdrop_task_address,
+                                                               readback_task_address,
                                                                mode as u32 as i32,
                                                                0,
                                                                z);
@@ -363,14 +299,9 @@ impl AlphaRenderItem {
                     flags |= AXIS_ALIGNED;
                 }
                 let item_bounding_rect = ctx.prim_store.cpu_bounding_rects[prim_index.0].as_ref().unwrap();
-                let clip_task_index = match prim_metadata.clip_task {
-                    Some(ref clip_task) => {
-                        render_tasks.get_task_index(&clip_task.id, child_pass_index)
-                    }
-                    None => {
-                        OPAQUE_TASK_INDEX
-                    }
-                };
+                let clip_task_address = prim_metadata.clip_task_id.map_or(OPAQUE_TASK_ADDRESS, |id| {
+                    render_tasks.get_task_address(id)
+                });
                 let needs_blending = !prim_metadata.opacity.is_opaque ||
                                      needs_clipping ||
                                      transform_kind == TransformedRectKind::Complex;
@@ -380,8 +311,8 @@ impl AlphaRenderItem {
                                                       .as_int(gpu_cache);
 
                 let base_instance = SimplePrimitiveInstance::new(prim_cache_address,
-                                                                 task_index,
-                                                                 clip_task_index,
+                                                                 task_address,
+                                                                 clip_task_address,
                                                                  packed_layer_index,
                                                                  z);
 
@@ -502,13 +433,12 @@ impl AlphaRenderItem {
                         }
                     }
                     PrimitiveKind::TextShadow => {
-                        let cache_task_id = prim_metadata.render_task.as_ref().expect("no render task!").id;
-                        let cache_task_index = render_tasks.get_task_index(&cache_task_id,
-                                                                           child_pass_index);
+                        let cache_task_id = prim_metadata.render_task_id.expect("no render task!");
+                        let cache_task_address = render_tasks.get_task_address(cache_task_id);
                         let textures = BatchTextures::render_target_cache();
                         let key = AlphaBatchKey::new(AlphaBatchKind::CacheImage, flags, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
-                        batch.add_instance(base_instance.build(0, cache_task_index.0 as i32, 0));
+                        batch.add_instance(base_instance.build(0, cache_task_address.0 as i32, 0));
                     }
                     PrimitiveKind::AlignedGradient => {
                         let gradient_cpu = &ctx.prim_store.cpu_gradients[prim_metadata.cpu_prim_index.0];
@@ -593,16 +523,15 @@ impl AlphaRenderItem {
                     }
                     PrimitiveKind::BoxShadow => {
                         let box_shadow = &ctx.prim_store.cpu_box_shadows[prim_metadata.cpu_prim_index.0];
-                        let cache_task_id = &prim_metadata.render_task.as_ref().unwrap().id;
-                        let cache_task_index = render_tasks.get_task_index(cache_task_id,
-                                                                           child_pass_index);
+                        let cache_task_id = prim_metadata.render_task_id.unwrap();
+                        let cache_task_address = render_tasks.get_task_address(cache_task_id);
 
                         let key = AlphaBatchKey::new(AlphaBatchKind::BoxShadow, flags, blend_mode, no_textures);
                         let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
 
                         for rect_index in 0..box_shadow.rects.len() {
                             batch.add_instance(base_instance.build(rect_index as i32,
-                                                                   cache_task_index.0 as i32, 0));
+                                                                   cache_task_address.0 as i32, 0));
                         }
                     }
                 }
@@ -614,12 +543,12 @@ impl AlphaRenderItem {
                                              BatchTextures::no_texture());
                 let stacking_context = &ctx.stacking_context_store[sc_index.0];
                 let batch = batch_list.get_suitable_batch(&key, &stacking_context.screen_bounds);
-                let source_task = render_tasks.get_task_index(&task_id, child_pass_index);
+                let source_task_address = render_tasks.get_task_address(task_id);
                 let gpu_address = gpu_handle.as_int(gpu_cache);
 
-                let instance = CompositePrimitiveInstance::new(task_index,
-                                                               source_task,
-                                                               RenderTaskIndex(0),
+                let instance = CompositePrimitiveInstance::new(task_address,
+                                                               source_task_address,
+                                                               RenderTaskAddress(0),
                                                                gpu_address,
                                                                0,
                                                                z);
@@ -638,26 +567,27 @@ impl AlphaBatcher {
         }
     }
 
-    fn add_task(&mut self, task: AlphaBatchTask) {
-        self.tasks.push(task);
+    fn add_task(&mut self, task_id: RenderTaskId) {
+        self.tasks.push(task_id);
     }
 
     fn build(&mut self,
              ctx: &RenderTargetContext,
              gpu_cache: &mut GpuCache,
-             render_tasks: &RenderTaskCollection,
-             child_pass_index: RenderPassIndex,
+             render_tasks: &RenderTaskTree,
              deferred_resolves: &mut Vec<DeferredResolve>) {
-        for task in &self.tasks {
-            let task_index = render_tasks.get_static_task_index(&task.task_id);
+        for task_id in &self.tasks {
+            let task_id = *task_id;
+            let task = render_tasks.get(task_id).as_alpha_batch();
+            let task_address = render_tasks.get_task_address(task_id);
 
             for item in &task.items {
                 item.add_to_batch(&mut self.batch_list,
                                   ctx,
                                   gpu_cache,
                                   render_tasks,
-                                  child_pass_index,
-                                  task_index,
+                                  task_id,
+                                  task_address,
                                   deferred_resolves);
             }
         }
@@ -693,7 +623,7 @@ impl ClipBatcher {
     }
 
     fn add<'a>(&mut self,
-               task_index: RenderTaskIndex,
+               task_address: RenderTaskAddress,
                clips: &[(PackedLayerIndex, MaskCacheInfo)],
                resource_cache: &ResourceCache,
                gpu_cache: &GpuCache,
@@ -701,7 +631,7 @@ impl ClipBatcher {
 
         for &(packed_layer_index, ref info) in clips.iter() {
             let instance = CacheClipInstance {
-                render_task_index: task_index.0 as i32,
+                render_task_address: task_address.0 as i32,
                 layer_index: packed_layer_index.0 as i32,
                 segment: 0,
                 clip_data_address: GpuCacheAddress::invalid(),
@@ -846,15 +776,13 @@ pub trait RenderTarget {
     fn build(&mut self,
              _ctx: &RenderTargetContext,
              _gpu_cache: &mut GpuCache,
-             _render_tasks: &mut RenderTaskCollection,
-             _child_pass_index: RenderPassIndex,
+             _render_tasks: &mut RenderTaskTree,
              _deferred_resolves: &mut Vec<DeferredResolve>) {}
     fn add_task(&mut self,
-                task: RenderTask,
+                task_id: RenderTaskId,
                 ctx: &RenderTargetContext,
                 gpu_cache: &GpuCache,
-                render_tasks: &RenderTaskCollection,
-                pass_index: RenderPassIndex);
+                render_tasks: &RenderTaskTree);
     fn used_rect(&self) -> DeviceIntRect;
 }
 
@@ -889,22 +817,19 @@ impl<T: RenderTarget> RenderTargetList<T> {
     fn build(&mut self,
              ctx: &RenderTargetContext,
              gpu_cache: &mut GpuCache,
-             render_tasks: &mut RenderTaskCollection,
-             pass_index: RenderPassIndex,
+             render_tasks: &mut RenderTaskTree,
              deferred_resolves: &mut Vec<DeferredResolve>) {
         for target in &mut self.targets {
-            let child_pass_index = RenderPassIndex(pass_index.0 - 1);
-            target.build(ctx, gpu_cache, render_tasks, child_pass_index, deferred_resolves);
+            target.build(ctx, gpu_cache, render_tasks, deferred_resolves);
         }
     }
 
     fn add_task(&mut self,
-                task: RenderTask,
+                task_id: RenderTaskId,
                 ctx: &RenderTargetContext,
                 gpu_cache: &GpuCache,
-                render_tasks: &mut RenderTaskCollection,
-                pass_index: RenderPassIndex) {
-        self.targets.last_mut().unwrap().add_task(task, ctx, gpu_cache, render_tasks, pass_index);
+                render_tasks: &mut RenderTaskTree) {
+        self.targets.last_mut().unwrap().add_task(task_id, ctx, gpu_cache, render_tasks);
     }
 
     fn allocate(&mut self, alloc_size: DeviceUintSize) -> (DeviceUintPoint, RenderTargetIndex) {
@@ -975,52 +900,43 @@ impl RenderTarget for ColorRenderTarget {
     fn build(&mut self,
              ctx: &RenderTargetContext,
              gpu_cache: &mut GpuCache,
-             render_tasks: &mut RenderTaskCollection,
-             child_pass_index: RenderPassIndex,
+             render_tasks: &mut RenderTaskTree,
              deferred_resolves: &mut Vec<DeferredResolve>) {
         self.alpha_batcher.build(ctx,
                                  gpu_cache,
                                  render_tasks,
-                                 child_pass_index,
                                  deferred_resolves);
     }
 
     fn add_task(&mut self,
-                task: RenderTask,
+                task_id: RenderTaskId,
                 ctx: &RenderTargetContext,
                 gpu_cache: &GpuCache,
-                render_tasks: &RenderTaskCollection,
-                pass_index: RenderPassIndex) {
+                render_tasks: &RenderTaskTree) {
+        let task = render_tasks.get(task_id);
+
         match task.kind {
-            RenderTaskKind::Alpha(mut info) => {
-                self.alpha_batcher.add_task(AlphaBatchTask {
-                    task_id: task.id,
-                    items: mem::replace(&mut info.items, Vec::new()),
-                });
+            RenderTaskKind::Alias(..) => {
+                panic!("BUG: add_task() called on invalidated task");
             }
-            RenderTaskKind::VerticalBlur(_, prim_index) => {
+            RenderTaskKind::Alpha(..) => {
+                self.alpha_batcher.add_task(task_id);
+            }
+            RenderTaskKind::VerticalBlur(..) => {
                 // Find the child render task that we are applying
                 // a vertical blur on.
-                // TODO(gw): Consider a simpler way for render tasks to find
-                //           their child tasks than having to construct the
-                //           correct id here.
-                let child_pass_index = RenderPassIndex(pass_index.0 - 1);
-                let task_key = RenderTaskKey::CachePrimitive(PrimitiveCacheKey::TextShadow(prim_index));
-                let src_id = RenderTaskId::Dynamic(task_key);
                 self.vertical_blurs.push(BlurCommand {
-                    task_id: render_tasks.get_task_index(&task.id, pass_index).0 as i32,
-                    src_task_id: render_tasks.get_task_index(&src_id, child_pass_index).0 as i32,
+                    task_id: task_id.0 as i32,
+                    src_task_id: task.children[0].0 as i32,
                     blur_direction: BlurDirection::Vertical as i32,
                 });
             }
-            RenderTaskKind::HorizontalBlur(blur_radius, prim_index) => {
+            RenderTaskKind::HorizontalBlur(..) => {
                 // Find the child render task that we are applying
                 // a horizontal blur on.
-                let child_pass_index = RenderPassIndex(pass_index.0 - 1);
-                let src_id = RenderTaskId::Dynamic(RenderTaskKey::VerticalBlur(blur_radius.0, prim_index));
                 self.horizontal_blurs.push(BlurCommand {
-                    task_id: render_tasks.get_task_index(&task.id, pass_index).0 as i32,
-                    src_task_id: render_tasks.get_task_index(&src_id, child_pass_index).0 as i32,
+                    task_id: task_id.0 as i32,
+                    src_task_id: task.children[0].0 as i32,
                     blur_direction: BlurDirection::Horizontal as i32,
                 });
             }
@@ -1032,8 +948,8 @@ impl RenderTarget for ColorRenderTarget {
                 match prim_metadata.prim_kind {
                     PrimitiveKind::BoxShadow => {
                         let instance = SimplePrimitiveInstance::new(prim_address,
-                                                                    render_tasks.get_task_index(&task.id, pass_index),
-                                                                    RenderTaskIndex(0),
+                                                                    render_tasks.get_task_address(task_id),
+                                                                    RenderTaskAddress(0),
                                                                     PackedLayerIndex(0),
                                                                     0);     // z is disabled for rendering cache primitives
                         self.box_shadow_cache_prims.push(instance.build(0, 0, 0));
@@ -1044,14 +960,14 @@ impl RenderTarget for ColorRenderTarget {
                         // todo(gw): avoid / recycle this allocation...
                         let mut instances = Vec::new();
 
-                        let task_index = render_tasks.get_task_index(&task.id, pass_index);
+                        let task_index = render_tasks.get_task_address(task_id);
 
                         for sub_prim_index in &prim.primitives {
                             let sub_metadata = ctx.prim_store.get_metadata(*sub_prim_index);
                             let sub_prim_address = sub_metadata.gpu_location.as_int(gpu_cache);
                             let instance = SimplePrimitiveInstance::new(sub_prim_address,
                                                                         task_index,
-                                                                        RenderTaskIndex(0),
+                                                                        RenderTaskAddress(0),
                                                                         PackedLayerIndex(0),
                                                                         0);     // z is disabled for rendering cache primitives
 
@@ -1140,12 +1056,15 @@ impl RenderTarget for AlphaRenderTarget {
     }
 
     fn add_task(&mut self,
-                task: RenderTask,
+                task_id: RenderTaskId,
                 ctx: &RenderTargetContext,
                 gpu_cache: &GpuCache,
-                render_tasks: &RenderTaskCollection,
-                pass_index: RenderPassIndex) {
+                render_tasks: &RenderTaskTree) {
+        let task = render_tasks.get(task_id);
         match task.kind {
+            RenderTaskKind::Alias(..) => {
+                panic!("BUG: add_task() called on invalidated task");
+            }
             RenderTaskKind::Alpha(..) |
             RenderTaskKind::VerticalBlur(..) |
             RenderTaskKind::HorizontalBlur(..) |
@@ -1154,8 +1073,8 @@ impl RenderTarget for AlphaRenderTarget {
                 panic!("Should not be added to alpha target!");
             }
             RenderTaskKind::CacheMask(ref task_info) => {
-                let task_index = render_tasks.get_task_index(&task.id, pass_index);
-                self.clip_batcher.add(task_index,
+                let task_address = render_tasks.get_task_address(task_id);
+                self.clip_batcher.add(task_address,
                                       &task_info.clips,
                                       &ctx.resource_cache,
                                       gpu_cache,
@@ -1171,50 +1090,30 @@ impl RenderTarget for AlphaRenderTarget {
 /// A render pass can have several render targets if there wasn't enough space in one
 /// target to do all of the rendering for that pass.
 pub struct RenderPass {
-    pass_index: RenderPassIndex,
     pub is_framebuffer: bool,
-    tasks: Vec<RenderTask>,
+    tasks: Vec<RenderTaskId>,
     pub color_targets: RenderTargetList<ColorRenderTarget>,
     pub alpha_targets: RenderTargetList<AlphaRenderTarget>,
     pub color_texture_id: Option<TextureId>,
     pub alpha_texture_id: Option<TextureId>,
+    dynamic_tasks: FastHashMap<RenderTaskKey, DynamicTaskInfo>,
 }
 
 impl RenderPass {
-    pub fn new(pass_index: isize, is_framebuffer: bool, size: DeviceUintSize) -> RenderPass {
+    pub fn new(is_framebuffer: bool, size: DeviceUintSize) -> RenderPass {
         RenderPass {
-            pass_index: RenderPassIndex(pass_index),
             is_framebuffer,
             color_targets: RenderTargetList::new(size, is_framebuffer),
             alpha_targets: RenderTargetList::new(size, false),
             tasks: vec![],
             color_texture_id: None,
             alpha_texture_id: None,
+            dynamic_tasks: FastHashMap::default(),
         }
     }
 
-    pub fn add_render_task(&mut self, task: RenderTask) {
-        self.tasks.push(task);
-    }
-
-    fn add_task(&mut self,
-                task: RenderTask,
-                ctx: &RenderTargetContext,
-                gpu_cache: &GpuCache,
-                render_tasks: &mut RenderTaskCollection) {
-        match task.target_kind() {
-            RenderTargetKind::Color => self.color_targets.add_task(task, ctx, gpu_cache, render_tasks, self.pass_index),
-            RenderTargetKind::Alpha => self.alpha_targets.add_task(task, ctx, gpu_cache, render_tasks, self.pass_index),
-        }
-    }
-
-    fn allocate_target(&mut self,
-                       kind: RenderTargetKind,
-                       alloc_size: DeviceUintSize) -> (DeviceUintPoint, RenderTargetIndex) {
-        match kind {
-            RenderTargetKind::Color => self.color_targets.allocate(alloc_size),
-            RenderTargetKind::Alpha => self.alpha_targets.allocate(alloc_size),
-        }
+    pub fn add_render_task(&mut self, task_id: RenderTaskId) {
+        self.tasks.push(task_id);
     }
 
     pub fn needs_render_target_kind(&self, kind: RenderTargetKind) -> bool {
@@ -1236,57 +1135,80 @@ impl RenderPass {
     pub fn build(&mut self,
                  ctx: &RenderTargetContext,
                  gpu_cache: &mut GpuCache,
-                 render_tasks: &mut RenderTaskCollection,
+                 render_tasks: &mut RenderTaskTree,
                  deferred_resolves: &mut Vec<DeferredResolve>) {
         profile_scope!("RenderPass::build");
 
         // Step through each task, adding to batches as appropriate.
-        let tasks = mem::replace(&mut self.tasks, Vec::new());
-        for mut task in tasks {
-            let target_kind = task.target_kind();
+        for task_id in &self.tasks {
+            let task_id = *task_id;
 
-            // Find a target to assign this task to, or create a new
-            // one if required.
-            match task.location {
-                RenderTaskLocation::Fixed => {}
-                RenderTaskLocation::Dynamic(ref mut origin, ref size) => {
-                    // See if this task is a duplicate.
-                    // If so, just skip adding it!
-                    match task.id {
-                        RenderTaskId::Static(..) => {}
-                        RenderTaskId::Dynamic(key) => {
-                            // Look up cache primitive key in the render
-                            // task data array. If a matching key exists
-                            // (that is in this pass) there is no need
-                            // to draw it again!
-                            if let Some(rect) = render_tasks.get_dynamic_allocation(self.pass_index, key) {
-                                debug_assert_eq!(rect.size, *size);
+            let target_kind = {
+                let task = render_tasks.get_mut(task_id);
+                let target_kind = task.target_kind();
+
+                // Find a target to assign this task to, or create a new
+                // one if required.
+                match task.location {
+                    RenderTaskLocation::Fixed => {}
+                    RenderTaskLocation::Dynamic(_, size) => {
+                        if let Some(cache_key) = task.cache_key {
+                            // See if this task is a duplicate.
+                            // If so, just skip adding it!
+                            if let Some(task_info) = self.dynamic_tasks.get(&cache_key) {
+                                task.set_alias(task_info.task_id);
+                                debug_assert_eq!(task_info.rect.size, size);
                                 continue;
                             }
                         }
+
+                        let alloc_size = DeviceUintSize::new(size.width as u32, size.height as u32);
+                        let (alloc_origin, target_index) = match target_kind {
+                            RenderTargetKind::Color => self.color_targets.allocate(alloc_size),
+                            RenderTargetKind::Alpha => self.alpha_targets.allocate(alloc_size),
+                        };
+
+                        let origin = Some((DeviceIntPoint::new(alloc_origin.x as i32,
+                                                               alloc_origin.y as i32),
+                                           target_index));
+                        task.location = RenderTaskLocation::Dynamic(origin, size);
+
+                        // If this task is cacheable / sharable, store it in the task hash
+                        // for this pass.
+                        if let Some(cache_key) = task.cache_key {
+                            self.dynamic_tasks.insert(cache_key, DynamicTaskInfo {
+                                task_id,
+                                rect: match task.location {
+                                    RenderTaskLocation::Fixed => panic!("Dynamic tasks should not have fixed locations!"),
+                                    RenderTaskLocation::Dynamic(Some((origin, _)), size) => DeviceIntRect::new(origin, size),
+                                    RenderTaskLocation::Dynamic(None, _) => panic!("Expect the task to be already allocated here"),
+                                },
+                            });
+                        }
                     }
-
-                    let alloc_size = DeviceUintSize::new(size.width as u32, size.height as u32);
-                    let (alloc_origin, target_index) = self.allocate_target(target_kind, alloc_size);
-
-                    *origin = Some((DeviceIntPoint::new(alloc_origin.x as i32,
-                                                        alloc_origin.y as i32),
-                                    target_index));
                 }
-            }
 
-            render_tasks.add(&task, self.pass_index);
-            self.add_task(task, ctx, gpu_cache, render_tasks);
+                target_kind
+            };
+
+            match target_kind {
+                RenderTargetKind::Color => self.color_targets.add_task(task_id, ctx, gpu_cache, render_tasks),
+                RenderTargetKind::Alpha => self.alpha_targets.add_task(task_id, ctx, gpu_cache, render_tasks),
+            }
         }
 
-        self.color_targets.build(ctx, gpu_cache, render_tasks, self.pass_index, deferred_resolves);
-        self.alpha_targets.build(ctx, gpu_cache, render_tasks, self.pass_index, deferred_resolves);
+        self.color_targets.build(ctx, gpu_cache, render_tasks, deferred_resolves);
+        self.alpha_targets.build(ctx, gpu_cache, render_tasks, deferred_resolves);
     }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum AlphaBatchKind {
-    Composite,
+    Composite {
+        task_id: RenderTaskId,
+        readback_id: RenderTaskId,
+        backdrop_id: RenderTaskId,
+    },
     HardwareComposite,
     SplitComposite,
     Blend,
@@ -1382,7 +1304,7 @@ pub struct BlurCommand {
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct CacheClipInstance {
-    render_task_index: i32,
+    render_task_address: i32,
     layer_index: i32,
     segment: i32,
     clip_data_address: GpuCacheAddress,
@@ -1411,8 +1333,8 @@ struct SimplePrimitiveInstance {
 
 impl SimplePrimitiveInstance {
     fn new(specific_prim_address: i32,
-           task_index: RenderTaskIndex,
-           clip_task_index: RenderTaskIndex,
+           task_index: RenderTaskAddress,
+           clip_task_index: RenderTaskAddress,
            layer_index: PackedLayerIndex,
            z_sort_index: i32) -> SimplePrimitiveInstance {
         SimplePrimitiveInstance {
@@ -1441,25 +1363,25 @@ impl SimplePrimitiveInstance {
 }
 
 pub struct CompositePrimitiveInstance {
-    pub task_index: RenderTaskIndex,
-    pub src_task_index: RenderTaskIndex,
-    pub backdrop_task_index: RenderTaskIndex,
+    pub task_address: RenderTaskAddress,
+    pub src_task_address: RenderTaskAddress,
+    pub backdrop_task_address: RenderTaskAddress,
     pub data0: i32,
     pub data1: i32,
     pub z: i32,
 }
 
 impl CompositePrimitiveInstance {
-    fn new(task_index: RenderTaskIndex,
-           src_task_index: RenderTaskIndex,
-           backdrop_task_index: RenderTaskIndex,
+    fn new(task_address: RenderTaskAddress,
+           src_task_address: RenderTaskAddress,
+           backdrop_task_address: RenderTaskAddress,
            data0: i32,
            data1: i32,
            z: i32) -> CompositePrimitiveInstance {
         CompositePrimitiveInstance {
-            task_index,
-            src_task_index,
-            backdrop_task_index,
+            task_address,
+            src_task_address,
+            backdrop_task_address,
             data0,
             data1,
             z,
@@ -1471,28 +1393,15 @@ impl From<CompositePrimitiveInstance> for PrimitiveInstance {
     fn from(instance: CompositePrimitiveInstance) -> PrimitiveInstance {
         PrimitiveInstance {
             data: [
-                instance.task_index.0 as i32,
-                instance.src_task_index.0 as i32,
-                instance.backdrop_task_index.0 as i32,
+                instance.task_address.0 as i32,
+                instance.src_task_address.0 as i32,
+                instance.backdrop_task_address.0 as i32,
                 instance.z,
                 instance.data0,
                 instance.data1,
                 0,
                 0,
             ]
-        }
-    }
-}
-
-impl<'a> From<&'a PrimitiveInstance> for CompositePrimitiveInstance {
-    fn from(instance: &'a PrimitiveInstance) -> CompositePrimitiveInstance {
-        CompositePrimitiveInstance {
-            task_index: RenderTaskIndex(instance.data[0] as usize),
-            src_task_index: RenderTaskIndex(instance.data[1] as usize),
-            backdrop_task_index: RenderTaskIndex(instance.data[2] as usize),
-            z: instance.data[3],
-            data0: instance.data[4],
-            data1: instance.data[5],
         }
     }
 }
@@ -1708,7 +1617,8 @@ pub struct Frame {
     pub profile_counters: FrameProfileCounters,
 
     pub layer_texture_data: Vec<PackedLayer>,
-    pub render_task_data: Vec<RenderTaskData>,
+
+    pub render_tasks: RenderTaskTree,
 
     // List of updates that need to be pushed to the
     // gpu resource cache.


### PR DESCRIPTION
This is mostly prep work for some upcoming
changes (specifically, moving render task
data to the GPU cache, which will allow us
to unify some of the shaders).

* Remove RenderTaskCollection.
* Introduce RenderTaskTree.
* Render task children are IDs.
	* Less cloning, less memory to move.
* Pass RenderTaskTree as part of Frame.
	* Allows fewer hacks in renderer / composites.
* Reduce amount of hashing for dynamic tasks.
	* Make tasks optionally cacheable.
	* Only hash on cacheable tasks (box shadows, shared clips).
* Create box shadow render tasks on demand (handle DPR changes).
* Cleaner implementation of shared / cached tasks.
	* Will be cleaned up further when using GPU cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1595)
<!-- Reviewable:end -->
