### PR TITLE
Add the mut keyword for font_key_from_native_handle() in windows platform

### DIFF
--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -273,7 +273,7 @@ impl Wrench {
     #[cfg(target_os = "windows")]
     pub fn font_key_from_native_handle(&mut self, descriptor: &NativeFontHandle) -> FontKey {
         let key = self.api.generate_font_key();
-        let resources = ResourceUpdates::new();
+        let mut resources = ResourceUpdates::new();
         resources.add_native_font(key, descriptor.clone());
         self.api.update_resources(resources);
         key


### PR DESCRIPTION
@glennw r?

Fix the build break in windows. The add_native_font() call in this function needs a mutable variable.

   --> src\wrench.rs:277:9
    |
276 |         let resources = ResourceUpdates::new();
    |             --------- consider changing this to `mut resources`
277 |         resources.add_native_font(key, descriptor.clone());
    |         ^^^^^^^^^ cannot borrow mutably
error: aborting due to previous error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1599)
<!-- Reviewable:end -->
