### PR TITLE
Add font instance keys which associate size and other options with a key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.49.0",
+ "webrender 0.50.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1050,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1078,13 +1078,13 @@ dependencies = [
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.49.0",
+ "webrender_api 0.50.0",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.49.0"
+version = "0.50.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -241,6 +241,9 @@ impl Example for App {
             let font_bytes = load_file("res/FreeSans.ttf");
             resources.add_raw_font(font_key, font_bytes, 0);
 
+            let font_instance_key = api.generate_font_instance_key();
+            resources.add_font_instance(font_instance_key, font_key, Au::from_px(32), None, None);
+
             let text_bounds = (100, 200).by(700, 300);
             let glyphs = vec![
                 GlyphInstance {
@@ -296,9 +299,8 @@ impl Example for App {
             builder.push_text(text_bounds,
                               None,
                               &glyphs,
-                              font_key,
+                              font_instance_key,
                               ColorF::new(1.0, 1.0, 0.0, 1.0),
-                              Au::from_px(32),
                               None);
         }
 

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -210,6 +210,7 @@ impl api::BlobImageRenderer for CheckerboardRenderer {
         Err(api::BlobImageError::Other("Channel closed".into()))
     }
     fn delete_font(&mut self, _font: api::FontKey) { }
+    fn delete_font_instance(&mut self, _instance: api::FontInstanceKey) { }
 }
 
 struct App {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -95,6 +95,7 @@ impl NestedDisplayListInfo {
 struct FlattenContext<'a> {
     scene: &'a Scene,
     builder: &'a mut FrameBuilder,
+    resource_cache: &'a ResourceCache,
     tiled_image_map: TiledImageMap,
     replacements: Vec<(ClipId, ClipId)>,
     nested_display_list_info: Vec<NestedDisplayListInfo>,
@@ -104,11 +105,12 @@ struct FlattenContext<'a> {
 impl<'a> FlattenContext<'a> {
     fn new(scene: &'a Scene,
            builder: &'a mut FrameBuilder,
-           resource_cache: &ResourceCache)
+           resource_cache: &'a ResourceCache)
            -> FlattenContext<'a> {
         FlattenContext {
             scene,
             builder,
+            resource_cache,
             tiled_image_map: resource_cache.get_tiled_image_map(),
             replacements: Vec::new(),
             nested_display_list_info: Vec::new(),
@@ -565,12 +567,12 @@ impl Frame {
                                               info.image_rendering);
             }
             SpecificDisplayItem::Text(ref text_info) => {
+                let instance = context.resource_cache.get_font_instance(text_info.font_key).unwrap();
                 context.builder.add_text(clip_and_scroll,
                                          reference_frame_relative_offset,
                                          item_rect_with_offset,
                                          &clip_with_offset,
-                                         text_info.font_key,
-                                         text_info.size,
+                                         instance,
                                          &text_info.color,
                                          item.glyphs(),
                                          item.display_list().get(item.glyphs()).count(),

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -4,7 +4,8 @@
 
 use api::{BorderDetails, BorderDisplayItem, BoxShadowClipMode, ClipAndScrollInfo, ClipId, ColorF};
 use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect, DeviceUintSize};
-use api::{ExtendMode, FontKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
+use api::{ExtendMode, FontInstance, FontInstanceKey, FontKey, FontRenderMode};
+use api::{GlyphInstance, GlyphOptions, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize};
 use api::{LayerToScrollTransform, LayerVector2D, LayoutVector2D, LineOrientation, LineStyle};
 use api::{LocalClip, PipelineId, RepeatMode, ScrollSensitivity, SubpixelDirection, TextShadow};
@@ -875,24 +876,37 @@ impl FrameBuilder {
                     run_offset: LayoutVector2D,
                     rect: LayerRect,
                     local_clip: &LocalClip,
-                    font_key: FontKey,
-                    size: Au,
+                    font: &FontInstance,
                     color: &ColorF,
                     glyph_range: ItemRange<GlyphInstance>,
                     glyph_count: usize,
                     glyph_options: Option<GlyphOptions>) {
         // Trivial early out checks
-        if size.0 <= 0 {
+        if font.size.0 <= 0 {
+            return
+        }
+
+        // Sanity check - anything with glyphs bigger than this
+        // is probably going to consume too much memory to render
+        // efficiently anyway. This is specifically to work around
+        // the font_advance.html reftest, which creates a very large
+        // font as a crash test - the rendering is also ignored
+        // by the azure renderer.
+        if font.size >= Au::from_px(4096) {
             return
         }
 
         // TODO(gw): Use a proper algorithm to select
         // whether this item should be rendered with
         // subpixel AA!
-        let mut normal_render_mode = self.config.default_font_render_mode;
+        let mut default_render_mode = self.config.default_font_render_mode.limit_by(font.render_mode);
+        if let Some(options) = glyph_options {
+            default_render_mode = default_render_mode.limit_by(options.render_mode);
+        }
 
         // There are some conditions under which we can't use
         // subpixel text rendering, even if enabled.
+        let mut normal_render_mode = default_render_mode;
         if normal_render_mode == FontRenderMode::Subpixel {
             if color.a != 1.0 {
                 normal_render_mode = FontRenderMode::Alpha;
@@ -913,30 +927,32 @@ impl FrameBuilder {
 
         // Shadows never use subpixel AA, but need to respect the alpha/mono flag
         // for reftests.
-        let (shadow_render_mode, subpx_dir) = match self.config.default_font_render_mode {
+        let (shadow_render_mode, subpx_dir) = match default_render_mode {
             FontRenderMode::Subpixel | FontRenderMode::Alpha => {
                 // TODO(gw): Expose subpixel direction in API once WR supports
                 //           vertical text runs.
-                (FontRenderMode::Alpha, SubpixelDirection::Horizontal)
+                (FontRenderMode::Alpha, font.subpx_dir)
             }
             FontRenderMode::Mono => {
                 (FontRenderMode::Mono, SubpixelDirection::None)
             }
         };
 
+        let prim_font = FontInstance::new(font.font_key,
+                                          font.size,
+                                          *color,
+                                          normal_render_mode,
+                                          subpx_dir,
+                                          font.platform_options);
         let prim = TextRunPrimitiveCpu {
-            font_key,
-            logical_font_size: size,
+            font: prim_font,
             glyph_range,
             glyph_count,
             glyph_gpu_blocks: Vec::new(),
             glyph_keys: Vec::new(),
-            glyph_options,
-            normal_render_mode,
             shadow_render_mode,
             offset: run_offset,
             color: *color,
-            subpx_dir,
         };
 
         // Text shadows that have a blur radius of 0 need to be rendered as normal
@@ -953,6 +969,7 @@ impl FrameBuilder {
             let shadow_prim = &self.prim_store.cpu_text_shadows[shadow_metadata.cpu_prim_index.0];
             if shadow_prim.shadow.blur_radius == 0.0 {
                 let mut text_prim = prim.clone();
+                text_prim.font.color = shadow_prim.shadow.color.into();
                 text_prim.color = shadow_prim.shadow.color;
                 text_prim.offset += shadow_prim.shadow.offset;
                 fast_text_shadow_prims.push(text_prim);

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -378,14 +378,12 @@ fn raterize_200_glyphs() {
     let font_key = FontKey::new(IdNamespace(0), 0);
     glyph_rasterizer.add_font(font_key, FontTemplate::Raw(Arc::new(font_data), 0));
 
-    let font = FontInstance {
-        font_key,
-        color: ColorF::new(0.0, 0.0, 0.0, 1.0).into(),
-        size: Au::from_px(32),
-        render_mode: FontRenderMode::Subpixel,
-        glyph_options: None,
-        subpx_dir: SubpixelDirection::Horizontal,
-    };
+    let font = FontInstance::new(font_key,
+                                 Au::from_px(32),
+                                 ColorF::new(0.0, 0.0, 0.0, 1.0),
+                                 FontRenderMode::Subpixel,
+                                 SubpixelDirection::Horizontal,
+                                 None);
 
     let mut glyph_keys = Vec::with_capacity(200);
     for i in 0..200 {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -504,21 +504,17 @@ pub struct TextShadowPrimitiveCpu {
 
 #[derive(Debug, Clone)]
 pub struct TextRunPrimitiveCpu {
-    pub font_key: FontKey,
+    pub font: FontInstance,
     pub offset: LayerVector2D,
-    pub logical_font_size: Au,
     pub glyph_range: ItemRange<GlyphInstance>,
     pub glyph_count: usize,
     pub glyph_keys: Vec<GlyphKey>,
     pub glyph_gpu_blocks: Vec<GpuBlockData>,
-    pub glyph_options: Option<GlyphOptions>,
-    pub normal_render_mode: FontRenderMode,
     pub shadow_render_mode: FontRenderMode,
     pub color: ColorF,
-    pub subpx_dir: SubpixelDirection,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TextRunMode {
     Normal,
     Shadow,
@@ -531,18 +527,18 @@ impl TextRunPrimitiveCpu {
                           display_list: &BuiltDisplayList,
                           run_mode: TextRunMode,
                           gpu_cache: &mut GpuCache) {
-        let font_size_dp = self.logical_font_size.scale_by(device_pixel_ratio);
-        let render_mode = match run_mode {
-            TextRunMode::Normal => self.normal_render_mode,
-            TextRunMode::Shadow => self.shadow_render_mode,
-        };
+        let mut font = self.font.clone();
+        font.size = font.size.scale_by(device_pixel_ratio);
+        match run_mode {
+            TextRunMode::Shadow => {
+                font.render_mode = self.shadow_render_mode;
+            }
+            TextRunMode::Normal => {}
+        }
 
-        let font = FontInstance::new(self.font_key,
-                                     font_size_dp,
-                                     self.color,
-                                     render_mode,
-                                     self.glyph_options,
-                                     self.subpx_dir);
+        if run_mode == TextRunMode::Shadow {
+            font.render_mode = self.shadow_render_mode;
+        }
 
         // Cache the glyph positions, if not in the cache already.
         // TODO(gw): In the future, remove `glyph_instances`
@@ -590,7 +586,7 @@ impl TextRunPrimitiveCpu {
         request.push(self.color);
         request.push([self.offset.x,
                       self.offset.y,
-                      self.subpx_dir as u32 as f32,
+                      self.font.subpx_dir as u32 as f32,
                       0.0]);
         request.extend_from_slice(&self.glyph_gpu_blocks);
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use device::TextureFilter;
 use frame::FrameId;
 use glyph_cache::GlyphCache;
@@ -17,7 +18,9 @@ use texture_cache::{TextureCache, TextureCacheHandle};
 use api::{BlobImageRenderer, BlobImageDescriptor, BlobImageError, BlobImageRequest};
 use api::{BlobImageResources, BlobImageData, ResourceUpdates, ResourceUpdate, AddFont};
 use api::{DevicePoint, DeviceUintRect, DeviceUintSize};
-use api::{Epoch, FontInstance, FontKey, FontTemplate};
+use api::{Epoch, FontInstance, FontInstanceKey, FontKey, FontTemplate};
+use api::{FontInstanceOptions, FontInstancePlatformOptions};
+use api::{ColorF, FontRenderMode, SubpixelDirection};
 use api::{GlyphDimensions, GlyphKey, IdNamespace};
 use api::{ImageData, ImageDescriptor, ImageKey, ImageRendering};
 use api::{TileOffset, TileSize};
@@ -170,6 +173,7 @@ impl Into<BlobImageRequest> for ImageRequest {
 
 struct Resources {
     font_templates: FastHashMap<FontKey, FontTemplate>,
+    font_instances: FastHashMap<FontInstanceKey, FontInstance>,
     image_templates: ImageTemplates,
 }
 
@@ -213,6 +217,7 @@ impl ResourceCache {
             cached_images: ResourceClassCache::new(),
             resources: Resources {
                 font_templates: FastHashMap::default(),
+                font_instances: FastHashMap::default(),
                 image_templates: ImageTemplates::new(),
             },
             cached_glyph_dimensions: FastHashMap::default(),
@@ -279,6 +284,13 @@ impl ResourceCache {
                 ResourceUpdate::DeleteFont(font) => {
                     self.delete_font_template(font);
                 }
+                ResourceUpdate::AddFontInstance(instance) => {
+                    self.add_font_instance(instance.key, instance.font_key, instance.glyph_size,
+                                           instance.options, instance.platform_options);
+                }
+                ResourceUpdate::DeleteFontInstance(instance) => {
+                    self.delete_font_instance(instance);
+                }
             }
         }
     }
@@ -296,6 +308,40 @@ impl ResourceCache {
         if let Some(ref mut r) = self.blob_image_renderer {
             r.delete_font(font_key);
         }
+    }
+
+    pub fn add_font_instance(&mut self,
+                             instance_key: FontInstanceKey,
+                             font_key: FontKey,
+                             glyph_size: Au,
+                             options: Option<FontInstanceOptions>,
+                             platform_options: Option<FontInstancePlatformOptions>) {
+        let mut render_mode = FontRenderMode::Subpixel;
+        let mut subpx_dir = SubpixelDirection::Horizontal;
+        if let Some(options) = options {
+            render_mode = options.render_mode;
+            if render_mode == FontRenderMode::Mono {
+                subpx_dir = SubpixelDirection::None;
+            }
+        }
+        let instance = FontInstance::new(font_key,
+                                         glyph_size,
+                                         ColorF::new(0.0, 0.0, 0.0, 1.0),
+                                         render_mode,
+                                         subpx_dir,
+                                         platform_options);
+        self.resources.font_instances.insert(instance_key, instance);
+    }
+
+    pub fn delete_font_instance(&mut self, instance_key: FontInstanceKey) {
+        self.resources.font_instances.remove(&instance_key);
+        if let Some(ref mut r) = self.blob_image_renderer {
+            r.delete_font_instance(instance_key);
+        }
+    }
+
+    pub fn get_font_instance(&self, instance_key: FontInstanceKey) -> Option<&FontInstance> {
+        self.resources.font_instances.get(&instance_key)
     }
 
     pub fn add_image_template(&mut self,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -43,7 +43,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
         match metadata.prim_kind {
             PrimitiveKind::TextRun => {
                 let text_run_cpu = &self.cpu_text_runs[metadata.cpu_prim_index.0];
-                match text_run_cpu.normal_render_mode {
+                match text_run_cpu.font.render_mode {
                     FontRenderMode::Subpixel => BlendMode::Subpixel(text_run_cpu.color),
                     FontRenderMode::Alpha | FontRenderMode::Mono => BlendMode::Alpha,
                 }
@@ -452,17 +452,12 @@ impl AlphaRenderItem {
                     }
                     PrimitiveKind::TextRun => {
                         let text_cpu = &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
-                        let font_size_dp = text_cpu.logical_font_size.scale_by(ctx.device_pixel_ratio);
 
                         // TODO(gw): avoid / recycle this allocation in the future.
                         let mut instances = Vec::new();
 
-                        let font = FontInstance::new(text_cpu.font_key,
-                                                     font_size_dp,
-                                                     text_cpu.color,
-                                                     text_cpu.normal_render_mode,
-                                                     text_cpu.glyph_options,
-                                                     text_cpu.subpx_dir);
+                        let mut font = text_cpu.font.clone();
+                        font.size = font.size.scale_by(ctx.device_pixel_ratio);
 
                         let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                        &text_cpu.glyph_keys,
@@ -1027,14 +1022,9 @@ impl RenderTarget for ColorRenderTarget {
                                     // the parent text-shadow prim address as a user data field, allowing
                                     // the shader to fetch the text-shadow parameters.
                                     let text = &ctx.prim_store.cpu_text_runs[sub_metadata.cpu_prim_index.0];
-                                    let font_size_dp = text.logical_font_size.scale_by(ctx.device_pixel_ratio);
 
-                                    let font = FontInstance::new(text.font_key,
-                                                                 font_size_dp,
-                                                                 text.color,
-                                                                 text.shadow_render_mode,
-                                                                 text.glyph_options,
-                                                                 text.subpx_dir);
+                                    let mut font = text.font.clone();
+                                    font.size = font.size.scale_by(ctx.device_pixel_ratio);
 
                                     let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                                    &text.glyph_keys,

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.49.0"
+version = "0.50.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use channel::{self, MsgSender, Payload, PayloadSenderHelperMethods, PayloadSender};
 use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint};
-use {DeviceUintRect, DeviceUintSize, FontKey, GlyphDimensions, GlyphKey};
+use {DeviceUintRect, DeviceUintSize, FontInstanceKey, FontKey, GlyphDimensions, GlyphKey};
 use {ImageData, ImageDescriptor, ImageKey, LayoutPoint, LayoutVector2D, LayoutSize, LayoutTransform};
-use {FontInstance, NativeFontHandle, WorldPoint};
+use {FontInstance, FontInstanceOptions, FontInstancePlatformOptions, NativeFontHandle, WorldPoint};
 
 pub type TileSize = u16;
 
@@ -26,6 +27,8 @@ pub enum ResourceUpdate {
     DeleteImage(ImageKey),
     AddFont(AddFont),
     DeleteFont(FontKey),
+    AddFontInstance(AddFontInstance),
+    DeleteFontInstance(FontInstanceKey),
 }
 
 impl ResourceUpdates {
@@ -71,6 +74,19 @@ impl ResourceUpdates {
         self.updates.push(ResourceUpdate::DeleteFont(key));
     }
 
+    pub fn add_font_instance(&mut self,
+                             key: FontInstanceKey,
+                             font_key: FontKey,
+                             glyph_size: Au,
+                             options: Option<FontInstanceOptions>,
+                             platform_options: Option<FontInstancePlatformOptions>) {
+        self.updates.push(ResourceUpdate::AddFontInstance(AddFontInstance { key, font_key, glyph_size, options, platform_options }));
+    }
+
+    pub fn delete_font_instance(&mut self, key: FontInstanceKey) {
+        self.updates.push(ResourceUpdate::DeleteFontInstance(key));
+    }
+
     pub fn merge(&mut self, mut other: ResourceUpdates) {
         self.updates.append(&mut other.updates);
     }
@@ -100,6 +116,15 @@ pub struct UpdateImage {
 pub enum AddFont {
     Raw(FontKey, Vec<u8>, u32),
     Native(FontKey, NativeFontHandle),
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AddFontInstance {
+    pub key: FontInstanceKey,
+    pub font_key: FontKey,
+    pub glyph_size: Au,
+    pub options: Option<FontInstanceOptions>,
+    pub platform_options: Option<FontInstancePlatformOptions>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -327,6 +352,11 @@ impl RenderApi {
     pub fn generate_font_key(&self) -> FontKey {
         let new_id = self.next_unique_id();
         FontKey::new(self.namespace_id, new_id)
+    }
+
+    pub fn generate_font_instance_key(&self) -> FontInstanceKey {
+        let new_id = self.next_unique_id();
+        FontInstanceKey::new(self.namespace_id, new_id)
     }
 
     /// Gets the dimensions for the supplied glyph keys

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use euclid::{SideOffsets2D, TypedSideOffsets2D};
-use {ColorF, FontKey, ImageKey, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
+use {ColorF, FontInstanceKey, ImageKey, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
 use {GlyphOptions, LayoutVector2D, PipelineId, PropertyBinding};
 
 // NOTE: some of these structs have an "IMPLICIT" comment.
@@ -139,8 +139,7 @@ pub enum LineStyle {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct TextDisplayItem {
-    pub font_key: FontKey,
-    pub size: Au,
+    pub font_key: FontInstanceKey,
     pub color: ColorF,
     pub glyph_options: Option<GlyphOptions>,
 } // IMPLICIT: glyphs: Vec<GlyphInstance>

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -9,7 +9,7 @@ use serde::ser::{SerializeSeq, SerializeMap};
 use time::precise_time_ns;
 use {BorderDetails, BorderDisplayItem, BorderWidths, BoxShadowClipMode, BoxShadowDisplayItem};
 use {ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion, DisplayItem};
-use {ExtendMode, FastHashMap, FastHashSet, FilterOp, FontKey, GlyphIndex, GlyphInstance};
+use {ExtendMode, FastHashMap, FastHashSet, FilterOp, FontInstanceKey, GlyphIndex, GlyphInstance};
 use {GlyphOptions, Gradient, GradientDisplayItem, GradientStop, IframeDisplayItem};
 use {ImageDisplayItem, ImageKey, ImageMask, ImageRendering, LayoutPoint, LayoutRect, LayoutSize};
 use {LayoutTransform, LayoutVector2D, LineDisplayItem, LineOrientation, LineStyle, LocalClip};
@@ -301,7 +301,7 @@ impl<'a> BuiltDisplayListIter<'a> {
 }
 
 impl<'a> Iterator for GlyphsIter<'a> {
-    type Item = (FontKey, ColorF, ItemRange<GlyphIndex>);
+    type Item = (FontInstanceKey, ColorF, ItemRange<GlyphIndex>);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.data.len() == 0 { return None; }
@@ -457,7 +457,7 @@ pub struct DisplayListBuilder {
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ClipAndScrollInfo>,
     // FIXME: audit whether fast hashers (FNV?) are safe here
-    glyphs: FastHashMap<(FontKey, ColorF), FastHashSet<GlyphIndex>>,
+    glyphs: FastHashMap<(FontInstanceKey, ColorF), FastHashSet<GlyphIndex>>,
     next_clip_id: u64,
     builder_start_time: u64,
 
@@ -605,38 +605,28 @@ impl DisplayListBuilder {
                      rect: LayoutRect,
                      local_clip: Option<LocalClip>,
                      glyphs: &[GlyphInstance],
-                     font_key: FontKey,
+                     font_key: FontInstanceKey,
                      color: ColorF,
-                     size: Au,
                      glyph_options: Option<GlyphOptions>) {
-        // Sanity check - anything with glyphs bigger than this
-        // is probably going to consume too much memory to render
-        // efficiently anyway. This is specifically to work around
-        // the font_advance.html reftest, which creates a very large
-        // font as a crash test - the rendering is also ignored
-        // by the azure renderer.
-        if size < Au::from_px(4096) {
-            let item = SpecificDisplayItem::Text(TextDisplayItem {
-                color,
-                font_key,
-                size,
-                glyph_options,
-            });
+        let item = SpecificDisplayItem::Text(TextDisplayItem {
+            color,
+            font_key,
+            glyph_options,
+        });
 
-            for split_glyphs in glyphs.chunks(MAX_TEXT_RUN_LENGTH) {
-                self.push_item(item, rect, local_clip);
-                self.push_iter(split_glyphs);
+        for split_glyphs in glyphs.chunks(MAX_TEXT_RUN_LENGTH) {
+            self.push_item(item, rect, local_clip);
+            self.push_iter(split_glyphs);
 
-                // Remember that we've seen these glyphs
-                self.cache_glyphs(font_key, color, split_glyphs.iter().map(|glyph| glyph.index));
-            }
+            // Remember that we've seen these glyphs
+            self.cache_glyphs(font_key, color, split_glyphs.iter().map(|glyph| glyph.index));
         }
     }
 
     fn cache_glyphs<I: Iterator<Item=GlyphIndex>>(&mut self,
-                                                     font_key: FontKey,
-                                                     color: ColorF,
-                                                     glyphs: I) {
+                                                  font_key: FontInstanceKey,
+                                                  color: ColorF,
+                                                  glyphs: I) {
         let mut font_glyphs = self.glyphs.entry((font_key, color))
                                          .or_insert(FastHashSet::default());
 

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -72,7 +72,7 @@ pub enum FontTemplate {
     Native(NativeFontHandle),
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum FontRenderMode {
     Mono = 0,
@@ -80,7 +80,7 @@ pub enum FontRenderMode {
     Subpixel,
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Deserialize, Serialize, Ord, PartialOrd)]
 pub enum SubpixelDirection {
     None = 0,
@@ -115,6 +115,14 @@ impl FontRenderMode {
             _ => panic!("Should only be given the fractional part"),
         }
     }
+
+    // Combine two font render modes such that the lesser amount of AA limits the AA of the result.
+    pub fn limit_by(self, other: FontRenderMode) -> FontRenderMode {
+        match (self, other) {
+            (FontRenderMode::Subpixel, _) | (_, FontRenderMode::Mono) => other,
+            _ => self,
+        }
+    }
 }
 
 #[repr(u8)]
@@ -137,8 +145,21 @@ impl Into<f64> for SubpixelOffset {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {
+    pub render_mode: FontRenderMode,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct FontInstanceOptions {
+    pub render_mode: FontRenderMode,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct FontInstancePlatformOptions {
     // These are currently only used on windows for dwrite fonts.
     pub use_embedded_bitmap: bool,
     pub force_gdi_rendering: bool,
@@ -155,8 +176,8 @@ pub struct FontInstance {
     pub size: Au,
     pub color: ColorU,
     pub render_mode: FontRenderMode,
-    pub glyph_options: Option<GlyphOptions>,
     pub subpx_dir: SubpixelDirection,
+    pub platform_options: Option<FontInstancePlatformOptions>,
 }
 
 impl FontInstance {
@@ -164,8 +185,8 @@ impl FontInstance {
                size: Au,
                mut color: ColorF,
                render_mode: FontRenderMode,
-               glyph_options: Option<GlyphOptions>,
-               subpx_dir: SubpixelDirection) -> FontInstance {
+               subpx_dir: SubpixelDirection,
+               platform_options: Option<FontInstancePlatformOptions>) -> FontInstance {
         // In alpha/mono mode, the color of the font is irrelevant.
         // Forcing it to black in those cases saves rasterizing glyphs
         // of different colors when not needed.
@@ -178,8 +199,8 @@ impl FontInstance {
             size,
             color: color.into(),
             render_mode,
-            glyph_options,
             subpx_dir,
+            platform_options,
         }
     }
 
@@ -189,6 +210,16 @@ impl FontInstance {
             SubpixelDirection::Horizontal => (glyph.subpixel_offset.into(), 0.0),
             SubpixelDirection::Vertical => (0.0, glyph.subpixel_offset.into()),
         }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, Ord, PartialOrd)]
+pub struct FontInstanceKey(pub IdNamespace, pub u32);
+
+impl FontInstanceKey {
+    pub fn new(namespace: IdNamespace, key: u32) -> FontInstanceKey {
+        FontInstanceKey(namespace, key)
     }
 }
 

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use {DeviceUintRect, DevicePoint};
 use {IdNamespace};
 use {TileOffset, TileSize};
-use font::{FontKey, FontTemplate};
+use font::{FontKey, FontInstanceKey, FontTemplate};
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -165,6 +165,8 @@ pub trait BlobImageRenderer: Send {
     fn resolve(&mut self, key: BlobImageRequest) -> BlobImageResult;
 
     fn delete_font(&mut self, key: FontKey);
+
+    fn delete_font_instance(&mut self, key: FontInstanceKey);
 }
 
 pub type BlobImageData = Vec<u8>;

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -134,6 +134,8 @@ impl BlobImageRenderer for CheckerboardRenderer {
     }
 
     fn delete_font(&mut self, _key: FontKey) { }
+
+    fn delete_font_instance(&mut self, _key: FontInstanceKey) { }
 }
 
 

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -6,6 +6,7 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+use app_units::Au;
 use image::{ColorType, save_buffer};
 use premultiply::unpremultiply;
 use serde_json;
@@ -25,6 +26,11 @@ enum CachedFont {
     Raw(Option<Vec<u8>>, u32, Option<PathBuf>),
 }
 
+struct CachedFontInstance {
+    font_key: FontKey,
+    glyph_size: Au,
+}
+
 struct CachedImage {
     width: u32,
     height: u32,
@@ -41,6 +47,7 @@ pub struct JsonFrameWriter {
     next_rsrc_num: u32,
     images: HashMap<ImageKey, CachedImage>,
     fonts: HashMap<FontKey, CachedFont>,
+    font_instances: HashMap<FontInstanceKey, CachedFontInstance>,
 
     last_frame_written: u32,
 
@@ -62,6 +69,7 @@ impl JsonFrameWriter {
             next_rsrc_num: 1,
             images: HashMap::new(),
             fonts: HashMap::new(),
+            font_instances: HashMap::new(),
 
             dl_descriptor: None,
 
@@ -155,6 +163,13 @@ impl JsonFrameWriter {
                     }
                 }
                 ResourceUpdate::DeleteFont(_) => {}
+                ResourceUpdate::AddFontInstance(ref instance) => {
+                    self.font_instances.insert(instance.key, CachedFontInstance {
+                        font_key: instance.font_key,
+                        glyph_size: instance.glyph_size,
+                    });
+                }
+                ResourceUpdate::DeleteFontInstance(_) => {}
             }
         }
     }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -229,8 +229,8 @@ impl Wrench {
                                      size,
                                      ColorF::new(0.0, 0.0, 0.0, 1.0),
                                      FontRenderMode::Alpha,
-                                     None,
-                                     SubpixelDirection::Horizontal);
+                                     SubpixelDirection::Horizontal,
+                                     None);
         let mut keys = Vec::new();
         for glyph_index in &indices {
             keys.push(GlyphKey::new(*glyph_index,
@@ -327,6 +327,14 @@ impl Wrench {
         let key = self.api.generate_font_key();
         let mut update = ResourceUpdates::new();
         update.add_raw_font(key, bytes, index);
+        self.api.update_resources(update);
+        key
+    }
+
+    pub fn add_font_instance(&mut self, font_key: FontKey, size: Au) -> FontInstanceKey {
+        let key = self.api.generate_font_instance_key();
+        let mut update = ResourceUpdates::new();
+        update.add_font_instance(key, font_key, size, None, None);
         self.api.update_resources(update);
         key
     }


### PR DESCRIPTION
This adds FontInstanceKey to the API, which alleviates the need to pass both
a FontKey and other options parameterizing a font to any functions using that
font. FontInstanceKeys are managed via the new add_font_instance and
delete_font_instance API functions. This enables validation of these parameters
to be done up front when add_font_instance is called, rather than every time
text is submitted. It also future-proofs FontInstances by allowing more
parameters than might otherwise be tenable if one had to supply them all when
submitting text.

At a minimum, one needs to specify a size, much like a ScaledFont in Gecko.
One can also optionally supply FontInstanceOptions for parameters common across
all platforms, and FontInstancePlatformOptions for parameters that are specific
to a given platform (which will be developed further in future patches).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1602)
<!-- Reviewable:end -->
