### PR TITLE
Fix assertion when decomposing tiled repeating images.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -994,22 +994,15 @@ impl Frame {
         // This can happen with very tall and thin images used as a repeating background.
         // Apparently web authors do that...
 
-        let mut repeat_x = false;
-        let mut repeat_y = false;
+        let needs_repeat_x = info.stretch_size.width < item_rect.size.width;
+        let needs_repeat_y = info.stretch_size.height < item_rect.size.height;
 
-        if info.stretch_size.width < item_rect.size.width {
-            // If this assert blows up it means we haven't properly decomposed the image in decompose_image_row.
-            debug_assert!(image_size.width <= tile_size);
-            // we don't actually tile in this dimension so repeating can be done in the shader.
-            repeat_x = true;
-        }
+        let tiled_in_x = image_size.width > tile_size;
+        let tiled_in_y = image_size.height > tile_size;
 
-        if info.stretch_size.height < item_rect.size.height {
-            // If this assert blows up it means we haven't properly decomposed the image in decompose_image.
-            debug_assert!(image_size.height <= tile_size);
-            // we don't actually tile in this dimension so repeating can be done in the shader.
-            repeat_y = true;
-        }
+        // If we don't actually tile in this dimension, repeating can be done in the shader.
+        let shader_repeat_x = needs_repeat_x && !tiled_in_x;
+        let shader_repeat_y = needs_repeat_y && !tiled_in_y;
 
         let tile_size_f32 = tile_size as f32;
 
@@ -1043,7 +1036,7 @@ impl Frame {
                                         TileOffset::new(tx, ty),
                                         stretched_tile_size,
                                         1.0, 1.0,
-                                        repeat_x, repeat_y);
+                                        shader_repeat_x, shader_repeat_y);
             }
             if leftover.width != 0 {
                 // Tiles on the right edge that are smaller than the tile size.
@@ -1056,7 +1049,7 @@ impl Frame {
                                         stretched_tile_size,
                                         (leftover.width as f32) / tile_size_f32,
                                         1.0,
-                                        repeat_x, repeat_y);
+                                        shader_repeat_x, shader_repeat_y);
             }
         }
 
@@ -1072,8 +1065,8 @@ impl Frame {
                                         stretched_tile_size,
                                         1.0,
                                         (leftover.height as f32) / tile_size_f32,
-                                        repeat_x,
-                                        repeat_y);
+                                        shader_repeat_x,
+                                        shader_repeat_y);
             }
 
             if leftover.width != 0 {
@@ -1087,8 +1080,8 @@ impl Frame {
                                         stretched_tile_size,
                                         (leftover.width as f32) / tile_size_f32,
                                         (leftover.height as f32) / tile_size_f32,
-                                        repeat_x,
-                                        repeat_y);
+                                        shader_repeat_x,
+                                        shader_repeat_y);
             }
         }
     }
@@ -1103,16 +1096,16 @@ impl Frame {
                           stretched_tile_size: LayerSize,
                           tile_ratio_width: f32,
                           tile_ratio_height: f32,
-                          repeat_x: bool,
-                          repeat_y: bool) {
+                          shader_repeat_x: bool,
+                          shader_repeat_y: bool) {
         // If the the image is tiled along a given axis, we can't have the shader compute
         // the image repetition pattern. In this case we base the primitive's rectangle size
         // on the stretched tile size which effectively cancels the repetion (and repetition
         // has to be emulated by generating more primitives).
-        // If the image is not tiling along this axis, we can perform the repetition in the
+        // If the image is not tiled along this axis, we can perform the repetition in the
         // shader. in this case we use the item's size in the primitive (on that particular
         // axis).
-        // See the repeat_x/y code below.
+        // See the shader_repeat_x/y code below.
 
         let stretched_size = LayerSize::new(
             stretched_tile_size.width * tile_ratio_width,
@@ -1127,12 +1120,12 @@ impl Frame {
             stretched_size,
         );
 
-        if repeat_x {
+        if shader_repeat_x {
             assert_eq!(tile_offset.x, 0);
             prim_rect.size.width = item_rect.size.width;
         }
 
-        if repeat_y {
+        if shader_repeat_y {
             assert_eq!(tile_offset.y, 0);
             prim_rect.size.height = item_rect.size.height;
         }


### PR DESCRIPTION
The code was asserting that if an image is repeated, its tile decomposition should already have been handled, but the decomposition is actually handled after the assertion.
The condition of the assertion does interact with whether we can do the repetition in the shader or if we have to do it on the CPU, so it should be part of that branch.
In addition, this PR renames a few variables to make it a bit easier to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1608)
<!-- Reviewable:end -->
