### PR TITLE
Reset cached gl state after calling into external image hooks.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -805,6 +805,14 @@ impl Device {
         &self.capabilities
     }
 
+    pub fn reset_state(&mut self) {
+        self.bound_textures = [ TextureId::invalid(); 16 ];
+        self.bound_vao = 0;
+        self.bound_pbo = PBOId(0);
+        self.bound_read_fbo = FBOId(0);
+        self.bound_draw_fbo = FBOId(0);
+    }
+
     pub fn compile_shader(gl: &gl::Gl,
                           name: &str,
                           shader_type: gl::GLenum,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2159,6 +2159,10 @@ impl Renderer {
                     }
                 };
 
+                // In order to produce the handle, the external image handler may call into
+                // the GL context and change some states.
+                self.device.reset_state();
+
                 let texture_id = match image.source {
                     ExternalImageSource::NativeTexture(texture_id) => TextureId::new(texture_id, texture_target),
                     _ => panic!("No native texture found."),


### PR DESCRIPTION
A naive fix for #1593.

If always resetting cached states turns out to be too expensive can easily extend this to do what @kvark suggests in  #1593 and let the handler communicate through a bitfield what states needs to be clobbered if any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1609)
<!-- Reviewable:end -->
