### PR TITLE
When creating a clip mask, only include relevant masks.

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -248,6 +248,15 @@ impl RenderTask {
         let clips: Vec<_> = raw_clips.iter()
                                      .chain(extra_clip.iter())
                                      .filter(|&&(_, ref clip_info)| {
+            // If this clip does not contribute to a mask, then ensure
+            // it gets filtered out here. Otherwise, if a mask is
+            // created (by a different clip in the list), the allocated
+            // rectangle for the mask could end up being much bigger
+            // than is actually required.
+            if !clip_info.is_masking() {
+                return false;
+            }
+
             match clip_info.bounds.inner {
                 Some(ref inner) if !inner.device_rect.is_empty() => {
                     inner_rect = inner_rect.and_then(|r| r.intersection(&inner.device_rect));


### PR DESCRIPTION
This ensures that the allocated rectangle for a clip mask
is not bigger than it needs to be, and is a very significant
GPU time optimization on some pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1613)
<!-- Reviewable:end -->
