### PR TITLE
Bump texture cache size from 32 MB -> 64 MB.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -17,7 +17,7 @@ use api::{ImageDescriptor};
 
 // The fixed number of layers for the shared texture cache.
 // There is one array texture per image format, allocated lazily.
-const TEXTURE_ARRAY_LAYERS: i32 = 2;
+const TEXTURE_ARRAY_LAYERS: i32 = 4;
 
 // The dimensions of each layer in the texture cache.
 const TEXTURE_LAYER_DIMENSIONS: u32 = 2048;


### PR DESCRIPTION
In the future, we'll resize thie automatically, so this is a
temporary change only.

Servo never seems to get near the smaller cache size, but Gecko
does on some pages, when it is using a lot of large painted
layers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1619)
<!-- Reviewable:end -->
