### PR TITLE
Remove the instance stride parameter from VAO creation.

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -90,9 +90,9 @@ impl DebugRenderer {
                                                   "",
                                                   &DESC_COLOR).unwrap();
 
-        let font_vao = device.create_vao(&DESC_FONT, 32);
-        let line_vao = device.create_vao(&DESC_COLOR, 32);
-        let tri_vao = device.create_vao(&DESC_COLOR, 32);
+        let font_vao = device.create_vao(&DESC_FONT);
+        let line_vao = device.create_vao(&DESC_COLOR);
+        let tri_vao = device.create_vao(&DESC_COLOR);
 
         let font_texture_id = device.create_texture_ids(1, TextureTarget::Array)[0];
         device.init_texture(font_texture_id,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -50,8 +50,8 @@ use std::thread;
 use texture_cache::TextureCache;
 use rayon::ThreadPool;
 use rayon::Configuration as ThreadPoolConfig;
-use tiling::{AlphaBatchKey, AlphaBatchKind, BlurCommand, Frame, RenderTarget};
-use tiling::{AlphaRenderTarget, CacheClipInstance, PrimitiveInstance, ColorRenderTarget, RenderTargetKind};
+use tiling::{AlphaBatchKey, AlphaBatchKind, Frame, RenderTarget};
+use tiling::{AlphaRenderTarget, PrimitiveInstance, ColorRenderTarget, RenderTargetKind};
 use time::precise_time_ns;
 use thread_profiler::{register_thread_with_profiler, write_profile};
 use util::TransformedRectKind;
@@ -1302,8 +1302,7 @@ impl Renderer {
             },
         ];
 
-        let prim_vao = device.create_vao(&DESC_PRIM_INSTANCES,
-                                         mem::size_of::<PrimitiveInstance>() as i32);
+        let prim_vao = device.create_vao(&DESC_PRIM_INSTANCES);
         device.bind_vao(&prim_vao);
         device.update_vao_indices(&prim_vao,
                                   &quad_indices,
@@ -1312,12 +1311,8 @@ impl Renderer {
                                         &quad_vertices,
                                         VertexUsageHint::Static);
 
-        let blur_vao = device.create_vao_with_new_instances(&DESC_BLUR,
-                                                            mem::size_of::<BlurCommand>() as i32,
-                                                            &prim_vao);
-        let clip_vao = device.create_vao_with_new_instances(&DESC_CLIP,
-                                                            mem::size_of::<CacheClipInstance>() as i32,
-                                                            &prim_vao);
+        let blur_vao = device.create_vao_with_new_instances(&DESC_BLUR, &prim_vao);
+        let clip_vao = device.create_vao_with_new_instances(&DESC_CLIP, &prim_vao);
 
         let texture_cache_upload_pbo = device.create_pbo();
 


### PR DESCRIPTION
Now that we have vertex descriptors, we can calculate the
instance stride internally, so there is no need for the caller
to specify it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1621)
<!-- Reviewable:end -->
