### PR TITLE
Check the pipeline id when calling convert_new_id_to_nested

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -36,6 +36,7 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF { r: 0.3, g: 0.3, b: 0.3, a: 0.6
 /// This structure keeps track of what ids are the "root" for one particular level of
 /// nesting as well as keeping and index, which can make ClipIds used internally unique
 /// in the full ClipScrollTree.
+#[derive(Debug)]
 struct NestedDisplayListInfo {
     /// The index of this nested display list, which is used to generate
     /// new ClipIds for clips that are defined inside it.
@@ -82,6 +83,13 @@ impl NestedDisplayListInfo {
             self.convert_id_to_nested(id)
         }
     }
+
+    fn convert_new_id_to_nested(&self, id: &ClipId) -> ClipId {
+        if id.pipeline_id() != self.clip_node_id.pipeline_id() {
+            return *id;
+        }
+        self.convert_id_to_nested(id)
+    }
 }
 
 struct FlattenContext<'a> {
@@ -123,7 +131,7 @@ impl<'a> FlattenContext<'a> {
 
     fn convert_new_id_to_nested(&self, id: &ClipId) -> ClipId {
         if let Some(nested_info) = self.nested_display_list_info.last() {
-            nested_info.convert_id_to_nested(id)
+            nested_info.convert_new_id_to_nested(id)
         } else {
             *id
         }


### PR DESCRIPTION
Without this we were seeing a problem where a generated clip id would get turned have it's nested_index set even though it was from a different pipeline. Later a ClipAndScrollInfo would be using the same clip id but it *wouldn't* get the nested_index set because `convert_clip_scroll_info_to_nested` does check the pipeline id. This resulted in an assertion failure later when clip_scroll_tree tried to look up the parent of a clip node.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1392523#c6 for details.

r? @mrobinson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1623)
<!-- Reviewable:end -->
