### PR TITLE
Use PBO for updating vertex textures.

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -6,7 +6,7 @@ use gpu_cache::GpuCacheHandle;
 use internal_types::HardwareCompositeOp;
 use mask_cache::MaskCacheInfo;
 use prim_store::{BoxShadowPrimitiveCacheKey, PrimitiveIndex};
-use std::{cmp, f32, i32, mem, usize};
+use std::{cmp, f32, i32, usize};
 use tiling::{ClipScrollGroupIndex, PackedLayerIndex, RenderPass, RenderTargetIndex};
 use tiling::{RenderTargetKind, StackingContextIndex};
 use api::{ClipId, DeviceIntLength, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
@@ -160,14 +160,6 @@ pub struct CacheMaskTask {
 #[derive(Debug, Clone)]
 pub struct RenderTaskData {
     pub data: [f32; FLOATS_PER_RENDER_TASK_INFO],
-}
-
-impl Default for RenderTaskData {
-    fn default() -> RenderTaskData {
-        RenderTaskData {
-            data: unsafe { mem::uninitialized() },
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1594,19 +1594,13 @@ pub struct PackedLayer {
     pub local_clip_rect: LayerRect,
 }
 
-impl Default for PackedLayer {
-    fn default() -> PackedLayer {
+impl PackedLayer {
+    pub fn empty() -> PackedLayer {
         PackedLayer {
             transform: LayerToWorldTransform::identity(),
             inv_transform: WorldToLayerTransform::identity(),
             local_clip_rect: LayerRect::zero(),
         }
-    }
-}
-
-impl PackedLayer {
-    pub fn empty() -> PackedLayer {
-        Default::default()
     }
 
     pub fn set_transform(&mut self, transform: LayerToWorldTransform) -> bool {


### PR DESCRIPTION
This means we don't need to manually cycle through a number of
textures to avoid driver stalls.

Also simplify the vertex texture logic, since we only use it
for a small number of data types now, which are all floats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1626)
<!-- Reviewable:end -->
