### PR TITLE
Using stack for storing preserve_3d_map.

### DIFF
--- a/wrench/reftests/split/nested-preserve3d-crash.yaml
+++ b/wrench/reftests/split/nested-preserve3d-crash.yaml
@@ -1,0 +1,37 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: 0 0 1024 768
+      items:
+        - type: stacking-context
+          bounds: 0 0 1024 768
+          transform-style: preserve-3d
+          transform: rotate-x(180)
+          items:
+            - type: stacking-context
+              bounds: 0 0 1024 768
+              items:
+                - type: rect
+                  bounds: 0 0 200 200
+                  color: green
+            - type: stacking-context
+              bounds: 0 0 1024 768
+              items:
+                - type: rect
+                  bounds: 0 0 200 200
+                  color: green
+                - type: stacking-context
+                  bounds: 0 0 1024 768
+                  transform-style: preserve-3d
+                  transform: rotate-x(180)
+                  items:
+                    - type: rect
+                      bounds: 0 0 200 200
+                      color: green
+                    - type: stacking-context
+                      bounds: 0 0 1024 768
+                      items:
+                        - type: rect
+                          bounds: 0 0 200 200
+                          color: green

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -1,4 +1,5 @@
 == simple.yaml simple-ref.yaml
 == order.yaml order-ref.yaml
 == nested.yaml nested-ref.yaml
+== nested-preserve3d-crash.yaml nested-preserve3d-crash.yaml
 #== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences


### PR DESCRIPTION
If we have nested preserve 3d stacking contexts, the preserve_3d_map
need using stack otherwise we'll handle wrong preserve_3d_map and cause
crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1628)
<!-- Reviewable:end -->
