### PR TITLE
Add ResourceUpdates::merge and clear.

### DIFF
--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -70,6 +70,14 @@ impl ResourceUpdates {
     pub fn delete_font(&mut self, key: FontKey) {
         self.updates.push(ResourceUpdate::DeleteFont(key));
     }
+
+    pub fn merge(&mut self, mut other: ResourceUpdates) {
+        self.updates.append(&mut other.updates);
+    }
+
+    pub fn clear(&mut self) {
+        self.updates.clear()
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Nothing fancy or surprising here, `merge` consumes another `ResourceUpdates` object and merges it into self, `clear` just clears the internal vector.
Gecko needs something like merge in a few places when two separate things are building up updates that have to be merged into a single list before sending to webrender, and there is also a place where we clear the vector if updates were built while webrender was shutdown for whatever expected or unexpected reason.

At least `merge` should also make sense for servo if/when frame consistency is implemented (updates built on various threads (layout, canvases, etc.) could be merged and then sent to webrender.

These can be implemented in the bindings (since the updates member is public), but since the use cases are sound, I would rather avoid logic in the bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1630)
<!-- Reviewable:end -->
