### PR TITLE
Add a basic display list treeview to the debugger.

### DIFF
--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -14,8 +14,9 @@ use ws;
 // debug command queue. These are sent in a separate queue so
 // that none of these types are exposed to the RenderApi interfaces.
 // We can't use select!() as it's not stable...
-pub enum DebugMsg {
-    FetchPasses(ws::Sender),
+enum DebugMsg {
+    AddSender(ws::Sender),
+    RemoveSender(ws::util::Token),
 }
 
 // Represents a connection to a client.
@@ -26,6 +27,16 @@ struct Server {
 }
 
 impl ws::Handler for Server {
+    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
+        self.debug_tx.send(DebugMsg::AddSender(self.ws.clone())).ok();
+
+        Ok(())
+    }
+
+    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
+        self.debug_tx.send(DebugMsg::RemoveSender(self.ws.token())).ok();
+    }
+
     fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
         match msg {
             ws::Message::Text(string) => {
@@ -49,9 +60,10 @@ impl ws::Handler for Server {
                         DebugCommand::EnableRenderTargetDebug(false)
                     }
                     "fetch_passes" => {
-                        let msg = DebugMsg::FetchPasses(self.ws.clone());
-                        self.debug_tx.send(msg).unwrap();
-                        DebugCommand::Flush
+                        DebugCommand::FetchPasses
+                    }
+                    "fetch_documents" => {
+                        DebugCommand::FetchDocuments
                     }
                     msg => {
                         println!("unknown msg {}", msg);
@@ -74,7 +86,8 @@ impl ws::Handler for Server {
 pub struct DebugServer {
     join_handle: Option<thread::JoinHandle<()>>,
     broadcaster: ws::Sender,
-    pub debug_rx: Receiver<DebugMsg>,
+    debug_rx: Receiver<DebugMsg>,
+    senders: Vec<ws::Sender>,
 }
 
 impl DebugServer {
@@ -101,6 +114,42 @@ impl DebugServer {
             join_handle,
             broadcaster,
             debug_rx,
+            senders: Vec::new(),
+        }
+    }
+
+    pub fn send(&mut self, message: String) {
+        // Add any new connections that have been queued.
+        while let Ok(msg) = self.debug_rx.try_recv() {
+            match msg {
+                DebugMsg::AddSender(sender) => {
+                    self.senders.push(sender);
+                }
+                DebugMsg::RemoveSender(token) => {
+                    self.senders.retain(|sender| {
+                        sender.token() != token
+                    });
+                }
+            }
+        }
+
+        // Broadcast the message to all senders. Keep
+        // track of the ones that failed, so they can
+        // be removed from the active sender list.
+        let mut disconnected_senders = Vec::new();
+
+        for (i, sender) in self.senders.iter().enumerate() {
+            if let Err(..) = sender.send(message.clone()) {
+                disconnected_senders.push(i);
+            }
+        }
+
+        // Remove the broken senders from the list
+        // for next broadcast. Remove in reverse
+        // order so the indices are valid for the
+        // entire loop.
+        for i in disconnected_senders.iter().rev() {
+            self.senders.remove(*i);
         }
     }
 }
@@ -189,4 +238,46 @@ struct Batch {
     kind: BatchKind,
     description: String,
     count: usize,
+}
+
+#[derive(Serialize)]
+pub struct TreeNode {
+    description: String,
+    children: Vec<TreeNode>,
+}
+
+impl TreeNode {
+    pub fn new(description: &str) -> TreeNode {
+        TreeNode {
+            description: description.to_owned(),
+            children: Vec::new(),
+        }
+    }
+
+    pub fn add_child(&mut self, child: TreeNode) {
+        self.children.push(child);
+    }
+
+    pub fn add_item(&mut self, description: &str) {
+        self.children.push(TreeNode::new(description));
+    }
+}
+
+#[derive(Serialize)]
+pub struct DocumentList {
+    kind: &'static str,
+    root: TreeNode,
+}
+
+impl DocumentList {
+    pub fn new() -> DocumentList {
+        DocumentList {
+            kind: "documents",
+            root: TreeNode::new("root"),
+        }
+    }
+
+    pub fn add(&mut self, item: TreeNode) {
+        self.root.add_child(item);
+    }
 }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -156,8 +156,13 @@ impl RendererFrame {
     }
 }
 
+pub enum DebugOutput {
+    FetchDocuments(String),
+}
+
 pub enum ResultMsg {
     DebugCommand(DebugCommand),
+    DebugOutput(DebugOutput),
     RefreshShader(PathBuf),
     NewFrame(DocumentId, RendererFrame, TextureUpdateList, BackendProfileCounters),
     UpdateResources { updates: TextureUpdateList, cancel_rendering: bool },

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -2,14 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(feature = "debugger")]
+use debug_server;
 use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
-use internal_types::{FastHashMap, ResultMsg, RendererFrame};
+use internal_types::{DebugOutput, FastHashMap, ResultMsg, RendererFrame};
 use profiler::{BackendProfileCounters, ResourceProfileCounters};
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
 use scene::Scene;
+#[cfg(feature = "debugger")]
+use serde_json;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 use std::u32;
@@ -19,9 +23,11 @@ use thread_profiler::register_thread_with_profiler;
 use rayon::ThreadPool;
 use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
-use api::{ApiMsg, BlobImageRenderer, BuiltDisplayList, DeviceIntPoint};
+use api::{ApiMsg, DebugCommand, BlobImageRenderer, BuiltDisplayList, DeviceIntPoint};
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentId, DocumentMsg};
 use api::{IdNamespace, LayerPoint, RenderNotifier};
+#[cfg(feature = "debugger")]
+use api::{BuiltDisplayListIter, SpecificDisplayItem};
 
 struct Document {
     scene: Scene,
@@ -462,7 +468,15 @@ impl RenderBackend {
                     self.notifier.lock().unwrap().as_mut().unwrap().new_frame_ready();
                 }
                 ApiMsg::DebugCommand(option) => {
-                    let msg = ResultMsg::DebugCommand(option);
+                    let msg = match option {
+                        DebugCommand::FetchDocuments => {
+                            let json = self.get_docs_for_debugger();
+                            ResultMsg::DebugOutput(DebugOutput::FetchDocuments(json))
+                        }
+                        _ => {
+                            ResultMsg::DebugCommand(option)
+                        }
+                    };
                     self.result_tx.send(msg).unwrap();
                     let notifier = self.notifier.lock();
                     notifier.unwrap()
@@ -513,5 +527,140 @@ impl RenderBackend {
         //           cleaner way to do this, or use the OnceMutex on crates.io?
         let mut notifier = self.notifier.lock();
         notifier.as_mut().unwrap().as_mut().unwrap().new_scroll_frame_ready(composite_needed);
+    }
+
+
+    #[cfg(not(feature = "debugger"))]
+    fn get_docs_for_debugger(&self) -> String {
+        String::new()
+    }
+
+    #[cfg(feature = "debugger")]
+    fn traverse_items<'a>(&self,
+                          traversal: &mut BuiltDisplayListIter<'a>,
+                          node: &mut debug_server::TreeNode) {
+        loop {
+            let subtraversal = {
+                let item = match traversal.next() {
+                    Some(item) => item,
+                    None => break,
+                };
+
+                match *item.item() {
+                    display_item @ SpecificDisplayItem::PushStackingContext(..) => {
+                        let mut subtraversal = item.sub_iter();
+                        let mut child_node = debug_server::TreeNode::new(&display_item.debug_string());
+                        self.traverse_items(&mut subtraversal, &mut child_node);
+                        node.add_child(child_node);
+                        Some(subtraversal)
+                    }
+                    SpecificDisplayItem::PopStackingContext => {
+                        return;
+                    }
+                    display_item => {
+                        node.add_item(&display_item.debug_string());
+                        None
+                    }
+                }
+            };
+
+            // If flatten_item created a sub-traversal, we need `traversal` to have the
+            // same state as the completed subtraversal, so we reinitialize it here.
+            if let Some(subtraversal) = subtraversal {
+                *traversal = subtraversal;
+            }
+        }
+    }
+
+    #[cfg(feature = "debugger")]
+    fn get_docs_for_debugger(&self) -> String {
+        let mut docs = debug_server::DocumentList::new();
+
+        for (_, doc) in &self.documents {
+            let mut debug_doc = debug_server::TreeNode::new("document");
+
+            for (_, display_list) in &doc.scene.display_lists {
+                let mut debug_dl = debug_server::TreeNode::new("display_list");
+                self.traverse_items(&mut display_list.iter(), &mut debug_dl);
+                debug_doc.add_child(debug_dl);
+            }
+
+            docs.add(debug_doc);
+        }
+
+        serde_json::to_string(&docs).unwrap()
+    }
+}
+
+#[cfg(feature = "debugger")]
+trait ToDebugString {
+    fn debug_string(&self) -> String;
+}
+
+#[cfg(feature = "debugger")]
+impl ToDebugString for SpecificDisplayItem {
+    fn debug_string(&self) -> String {
+        match *self {
+            SpecificDisplayItem::Image(..) => {
+                String::from("image")
+            }
+            SpecificDisplayItem::YuvImage(..) => {
+                String::from("yuv_image")
+            }
+            SpecificDisplayItem::Text(..) => {
+                String::from("text")
+            }
+            SpecificDisplayItem::Rectangle(..) => {
+                String::from("rectangle")
+            }
+            SpecificDisplayItem::Line(..) => {
+                String::from("line")
+            }
+            SpecificDisplayItem::Gradient(..) => {
+                String::from("gradient")
+            }
+            SpecificDisplayItem::RadialGradient(..) => {
+                String::from("radial_gradient")
+            }
+            SpecificDisplayItem::BoxShadow(..) => {
+                String::from("box_shadow")
+            }
+            SpecificDisplayItem::Border(..) => {
+                String::from("border")
+            }
+            SpecificDisplayItem::PushStackingContext(..) => {
+                String::from("push_stacking_context")
+            }
+            SpecificDisplayItem::Iframe(..) => {
+                String::from("iframe")
+            }
+            SpecificDisplayItem::Clip(..) => {
+                String::from("clip")
+            }
+            SpecificDisplayItem::ScrollFrame(..) => {
+                String::from("scroll_frame")
+            }
+            SpecificDisplayItem::StickyFrame(..) => {
+                String::from("sticky_frame")
+            }
+            SpecificDisplayItem::PushNestedDisplayList => {
+                String::from("push_nested_display_list")
+            }
+            SpecificDisplayItem::PopNestedDisplayList => {
+                String::from("pop_nested_display_list")
+            }
+            SpecificDisplayItem::SetGradientStops => {
+                String::from("set_gradient_stops")
+            }
+            SpecificDisplayItem::PopStackingContext => {
+                String::from("pop_stacking_context")
+            }
+            SpecificDisplayItem::PushTextShadow(..) => {
+                String::from("push_text_shadow")
+            }
+            SpecificDisplayItem::PopTextShadow => {
+                String::from("pop_text_shadow")
+            }
+        }
     }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -17,7 +17,7 @@ use api::DebugCommand;
 use debug_colors;
 use debug_render::DebugRenderer;
 #[cfg(feature = "debugger")]
-use debug_server::{self, DebugMsg, DebugServer};
+use debug_server::{self, DebugServer};
 use device::{DepthFunction, Device, FrameId, Program, Texture, VertexDescriptor, GpuMarker, GpuProfiler, PBOId};
 use device::{GpuTimer, TextureFilter, VAO, VertexUsageHint, FileWatcherHandler, TextureTarget, ShaderError};
 use device::{ExternalTexture, get_gl_format_bgra, TextureSlot, VertexAttribute, VertexAttributeKind};
@@ -26,7 +26,7 @@ use frame_builder::FrameBuilderConfig;
 use gleam::gl;
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
 use internal_types::{FastHashMap, CacheTextureId, RendererFrame, ResultMsg, TextureUpdateOp};
-use internal_types::{TextureUpdateList, RenderTargetMode, TextureUpdateSource};
+use internal_types::{DebugOutput, TextureUpdateList, RenderTargetMode, TextureUpdateSource};
 use internal_types::{BatchTextures, ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, SourceTexture};
 use profiler::{Profiler, BackendProfileCounters};
 use profiler::{GpuProfileTag, RendererProfileTimers, RendererProfileCounters};
@@ -1587,6 +1587,13 @@ impl Renderer {
                 ResultMsg::RefreshShader(path) => {
                     self.pending_shader_updates.push(path);
                 }
+                ResultMsg::DebugOutput(output) => {
+                    match output {
+                        DebugOutput::FetchDocuments(string) => {
+                            self.debug_server.send(string);
+                        }
+                    }
+                }
                 ResultMsg::DebugCommand(command) => {
                     self.handle_debug_command(command);
                 }
@@ -1595,72 +1602,66 @@ impl Renderer {
     }
 
     #[cfg(not(feature = "debugger"))]
-    fn update_debug_server(&self) {
+    fn get_passes_for_debugger(&self) -> String {
         // Avoid unused param warning.
         let _ = &self.debug_server;
+        String::new()
     }
 
     #[cfg(feature = "debugger")]
-    fn update_debug_server(&self) {
-        while let Ok(msg) = self.debug_server.debug_rx.try_recv() {
-            match msg {
-                DebugMsg::FetchPasses(sender) => {
-                    let mut debug_passes = debug_server::PassList::new();
+    fn get_passes_for_debugger(&self) -> String {
+        let mut debug_passes = debug_server::PassList::new();
 
-                    if let Some(frame) = self.current_frame.as_ref().and_then(|frame| frame.frame.as_ref()) {
-                        for pass in &frame.passes {
-                            let mut debug_pass = debug_server::Pass::new();
+        if let Some(frame) = self.current_frame.as_ref().and_then(|frame| frame.frame.as_ref()) {
+            for pass in &frame.passes {
+                let mut debug_pass = debug_server::Pass::new();
 
-                            for target in &pass.alpha_targets.targets {
-                                let mut debug_target = debug_server::Target::new("A8");
+                for target in &pass.alpha_targets.targets {
+                    let mut debug_target = debug_server::Target::new("A8");
 
-                                debug_target.add(debug_server::BatchKind::Clip, "Clear", target.clip_batcher.border_clears.len());
-                                debug_target.add(debug_server::BatchKind::Clip, "Borders", target.clip_batcher.borders.len());
-                                debug_target.add(debug_server::BatchKind::Clip, "Rectangles", target.clip_batcher.rectangles.len());
-                                for (_, items) in target.clip_batcher.images.iter() {
-                                    debug_target.add(debug_server::BatchKind::Clip, "Image mask", items.len());
-                                }
-                                debug_target.add(debug_server::BatchKind::Cache, "Box Shadow", target.box_shadow_cache_prims.len());
+                    debug_target.add(debug_server::BatchKind::Clip, "Clear", target.clip_batcher.border_clears.len());
+                    debug_target.add(debug_server::BatchKind::Clip, "Borders", target.clip_batcher.borders.len());
+                    debug_target.add(debug_server::BatchKind::Clip, "Rectangles", target.clip_batcher.rectangles.len());
+                    for (_, items) in target.clip_batcher.images.iter() {
+                        debug_target.add(debug_server::BatchKind::Clip, "Image mask", items.len());
+                    }
+                    debug_target.add(debug_server::BatchKind::Cache, "Box Shadow", target.box_shadow_cache_prims.len());
 
-                                debug_pass.add(debug_target);
-                            }
+                    debug_pass.add(debug_target);
+                }
 
-                            for target in &pass.color_targets.targets {
-                                let mut debug_target = debug_server::Target::new("RGBA8");
+                for target in &pass.color_targets.targets {
+                    let mut debug_target = debug_server::Target::new("RGBA8");
 
-                                debug_target.add(debug_server::BatchKind::Cache, "Vertical Blur", target.vertical_blurs.len());
-                                debug_target.add(debug_server::BatchKind::Cache, "Horizontal Blur", target.horizontal_blurs.len());
-                                debug_target.add(debug_server::BatchKind::Cache, "Text Shadow", target.text_run_cache_prims.len());
-                                debug_target.add(debug_server::BatchKind::Cache, "Lines", target.line_cache_prims.len());
+                    debug_target.add(debug_server::BatchKind::Cache, "Vertical Blur", target.vertical_blurs.len());
+                    debug_target.add(debug_server::BatchKind::Cache, "Horizontal Blur", target.horizontal_blurs.len());
+                    debug_target.add(debug_server::BatchKind::Cache, "Text Shadow", target.text_run_cache_prims.len());
+                    debug_target.add(debug_server::BatchKind::Cache, "Lines", target.line_cache_prims.len());
 
-                                for batch in target.alpha_batcher
-                                                   .batch_list
-                                                   .opaque_batch_list
-                                                   .batches
-                                                   .iter()
-                                                   .rev() {
-                                    debug_target.add(debug_server::BatchKind::Opaque, batch.key.kind.debug_name(), batch.instances.len());
-                                }
-
-                                for batch in &target.alpha_batcher
-                                                    .batch_list
-                                                    .alpha_batch_list
-                                                    .batches {
-                                    debug_target.add(debug_server::BatchKind::Alpha, batch.key.kind.debug_name(), batch.instances.len());
-                                }
-
-                                debug_pass.add(debug_target);
-                            }
-
-                            debug_passes.add(debug_pass);
-                        }
+                    for batch in target.alpha_batcher
+                                       .batch_list
+                                       .opaque_batch_list
+                                       .batches
+                                       .iter()
+                                       .rev() {
+                        debug_target.add(debug_server::BatchKind::Opaque, batch.key.kind.debug_name(), batch.instances.len());
                     }
 
-                    let json = serde_json::to_string(&debug_passes).unwrap();
-                    sender.send(json).ok();
+                    for batch in &target.alpha_batcher
+                                        .batch_list
+                                        .alpha_batch_list
+                                        .batches {
+                        debug_target.add(debug_server::BatchKind::Alpha, batch.key.kind.debug_name(), batch.instances.len());
+                    }
+
+                    debug_pass.add(debug_target);
                 }
+
+                debug_passes.add(debug_pass);
             }
         }
+
+        serde_json::to_string(&debug_passes).unwrap()
     }
 
     fn handle_debug_command(&mut self, command: DebugCommand) {
@@ -1686,8 +1687,10 @@ impl Renderer {
                     self.debug_flags.remove(RENDER_TARGET_DBG);
                 }
             }
-            DebugCommand::Flush => {
-                self.update_debug_server();
+            DebugCommand::FetchDocuments => {}
+            DebugCommand::FetchPasses => {
+                let json = self.get_passes_for_debugger();
+                self.debug_server.send(json);
             }
         }
     }
@@ -2863,4 +2866,6 @@ impl DebugServer {
     pub fn new(_: MsgSender<ApiMsg>) -> DebugServer {
         DebugServer
     }
+
+    pub fn send(&mut self, _: String) {}
 }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -155,8 +155,10 @@ pub enum DebugCommand {
     EnableTextureCacheDebug(bool),
     // Display intermediate render targets on screen.
     EnableRenderTargetDebug(bool),
-    // Flush any pending debug commands.
-    Flush,
+    // Fetch current documents and display lists.
+    FetchDocuments,
+    // Fetch current passes and batches.
+    FetchPasses,
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
This allows viewing the input set of display lists and documents
for a given WR instance.

The treeview itself is very basic, and the information provided
per item is minimal. Consider this a proof of concept which can
be expanded upon to provide more information.

Importantly, it demonstrates how to provide information to the
debugger websocket that is only available in the render backend
(the previous debug items were all available in the renderer
instance).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1636)
<!-- Reviewable:end -->
