### PR TITLE
Fix texture cache profiler display.

### DIFF
--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -131,6 +131,11 @@ impl ResourceProfileCounter {
         self.value += 1;
         self.size += size;
     }
+
+    pub fn set(&mut self, count: usize, size: usize) {
+        self.value = count;
+        self.size = size;
+    }
 }
 
 impl ProfileCounter for ResourceProfileCounter {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -607,13 +607,11 @@ impl ResourceCache {
         );
 
         // Apply any updates of new / updated images (incl. blobs) to the texture cache.
-        self.update_texture_cache(gpu_cache, texture_cache_profile);
-        self.texture_cache.end_frame();
+        self.update_texture_cache(gpu_cache);
+        self.texture_cache.end_frame(texture_cache_profile);
     }
 
-    fn update_texture_cache(&mut self,
-                            gpu_cache: &mut GpuCache,
-                            _texture_cache_profile: &mut TextureCacheProfileCounters) {
+    fn update_texture_cache(&mut self, gpu_cache: &mut GpuCache) {
         for request in self.pending_image_requests.drain() {
             let image_template = self.resources.image_templates.get_mut(request.key).unwrap();
             debug_assert!(image_template.data.uses_texture_cache());
@@ -667,7 +665,7 @@ impl ResourceCache {
                 let (stride, offset) = if tiled_on_cpu {
                     (image_descriptor.stride, 0)
                 } else {
-                    let bpp = image_descriptor.format.bytes_per_pixel().unwrap();
+                    let bpp = image_descriptor.format.bytes_per_pixel();
                     let stride = image_descriptor.compute_stride();
                     let offset = image_descriptor.offset + tile.y as u32 * tile_size as u32 * stride
                                                          + tile.x as u32 * tile_size as u32 * bpp;

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -59,14 +59,14 @@ pub enum ImageFormat {
 }
 
 impl ImageFormat {
-    pub fn bytes_per_pixel(self) -> Option<u32> {
+    pub fn bytes_per_pixel(self) -> u32 {
         match self {
-            ImageFormat::A8 => Some(1),
-            ImageFormat::RGB8 => Some(3),
-            ImageFormat::BGRA8 => Some(4),
-            ImageFormat::RGBAF32 => Some(16),
-            ImageFormat::RG8 => Some(2),
-            ImageFormat::Invalid => None,
+            ImageFormat::A8 => 1,
+            ImageFormat::RGB8 => 3,
+            ImageFormat::BGRA8 => 4,
+            ImageFormat::RGBAF32 => 16,
+            ImageFormat::RG8 => 2,
+            ImageFormat::Invalid => 0,
         }
     }
 }
@@ -94,7 +94,7 @@ impl ImageDescriptor {
     }
 
     pub fn compute_stride(&self) -> u32 {
-        self.stride.unwrap_or(self.width * self.format.bytes_per_pixel().unwrap())
+        self.stride.unwrap_or(self.width * self.format.bytes_per_pixel())
     }
 }
 

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -111,7 +111,7 @@ impl JsonFrameWriter {
             match *update {
                 ResourceUpdate::AddImage(ref img) => {
                     let stride = img.descriptor.stride.unwrap_or(
-                        img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
+                        img.descriptor.width * img.descriptor.format.bytes_per_pixel()
                     );
                     let bytes = match img.data {
                         ImageData::Raw(ref v) => { (**v).clone() }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -363,7 +363,7 @@ impl YamlFrameWriter {
             match *update {
                 ResourceUpdate::AddImage(ref img) => {
                     let stride = img.descriptor.stride.unwrap_or(
-                        img.descriptor.width * img.descriptor.format.bytes_per_pixel().unwrap()
+                        img.descriptor.width * img.descriptor.format.bytes_per_pixel()
                     );
                     let bytes = match img.data {
                         ImageData::Raw(ref v) => { (**v).clone() }


### PR DESCRIPTION
This was disabled when the new texture cache allocator was merged.
The numbers aren't super meaningful right now, since the caches
don't grow, but they at least show which texture caches are
allocated and what the fixed size of them is.

Fixes #1637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1638)
<!-- Reviewable:end -->
