### PR TITLE
Introduce shared A8 target that is available as input to all subsequent passes.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -17,6 +17,9 @@
 uniform sampler2DArray sCacheA8;
 uniform sampler2DArray sCacheRGBA8;
 
+// An A8 target for standalone tasks that is available to all passes.
+uniform sampler2DArray sSharedCacheA8;
+
 uniform sampler2D sGradients;
 
 struct RectWithSize {
@@ -767,7 +770,7 @@ BoxShadow fetch_boxshadow_direct(ivec2 address) {
 }
 
 void write_clip(vec2 global_pos, ClipArea area) {
-    vec2 texture_size = vec2(textureSize(sCacheA8, 0).xy);
+    vec2 texture_size = vec2(textureSize(sSharedCacheA8, 0).xy);
     vec2 uv = global_pos + area.task_bounds.xy - area.screen_origin_target_index.xy;
     vClipMaskUvBounds = area.task_bounds / texture_size.xyxy;
     vClipMaskUv = vec3(uv / texture_size, area.screen_origin_target_index.z);
@@ -806,7 +809,7 @@ float do_clip() {
         vec4(vClipMaskUv.xy, vClipMaskUvBounds.zw));
     // check for the dummy bounds, which are given to the opaque objects
     return vClipMaskUvBounds.xy == vClipMaskUvBounds.zw ? 1.0:
-        all(inside) ? textureLod(sCacheA8, vClipMaskUv, 0.0).r : 0.0;
+        all(inside) ? textureLod(sSharedCacheA8, vClipMaskUv, 0.0).r : 0.0;
 }
 
 #ifdef WR_FEATURE_DITHERING

--- a/webrender/res/ps_box_shadow.fs.glsl
+++ b/webrender/res/ps_box_shadow.fs.glsl
@@ -18,6 +18,6 @@ void main(void) {
     uv = mix(vCacheUvRectCoords.xy, vCacheUvRectCoords.zw, uv);
 
     // Modulate the box shadow by the color.
-    float mask = texture(sColor1, vec3(uv, vUv.z)).r;
+    float mask = texture(sSharedCacheA8, vec3(uv, vUv.z)).r;
     oFragColor = clip_scale * dither(vColor * vec4(1.0, 1.0, 1.0, mask));
 }

--- a/webrender/res/ps_box_shadow.vs.glsl
+++ b/webrender/res/ps_box_shadow.vs.glsl
@@ -27,7 +27,7 @@ void main(void) {
     vUv.xy = (vi.local_pos - prim.local_rect.p0) / patch_size;
     vMirrorPoint = 0.5 * prim.local_rect.size / patch_size;
 
-    vec2 texture_size = vec2(textureSize(sCacheA8, 0));
+    vec2 texture_size = vec2(textureSize(sSharedCacheA8, 0));
     vCacheUvRectCoords = vec4(patch_origin, patch_origin + patch_size_device_pixels) / texture_size.xyxy;
 
     vColor = bs.color;

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -68,6 +68,16 @@ impl RenderTaskTree {
             }
         }
 
+        // If this task can be shared between multiple
+        // passes, render it in the first pass so that
+        // it is available to all subsequent passes.
+        let pass_index = if task.is_shared() {
+            debug_assert!(task.children.is_empty());
+            0
+        } else {
+            pass_index
+        };
+
         let pass = &mut passes[pass_index];
         pass.add_render_task(id);
     }
@@ -510,6 +520,29 @@ impl RenderTask {
 
             RenderTaskKind::Alias(..) => {
                 panic!("BUG: target_kind() called on invalidated task");
+            }
+        }
+    }
+
+    // Check if this task wants to be made available as an input
+    // to all passes (except the first) in the render task tree.
+    // To qualify for this, the task needs to have no children / dependencies.
+    // Currently, this is only supported for A8 targets, but it can be
+    // trivially extended to also support RGBA8 targets in the future
+    // if we decide that is useful.
+    pub fn is_shared(&self) -> bool {
+        match self.kind {
+            RenderTaskKind::Alpha(..) |
+            RenderTaskKind::CachePrimitive(..) |
+            RenderTaskKind::VerticalBlur(..) |
+            RenderTaskKind::Readback(..) |
+            RenderTaskKind::HorizontalBlur(..) => false,
+
+            RenderTaskKind::CacheMask(..) |
+            RenderTaskKind::BoxShadow(..) => true,
+
+            RenderTaskKind::Alias(..) => {
+                panic!("BUG: is_shared() called on aliased task");
             }
         }
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -394,14 +394,35 @@ impl SourceTextureResolver {
         }
     }
 
-    fn set_cache_textures(&mut self,
-                          a8_texture: Option<Texture>,
-                          rgba8_texture: Option<Texture>) {
-        // todo(gw): make the texture recycling cleaner...
-        debug_assert!(self.cache_a8_texture.is_none());
-        debug_assert!(self.cache_rgba8_texture.is_none());
-        self.cache_a8_texture = a8_texture;
-        self.cache_rgba8_texture = rgba8_texture;
+    fn end_pass(&mut self,
+                pass_index: usize,
+                pass_count: usize,
+                mut a8_texture: Option<Texture>,
+                mut rgba8_texture: Option<Texture>,
+                a8_pool: &mut Vec<Texture>,
+                rgba8_pool: &mut Vec<Texture>) {
+        // If we have cache textures from previous pass, return them to the pool.
+        if let Some(texture) = self.cache_rgba8_texture.take() {
+            rgba8_pool.push(texture);
+        }
+        if let Some(texture) = self.cache_a8_texture.take() {
+            a8_pool.push(texture);
+        }
+
+        if pass_index == pass_count-1 {
+            // On the last pass, return the textures from this pass to the pool.
+            if let Some(texture) = rgba8_texture.take() {
+                rgba8_pool.push(texture);
+            }
+            if let Some(texture) = a8_texture.take() {
+                a8_pool.push(texture);
+            }
+        } else {
+            // We have another pass to process, make these textures available
+            // as inputs to the next pass.
+            self.cache_rgba8_texture = rgba8_texture.take();
+            self.cache_a8_texture = a8_texture.take();
+        }
     }
 
     // Bind a source texture to the device.
@@ -2487,7 +2508,8 @@ impl Renderer {
         self.device.bind_texture(TextureSampler::Layers, &self.layer_texture.texture);
         self.device.bind_texture(TextureSampler::RenderTasks, &self.render_task_texture.texture);
 
-        self.texture_resolver.set_cache_textures(None, None);
+        debug_assert!(self.texture_resolver.cache_a8_texture.is_none());
+        debug_assert!(self.texture_resolver.cache_rgba8_texture.is_none());
     }
 
     fn draw_tile_frame(&mut self,
@@ -2509,8 +2531,9 @@ impl Renderer {
             self.device.clear_target(Some(self.clear_color.to_array()), Some(1.0));
         } else {
             self.start_frame(frame);
+            let pass_count = frame.passes.len();
 
-            for pass in &mut frame.passes {
+            for (pass_index, pass) in frame.passes.iter_mut().enumerate() {
                 let size;
                 let clear_color;
                 let projection;
@@ -2564,25 +2587,12 @@ impl Renderer {
 
                 }
 
-                // Return the texture IDs to the pool for next frame.
-                if let Some(texture) = self.texture_resolver.cache_rgba8_texture.take() {
-                    self.color_render_targets.push(texture);
-                }
-                if let Some(texture) = self.texture_resolver.cache_a8_texture.take() {
-                    self.alpha_render_targets.push(texture);
-                }
-
-                self.texture_resolver.set_cache_textures(pass.alpha_texture.take(),
-                                                         pass.color_texture.take());
-
-            }
-
-            // Return the texture IDs to the pool for next frame.
-            if let Some(texture) = self.texture_resolver.cache_rgba8_texture.take() {
-                self.color_render_targets.push(texture);
-            }
-            if let Some(texture) = self.texture_resolver.cache_a8_texture.take() {
-                self.alpha_render_targets.push(texture);
+                self.texture_resolver.end_pass(pass_index,
+                                               pass_count,
+                                               pass.alpha_texture.take(),
+                                               pass.color_texture.take(),
+                                               &mut self.alpha_render_targets,
+                                               &mut self.color_render_targets);
             }
 
             self.color_render_targets.reverse();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -141,6 +141,10 @@ enum TextureSampler {
     Layers,
     RenderTasks,
     Dither,
+    // A special sampler that is bound to the A8 output of
+    // the *first* pass. Items rendered in this target are
+    // available as inputs to tasks in any subsequent pass.
+    SharedCacheA8,
 }
 
 impl TextureSampler {
@@ -168,6 +172,7 @@ impl Into<TextureSlot> for TextureSampler {
             TextureSampler::Layers => TextureSlot(6),
             TextureSampler::RenderTasks => TextureSlot(7),
             TextureSampler::Dither => TextureSlot(8),
+            TextureSampler::SharedCacheA8 => TextureSlot(9),
         }
     }
 }
@@ -402,12 +407,8 @@ impl SourceTextureResolver {
                 a8_pool: &mut Vec<Texture>,
                 rgba8_pool: &mut Vec<Texture>) {
         // If we have cache textures from previous pass, return them to the pool.
-        if let Some(texture) = self.cache_rgba8_texture.take() {
-            rgba8_pool.push(texture);
-        }
-        if let Some(texture) = self.cache_a8_texture.take() {
-            a8_pool.push(texture);
-        }
+        rgba8_pool.extend(self.cache_rgba8_texture.take());
+        a8_pool.extend(self.cache_a8_texture.take());
 
         if pass_index == pass_count-1 {
             // On the last pass, return the textures from this pass to the pool.
@@ -875,6 +876,7 @@ fn create_prim_shader(name: &'static str,
             ("sLayers", TextureSampler::Layers),
             ("sRenderTasks", TextureSampler::RenderTasks),
             ("sResourceCache", TextureSampler::ResourceCache),
+            ("sSharedCacheA8", TextureSampler::SharedCacheA8),
         ]);
     }
 
@@ -896,6 +898,7 @@ fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program
             ("sLayers", TextureSampler::Layers),
             ("sRenderTasks", TextureSampler::RenderTasks),
             ("sResourceCache", TextureSampler::ResourceCache),
+            ("sSharedCacheA8", TextureSampler::SharedCacheA8),
         ]);
     }
 
@@ -2593,6 +2596,14 @@ impl Renderer {
                                                pass.color_texture.take(),
                                                &mut self.alpha_render_targets,
                                                &mut self.color_render_targets);
+
+                // After completing the first pass, make the A8 target available as an
+                // input to any subsequent passes.
+                if pass_index == 0 {
+                    if let Some(shared_alpha_texture) = self.texture_resolver.resolve(&SourceTexture::CacheA8) {
+                        self.device.bind_texture(TextureSampler::SharedCacheA8, shared_alpha_texture);
+                    }
+                }
             }
 
             self.color_render_targets.reverse();


### PR DESCRIPTION
Many tasks (such as box shadows) are simple tasks that don't
have dependencies on other tasks in the tree. This change
ensures that those tasks are always drawn in the first render pass.

A new sampler is introduced that is always bound to the shared
target as an input for all subsequent passes, for tasks that
opt in.

This is a performance win where a cacheable task would previously
be rendered in multiple passes. For example, a box shadow that is
used by pass 1 and 2 would previously be drawn twice, but with this
change the box shadow is drawn only once (if the box shadow cache
key is the same).

This is a performance win by itself, but is also some prep work
for some ideas I want to prototype related to how we manage
clip masks as part of the clip stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1642)
<!-- Reviewable:end -->
