### PR TITLE
Fix nightly compile warnings and add fail-on-warnings annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ addons:
       - llvm-3.8-dev
       - libedit-dev
 env:
-  - BUILD_KIND=DEBUG RUST_BACKTRACE=1
-  - BUILD_KIND=RELEASE RUST_BACKTRACE=1
+  - BUILD_KIND=DEBUG RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
+  - BUILD_KIND=RELEASE RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
 before_install:
   - pip install mako servo-tidy
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: rust
 rust:
-  - 1.17.0
+  - 1.19.0
   - nightly
 matrix:
   allow_failures:

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate app_units;
-extern crate euclid;
 extern crate gleam;
 extern crate glutin;
 extern crate webrender;

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate app_units;
-extern crate euclid;
 extern crate gleam;
 extern crate glutin;
 extern crate webrender;

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -251,7 +251,7 @@ impl ClipScrollTree {
         // TODO(gw): This is an ugly borrow check workaround to clone these.
         //           Restructure this to avoid the clones!
         let (state, node_children) = {
-            let mut node = match self.nodes.get_mut(&layer_id) {
+            let node = match self.nodes.get_mut(&layer_id) {
                 Some(node) => node,
                 None => return,
             };

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -409,7 +409,7 @@ impl FontContext {
             let current_height = (i * metrics.rasterized_width * 4) as usize;
             let end_row = current_height + (metrics.rasterized_width as usize * 4);
 
-            for mut pixel in rasterized_pixels[current_height .. end_row].chunks_mut(4) {
+            for pixel in rasterized_pixels[current_height .. end_row].chunks_mut(4) {
                 pixel[0] = 255 - pixel[0];
                 pixel[1] = 255 - pixel[1];
                 pixel[2] = 255 - pixel[2];

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{FontInstance, FontInstancePlatformOptions, FontKey, FontRenderMode};
-use api::{GlyphDimensions, GlyphKey, GlyphOptions, SubpixelDirection};
+use api::{GlyphDimensions, GlyphKey};
 use gamma_lut::{GammaLut, Color as ColorLut};
 use internal_types::FastHashMap;
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -176,7 +176,7 @@ impl RenderBackend {
     }
 
     fn process_document(&mut self, document_id: DocumentId, message: DocumentMsg,
-                        frame_counter: u32, mut profile_counters: &mut BackendProfileCounters)
+                        frame_counter: u32, profile_counters: &mut BackendProfileCounters)
                         -> DocumentOp
     {
         let doc = self.documents.get_mut(&document_id).expect("No document?");

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -626,7 +626,7 @@ impl DisplayListBuilder {
                                                   font_key: FontInstanceKey,
                                                   color: ColorF,
                                                   glyphs: I) {
-        let mut font_glyphs = self.glyphs.entry((font_key, color))
+        let font_glyphs = self.glyphs.entry((font_key, color))
                                          .or_insert(FastHashSet::default());
 
         font_glyphs.extend(glyphs);


### PR DESCRIPTION
To prevent more things like #1641 . I tested that this builds on {Mac, Linux, Windows} using {stable, nightly} compilers, in the default configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1644)
<!-- Reviewable:end -->
