### PR TITLE
disable samplers, as they cause gecko to crash on macos

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -569,19 +569,23 @@ impl<T> GpuFrameProfile<T> {
     }
 
     fn done_sampler(&mut self) {
+        /* FIXME: samplers crash on MacOS
         debug_assert!(self.inside_frame);
         if self.samplers.pending != 0 {
             self.gl.end_query(gl::SAMPLES_PASSED);
             self.samplers.pending = 0;
         }
+        */
     }
 
-    fn add_sampler(&mut self, tag: T) where T: NamedTag {
+    fn add_sampler(&mut self, _tag: T) where T: NamedTag {
+        /* FIXME: samplers crash on MacOS
         self.done_sampler();
 
         if let Some(query) = self.samplers.add(GpuSampler { tag, count: 0 }) {
             self.gl.begin_query(gl::SAMPLES_PASSED, query);
         }
+        */
     }
 
     fn is_valid(&self) -> bool {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1647)
<!-- Reviewable:end -->
