### PR TITLE
Skip clip masks where the inner rect encloses the primitive rect.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -2037,7 +2037,8 @@ impl<'a> LayerRectCalculationAndCullingPass<'a> {
                 let clip_task = RenderTask::new_mask(cache_key,
                                                      mask_rect,
                                                      &self.current_clip_stack,
-                                                     extra);
+                                                     extra,
+                                                     prim_screen_rect);
                 let render_tasks = &mut self.render_tasks;
                 prim_metadata.clip_task_id = clip_task.map(|clip_task| {
                     render_tasks.add(clip_task)


### PR DESCRIPTION
This fixes some performance issues in the Motionmark images demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1649)
<!-- Reviewable:end -->
