### PR TITLE
don't panic when an invalid font instance key is supplied

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -567,16 +567,22 @@ impl Frame {
                                               info.image_rendering);
             }
             SpecificDisplayItem::Text(ref text_info) => {
-                let instance = context.resource_cache.get_font_instance(text_info.font_key).unwrap();
-                context.builder.add_text(clip_and_scroll,
-                                         reference_frame_relative_offset,
-                                         item_rect_with_offset,
-                                         &clip_with_offset,
-                                         instance,
-                                         &text_info.color,
-                                         item.glyphs(),
-                                         item.display_list().get(item.glyphs()).count(),
-                                         text_info.glyph_options);
+                match context.resource_cache.get_font_instance(text_info.font_key) {
+                    Some(instance) => {
+                        context.builder.add_text(clip_and_scroll,
+                                                 reference_frame_relative_offset,
+                                                 item_rect_with_offset,
+                                                 &clip_with_offset,
+                                                 instance,
+                                                 &text_info.color,
+                                                 item.glyphs(),
+                                                 item.display_list().get(item.glyphs()).count(),
+                                                 text_info.glyph_options);
+                    }
+                    None => {
+                        warn!("Unknown font instance key: {:?}", text_info.font_key);
+                    }
+                }
             }
             SpecificDisplayItem::Rectangle(ref info) => {
                 if !self.try_to_add_rectangle_splitting_on_clip(context,


### PR DESCRIPTION
This is a small modification to my previous FontInstanceKey to allow invalid font instance keys to work around the issue described in https://bugzilla.mozilla.org/show_bug.cgi?id=1396056

There are somewhat legitimate situations where this can occur, so we don't want to panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1664)
<!-- Reviewable:end -->
