### PR TITLE
Fix text shadow rendering regression.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1016,6 +1016,7 @@ impl RenderTarget for ColorRenderTarget {
 
                                     let mut font = text.font.clone();
                                     font.size = font.size.scale_by(ctx.device_pixel_ratio);
+                                    font.render_mode = text.shadow_render_mode;
 
                                     let texture_id = ctx.resource_cache.get_glyphs(font,
                                                                                    &text.glyph_keys,

--- a/wrench/reftests/text/1658-ref.yaml
+++ b/wrench/reftests/text/1658-ref.yaml
@@ -1,0 +1,26 @@
+---
+root:
+  items:
+        -
+          type: "text-shadow"
+          blur-radius: 5
+          bounds: [14, 18, 205, 35]
+          offset: [0, 0]
+          color: black
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [55]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 0, 0.0]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"
+        -
+          type: text
+          bounds: [14, 18, 205, 35]
+          glyphs: [55]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 0, 1.0]
+          font: "VeraBd.ttf"

--- a/wrench/reftests/text/1658.yaml
+++ b/wrench/reftests/text/1658.yaml
@@ -1,0 +1,19 @@
+---
+root:
+  items:
+        -
+          type: "text-shadow"
+          blur-radius: 5
+          bounds: [14, 18, 205, 35]
+          offset: [0, 0]
+          color: black
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [55]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 0, 1.0]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"
+

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -14,3 +14,5 @@
 != non-opaque.yaml non-opaque-notref.yaml
 == decorations.yaml decorations-ref.yaml
 fuzzy(1,100) == decorations-suite.yaml decorations-suite.png
+== 1658.yaml 1658-ref.yaml
+


### PR DESCRIPTION
The text shadow blur was selecting the subpixel glyphs, instead
of the alpha masked glyphs.

Unfortunately we don't have any way to easily automate a test
case for this right now. We need to improve how we can test
glyph blurring (perhaps support per-platform comparison images?).

Fixes #1658.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1665)
<!-- Reviewable:end -->
