### PR TITLE
Change internal clip sources to be a simple array of clips.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -228,7 +228,7 @@ impl FrameBuilder {
                                    clip_and_scroll: ClipAndScrollInfo,
                                    local_clip: &LocalClip,
                                    corner_instances: [BorderCornerInstance; 4],
-                                   extra_clips: &[ClipSource]) {
+                                   clip_sources: Vec<ClipSource>) {
         let radius = &border.radius;
         let left = &border.left;
         let right = &border.right;
@@ -274,7 +274,7 @@ impl FrameBuilder {
         self.add_primitive(clip_and_scroll,
                            &rect,
                            local_clip,
-                           extra_clips,
+                           clip_sources,
                            PrimitiveContainer::Border(prim_cpu));
     }
 
@@ -425,7 +425,7 @@ impl FrameBuilder {
                                              clip_and_scroll,
                                              local_clip,
                                              corner_instances,
-                                             &extra_clips);
+                                             extra_clips);
         }
     }
 }

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -6,7 +6,7 @@ use api::{ClipId, DeviceIntRect, LayerPixel, LayerPoint, LayerRect, LayerSize};
 use api::{LayerToScrollTransform, LayerToWorldTransform, LayerVector2D, PipelineId};
 use api::{ScrollClamping, ScrollEventPhase, ScrollLocation, ScrollSensitivity, StickyFrameInfo};
 use api::WorldPoint;
-use clip::{ClipRegion, ClipSource, ClipSources};
+use clip::{ClipRegion, ClipSources};
 use clip_scroll_tree::TransformUpdateState;
 use geometry::ray_intersects_rect;
 use spring::{DAMPING, STIFFNESS, Spring};
@@ -42,7 +42,7 @@ impl ClipInfo {
     pub fn new(clip_region: ClipRegion, packed_layer_index: PackedLayerIndex) -> ClipInfo {
         let clip_rect = LayerRect::new(clip_region.origin, clip_region.main.size);
         ClipInfo {
-            clip_sources: ClipSources::new(vec![ClipSource::Region(clip_region)]),
+            clip_sources: ClipSources::from(clip_region),
             packed_layer_index,
             screen_bounding_rect: None,
             clip_rect: clip_rect,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntSize, DevicePoint};
-use api::{ExtendMode, FontRenderMode, GlyphInstance, GradientStop};
+use api::{BorderRadius, ExtendMode, FontRenderMode, GlyphInstance, GradientStop};
 use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, TextShadow};
 use api::{GlyphKey, LayerToWorldTransform, TileOffset, YuvColorSpace, YuvFormat};
 use api::{device_length, FontInstance, LayerVector2D, LineOrientation, LineStyle};
@@ -664,47 +664,46 @@ pub struct ClipData {
 }
 
 impl ClipData {
-    pub fn from_clip_region(clip: &ComplexClipRegion) -> ClipData {
+    pub fn rounded_rect(rect: &LayerRect, radii: &BorderRadius, mode: ClipMode) -> ClipData {
         ClipData {
             rect: ClipRect {
-                rect: clip.rect,
-                // TODO(gw): Support other clip modes for regions?
-                mode: ClipMode::Clip as u32 as f32,
+                rect: *rect,
+                mode: mode as u32 as f32,
             },
             top_left: ClipCorner {
                 rect: LayerRect::new(
-                    LayerPoint::new(clip.rect.origin.x, clip.rect.origin.y),
-                    LayerSize::new(clip.radii.top_left.width, clip.radii.top_left.height)),
-                outer_radius_x: clip.radii.top_left.width,
-                outer_radius_y: clip.radii.top_left.height,
+                    LayerPoint::new(rect.origin.x, rect.origin.y),
+                    LayerSize::new(radii.top_left.width, radii.top_left.height)),
+                outer_radius_x: radii.top_left.width,
+                outer_radius_y: radii.top_left.height,
                 inner_radius_x: 0.0,
                 inner_radius_y: 0.0,
             },
             top_right: ClipCorner {
                 rect: LayerRect::new(
-                    LayerPoint::new(clip.rect.origin.x + clip.rect.size.width - clip.radii.top_right.width, clip.rect.origin.y),
-                    LayerSize::new(clip.radii.top_right.width, clip.radii.top_right.height)),
-                outer_radius_x: clip.radii.top_right.width,
-                outer_radius_y: clip.radii.top_right.height,
+                    LayerPoint::new(rect.origin.x + rect.size.width - radii.top_right.width, rect.origin.y),
+                    LayerSize::new(radii.top_right.width, radii.top_right.height)),
+                outer_radius_x: radii.top_right.width,
+                outer_radius_y: radii.top_right.height,
                 inner_radius_x: 0.0,
                 inner_radius_y: 0.0,
             },
             bottom_left: ClipCorner {
                 rect: LayerRect::new(
-                    LayerPoint::new(clip.rect.origin.x, clip.rect.origin.y + clip.rect.size.height - clip.radii.bottom_left.height),
-                    LayerSize::new(clip.radii.bottom_left.width, clip.radii.bottom_left.height)),
-                outer_radius_x: clip.radii.bottom_left.width,
-                outer_radius_y: clip.radii.bottom_left.height,
+                    LayerPoint::new(rect.origin.x, rect.origin.y + rect.size.height - radii.bottom_left.height),
+                    LayerSize::new(radii.bottom_left.width, radii.bottom_left.height)),
+                outer_radius_x: radii.bottom_left.width,
+                outer_radius_y: radii.bottom_left.height,
                 inner_radius_x: 0.0,
                 inner_radius_y: 0.0,
             },
             bottom_right: ClipCorner {
                 rect: LayerRect::new(
-                    LayerPoint::new(clip.rect.origin.x + clip.rect.size.width - clip.radii.bottom_right.width,
-                                    clip.rect.origin.y + clip.rect.size.height - clip.radii.bottom_right.height),
-                    LayerSize::new(clip.radii.bottom_right.width, clip.radii.bottom_right.height)),
-                outer_radius_x: clip.radii.bottom_right.width,
-                outer_radius_y: clip.radii.bottom_right.height,
+                    LayerPoint::new(rect.origin.x + rect.size.width - radii.bottom_right.width,
+                                    rect.origin.y + rect.size.height - radii.bottom_right.height),
+                    LayerSize::new(radii.bottom_right.width, radii.bottom_right.height)),
+                outer_radius_x: radii.bottom_right.width,
+                outer_radius_y: radii.bottom_right.height,
                 inner_radius_x: 0.0,
                 inner_radius_y: 0.0,
             },

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -267,21 +267,12 @@ pub fn pack_as_float(value: u32) -> f32 {
 
 
 pub trait ComplexClipRegionHelpers {
-    /// Return an aligned rectangle that is inside the clip region and doesn't intersect
-    /// any of the bounding rectangles of the rounded corners.
-    fn get_inner_rect_safe(&self) -> Option<LayoutRect>;
     /// Return the approximately largest aligned rectangle that is fully inside
     /// the provided clip region.
     fn get_inner_rect_full(&self) -> Option<LayoutRect>;
 }
 
 impl ComplexClipRegionHelpers for ComplexClipRegion {
-    fn get_inner_rect_safe(&self) -> Option<LayoutRect> {
-        // value of `k==1.0` is used for extraction of the corner rectangles
-        // see `SEGMENT_CORNER_*` in `clip_shared.glsl`
-        extract_inner_rect_impl(&self.rect, &self.radii, 1.0)
-    }
-
     fn get_inner_rect_full(&self) -> Option<LayoutRect> {
         // this `k` optimal for a simple case of all border radii being equal
         let k = 1.0 - 0.5 * FRAC_1_SQRT_2; // could be nicely approximated to `0.3`
@@ -308,6 +299,15 @@ fn extract_inner_rect_impl<U>(rect: &TypedRect<f32, U>,
     } else {
         None
     }
+}
+
+/// Return an aligned rectangle that is inside the clip region and doesn't intersect
+/// any of the bounding rectangles of the rounded corners.
+pub fn extract_inner_rect_safe<U>(rect: &TypedRect<f32, U>,
+                                  radii: &BorderRadius) -> Option<TypedRect<f32, U>> {
+    // value of `k==1.0` is used for extraction of the corner rectangles
+    // see `SEGMENT_CORNER_*` in `clip_shared.glsl`
+    extract_inner_rect_impl(rect, radii, 1.0)
 }
 
 /// Consumes the old vector and returns a new one that may reuse the old vector's allocated


### PR DESCRIPTION
Instead of maintaining a copy of a ClipRegion etc, flatten
any input clip structures into a list of simple clips.

This simplifies some of the mask cache code, and is also
prep work for some further simplifications and optimizations
to how we handle the mask cache structures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1667)
<!-- Reviewable:end -->
