### PR TITLE
Add a basic clip-scroll tree view to the debugger

### DIFF
--- a/debugger/js/app.js
+++ b/debugger/js/app.js
@@ -3,6 +3,7 @@ var state = {
     page: "options",
     passes: [],
     documents: [],
+    clipscrolltree: [],
 }
 
 class Connection {
@@ -24,6 +25,10 @@ class Connection {
                 state.passes = json['passes'];
             } else if (json['kind'] == "documents") {
                 state.documents = json['root'];
+            } else if (json['kind'] == "clipscrolltree") {
+                state.clipscrolltree = json['root'];
+            } else {
+                console.warn("unknown message kind: " + json['kind']);
             }
         }
 
@@ -67,6 +72,7 @@ Vue.component('app', {
                             <options v-if="state.page == 'options'"></options>
                             <passview v-if="state.page == 'passes'" :passes=state.passes></passview>
                             <documentview v-if="state.page == 'documents'" :documents=state.documents></documentview>
+                            <clipscrolltreeview v-if="state.page == 'clipscrolltree'" :clipscrolltree=state.clipscrolltree></documentview>
                         </div>
                     </div>
                 </div>
@@ -242,6 +248,28 @@ Vue.component('documentview', {
     `
 })
 
+Vue.component('clipscrolltreeview', {
+    props: [
+        'clipscrolltree'
+    ],
+    methods: {
+        fetch: function() {
+            connection.send("fetch_clipscrolltree");
+        }
+    },
+    template: `
+        <div class="box">
+            <h1 class="title">Clip-scroll Tree <a v-on:click="fetch" class="button is-info">Refresh</a></h1>
+            <hr/>
+            <div>
+                <ul>
+                    <treeview :model=clipscrolltree></treeview>
+                </ul>
+            </div>
+        </div>
+    `
+})
+
 Vue.component('mainmenu', {
     props: [
         'page',
@@ -260,6 +288,7 @@ Vue.component('mainmenu', {
                 <li><a v-on:click="setPage('options')" v-bind:class="{ 'is-active': page == 'options' }">Debug Options</a></li>
                 <li><a v-on:click="setPage('passes')" v-bind:class="{ 'is-active': page == 'passes' }">Passes</a></li>
                 <li><a v-on:click="setPage('documents')" v-bind:class="{ 'is-active': page == 'documents' }">Documents</a></li>
+                <li><a v-on:click="setPage('clipscrolltree')" v-bind:class="{ 'is-active': page == 'clipscrolltree' }">Clip-scroll Tree</a></li>
             </ul>
         </aside>
     `

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -4,7 +4,7 @@
 
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollingState};
 use internal_types::{FastHashSet, FastHashMap};
-use print_tree::PrintTree;
+use print_tree::{PrintTree, PrintTreePrinter};
 use api::{ClipId, LayerPoint, LayerRect, LayerToScrollTransform, LayerToWorldTransform};
 use api::{LayerVector2D, PipelineId, ScrollClamping, ScrollEventPhase, ScrollLayerState};
 use api::{ScrollLocation, StickyFrameInfo, WorldPoint};
@@ -370,7 +370,7 @@ impl ClipScrollTree {
         }
     }
 
-    fn print_node(&self, id: &ClipId, pt: &mut PrintTree) {
+    fn print_node<T: PrintTreePrinter>(&self, id: &ClipId, pt: &mut T) {
         let node = self.nodes.get(id).unwrap();
 
         match node.node_type {
@@ -416,7 +416,13 @@ impl ClipScrollTree {
     pub fn print(&self) {
         if !self.nodes.is_empty() {
             let mut pt = PrintTree::new("clip_scroll tree");
-            self.print_node(&self.root_reference_frame_id, &mut pt);
+            self.print_with(&mut pt);
+        }
+    }
+
+    pub fn print_with<T: PrintTreePrinter>(&self, pt: &mut T) {
+        if !self.nodes.is_empty() {
+            self.print_node(&self.root_reference_frame_id, pt);
         }
     }
 }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -158,6 +158,7 @@ impl RendererFrame {
 
 pub enum DebugOutput {
     FetchDocuments(String),
+    FetchClipScrollTree(String),
 }
 
 pub enum ResultMsg {

--- a/webrender/src/print_tree.rs
+++ b/webrender/src/print_tree.rs
@@ -13,6 +13,15 @@ pub struct PrintTree {
     queued_item: Option<String>,
 }
 
+/// A trait that makes it easy to describe a pretty tree of data,
+/// regardless of the printing destination, to either print it
+/// directly to stdout, or serialize it as in the debugger
+pub trait PrintTreePrinter {
+    fn new_level(&mut self, title: String);
+    fn end_level(&mut self);
+    fn add_item(&mut self, text: String);
+}
+
 impl PrintTree {
     pub fn new(title: &str) -> PrintTree {
         println!("\u{250c} {}", title);
@@ -20,28 +29,6 @@ impl PrintTree {
             level: 1,
             queued_item: None,
         }
-    }
-
-    /// Descend one level in the tree with the given title.
-    pub fn new_level(&mut self, title: String) {
-        self.flush_queued_item("\u{251C}\u{2500}");
-
-        self.print_level_prefix();
-        println!("\u{251C}\u{2500} {}", title);
-
-        self.level = self.level + 1;
-    }
-
-    /// Ascend one level in the tree.
-    pub fn end_level(&mut self) {
-        self.flush_queued_item("\u{2514}\u{2500}");
-        self.level = self.level - 1;
-    }
-
-    /// Add an item to the current level in the tree.
-    pub fn add_item(&mut self, text: String) {
-        self.flush_queued_item("\u{251C}\u{2500}");
-        self.queued_item = Some(text);
     }
 
     fn print_level_prefix(&self) {
@@ -56,6 +43,31 @@ impl PrintTree {
             println!("{} {}", prefix, queued_item);
         }
     }
+}
+
+// The default `println!` based printer
+impl PrintTreePrinter for PrintTree {
+    /// Descend one level in the tree with the given title.
+    fn new_level(&mut self, title: String) {
+        self.flush_queued_item("\u{251C}\u{2500}");
+
+        self.print_level_prefix();
+        println!("\u{251C}\u{2500} {}", title);
+
+        self.level = self.level + 1;
+    }
+
+    /// Ascend one level in the tree.
+    fn end_level(&mut self) {
+        self.flush_queued_item("\u{2514}\u{2500}");
+        self.level = self.level - 1;
+    }
+
+    /// Add an item to the current level in the tree.
+    fn add_item(&mut self, text: String) {
+        self.flush_queued_item("\u{251C}\u{2500}");
+        self.queued_item = Some(text);
+    }    
 }
 
 impl Drop for PrintTree {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -479,6 +479,10 @@ impl RenderBackend {
                             let json = self.get_docs_for_debugger();
                             ResultMsg::DebugOutput(DebugOutput::FetchDocuments(json))
                         }
+                        DebugCommand::FetchClipScrollTree => {
+                            let json = self.get_clip_scroll_tree_for_debugger();
+                            ResultMsg::DebugOutput(DebugOutput::FetchClipScrollTree(json))
+                        }
                         _ => {
                             ResultMsg::DebugCommand(option)
                         }
@@ -595,6 +599,26 @@ impl RenderBackend {
         }
 
         serde_json::to_string(&docs).unwrap()
+    }
+
+    #[cfg(not(feature = "debugger"))]
+    fn get_clip_scroll_tree_for_debugger(&self) -> String {
+        String::new()
+    }
+
+    #[cfg(feature = "debugger")]
+    fn get_clip_scroll_tree_for_debugger(&self) -> String {
+        let mut debug_root = debug_server::ClipScrollTreeList::new();
+
+        for (_, doc) in &self.documents {
+            let debug_node = debug_server::TreeNode::new("document clip_scroll tree");
+            let mut builder = debug_server::TreeNodeBuilder::new(debug_node);
+            doc.frame.clip_scroll_tree.print_with(&mut builder);
+
+            debug_root.add(builder.build());            
+        }
+
+        serde_json::to_string(&debug_root).unwrap()
     }
 }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1622,7 +1622,8 @@ impl Renderer {
                 }
                 ResultMsg::DebugOutput(output) => {
                     match output {
-                        DebugOutput::FetchDocuments(string) => {
+                        DebugOutput::FetchDocuments(string) |
+                        DebugOutput::FetchClipScrollTree(string) => {
                             self.debug_server.send(string);
                         }
                     }
@@ -1721,6 +1722,7 @@ impl Renderer {
                 }
             }
             DebugCommand::FetchDocuments => {}
+            DebugCommand::FetchClipScrollTree => {}
             DebugCommand::FetchPasses => {
                 let json = self.get_passes_for_debugger();
                 self.debug_server.send(json);

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -186,6 +186,8 @@ pub enum DebugCommand {
     FetchDocuments,
     // Fetch current passes and batches.
     FetchPasses,
+    // Fetch clip-scroll tree.
+    FetchClipScrollTree,
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
This allows viewing the frames' clip_scroll_tree data in the debugger, using the existing "pretty-print" display feature.

Since it's ultimately a tree, I thought it had to look more like the documents view rather than the passes (since passes seem only 2-deep, whereas the clip-scroll tree depth is not fixed):

![image](https://user-images.githubusercontent.com/247183/30112751-b4907110-9312-11e7-8428-092d7f9feaec.png)


toughts @glennw ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1669)
<!-- Reviewable:end -->
