### PR TITLE
Update app_units to v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "wrench"
 version = "0.2.3"
 dependencies = [
- "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "app_units"
-version = "0.5.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,7 +1053,7 @@ name = "webrender"
 version = "0.50.0"
 dependencies = [
  "angle 0.5.0 (git+https://github.com/servo/angle?branch=servo)",
- "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1086,7 +1086,7 @@ dependencies = [
 name = "webrender_api"
 version = "0.50.0"
 dependencies = [
- "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1172,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e2b80445d331077679dfc6f3014f3e9ab7083e588423d35041d3fc017198189"
 "checksum angle 0.5.0 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99f3af85d0c7c054d95da6405117b523284a97484494b44a6dec58b9617eabf6"
+"checksum app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed0a4de09a3b8449515e649f3bb84f72ea15fc2d10639beb0776a09b7d308074"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d156a04ec694d726e92ea3c13e4a62949b4f0488a9344f04341d679ec6b127b"
 "checksum binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -13,7 +13,7 @@ profiler = ["thread_profiler/thread_profiler"]
 debugger = ["ws", "serde_json", "serde", "serde_derive"]
 
 [dependencies]
-app_units = "0.5"
+app_units = "0.5.6"
 bincode = "0.8"
 bit-set = "0.4"
 byteorder = "1.0"

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -10,7 +10,7 @@ nightly = ["euclid/unstable", "serde/unstable"]
 ipc = ["ipc-channel"]
 
 [dependencies]
-app_units = "0.5"
+app_units = "0.5.6"
 bincode = "0.8"
 byteorder = "1.0"
 euclid = "0.15"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = { version = "0.4", optional = true }
 euclid = "0.15"
 gleam = "0.4"
 servo-glutin = "0.11"
-app_units = "0.5"
+app_units = "0.5.6"
 image = "0.14"
 clap = { version = "2", features = ["yaml"] }
 lazy_static = "0.2"


### PR DESCRIPTION
Fix the CI build error at windows.

error: use of unstable library feature 'clamp' (see issue #44095)
   --> C:\Users\appveyor\.cargo\registry\src\github.com-1ecc6299db9ec823\app_units-0.5.0\src\app_unit.rs:192:22
    |
192 |         *self = self.clamp()
    |                      ^^^^^
    |
    = help: add #![feature(clamp)] to the crate attributes to enable
error[E0061]: this function takes 2 parameters but 0 parameters were supplied
   --> C:\Users\appveyor\.cargo\registry\src\github.com-1ecc6299db9ec823\app_units-0.5.0\src\app_unit.rs:192:22
    |
192 |         *self = self.clamp()
    |                      ^^^^^ expected 2 parameters
error[E0308]: mismatched types
   --> C:\Users\appveyor\.cargo\registry\src\github.com-1ecc6299db9ec823\app_units-0.5.0\src\app_unit.rs:192:17
    |
192 |         *self = self.clamp()
    |                 ^^^^^^^^^^^^ expected struct `app_unit::Au`, found mutable reference
    |
    = note: expected type `app_unit::Au`
               found type `&mut app_unit::Au`
    = help: here are some functions which might fulfill your needs:
            - .clamp()
error: aborting due to 3 previous errors
error: Could not compile `app_units`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1681)
<!-- Reviewable:end -->
