### PR TITLE
remove broken optimization, fixes #1682

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -437,11 +437,6 @@ impl Frame {
                 stacking_context.mix_blend_mode_for_compositing())
         };
 
-        if composition_operations.will_make_invisible() {
-            traversal.skip_current_stacking_context();
-            return;
-        }
-
         if stacking_context.scroll_policy == ScrollPolicy::Fixed {
             context.replacements.push((context_scroll_node_id,
                                        context.builder.current_reference_frame_id()));

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -10,3 +10,4 @@
 == clip-and-scroll-property.yaml clip-and-scroll-property-ref.yaml
 == translate-nested.yaml translate-nested-ref.yaml
 == sticky.yaml sticky-ref.yaml
+== sibling-hidden-clip.yaml sibling-hidden-clip-ref.yaml

--- a/wrench/reftests/scrolling/sibling-hidden-clip-ref.yaml
+++ b/wrench/reftests/scrolling/sibling-hidden-clip-ref.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: [10, 10, 40, 70]
+      color: red
+  id: [0, 0]
+pipelines: []

--- a/wrench/reftests/scrolling/sibling-hidden-clip.yaml
+++ b/wrench/reftests/scrolling/sibling-hidden-clip.yaml
@@ -1,0 +1,22 @@
+---
+root:
+  items:
+    -
+      bounds: [0, 0, 200, 200]
+      "clip-and-scroll": 0
+      type: "stacking-context"
+      "scroll-policy": scrollable
+      filters: [opacity(0.0)]
+      items:
+        -
+          bounds: [0, 0, 50, 80]
+          "clip-and-scroll": 0
+          type: clip
+          id: 1
+    - type: rect
+      bounds: [10, 10, 100, 100]
+      color: red
+      "clip-and-scroll": 1
+
+  id: [0, 0]
+pipelines: []


### PR DESCRIPTION
If we skip a stacking context with clips that are referenced externally, this corrupts the clip_scroll tree. Just as a general safety thing, I'm completely removing this (marginal?) optimization to avoid this sort of problem from cropping up again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1683)
<!-- Reviewable:end -->
