### PR TITLE
Introduce frame output support.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -66,6 +66,11 @@ pub trait Example {
     fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
         None
     }
+    fn get_output_image_handler(&mut self, _gl: &gl::Gl) -> Option<Box<webrender::OutputImageHandler>> {
+        None
+    }
+    fn draw_custom(&self, _gl: &gl::Gl) {
+    }
 }
 
 pub fn main_wrapper(example: &mut Example,
@@ -111,7 +116,7 @@ pub fn main_wrapper(example: &mut Example,
     };
 
     let size = DeviceUintSize::new(width, height);
-    let (mut renderer, sender) = webrender::Renderer::new(gl, opts).unwrap();
+    let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), opts).unwrap();
     let api = sender.create_api();
     let document_id = api.add_document(size);
 
@@ -120,6 +125,9 @@ pub fn main_wrapper(example: &mut Example,
 
     if let Some(external_image_handler) = example.get_external_image_handler() {
         renderer.set_external_image_handler(external_image_handler);
+    }
+    if let Some(output_image_handler) = example.get_output_image_handler(&*gl) {
+        renderer.set_output_image_handler(output_image_handler);
     }
 
     let epoch = Epoch(0);
@@ -202,6 +210,7 @@ pub fn main_wrapper(example: &mut Example,
 
         renderer.update();
         renderer.render(DeviceUintSize::new(width, height)).unwrap();
+        example.draw_custom(&*gl);
         window.swap_buffers().ok();
     }
 

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate gleam;
+extern crate glutin;
+extern crate webrender;
+
+#[path="common/boilerplate.rs"]
+mod boilerplate;
+
+use boilerplate::{Example, HandyDandyRectBuilder};
+use gleam::gl;
+use webrender::api::*;
+
+// This example demonstrates using the frame output feature to copy
+// the output of a WR framebuffer to a custom texture.
+
+const VS: &str = "#version 130\nin vec2 aPos;out vec2 vUv;\nvoid main() { vUv = aPos; gl_Position = vec4(aPos, 0.0, 1.0); }\n";
+const FS: &str = "#version 130\nout vec4 oFragColor;\nin vec2 vUv;\nuniform sampler2D s;\nvoid main() { oFragColor = texture(s, vUv); }\n";
+
+struct App {
+    iframe_pipeline_id: Option<PipelineId>,
+    texture_id: gl::GLuint,
+}
+
+struct OutputHandler {
+    texture_id: gl::GLuint,
+}
+
+impl OutputHandler {
+    fn new(texture_id: gl::GLuint) -> OutputHandler {
+        OutputHandler {
+            texture_id
+        }
+    }
+}
+
+impl webrender::OutputImageHandler for OutputHandler {
+    fn lock(&mut self, _id: PipelineId) -> Option<(u32, DeviceIntSize)> {
+        Some((self.texture_id, DeviceIntSize::new(100, 100)))
+    }
+
+    fn unlock(&mut self, _id: PipelineId) {
+    }
+}
+
+impl Example for App {
+    fn render(&mut self,
+              api: &RenderApi,
+              builder: &mut DisplayListBuilder,
+              _resources: &mut ResourceUpdates,
+              _layout_size: LayoutSize,
+              _pipeline_id: PipelineId,
+              document_id: DocumentId) {
+        // Build the iframe display list on first render.
+        if self.iframe_pipeline_id.is_none() {
+            let epoch = Epoch(0);
+            let root_background_color = ColorF::new(0.0, 1.0, 0.0, 1.0);
+
+            let iframe_pipeline_id = PipelineId(0, 1);
+            let layout_size = LayoutSize::new(100.0, 100.0);
+            let mut builder = DisplayListBuilder::new(iframe_pipeline_id, layout_size);
+            let resources = ResourceUpdates::new();
+
+            let bounds = (0,0).to(50, 50);
+            let info = LayoutPrimitiveInfo {
+                rect: bounds,
+                local_clip: None,
+                is_backface_visible: true,
+            };
+            builder.push_stacking_context(&info,
+                                          ScrollPolicy::Scrollable,
+                                          None,
+                                          TransformStyle::Flat,
+                                          None,
+                                          MixBlendMode::Normal,
+                                          Vec::new());
+
+            builder.push_rect(&info, ColorF::new(1.0, 1.0, 0.0, 1.0));
+            builder.pop_stacking_context();
+
+            api.set_display_list(
+                document_id,
+                epoch,
+                Some(root_background_color),
+                layout_size,
+                builder.finalize(),
+                true,
+                resources
+            );
+
+            self.iframe_pipeline_id = Some(iframe_pipeline_id);
+            api.enable_frame_output(document_id, iframe_pipeline_id, true);
+        }
+
+        let bounds = (100,100).to(200, 200);
+        let info = LayoutPrimitiveInfo {
+            rect: bounds,
+            local_clip: None,
+            is_backface_visible: true,
+        };
+        builder.push_stacking_context(&info,
+                                      ScrollPolicy::Scrollable,
+                                      None,
+                                      TransformStyle::Flat,
+                                      None,
+                                      MixBlendMode::Normal,
+                                      Vec::new());
+
+        builder.push_iframe(&info, self.iframe_pipeline_id.unwrap());
+
+        builder.pop_stacking_context();
+    }
+
+    fn draw_custom(&self, gl: &gl::Gl) {
+        let vbo = gl.gen_buffers(1)[0];
+        let vao = gl.gen_vertex_arrays(1)[0];
+
+        let pid = create_program(gl);
+
+        let vertices: [f32; 12] = [
+            0.0, 1.0,
+            1.0, 0.0,
+            0.0, 0.0,
+            0.0, 1.0,
+            1.0, 1.0,
+            1.0, 0.0
+        ];
+
+        gl.active_texture(gl::TEXTURE0);
+        gl.bind_texture(gl::TEXTURE_2D, self.texture_id);
+
+        gl.use_program(pid);
+        let sampler = gl.get_uniform_location(pid, "s");
+        debug_assert!(sampler != -1);
+        gl.uniform_1i(sampler, 0);
+
+        gl.bind_buffer(gl::ARRAY_BUFFER, vbo);
+        gl::buffer_data(gl, gl::ARRAY_BUFFER, &vertices, gl::STATIC_DRAW);
+
+        gl.bind_vertex_array(vao);
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer(0, 2, gl::FLOAT, false, 8, 0);
+
+        gl.draw_arrays(gl::TRIANGLES, 0, 6);
+
+        gl.delete_vertex_arrays(&[vao]);
+        gl.delete_buffers(&[vbo]);
+        gl.delete_program(pid);
+    }
+
+    fn on_event(&mut self,
+                _event: glutin::Event,
+                _api: &RenderApi,
+                _document_id: DocumentId) -> bool {
+        false
+    }
+
+    fn get_output_image_handler(&mut self, gl: &gl::Gl) -> Option<Box<webrender::OutputImageHandler>> {
+        let texture_id = gl.gen_textures(1)[0];
+
+        gl.bind_texture(gl::TEXTURE_2D, texture_id);
+        gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as gl::GLint);
+        gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as gl::GLint);
+        gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as gl::GLint);
+        gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as gl::GLint);
+        gl.tex_image_2d(gl::TEXTURE_2D,
+                        0,
+                        gl::RGBA as gl::GLint,
+                        100,
+                        100,
+                        0,
+                        gl::BGRA,
+                        gl::UNSIGNED_BYTE,
+                        None);
+        gl.bind_texture(gl::TEXTURE_2D, 0);
+
+        self.texture_id = texture_id;
+        Some(Box::new(OutputHandler::new(texture_id)))
+    }
+}
+
+fn main() {
+    let mut app = App {
+        iframe_pipeline_id: None,
+        texture_id: 0,
+    };
+    boilerplate::main_wrapper(&mut app, None);
+}
+
+pub fn compile_shader(gl: &gl::Gl,
+                      shader_type: gl::GLenum,
+                      source: &str)
+                      -> gl::GLuint {
+    let id = gl.create_shader(shader_type);
+    gl.shader_source(id, &[source.as_bytes()]);
+    gl.compile_shader(id);
+    let log = gl.get_shader_info_log(id);
+    if gl.get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
+        panic!("{:?} {}", source, log);
+    }
+    id
+}
+
+pub fn create_program(gl: &gl::Gl) -> gl::GLuint {
+    let vs_id = compile_shader(gl, gl::VERTEX_SHADER, VS);
+    let fs_id = compile_shader(gl, gl::FRAGMENT_SHADER, FS);
+
+    let pid = gl.create_program();
+    gl.attach_shader(pid, vs_id);
+    gl.attach_shader(pid, fs_id);
+
+    gl.bind_attrib_location(pid, 0, "aPos");
+    gl.link_program(pid);
+
+    gl.detach_shader(pid, vs_id);
+    gl.detach_shader(pid, fs_id);
+    gl.delete_shader(vs_id);
+    gl.delete_shader(fs_id);
+
+    if gl.get_program_iv(pid, gl::LINK_STATUS) == (0 as gl::GLint) {
+        let error_log = gl.get_program_info_log(pid);
+        panic!("{}", error_log);
+    }
+
+    pid
+}

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -13,7 +13,7 @@ use clip::ClipRegion;
 use clip_scroll_tree::{ClipScrollTree, ScrollStates};
 use euclid::rect;
 use gpu_cache::GpuCache;
-use internal_types::{FastHashMap, RendererFrame};
+use internal_types::{FastHashMap, FastHashSet, RendererFrame};
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{ResourceCache, TiledImageMap};
@@ -478,7 +478,8 @@ impl Frame {
                                               pipeline_id,
                                               composition_operations,
                                               stacking_context.transform_style,
-                                              is_backface_visible);
+                                              is_backface_visible,
+                                              false);
 
         self.flatten_items(traversal,
                            pipeline_id,
@@ -848,6 +849,7 @@ impl Frame {
                                               pipeline_id,
                                               CompositeOps::default(),
                                               TransformStyle::Flat,
+                                              true,
                                               true);
 
         // We do this here, rather than above because we want any of the top-level
@@ -1202,6 +1204,7 @@ impl Frame {
                  display_lists: &DisplayListMap,
                  device_pixel_ratio: f32,
                  pan: LayerPoint,
+                 output_pipelines: &FastHashSet<PipelineId>,
                  texture_cache_profile: &mut TextureCacheProfileCounters,
                  gpu_cache_profile: &mut GpuCacheProfileCounters)
                  -> RendererFrame {
@@ -1210,6 +1213,7 @@ impl Frame {
                                      gpu_cache,
                                      display_lists,
                                      device_pixel_ratio,
+                                     output_pipelines,
                                      texture_cache_profile,
                                      gpu_cache_profile);
         frame
@@ -1220,6 +1224,7 @@ impl Frame {
                    gpu_cache: &mut GpuCache,
                    display_lists: &DisplayListMap,
                    device_pixel_ratio: f32,
+                   output_pipelines: &FastHashSet<PipelineId>,
                    texture_cache_profile: &mut TextureCacheProfileCounters,
                    gpu_cache_profile: &mut GpuCacheProfileCounters)
                    -> RendererFrame {
@@ -1231,6 +1236,7 @@ impl Frame {
                           &mut self.clip_scroll_tree,
                           display_lists,
                           device_pixel_ratio,
+                          output_pipelines,
                           texture_cache_profile,
                           gpu_cache_profile)
         );

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -148,7 +148,7 @@ extern crate gamma_lut;
 
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, ReadPixelsFormat, Renderer, RendererOptions};
-pub use renderer::{CpuProfile, GpuProfile, DebugFlags, RendererKind};
+pub use renderer::{CpuProfile, GpuProfile, DebugFlags, OutputImageHandler, RendererKind};
 pub use renderer::{MAX_VERTEX_TEXTURE_WIDTH, PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
 
 pub use webrender_api as api;

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -7,7 +7,7 @@ use debug_server;
 use frame::Frame;
 use frame_builder::FrameBuilderConfig;
 use gpu_cache::GpuCache;
-use internal_types::{DebugOutput, FastHashMap, ResultMsg, RendererFrame};
+use internal_types::{DebugOutput, FastHashMap, FastHashSet, ResultMsg, RendererFrame};
 use profiler::{BackendProfileCounters, ResourceProfileCounters};
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
@@ -25,7 +25,7 @@ use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
 use api::{ApiMsg, DebugCommand, BlobImageRenderer, BuiltDisplayList, DeviceIntPoint};
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentId, DocumentMsg};
-use api::{IdNamespace, LayerPoint, RenderNotifier};
+use api::{IdNamespace, LayerPoint, PipelineId, RenderNotifier};
 #[cfg(feature = "debugger")]
 use api::{BuiltDisplayListIter, SpecificDisplayItem};
 
@@ -37,6 +37,9 @@ struct Document {
     pan: DeviceIntPoint,
     page_zoom_factor: f32,
     pinch_zoom_factor: f32,
+    // A set of pipelines that the caller has requested be
+    // made available as output textures.
+    output_pipelines: FastHashSet<PipelineId>,
     // A helper switch to prevent any frames rendering triggered by scrolling
     // messages between `SetDisplayList` and `GenerateFrame`.
     // If we allow them, then a reftest that scrolls a few layers before generating
@@ -65,6 +68,7 @@ impl Document {
             page_zoom_factor: 1.0,
             pinch_zoom_factor: 1.0,
             render_on_scroll,
+            output_pipelines: FastHashSet::default(),
         }
     }
 
@@ -95,6 +99,7 @@ impl Document {
                          &self.scene.display_lists,
                          accumulated_scale_factor,
                          pan,
+                         &self.output_pipelines,
                          &mut resource_profile.texture_cache,
                          &mut resource_profile.gpu_cache)
     }
@@ -184,6 +189,14 @@ impl RenderBackend {
         match message {
             DocumentMsg::SetPageZoom(factor) => {
                 doc.page_zoom_factor = factor.get();
+                DocumentOp::Nop
+            }
+            DocumentMsg::EnableFrameOutput(pipeline_id, enable) => {
+                if enable {
+                    doc.output_pipelines.insert(pipeline_id);
+                } else {
+                    doc.output_pipelines.remove(&pipeline_id);
+                }
                 DocumentOp::Nop
             }
             DocumentMsg::SetPinchZoom(factor) => {

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use api::PipelineId;
 use clip::{ClipSource, ClipSourcesWeakHandle, ClipStore};
 use gpu_cache::GpuCacheHandle;
 use internal_types::HardwareCompositeOp;
@@ -136,6 +137,9 @@ pub enum AlphaRenderItem {
 pub struct AlphaRenderTask {
     pub screen_origin: DeviceIntPoint,
     pub items: Vec<AlphaRenderItem>,
+    // If this render task is a registered frame output, this
+    // contains the pipeline ID it maps to.
+    pub frame_output_pipeline_id: Option<PipelineId>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -231,7 +235,8 @@ pub struct RenderTask {
 
 impl RenderTask {
     pub fn new_alpha_batch(screen_origin: DeviceIntPoint,
-                           location: RenderTaskLocation) -> RenderTask {
+                           location: RenderTaskLocation,
+                           frame_output_pipeline_id: Option<PipelineId>) -> RenderTask {
         RenderTask {
             cache_key: None,
             children: Vec::new(),
@@ -239,13 +244,15 @@ impl RenderTask {
             kind: RenderTaskKind::Alpha(AlphaRenderTask {
                 screen_origin,
                 items: Vec::new(),
+                frame_output_pipeline_id,
             }),
         }
     }
 
-    pub fn new_dynamic_alpha_batch(rect: &DeviceIntRect) -> RenderTask {
+    pub fn new_dynamic_alpha_batch(rect: &DeviceIntRect,
+                                   frame_output_pipeline_id: Option<PipelineId>) -> RenderTask {
         let location = RenderTaskLocation::Dynamic(None, rect.size);
-        Self::new_alpha_batch(rect.origin, location)
+        Self::new_alpha_batch(rect.origin, location, frame_output_pipeline_id)
     }
 
     pub fn new_prim_cache(size: DeviceIntSize,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -20,7 +20,7 @@ use debug_render::DebugRenderer;
 use debug_server::{self, DebugServer};
 use device::{DepthFunction, Device, FrameId, Program, Texture, VertexDescriptor, GpuMarker, GpuProfiler, PBO};
 use device::{GpuTimer, TextureFilter, VAO, VertexUsageHint, FileWatcherHandler, TextureTarget, ShaderError};
-use device::{ExternalTexture, get_gl_format_bgra, TextureSlot, VertexAttribute, VertexAttributeKind};
+use device::{ExternalTexture, FBOId, get_gl_format_bgra, TextureSlot, VertexAttribute, VertexAttributeKind};
 use euclid::{Transform3D, rect};
 use frame_builder::FrameBuilderConfig;
 use gleam::gl;
@@ -37,6 +37,7 @@ use render_task::RenderTaskTree;
 use serde_json;
 use std;
 use std::cmp;
+use std::collections::hash_map::Entry;
 use std::collections::VecDeque;
 use std::f32;
 use std::mem;
@@ -917,6 +918,11 @@ pub enum ReadPixelsFormat {
     Bgra8,
 }
 
+struct FrameOutput {
+    last_access: FrameId,
+    fbo_id: FBOId,
+}
+
 /// The renderer is responsible for submitting to the GPU the work prepared by the
 /// RenderBackend.
 pub struct Renderer {
@@ -1012,6 +1018,14 @@ pub struct Renderer {
     /// Optional trait object that allows the client
     /// application to provide external buffers for image data.
     external_image_handler: Option<Box<ExternalImageHandler>>,
+
+    /// Optional trait object that allows the client
+    /// application to provide a texture handle to
+    /// copy the WR output to.
+    output_image_handler: Option<Box<OutputImageHandler>>,
+
+    // Currently allocated FBOs for output frames.
+    output_targets: FastHashMap<u32, FrameOutput>,
 
     renderer_errors: Vec<RendererError>,
 
@@ -1529,6 +1543,8 @@ impl Renderer {
             pipeline_epoch_map: FastHashMap::default(),
             dither_matrix_texture,
             external_image_handler: None,
+            output_image_handler: None,
+            output_targets: FastHashMap::default(),
             cpu_profiles: VecDeque::new(),
             gpu_profiles: VecDeque::new(),
             gpu_cache_texture,
@@ -1737,6 +1753,11 @@ impl Renderer {
         self.external_image_handler = Some(handler);
     }
 
+    /// Set a callback for handling external outputs.
+    pub fn set_output_image_handler(&mut self, handler: Box<OutputImageHandler>) {
+        self.output_image_handler = Some(handler);
+    }
+
     /// Retrieve (and clear) the current list of recorded frame profiles.
     pub fn get_frame_profiles(&mut self) -> (Vec<CpuProfile>, Vec<GpuProfile>) {
         let cpu_profiles = self.cpu_profiles.drain(..).collect();
@@ -1793,7 +1814,7 @@ impl Renderer {
                         frame_id
                     };
 
-                    self.draw_tile_frame(frame, &framebuffer_size);
+                    self.draw_tile_frame(frame, &framebuffer_size, cpu_frame_id);
 
                     self.gpu_profile.end_frame();
                     cpu_frame_id
@@ -2143,9 +2164,8 @@ impl Renderer {
                     dest.size.height = -dest.size.height;
                 }
 
-                self.device.blit_render_target(render_target,
-                                               Some(src),
-                                               dest);
+                self.device.bind_read_target(render_target);
+                self.device.blit_render_target(src, dest);
 
                 // Restore draw target to current pass render target + layer.
                 self.device.bind_draw_target(render_target, Some(target_dimensions));
@@ -2166,6 +2186,7 @@ impl Renderer {
         clear_color: Option<[f32; 4]>,
         render_tasks: &RenderTaskTree,
         projection: &Transform3D<f32>,
+        frame_id: FrameId,
     ) {
         {
             let _gm = self.gpu_profile.add_marker(GPU_TAG_SETUP_TARGET);
@@ -2322,6 +2343,39 @@ impl Renderer {
             self.device.disable_depth();
             self.device.set_blend(false);
             self.gpu_profile.done_sampler();
+        }
+
+        // For any registered image outputs on this render target,
+        // get the texture from caller and blit it.
+        for output in &target.outputs {
+            let handler = self.output_image_handler
+                              .as_mut()
+                              .expect("Found output image, but no handler set!");
+            if let Some((texture_id, output_size)) = handler.lock(output.pipeline_id) {
+                let device = &mut self.device;
+                let fbo_id = match self.output_targets.entry(texture_id) {
+                    Entry::Vacant(entry) => {
+                        let fbo_id = device.create_fbo_for_external_texture(texture_id);
+                        entry.insert(FrameOutput {
+                            fbo_id,
+                            last_access: frame_id,
+                        });
+                        fbo_id
+                    }
+                    Entry::Occupied(mut entry) => {
+                        let target = entry.get_mut();
+                        target.last_access = frame_id;
+                        target.fbo_id
+                    }
+                };
+                let task = render_tasks.get(output.task_id);
+                let (src_rect, _) = task.get_target_rect();
+                let dest_rect = DeviceIntRect::new(DeviceIntPoint::zero(), output_size);
+                device.bind_read_target(render_target);
+                device.bind_external_draw_target(fbo_id);
+                device.blit_render_target(src_rect, dest_rect);
+                handler.unlock(output.pipeline_id);
+            }
         }
     }
 
@@ -2559,7 +2613,8 @@ impl Renderer {
 
     fn draw_tile_frame(&mut self,
                        frame: &mut Frame,
-                       framebuffer_size: &DeviceUintSize) {
+                       framebuffer_size: &DeviceUintSize,
+                       frame_id: FrameId) {
         let _gm = GpuMarker::new(self.device.rc_gl(), "tile frame draw");
 
         // Some tests use a restricted viewport smaller than the main screen size.
@@ -2628,7 +2683,8 @@ impl Renderer {
                                            *size,
                                            clear_color,
                                            &frame.render_tasks,
-                                           &projection);
+                                           &projection,
+                                           frame_id);
 
                 }
 
@@ -2652,6 +2708,17 @@ impl Renderer {
             self.alpha_render_targets.reverse();
             self.draw_render_target_debug(framebuffer_size);
             self.draw_texture_cache_debug(framebuffer_size);
+
+            // Garbage collect any frame outputs that weren't used this frame.
+            let device = &mut self.device;
+            self.output_targets.retain(|_, target| {
+                if target.last_access != frame_id {
+                    device.delete_fbo(target.fbo_id);
+                    true
+                } else {
+                    false
+                }
+            });
         }
 
         self.unlock_external_images();
@@ -2691,17 +2758,18 @@ impl Renderer {
         }
 
         for (i, texture) in self.color_render_targets.iter().chain(self.alpha_render_targets.iter()).enumerate() {
+            let dimensions = texture.get_dimensions();
+            let src_rect = DeviceIntRect::new(DeviceIntPoint::zero(),
+                                              dimensions.to_i32());
+
             let layer_count = texture.get_render_target_layer_count();
             for layer_index in 0..layer_count {
+                self.device.bind_read_target(Some((texture, layer_index as i32)));
                 let x = fb_width - (spacing + size) * (i as i32 + 1);
                 let y = spacing;
 
                 let dest_rect = rect(x, y, size, size);
-                self.device.blit_render_target(
-                    Some((texture, layer_index as i32)),
-                    None,
-                    dest_rect
-                );
+                self.device.blit_render_target(src_rect, dest_rect);
             }
         }
     }
@@ -2731,9 +2799,15 @@ impl Renderer {
         let mut i = 0;
         for texture in &self.texture_resolver.cache_texture_map {
             let y = spacing + if self.debug_flags.contains(RENDER_TARGET_DBG) { 528 } else { 0 };
+            let dimensions = texture.get_dimensions();
+            let src_rect = DeviceIntRect::new(DeviceIntPoint::zero(),
+                                              DeviceIntSize::new(dimensions.width as i32,
+                                                                 dimensions.height as i32));
 
             let layer_count = texture.get_layer_count();
             for layer_index in 0..layer_count {
+                self.device.bind_read_target(Some((texture, layer_index)));
+
                 let x = fb_width - (spacing + size) * (i as i32 + 1);
 
                 // If we have more targets than fit on one row in screen, just early exit.
@@ -2742,7 +2816,7 @@ impl Renderer {
                 }
 
                 let dest_rect = rect(x, y, size, size);
-                self.device.blit_render_target(Some((texture, layer_index)), None, dest_rect);
+                self.device.blit_render_target(src_rect, dest_rect);
                 i += 1;
             }
         }
@@ -2817,6 +2891,9 @@ impl Renderer {
                 shader.deinit(&mut self.device);
             }
         }
+        for (_, target) in self.output_targets {
+            self.device.delete_fbo(target.fbo_id);
+        }
         self.ps_border_corner.deinit(&mut self.device);
         self.ps_border_edge.deinit(&mut self.device);
         self.ps_gradient.deinit(&mut self.device);
@@ -2870,6 +2947,16 @@ pub trait ExternalImageHandler {
     /// Unlock the external image. The WR should not read the image content
     /// after this call.
     fn unlock(&mut self, key: ExternalImageId, channel_index: u8);
+}
+
+/// Allows callers to receive a texture with the contents of a specific
+/// pipeline copied to it. Lock should return the native texture handle
+/// and the size of the texture. Unlock will only be called if the lock()
+/// call succeeds, when WR has issued the GL commands to copy the output
+/// to the texture handle.
+pub trait OutputImageHandler {
+    fn lock(&mut self, pipeline_id: PipelineId) -> Option<(u32, DeviceIntSize)>;
+    fn unlock(&mut self, pipeline_id: PipelineId);
 }
 
 pub struct RendererOptions {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -144,6 +144,7 @@ pub enum DocumentMsg {
     SetPan(DeviceIntPoint),
     SetRootPipeline(PipelineId),
     RemovePipeline(PipelineId),
+    EnableFrameOutput(PipelineId, bool),
     SetWindowParameters {
         window_size: DeviceUintSize,
         inner_rect: DeviceUintRect,
@@ -170,6 +171,7 @@ impl fmt::Debug for DocumentMsg {
             DocumentMsg::TickScrollingBounce => "DocumentMsg::TickScrollingBounce",
             DocumentMsg::GetScrollNodeState(..) => "DocumentMsg::GetScrollNodeState",
             DocumentMsg::GenerateFrame(..) => "DocumentMsg::GenerateFrame",
+            DocumentMsg::EnableFrameOutput(..) => "DocumentMsg::EnableFrameOutput",
         })
     }
 }
@@ -579,6 +581,15 @@ impl RenderApi {
         let (tx, rx) = channel::msg_channel().unwrap();
         self.send(document_id, DocumentMsg::GetScrollNodeState(tx));
         rx.recv().unwrap()
+    }
+
+    /// Enable copying of the output of this pipeline id to
+    /// an external texture for callers to consume.
+    pub fn enable_frame_output(&self,
+                               document_id: DocumentId,
+                               pipeline_id: PipelineId,
+                               enable: bool) {
+        self.send(document_id, DocumentMsg::EnableFrameOutput(pipeline_id, enable));
     }
 
     /// Generate a new frame. Optionally, supply a list of animated


### PR DESCRIPTION
This adds a new feature to WR, that allows copying the output
of a given pipeline ID to an external texture. This is a feature
request from the webvr prototyping team.

The included example demonstrates how to use the API to copy the
output of an iframe to an external texture, which is then copied
onto the screen via custom GL commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1687)
<!-- Reviewable:end -->
