### PR TITLE
Make render task IDs be primitive type specific.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -436,6 +436,7 @@ impl FrameBuilder {
         let prim = TextShadowPrimitiveCpu {
             shadow,
             primitives: Vec::new(),
+            render_task_id: None,
         };
 
         // Create an empty text-shadow primitive. Insert it into
@@ -1207,6 +1208,7 @@ impl FrameBuilder {
                     edge_size,
                     inverted,
                     rects,
+                    render_task_id: None,
                 };
 
                 self.add_primitive(clip_and_scroll,
@@ -1535,16 +1537,7 @@ impl FrameBuilder {
                         let prim_index = PrimitiveIndex(first_prim_index.0 + i);
 
                         if self.prim_store.cpu_bounding_rects[prim_index.0].is_some() {
-                            let prim_metadata = self.prim_store.get_metadata(prim_index);
-
-                            // Add any dynamic render tasks needed to render this primitive
-                            if let Some(render_task_id) = prim_metadata.render_task_id {
-                                current_task.children.push(render_task_id);
-                            }
-                            if let Some(clip_task_id) = prim_metadata.clip_task_id {
-                                current_task.children.push(clip_task_id);
-                            }
-
+                            self.prim_store.add_render_tasks_for_prim(prim_index, &mut current_task);
                             let item = AlphaRenderItem::Primitive(Some(group_index), prim_index, next_z);
                             current_task.as_alpha_batch_mut().items.push(item);
                             next_z += 1;

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -479,7 +479,8 @@ impl AlphaRenderItem {
                         }
                     }
                     PrimitiveKind::TextShadow => {
-                        let cache_task_id = prim_metadata.render_task_id.expect("no render task!");
+                        let text_shadow = &ctx.prim_store.cpu_text_shadows[prim_metadata.cpu_prim_index.0];
+                        let cache_task_id = text_shadow.render_task_id.expect("no render task!");
                         let cache_task_address = render_tasks.get_task_address(cache_task_id);
                         let textures = BatchTextures::render_target_cache();
                         let key = AlphaBatchKey::new(AlphaBatchKind::CacheImage, flags, blend_mode, textures);
@@ -569,7 +570,7 @@ impl AlphaRenderItem {
                     }
                     PrimitiveKind::BoxShadow => {
                         let box_shadow = &ctx.prim_store.cpu_box_shadows[prim_metadata.cpu_prim_index.0];
-                        let cache_task_id = prim_metadata.render_task_id.unwrap();
+                        let cache_task_id = box_shadow.render_task_id.unwrap();
                         let cache_task_address = render_tasks.get_task_address(cache_task_id);
                         let textures = BatchTextures::render_target_cache();
 


### PR DESCRIPTION
This is a small memory saving optimization, since most primitives
don't actually use a render task. The main benefit is making it
simpler for future changes that may contain multiple render tasks
per primitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1688)
<!-- Reviewable:end -->
