### PR TITLE
Handle text runs that need split batches, and reduce allocations.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -74,6 +74,14 @@ impl BatchTextures {
             ]
         }
     }
+
+    pub fn color(texture: SourceTexture) -> Self {
+        BatchTextures {
+            colors: [ texture,
+                      SourceTexture::Invalid,
+                      SourceTexture::Invalid ]
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -121,12 +121,16 @@ pub enum PrimitiveKind {
 
 impl GpuCacheHandle {
     pub fn as_int(&self, gpu_cache: &GpuCache) -> i32 {
-        let address = gpu_cache.get_address(self);
+        gpu_cache.get_address(self).as_int()
+    }
+}
 
+impl GpuCacheAddress {
+    pub fn as_int(&self) -> i32 {
         // TODO(gw): Temporarily encode GPU Cache addresses as a single int.
         //           In the future, we can change the PrimitiveInstance struct
         //           to use 2x u16 for the vertex attribute instead of an i32.
-        address.v as i32 * MAX_VERTEX_TEXTURE_WIDTH as i32 + address.u as i32
+        self.v as i32 * MAX_VERTEX_TEXTURE_WIDTH as i32 + self.u as i32
     }
 }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1668,7 +1668,9 @@ impl Renderer {
 
                     debug_target.add(debug_server::BatchKind::Cache, "Vertical Blur", target.vertical_blurs.len());
                     debug_target.add(debug_server::BatchKind::Cache, "Horizontal Blur", target.horizontal_blurs.len());
-                    debug_target.add(debug_server::BatchKind::Cache, "Text Shadow", target.text_run_cache_prims.len());
+                    for (_, batch) in &target.text_run_cache_prims {
+                        debug_target.add(debug_server::BatchKind::Cache, "Text Shadow", batch.len());
+                    }
                     debug_target.add(debug_server::BatchKind::Cache, "Lines", target.line_cache_prims.len());
 
                     for batch in target.alpha_batcher
@@ -2227,9 +2229,11 @@ impl Renderer {
 
             let _gm = self.gpu_profile.add_marker(GPU_TAG_CACHE_TEXT_RUN);
             self.cs_text_run.bind(&mut self.device, projection, &mut self.renderer_errors);
-            self.draw_instanced_batch(&target.text_run_cache_prims,
-                                      VertexArrayKind::Primitive,
-                                      &target.text_run_textures);
+            for (texture_id, instances) in &target.text_run_cache_prims {
+                self.draw_instanced_batch(instances,
+                                          VertexArrayKind::Primitive,
+                                          &BatchTextures::color(*texture_id));
+            }
         }
         if !target.line_cache_prims.is_empty() {
             // TODO(gw): Technically, we don't need blend for solid

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -17,7 +17,7 @@ use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKey, RenderTaskKind
 use render_task::{RenderTaskLocation, RenderTaskTree};
 use renderer::BlendMode;
 use renderer::ImageBufferKind;
-use resource_cache::ResourceCache;
+use resource_cache::{GlyphFetchResult, ResourceCache};
 use std::{f32, i32, usize};
 use texture_allocator::GuillotineAllocator;
 use util::{TransformedRect, TransformedRectKind};
@@ -243,6 +243,7 @@ impl BatchList {
 pub struct AlphaBatcher {
     pub batch_list: BatchList,
     tasks: Vec<RenderTaskId>,
+    glyph_fetch_buffer: Vec<GlyphFetchResult>,
 }
 
 impl AlphaRenderItem {
@@ -253,7 +254,8 @@ impl AlphaRenderItem {
                     render_tasks: &RenderTaskTree,
                     task_id: RenderTaskId,
                     task_address: RenderTaskAddress,
-                    deferred_resolves: &mut Vec<DeferredResolve>) {
+                    deferred_resolves: &mut Vec<DeferredResolve>,
+                    glyph_fetch_buffer: &mut Vec<GlyphFetchResult>) {
         match *self {
             AlphaRenderItem::Blend(stacking_context_index, src_id, filter, z) => {
                 let stacking_context = &ctx.stacking_context_store[stacking_context_index.0];
@@ -454,20 +456,14 @@ impl AlphaRenderItem {
                     PrimitiveKind::TextRun => {
                         let text_cpu = &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
 
-                        // TODO(gw): avoid / recycle this allocation in the future.
-                        let mut instances = Vec::new();
-
                         let mut font = text_cpu.font.clone();
                         font.size = font.size.scale_by(ctx.device_pixel_ratio);
 
-                        let texture_id = ctx.resource_cache.get_glyphs(font,
-                                                                       &text_cpu.glyph_keys,
-                                                                       |index, handle| {
-                            let uv_address = handle.as_int(gpu_cache);
-                            instances.push(base_instance.build(index as i32, uv_address, 0));
-                        });
-
-                        if texture_id != SourceTexture::Invalid {
+                        ctx.resource_cache.fetch_glyphs(font,
+                                                        &text_cpu.glyph_keys,
+                                                        glyph_fetch_buffer,
+                                                        gpu_cache,
+                                                        |texture_id, glyphs| {
                             let textures = BatchTextures {
                                 colors: [texture_id, SourceTexture::Invalid, SourceTexture::Invalid],
                             };
@@ -475,8 +471,12 @@ impl AlphaRenderItem {
                             let key = AlphaBatchKey::new(AlphaBatchKind::TextRun, flags, blend_mode, textures);
                             let batch = batch_list.get_suitable_batch(&key, item_bounding_rect);
 
-                            batch.extend_from_slice(&instances);
-                        }
+                            for glyph in glyphs {
+                                batch.push(base_instance.build(glyph.index_in_text_run,
+                                                               glyph.uv_rect_address.as_int(),
+                                                               0));
+                            }
+                        });
                     }
                     PrimitiveKind::TextShadow => {
                         let text_shadow = &ctx.prim_store.cpu_text_shadows[prim_metadata.cpu_prim_index.0];
@@ -612,6 +612,7 @@ impl AlphaBatcher {
         AlphaBatcher {
             tasks: Vec::new(),
             batch_list: BatchList::new(),
+            glyph_fetch_buffer: Vec::new(),
         }
     }
 
@@ -636,7 +637,8 @@ impl AlphaBatcher {
                                   render_tasks,
                                   task_id,
                                   task_address,
-                                  deferred_resolves);
+                                  deferred_resolves,
+                                  &mut self.glyph_fetch_buffer);
             }
         }
 
@@ -904,21 +906,14 @@ impl<T: RenderTarget> RenderTargetList<T> {
 pub struct ColorRenderTarget {
     pub alpha_batcher: AlphaBatcher,
     // List of text runs to be cached to this render target.
-    // TODO(gw): For now, assume that these all come from
-    //           the same source texture id. This is almost
-    //           always true except for pathological test
-    //           cases with more than 4k x 4k of unique
-    //           glyphs visible. Once the future glyph / texture
-    //           cache changes land, this restriction will
-    //           be removed anyway.
-    pub text_run_cache_prims: Vec<PrimitiveInstance>,
+    pub text_run_cache_prims: FastHashMap<SourceTexture, Vec<PrimitiveInstance>>,
     pub line_cache_prims: Vec<PrimitiveInstance>,
-    pub text_run_textures: BatchTextures,
     // List of blur operations to apply for this render target.
     pub vertical_blurs: Vec<BlurCommand>,
     pub horizontal_blurs: Vec<BlurCommand>,
     pub readbacks: Vec<DeviceIntRect>,
     allocator: TextureAllocator,
+    glyph_fetch_buffer: Vec<GlyphFetchResult>,
 }
 
 impl RenderTarget for ColorRenderTarget {
@@ -929,13 +924,13 @@ impl RenderTarget for ColorRenderTarget {
     fn new(size: DeviceUintSize) -> ColorRenderTarget {
         ColorRenderTarget {
             alpha_batcher: AlphaBatcher::new(),
-            text_run_cache_prims: Vec::new(),
+            text_run_cache_prims: FastHashMap::default(),
             line_cache_prims: Vec::new(),
-            text_run_textures: BatchTextures::no_texture(),
             vertical_blurs: Vec::new(),
             horizontal_blurs: Vec::new(),
             readbacks: Vec::new(),
             allocator: TextureAllocator::new(size),
+            glyph_fetch_buffer: Vec::new(),
         }
     }
 
@@ -994,9 +989,6 @@ impl RenderTarget for ColorRenderTarget {
                     PrimitiveKind::TextShadow => {
                         let prim = &ctx.prim_store.cpu_text_shadows[prim_metadata.cpu_prim_index.0];
 
-                        // todo(gw): avoid / recycle this allocation...
-                        let mut instances = Vec::new();
-
                         let task_index = render_tasks.get_task_address(task_id);
 
                         for sub_prim_index in &prim.primitives {
@@ -1014,33 +1006,26 @@ impl RenderTarget for ColorRenderTarget {
                                     // the parent text-shadow prim address as a user data field, allowing
                                     // the shader to fetch the text-shadow parameters.
                                     let text = &ctx.prim_store.cpu_text_runs[sub_metadata.cpu_prim_index.0];
+                                    let text_run_cache_prims = &mut self.text_run_cache_prims;
 
                                     let mut font = text.font.clone();
                                     font.size = font.size.scale_by(ctx.device_pixel_ratio);
                                     font.render_mode = text.shadow_render_mode;
 
-                                    let texture_id = ctx.resource_cache.get_glyphs(font,
-                                                                                   &text.glyph_keys,
-                                                                                   |index, handle| {
-                                        let uv_address = handle.as_int(gpu_cache);
-                                        instances.push(instance.build(index as i32,
-                                                                      uv_address,
+                                    ctx.resource_cache.fetch_glyphs(font,
+                                                                    &text.glyph_keys,
+                                                                    &mut self.glyph_fetch_buffer,
+                                                                    gpu_cache,
+                                                                    |texture_id, glyphs| {
+                                        let batch = text_run_cache_prims.entry(texture_id)
+                                                                        .or_insert(Vec::new());
+
+                                        for glyph in glyphs {
+                                            batch.push(instance.build(glyph.index_in_text_run,
+                                                                      glyph.uv_rect_address.as_int(),
                                                                       prim_address));
+                                        }
                                     });
-
-                                    if texture_id != SourceTexture::Invalid {
-                                        let textures = BatchTextures {
-                                            colors: [texture_id, SourceTexture::Invalid, SourceTexture::Invalid],
-                                        };
-
-                                        self.text_run_cache_prims.extend_from_slice(&instances);
-                                        instances.clear();
-
-                                        debug_assert!(textures.colors[0] != SourceTexture::Invalid);
-                                        debug_assert!(self.text_run_textures.colors[0] == SourceTexture::Invalid ||
-                                                      self.text_run_textures.colors[0] == textures.colors[0]);
-                                        self.text_run_textures = textures;
-                                    }
                                 }
                                 PrimitiveKind::Line => {
                                     self.line_cache_prims.push(instance.build(prim_address, 0, 0));

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -15,4 +15,4 @@
 == decorations.yaml decorations-ref.yaml
 fuzzy(1,100) == decorations-suite.yaml decorations-suite.png
 == 1658.yaml 1658-ref.yaml
-
+== split-batch.yaml split-batch-ref.yaml

--- a/wrench/reftests/text/split-batch-ref.yaml
+++ b/wrench/reftests/text/split-batch-ref.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+    -
+      type: "text-shadow"
+      bounds: [0, 0, 650, 670]
+      blur-radius: 2
+      offset: [10, 10]
+      color: black
+    -
+      bounds: [0, 0, 650, 670]
+      glyphs: [55, 45]
+      offsets: [20, 500, 400, 500]
+      size: 500
+      color: [255, 0, 0, 1]
+      font: "VeraBd.ttf"
+    -
+      type: "pop-text-shadow"

--- a/wrench/reftests/text/split-batch.yaml
+++ b/wrench/reftests/text/split-batch.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+    -
+      type: "text-shadow"
+      bounds: [0, 0, 650, 670]
+      blur-radius: 2
+      offset: [10, 10]
+      color: black
+    -
+      bounds: [0, 0, 650, 670]
+      glyphs: [55, 45]
+      offsets: [20, 500, 400, 500]
+      size: 500
+      color: [255, 0, 0, 1]
+      font: "VeraBd.ttf"
+    -
+      type: "pop-text-shadow"


### PR DESCRIPTION
Previously, both the normal text run and text shadow code assumed
that all the glyphs in a single text run were placed in the same
texture. This is generally true, but not *always*. In particular,
a text run that contains a glyph that fits in the texture cache, and
one that is too large for the texture cache would trigger this condition.

Now, create a text shadow batch per texture ID. For normal text runs,
flush and create a new batch each time a glyph is encountered that
belongs to a different source texture.

Also, remove an allocation per text run by using a shared buffer
to store glyphs as they are fetched for a text run. This is a bit
untidy - the caller must provide the fetch buffer since the resource
cache is considered immutable at this point (batching may be
spread across threads in the future). However, since this is such
a hot code path on most pages, it's worth it (typically a 10% CPU
time saving on pages I tested).

The reftests just need to not crash - the content is identical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1689)
<!-- Reviewable:end -->
