### PR TITLE
Use strong types for instance vertex structures, and fix some inconsistencies.

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -10,29 +10,29 @@
 #define SEGMENT_CORNER_BL   3
 #define SEGMENT_CORNER_BR   4
 
-in int aClipRenderTaskIndex;
-in int aClipLayerIndex;
+in int aClipRenderTaskAddress;
+in int aClipLayerAddress;
 in int aClipSegment;
 in ivec4 aClipDataResourceAddress;
 
-struct CacheClipInstance {
-    int render_task_index;
-    int layer_index;
+struct ClipMaskInstance {
+    int render_task_address;
+    int layer_address;
     int segment;
     ivec2 clip_data_address;
     ivec2 resource_address;
 };
 
-CacheClipInstance fetch_clip_item(int index) {
-    CacheClipInstance cci;
+ClipMaskInstance fetch_clip_item() {
+    ClipMaskInstance cmi;
 
-    cci.render_task_index = aClipRenderTaskIndex;
-    cci.layer_index = aClipLayerIndex;
-    cci.segment = aClipSegment;
-    cci.clip_data_address = aClipDataResourceAddress.xy;
-    cci.resource_address = aClipDataResourceAddress.zw;
+    cmi.render_task_address = aClipRenderTaskAddress;
+    cmi.layer_address = aClipLayerAddress;
+    cmi.segment = aClipSegment;
+    cmi.clip_data_address = aClipDataResourceAddress.xy;
+    cmi.resource_address = aClipDataResourceAddress.zw;
 
-    return cci;
+    return cmi;
 }
 
 struct ClipVertexInfo {

--- a/webrender/res/cs_blur.glsl
+++ b/webrender/res/cs_blur.glsl
@@ -17,30 +17,13 @@ flat varying int vBlurRadius;
 #define DIR_HORIZONTAL  0
 #define DIR_VERTICAL    1
 
-in int aBlurRenderTaskIndex;
-in int aBlurSourceTaskIndex;
+in int aBlurRenderTaskAddress;
+in int aBlurSourceTaskAddress;
 in int aBlurDirection;
 
-struct BlurCommand {
-    int task_id;
-    int src_task_id;
-    int dir;
-};
-
-BlurCommand fetch_blur() {
-    BlurCommand blur;
-
-    blur.task_id = aBlurRenderTaskIndex;
-    blur.src_task_id = aBlurSourceTaskIndex;
-    blur.dir = aBlurDirection;
-
-    return blur;
-}
-
 void main(void) {
-    BlurCommand cmd = fetch_blur();
-    RenderTaskData task = fetch_render_task(cmd.task_id);
-    RenderTaskData src_task = fetch_render_task(cmd.src_task_id);
+    RenderTaskData task = fetch_render_task(aBlurRenderTaskAddress);
+    RenderTaskData src_task = fetch_render_task(aBlurSourceTaskAddress);
 
     vec4 local_rect = task.data0;
 
@@ -53,7 +36,7 @@ void main(void) {
     vBlurRadius = int(task.data1.y);
     vSigma = task.data1.y * 0.5;
 
-    switch (cmd.dir) {
+    switch (aBlurDirection) {
         case DIR_HORIZONTAL:
             vOffsetScale = vec2(1.0 / texture_size.x, 0.0);
             break;

--- a/webrender/res/cs_clip_border.vs.glsl
+++ b/webrender/res/cs_clip_border.vs.glsl
@@ -50,15 +50,15 @@ BorderClipDot fetch_border_clip_dot(ivec2 address, int segment) {
 }
 
 void main(void) {
-    CacheClipInstance cci = fetch_clip_item(gl_InstanceID);
-    ClipArea area = fetch_clip_area(cci.render_task_index);
-    Layer layer = fetch_layer(cci.layer_index);
+    ClipMaskInstance cmi = fetch_clip_item();
+    ClipArea area = fetch_clip_area(cmi.render_task_address);
+    Layer layer = fetch_layer(cmi.layer_address);
 
     // Fetch the header information for this corner clip.
-    BorderCorner corner = fetch_border_corner(cci.clip_data_address);
+    BorderCorner corner = fetch_border_corner(cmi.clip_data_address);
     vClipCenter = corner.clip_center;
 
-    if (cci.segment == 0) {
+    if (cmi.segment == 0) {
         // The first segment is used to zero out the border corner.
         vAlphaMask = vec2(0.0);
         vDotParams = vec3(0.0);
@@ -84,7 +84,7 @@ void main(void) {
         switch (corner.clip_mode) {
             case CLIP_MODE_DASH: {
                 // Fetch the information about this particular dash.
-                BorderClipDash dash = fetch_border_clip_dash(cci.clip_data_address, cci.segment);
+                BorderClipDash dash = fetch_border_clip_dash(cmi.clip_data_address, cmi.segment);
                 vPoint_Tangent0 = dash.point_tangent_0 * sign_modifier.xyxy;
                 vPoint_Tangent1 = dash.point_tangent_1 * sign_modifier.xyxy;
                 vDotParams = vec3(0.0);
@@ -92,7 +92,7 @@ void main(void) {
                 break;
             }
             case CLIP_MODE_DOT: {
-                BorderClipDot cdot = fetch_border_clip_dot(cci.clip_data_address, cci.segment);
+                BorderClipDot cdot = fetch_border_clip_dot(cmi.clip_data_address, cmi.segment);
                 vPoint_Tangent0 = vec4(1.0);
                 vPoint_Tangent1 = vec4(1.0);
                 vDotParams = vec3(cdot.center_radius.xy * sign_modifier, cdot.center_radius.z);

--- a/webrender/res/cs_clip_image.vs.glsl
+++ b/webrender/res/cs_clip_image.vs.glsl
@@ -12,17 +12,17 @@ ImageMaskData fetch_mask_data(ivec2 address) {
 }
 
 void main(void) {
-    CacheClipInstance cci = fetch_clip_item(gl_InstanceID);
-    ClipArea area = fetch_clip_area(cci.render_task_index);
-    Layer layer = fetch_layer(cci.layer_index);
-    ImageMaskData mask = fetch_mask_data(cci.clip_data_address);
+    ClipMaskInstance cmi = fetch_clip_item();
+    ClipArea area = fetch_clip_area(cmi.render_task_address);
+    Layer layer = fetch_layer(cmi.layer_address);
+    ImageMaskData mask = fetch_mask_data(cmi.clip_data_address);
     RectWithSize local_rect = mask.local_rect;
-    ImageResource res = fetch_image_resource_direct(cci.resource_address);
+    ImageResource res = fetch_image_resource_direct(cmi.resource_address);
 
     ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
                                                layer,
                                                area,
-                                               cci.segment);
+                                               cmi.segment);
 
     vPos = vi.local_pos;
     vLayer = res.layer;

--- a/webrender/res/cs_clip_rectangle.glsl
+++ b/webrender/res/cs_clip_rectangle.glsl
@@ -54,16 +54,16 @@ ClipData fetch_clip(ivec2 address) {
 }
 
 void main(void) {
-    CacheClipInstance cci = fetch_clip_item(gl_InstanceID);
-    ClipArea area = fetch_clip_area(cci.render_task_index);
-    Layer layer = fetch_layer(cci.layer_index);
-    ClipData clip = fetch_clip(cci.clip_data_address);
+    ClipMaskInstance cmi = fetch_clip_item();
+    ClipArea area = fetch_clip_area(cmi.render_task_address);
+    Layer layer = fetch_layer(cmi.layer_address);
+    ClipData clip = fetch_clip(cmi.clip_data_address);
     RectWithSize local_rect = clip.rect.rect;
 
     ClipVertexInfo vi = write_clip_tile_vertex(local_rect,
                                                layer,
                                                area,
-                                               cci.segment);
+                                               cmi.segment);
     vPos = vi.local_pos;
 
     vClipMode = clip.rect.mode.x;

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -14,3 +14,18 @@ pub struct BoxShadowCacheInstance {
     pub prim_address: GpuCacheAddress,
     pub task_index: RenderTaskAddress,
 }
+
+#[repr(i32)]
+#[derive(Debug)]
+pub enum BlurDirection {
+    Horizontal = 0,
+    Vertical,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct BlurInstance {
+    pub task_address: RenderTaskAddress,
+    pub src_task_address: RenderTaskAddress,
+    pub blur_direction: BlurDirection,
+}

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -4,8 +4,18 @@
 
 use gpu_cache::GpuCacheAddress;
 use render_task::RenderTaskAddress;
+use tiling::PackedLayerIndex;
 
 // Contains type that must exactly match the same structures declared in GLSL.
+
+#[derive(Debug, Copy, Clone)]
+pub struct PackedLayerAddress(i32);
+
+impl From<PackedLayerIndex> for PackedLayerAddress {
+    fn from(index: PackedLayerIndex) -> PackedLayerAddress {
+        PackedLayerAddress(index.0 as i32)
+    }
+}
 
 // Instance structure for box shadows being drawn into target cache.
 #[derive(Debug)]
@@ -28,4 +38,106 @@ pub struct BlurInstance {
     pub task_address: RenderTaskAddress,
     pub src_task_address: RenderTaskAddress,
     pub blur_direction: BlurDirection,
+}
+
+/// A clipping primitive drawn into the clipping mask.
+/// Could be an image or a rectangle, which defines the
+/// way `address` is treated.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct ClipMaskInstance {
+    pub render_task_address: RenderTaskAddress,
+    pub layer_address: PackedLayerAddress,
+    pub segment: i32,
+    pub clip_data_address: GpuCacheAddress,
+    pub resource_address: GpuCacheAddress,
+}
+
+// 32 bytes per instance should be enough for anyone!
+#[derive(Debug, Clone)]
+pub struct PrimitiveInstance {
+    data: [i32; 8],
+}
+
+pub struct SimplePrimitiveInstance {
+    pub specific_prim_address: GpuCacheAddress,
+    pub task_address: RenderTaskAddress,
+    pub clip_task_address: RenderTaskAddress,
+    pub layer_address: PackedLayerAddress,
+    pub z_sort_index: i32,
+}
+
+impl SimplePrimitiveInstance {
+    pub fn new(specific_prim_address: GpuCacheAddress,
+               task_address: RenderTaskAddress,
+               clip_task_address: RenderTaskAddress,
+               layer_address: PackedLayerAddress,
+               z_sort_index: i32) -> SimplePrimitiveInstance {
+        SimplePrimitiveInstance {
+            specific_prim_address,
+            task_address,
+            clip_task_address,
+            layer_address,
+            z_sort_index,
+        }
+    }
+
+    pub fn build(&self, data0: i32, data1: i32, data2: i32) -> PrimitiveInstance {
+        PrimitiveInstance {
+            data: [
+                self.specific_prim_address.as_int(),
+                self.task_address.0 as i32,
+                self.clip_task_address.0 as i32,
+                self.layer_address.0,
+                self.z_sort_index,
+                data0,
+                data1,
+                data2,
+            ]
+        }
+    }
+}
+
+pub struct CompositePrimitiveInstance {
+    pub task_address: RenderTaskAddress,
+    pub src_task_address: RenderTaskAddress,
+    pub backdrop_task_address: RenderTaskAddress,
+    pub data0: i32,
+    pub data1: i32,
+    pub z: i32,
+}
+
+impl CompositePrimitiveInstance {
+    pub fn new(task_address: RenderTaskAddress,
+               src_task_address: RenderTaskAddress,
+               backdrop_task_address: RenderTaskAddress,
+               data0: i32,
+               data1: i32,
+               z: i32) -> CompositePrimitiveInstance {
+        CompositePrimitiveInstance {
+            task_address,
+            src_task_address,
+            backdrop_task_address,
+            data0,
+            data1,
+            z,
+        }
+    }
+}
+
+impl From<CompositePrimitiveInstance> for PrimitiveInstance {
+    fn from(instance: CompositePrimitiveInstance) -> PrimitiveInstance {
+        PrimitiveInstance {
+            data: [
+                instance.task_address.0 as i32,
+                instance.src_task_address.0 as i32,
+                instance.backdrop_task_address.0 as i32,
+                instance.z,
+                instance.data0,
+                instance.data1,
+                0,
+                0,
+            ]
+        }
+    }
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -18,6 +18,7 @@ const FLOATS_PER_RENDER_TASK_INFO: usize = 12;
 pub struct RenderTaskId(pub u32);       // TODO(gw): Make private when using GPU cache!
 
 #[derive(Debug, Copy, Clone)]
+#[repr(C)]
 pub struct RenderTaskAddress(pub u32);
 
 #[derive(Debug)]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -198,8 +198,8 @@ const DESC_BLUR: VertexDescriptor = VertexDescriptor {
         VertexAttribute { name: "aPosition", count: 2, kind: VertexAttributeKind::F32 },
     ],
     instance_attributes: &[
-        VertexAttribute { name: "aBlurRenderTaskIndex", count: 1, kind: VertexAttributeKind::I32 },
-        VertexAttribute { name: "aBlurSourceTaskIndex", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aBlurRenderTaskAddress", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aBlurSourceTaskAddress", count: 1, kind: VertexAttributeKind::I32 },
         VertexAttribute { name: "aBlurDirection", count: 1, kind: VertexAttributeKind::I32 },
     ]
 };

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -25,6 +25,7 @@ use euclid::{Transform3D, rect};
 use frame_builder::FrameBuilderConfig;
 use gleam::gl;
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
+use gpu_types::{PrimitiveInstance};
 use internal_types::{FastHashMap, CacheTextureId, RendererFrame, ResultMsg, TextureUpdateOp};
 use internal_types::{DebugOutput, TextureUpdateList, RenderTargetMode, TextureUpdateSource};
 use internal_types::{BatchTextures, ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE, SourceTexture};
@@ -49,7 +50,7 @@ use texture_cache::TextureCache;
 use rayon::ThreadPool;
 use rayon::Configuration as ThreadPoolConfig;
 use tiling::{AlphaBatchKey, AlphaBatchKind, Frame, RenderTarget};
-use tiling::{AlphaRenderTarget, PrimitiveInstance, ColorRenderTarget, RenderTargetKind};
+use tiling::{AlphaRenderTarget, ColorRenderTarget, RenderTargetKind};
 use time::precise_time_ns;
 use thread_profiler::{register_thread_with_profiler, write_profile};
 use util::TransformedRectKind;
@@ -209,8 +210,8 @@ const DESC_CLIP: VertexDescriptor = VertexDescriptor {
         VertexAttribute { name: "aPosition", count: 2, kind: VertexAttributeKind::F32 },
     ],
     instance_attributes: &[
-        VertexAttribute { name: "aClipRenderTaskIndex", count: 1, kind: VertexAttributeKind::I32 },
-        VertexAttribute { name: "aClipLayerIndex", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aClipRenderTaskAddress", count: 1, kind: VertexAttributeKind::I32 },
+        VertexAttribute { name: "aClipLayerAddress", count: 1, kind: VertexAttributeKind::I32 },
         VertexAttribute { name: "aClipSegment", count: 1, kind: VertexAttributeKind::I32 },
         VertexAttribute { name: "aClipDataResourceAddress", count: 4, kind: VertexAttributeKind::U16 },
     ]


### PR DESCRIPTION
This just makes naming a bit more consistent, uses strong types in some of the instance structures, and moves a bit more code out of ```tiling.rs```. The main benefit of using strong types here is to simplify some follow up work to compress these instance fields (e.g. start using u16 instead of i32 where possible, for layer and render task addresses).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1691)
<!-- Reviewable:end -->
