### PR TITLE
Add a debug flag to see alpha primitive rects.

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -9,7 +9,7 @@ use euclid::{Transform3D, Point2D, Size2D, Rect};
 use internal_types::{ORTHO_NEAR_PLANE, ORTHO_FAR_PLANE};
 use internal_types::RenderTargetMode;
 use std::f32;
-use api::{ColorU, ImageFormat, DeviceUintSize};
+use api::{ColorU, ImageFormat, DeviceUintSize, DeviceIntRect};
 
 #[derive(Debug, Copy, Clone)]
 enum DebugSampler {
@@ -237,6 +237,16 @@ impl DebugRenderer {
                     color1: ColorU) {
         self.line_vertices.push(DebugColorVertex::new(x0 as f32, y0 as f32, color0));
         self.line_vertices.push(DebugColorVertex::new(x1 as f32, y1 as f32, color1));
+    }
+
+
+    pub fn add_rect(&mut self, rect: &DeviceIntRect, color: ColorU) {
+        let p0 = rect.origin;
+        let p1 = p0 + rect.size;
+        self.add_line(p0.x, p0.y, color, p1.x, p0.y, color);
+        self.add_line(p1.x, p0.y, color, p1.x, p1.y, color);
+        self.add_line(p1.x, p1.y, color, p0.x, p1.y, color);
+        self.add_line(p0.x, p1.y, color, p0.x, p0.y, color);
     }
 
     pub fn render(&mut self,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -127,6 +127,7 @@ bitflags! {
         const PROFILER_DBG      = 1 << 0;
         const RENDER_TARGET_DBG = 1 << 1;
         const TEXTURE_CACHE_DBG = 1 << 2;
+        const ALPHA_PRIM_DBG    = 1 << 3;
     }
 }
 
@@ -2301,6 +2302,13 @@ impl Renderer {
                         }
                     }
                     prev_blend_mode = batch.key.blend_mode;
+                }
+
+                if self.debug_flags.contains(ALPHA_PRIM_DBG) {
+                    let color = ColorF::new(1.0, 0.0, 0.0, 1.0).into();
+                    for item_rect in &batch.item_rects {
+                        self.debug.add_rect(item_rect, color);
+                    }
                 }
 
                 self.submit_batch(&batch.key,


### PR DESCRIPTION
I extracted @glennw's [quick hack to see alpha primitive rects](https://github.com/glennw/webrender/commit/b5f36cd3a83ce622411c62543393328ef1566ffa) and added it to the debug flags (as ALPHA_PRIM_DBG) because I think this is a useful tool to have.

r? @kvark or @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1692)
<!-- Reviewable:end -->
