### PR TITLE
If the transform contains perspective component, the clip rect don't affect by this transform.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -26,7 +26,8 @@ use renderer::ImageBufferKind;
 use resource_cache::{GlyphFetchResult, ResourceCache};
 use std::{cmp, usize, f32, i32};
 use texture_allocator::GuillotineAllocator;
-use util::{TransformedRect, TransformedRectKind};
+use util::{MatrixHelpers, TransformedRect, TransformedRectKind};
+use euclid::rect;
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.
@@ -1686,7 +1687,13 @@ impl PackedLayer {
         screen_rect: &DeviceIntRect,
         device_pixel_ratio: f32,
     ) -> Option<(TransformedRectKind, DeviceIntRect)> {
-        self.local_clip_rect = *local_rect;
+        self.local_clip_rect = if self.transform.has_perspective_component() {
+            // Given a very large rect which means any rect would be inside this rect.
+            // That is, nothing would be clipped.
+            rect(f32::MIN / 2.0, f32::MIN / 2.0, f32::MAX, f32::MAX)
+        } else {
+            *local_rect
+        };
         let xf_rect = TransformedRect::new(local_rect, &self.transform, device_pixel_ratio);
         xf_rect
             .bounding_rect

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -17,6 +17,7 @@ pub trait MatrixHelpers<Src, Dst> {
     fn transform_rect(&self, rect: &TypedRect<f32, Src>) -> TypedRect<f32, Dst>;
     fn is_identity(&self) -> bool;
     fn preserves_2d_axis_alignment(&self) -> bool;
+    fn has_perspective_component(&self) -> bool;
     fn inverse_project(&self, target: &TypedPoint2D<f32, Dst>) -> Option<TypedPoint2D<f32, Src>>;
     fn inverse_rect_footprint(&self, rect: &TypedRect<f32, Dst>) -> TypedRect<f32, Src>;
 }
@@ -64,6 +65,10 @@ impl<Src, Dst> MatrixHelpers<Src, Dst> for TypedTransform3D<f32, Src, Dst> {
         }
 
         col0 < 2 && col1 < 2 && row0 < 2 && row1 < 2
+    }
+
+    fn has_perspective_component(&self) -> bool {
+         self.m14 != 0.0 || self.m24 != 0.0 || self.m34 != 0.0 || self.m44 != 1.0
     }
 
     fn inverse_project(&self, target: &TypedPoint2D<f32, Dst>) -> Option<TypedPoint2D<f32, Src>> {

--- a/wrench/reftests/split/perspective-clipping-ref.yaml
+++ b/wrench/reftests/split/perspective-clipping-ref.yaml
@@ -1,0 +1,9 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: 0 0 1024 768
+      items:
+        - type: rect
+          bounds: 0 0 1024 768
+          color: green

--- a/wrench/reftests/split/perspective-clipping.yaml
+++ b/wrench/reftests/split/perspective-clipping.yaml
@@ -1,0 +1,22 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: 0 0 1024 768
+      items:
+        - type: rect
+          bounds: 0 0 1024 768
+          color: red
+        - type: stacking-context
+          bounds: 0 0 1024 768
+          transform-style: preserve-3d
+          perspective: 300
+          items:
+            - type: stacking-context
+              bounds: 0 0 1024 768
+              # translate-Z(-300) scale(2)
+              transform: 2 0 0 0 0 2 0 0 0 0 2 0 0 0 -300 1
+              items:
+                - type: rect
+                  bounds: 0 0 1024 768
+                  color: green

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -2,4 +2,5 @@
 == order.yaml order-ref.yaml
 == nested.yaml nested-ref.yaml
 == nested-preserve3d-crash.yaml nested-preserve3d-crash.yaml
+== perspective-clipping.yaml perspective-clipping-ref.yaml
 #== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences


### PR DESCRIPTION
When calculating the LCCR. If current transform or parent transform has
perspective component, then we shouldn't transform the LCCR by this
transform because we only consider 2d component for LCCR. Once the
perspective component is presence, the LCCR would be wrong.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1693)
<!-- Reviewable:end -->
