### PR TITLE
Gate builds on travis + rust nightly again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: rust
 rust:
   - 1.19.0
   - nightly
-matrix:
-  allow_failures:
-  - rust: nightly
 os:
   - linux
   - osx


### PR DESCRIPTION
The other CI related changes I landed earlier to update OSMesa
appear to have also resolved the failures we were seeing when
building with nightly rustc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1698)
<!-- Reviewable:end -->
