### PR TITLE
Improvements to the alpha rects debugging options.

### DIFF
--- a/debugger/js/app.js
+++ b/debugger/js/app.js
@@ -140,6 +140,13 @@ Vue.component('options', {
                 connection.send("disable_render_target_debug");
             }
         }
+        setAlphaRectsDebugger(enabled) {
+            if (enabled) {
+                connection.send("enable_alpha_rects_debug");
+            } else {
+                connection.send("disable_alpha_rects_debug");
+            }
+        }
     },
     template: `
         <div class="box">
@@ -159,6 +166,12 @@ Vue.component('options', {
                 <label class="checkbox">
                     <input type="checkbox" v-on:click="setRenderTargetDebugger($event.target.checked)">
                     Render target debugger
+                </label>
+            </div>
+            <div class="field">
+                <label class="checkbox">
+                    <input type="checkbox" v-on:click="setAlphaRectsDebugger($event.target.checked)">
+                    Alpha primitive rects debugger
                 </label>
             </div>
         </div>

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -184,6 +184,12 @@ pub fn main_wrapper(example: &mut Example,
                     renderer.set_debug_flags(flags);
                 }
                 glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
+                                             _, Some(glutin::VirtualKeyCode::B)) => {
+                    let mut flags = renderer.get_debug_flags();
+                    flags.toggle(webrender::ALPHA_PRIM_DBG);
+                    renderer.set_debug_flags(flags);
+                }
+                glutin::Event::KeyboardInput(glutin::ElementState::Pressed,
                                              _, Some(glutin::VirtualKeyCode::M)) => {
                     api.notify_memory_pressure();
                 }

--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -60,6 +60,12 @@ impl ws::Handler for Server {
                     "disable_render_target_debug" => {
                         DebugCommand::EnableRenderTargetDebug(false)
                     }
+                    "enable_alpha_rects_debug" => {
+                        DebugCommand::EnableAlphaRectsDebug(true)
+                    }
+                    "disable_alpha_rects_debug" => {
+                        DebugCommand::EnableAlphaRectsDebug(false)
+                    }
                     "fetch_passes" => {
                         DebugCommand::FetchPasses
                     }
@@ -109,7 +115,9 @@ impl DebugServer {
         let broadcaster = socket.broadcaster();
 
         let join_handle = Some(thread::spawn(move || {
-            if let Err(..) = socket.listen("127.0.0.1:3583") {
+            let address = "127.0.0.1:3583";
+            println!("WebRender debug server started: {}", address);
+            if let Err(..) = socket.listen(address) {
                 println!("ERROR: Unable to bind debugger websocket (port may be in use).");
             }
         }));

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -149,7 +149,8 @@ extern crate gamma_lut;
 pub use renderer::{ExternalImage, ExternalImageSource, ExternalImageHandler};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, ReadPixelsFormat, Renderer, RendererOptions};
 pub use renderer::{CpuProfile, GpuProfile, DebugFlags, OutputImageHandler, RendererKind};
-pub use renderer::{MAX_VERTEX_TEXTURE_WIDTH, PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG};
+pub use renderer::{PROFILER_DBG, RENDER_TARGET_DBG, TEXTURE_CACHE_DBG, ALPHA_PRIM_DBG};
+pub use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 
 pub use webrender_api as api;
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2327,7 +2327,12 @@ impl Renderer {
                 }
 
                 if self.debug_flags.contains(ALPHA_PRIM_DBG) {
-                    let color = ColorF::new(1.0, 0.0, 0.0, 1.0).into();
+                    let color = match batch.key.blend_mode {
+                        BlendMode::None => ColorF::new(0.3, 0.3, 0.3, 1.0),
+                        BlendMode::Alpha => ColorF::new(0.0, 0.9, 0.1, 1.0),
+                        BlendMode::PremultipliedAlpha => ColorF::new(0.0, 0.3, 0.7, 1.0),
+                        BlendMode::Subpixel(_) => ColorF::new(0.5, 0.0, 0.4, 1.0),
+                    }.into();
                     for item_rect in &batch.item_rects {
                         self.debug.add_rect(item_rect, color);
                     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1740,6 +1740,13 @@ impl Renderer {
                     self.debug_flags.remove(RENDER_TARGET_DBG);
                 }
             }
+            DebugCommand::EnableAlphaRectsDebug(enable) => {
+                if enable {
+                    self.debug_flags.insert(ALPHA_PRIM_DBG);
+                } else {
+                    self.debug_flags.remove(ALPHA_PRIM_DBG);
+                }
+            }
             DebugCommand::FetchDocuments => {}
             DebugCommand::FetchClipScrollTree => {}
             DebugCommand::FetchPasses => {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -184,6 +184,8 @@ pub enum DebugCommand {
     EnableTextureCacheDebug(bool),
     // Display intermediate render targets on screen.
     EnableRenderTargetDebug(bool),
+    // Display alpha primitive rects.
+    EnableAlphaRectsDebug(bool),
     // Fetch current documents and display lists.
     FetchDocuments,
     // Fetch current passes and batches.

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -539,6 +539,11 @@ fn main() {
                         flags.toggle(webrender::TEXTURE_CACHE_DBG);
                         wrench.renderer.set_debug_flags(flags);
                     },
+                    VirtualKeyCode::B => {
+                        let mut flags = wrench.renderer.get_debug_flags();
+                        flags.toggle(webrender::ALPHA_PRIM_DBG);
+                        wrench.renderer.set_debug_flags(flags);
+                    },
                     VirtualKeyCode::M => {
                         wrench.api.notify_memory_pressure();
                     },

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -461,6 +461,7 @@ impl Wrench {
             "P - Toggle profiler",
             "O - Toggle showing intermediate targets",
             "I - Toggle showing texture caches",
+            "B - Toggle showing alpha primitive rects",
             "M - Trigger memory pressure event",
         ];
 


### PR DESCRIPTION
This is a followup from #1692.

 - Adds difference colors for each blend mode.
 - Adds keys to toggle the ALPHA_PRIM_DBG debug flag in wrench and the examples.
 - Exposes the flag to the debug server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1700)
<!-- Reviewable:end -->
