### PR TITLE
support font variations for font instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ addons:
       - libedit-dev
       - python
 env:
-  - BUILD_KIND=DEBUG RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
-  - BUILD_KIND=RELEASE RUST_BACKTRACE=1 RUSTFLAGS='--deny warnings'
+  - BUILD_KIND=DEBUG RUST_BACKTRACE=1
+  - BUILD_KIND=RELEASE RUST_BACKTRACE=1
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zlib; fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.50.0",
+ "webrender 0.51.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1037,13 +1037,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "angle 0.5.0 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1064,13 +1065,13 @@ dependencies = [
  "servo-glutin 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.50.0",
+ "webrender_api 0.51.0",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
@@ -46,6 +46,7 @@ dwrote = "0.4"
 gamma-lut = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.3"
 core-graphics = "0.8.0"
 core-text = { version = "6.1", default-features = false }
 gamma-lut = "0.2"

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -256,7 +256,7 @@ impl Example for App {
             resources.add_raw_font(font_key, font_bytes, 0);
 
             let font_instance_key = api.generate_font_instance_key();
-            resources.add_font_instance(font_instance_key, font_key, Au::from_px(32), None, None);
+            resources.add_font_instance(font_instance_key, font_key, Au::from_px(32), None, None, Vec::new());
 
             let text_bounds = (100, 200).by(700, 300);
             let glyphs = vec![

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1064,6 +1064,7 @@ impl FrameBuilder {
             normal_render_mode,
             subpx_dir,
             font.platform_options,
+            font.variations.clone(),
         );
         let prim = TextRunPrimitiveCpu {
             font: prim_font,

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -410,6 +410,7 @@ fn raterize_200_glyphs() {
         FontRenderMode::Subpixel,
         SubpixelDirection::Horizontal,
         None,
+        Vec::new(),
     );
 
     let mut glyph_keys = Vec::with_capacity(200);

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -113,6 +113,8 @@ mod platform {
 }
 
 #[cfg(target_os = "macos")]
+extern crate core_foundation;
+#[cfg(target_os = "macos")]
 extern crate core_graphics;
 #[cfg(target_os = "macos")]
 extern crate core_text;

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -3,18 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{ColorU, FontKey, FontRenderMode, GlyphDimensions};
-use api::{FontInstance, NativeFontHandle};
+use api::{FontInstance, FontVariation, NativeFontHandle};
 use api::GlyphKey;
 use app_units::Au;
+use core_foundation::array::{CFArray, CFArrayRef};
+use core_foundation::base::TCFType;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::number::{CFNumber, CFNumberRef};
+use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::base::{kCGImageAlphaNoneSkipFirst, kCGImageAlphaPremultipliedLast};
 use core_graphics::base::kCGBitmapByteOrder32Little;
 use core_graphics::color_space::CGColorSpace;
 use core_graphics::context::{CGContext, CGTextDrawingMode};
 use core_graphics::data_provider::CGDataProvider;
-use core_graphics::font::{CGFont, CGGlyph};
+use core_graphics::font::{CGFont, CGFontRef, CGGlyph};
 use core_graphics::geometry::{CGPoint, CGRect, CGSize};
 use core_text;
-use core_text::font::CTFont;
+use core_text::font::{CTFont, CTFontRef};
 use core_text::font_descriptor::kCTFontDefaultOrientation;
 use gamma_lut::{Color as ColorLut, GammaLut};
 use internal_types::FastHashMap;
@@ -24,7 +29,7 @@ use std::sync::Arc;
 
 pub struct FontContext {
     cg_fonts: FastHashMap<FontKey, CGFont>,
-    ct_fonts: FastHashMap<(FontKey, Au), CTFont>,
+    ct_fonts: FastHashMap<(FontKey, Au, Vec<FontVariation>), CTFont>,
     gamma_lut: GammaLut,
 }
 
@@ -147,6 +152,117 @@ fn get_glyph_metrics(
     metrics
 }
 
+#[link(name = "ApplicationServices", kind = "framework")]
+extern {
+    static kCTFontVariationAxisIdentifierKey: CFStringRef;
+    static kCTFontVariationAxisNameKey: CFStringRef;
+    static kCTFontVariationAxisMinimumValueKey: CFStringRef;
+    static kCTFontVariationAxisMaximumValueKey: CFStringRef;
+    static kCTFontVariationAxisDefaultValueKey: CFStringRef;
+
+    fn CTFontCopyVariationAxes(font: CTFontRef) -> CFArrayRef;
+
+    fn CGFontCreateCopyWithVariations(font: CGFontRef, vars: CFDictionaryRef) -> CGFontRef;
+}
+
+fn new_ct_font_with_variations(cg_font: &CGFont, size: Au, variations: &[FontVariation]) -> CTFont {
+    unsafe {
+        let ct_font = core_text::font::new_from_CGFont(cg_font, size.to_f64_px());
+        if variations.is_empty() {
+            return ct_font;
+        }
+        let axes_ref = CTFontCopyVariationAxes(ct_font.as_concrete_TypeRef());
+        if axes_ref.is_null() {
+            return ct_font;
+        }
+        let axes: CFArray = TCFType::wrap_under_create_rule(axes_ref);
+        let mut vals: Vec<(CFString, CFNumber)> = Vec::with_capacity(variations.len() as usize);
+        for axis_ptr in axes.iter() {
+            let axis: CFDictionary = TCFType::wrap_under_get_rule(axis_ptr as CFDictionaryRef);
+            if !axis.instance_of::<CFDictionaryRef, CFDictionary>() {
+                return ct_font;
+            }
+            let tag_val = match axis.find(kCTFontVariationAxisIdentifierKey as *const _) {
+                Some(tag_ptr) => {
+                    let tag: CFNumber = TCFType::wrap_under_get_rule(tag_ptr as CFNumberRef);
+                    if !tag.instance_of::<CFNumberRef, CFNumber>() {
+                        return ct_font;
+                    }
+                    match tag.to_i64() {
+                        Some(val) => val,
+                        None => return ct_font,
+                    }
+                }
+                None => return ct_font,
+            };
+            let mut val = match variations.iter().find(|variation| (variation.tag as i64) == tag_val) {
+                Some(variation) => variation.value as f64,
+                None => continue,
+            };
+
+            let name: CFString = match axis.find(kCTFontVariationAxisNameKey as *const _) {
+                Some(name_ptr) => TCFType::wrap_under_get_rule(name_ptr as CFStringRef),
+                None => return ct_font,
+            };
+            if !name.instance_of::<CFStringRef, CFString>() {
+                return ct_font;
+            }
+
+            let min_val = match axis.find(kCTFontVariationAxisMinimumValueKey as *const _) {
+                Some(min_ptr) => {
+                    let min: CFNumber = TCFType::wrap_under_get_rule(min_ptr as CFNumberRef);
+                    if !min.instance_of::<CFNumberRef, CFNumber>() {
+                        return ct_font;
+                    }
+                    match min.to_f64() {
+                        Some(val) => val,
+                        None => return ct_font,
+                    }
+                }
+                None => return ct_font,
+            };
+            let max_val = match axis.find(kCTFontVariationAxisMaximumValueKey as *const _) {
+                Some(max_ptr) => {
+                    let max: CFNumber = TCFType::wrap_under_get_rule(max_ptr as CFNumberRef);
+                    if !max.instance_of::<CFNumberRef, CFNumber>() {
+                        return ct_font;
+                    }
+                    match max.to_f64() {
+                        Some(val) => val,
+                        None => return ct_font,
+                    }
+                }
+                None => return ct_font,
+            };
+            let def_val = match axis.find(kCTFontVariationAxisDefaultValueKey as *const _) {
+                Some(def_ptr) => {
+                    let def: CFNumber = TCFType::wrap_under_get_rule(def_ptr as CFNumberRef);
+                    if !def.instance_of::<CFNumberRef, CFNumber>() {
+                        return ct_font;
+                    }
+                    match def.to_f64() {
+                        Some(val) => val,
+                        None => return ct_font,
+                    }
+                }
+                None => return ct_font,
+            };
+
+            val = val.max(min_val).min(max_val);
+            if val != def_val {
+                vals.push((name, CFNumber::from_f64(val)));
+            }
+        }
+        if vals.is_empty() {
+            return ct_font;
+        }
+        let vals_dict = CFDictionary::from_CFType_pairs(&vals);
+        let cg_var_font_ref = CGFontCreateCopyWithVariations(cg_font.as_concrete_TypeRef(), vals_dict.as_concrete_TypeRef());
+        let cg_var_font: CGFont = TCFType::wrap_under_create_rule(cg_var_font_ref);
+        core_text::font::new_from_CGFont(&cg_var_font, size.to_f64_px())
+    }
+}
+
 impl FontContext {
     pub fn new() -> FontContext {
         debug!("Test for subpixel AA support: {}", supports_subpixel_aa());
@@ -204,15 +320,20 @@ impl FontContext {
         }
     }
 
-    fn get_ct_font(&mut self, font_key: FontKey, size: Au) -> Option<CTFont> {
-        match self.ct_fonts.entry(((font_key).clone(), size)) {
+    fn get_ct_font(
+        &mut self,
+        font_key: FontKey,
+        size: Au,
+        variations: &[FontVariation],
+    ) -> Option<CTFont> {
+        match self.ct_fonts.entry((font_key, size, variations.to_vec())) {
             Entry::Occupied(entry) => Some((*entry.get()).clone()),
             Entry::Vacant(entry) => {
                 let cg_font = match self.cg_fonts.get(&font_key) {
                     None => return None,
                     Some(cg_font) => cg_font,
                 };
-                let ct_font = core_text::font::new_from_CGFont(cg_font, size.to_f64_px());
+                let ct_font = new_ct_font_with_variations(cg_font, size, variations);
                 entry.insert(ct_font.clone());
                 Some(ct_font)
             }
@@ -223,7 +344,7 @@ impl FontContext {
         let character = ch as u16;
         let mut glyph = 0;
 
-        self.get_ct_font(font_key, Au(16 * 60))
+        self.get_ct_font(font_key, Au(16 * 60), &[])
             .and_then(|ref ct_font| {
                 let result = ct_font.get_glyphs_for_characters(&character, &mut glyph, 1);
 
@@ -240,7 +361,7 @@ impl FontContext {
         font: &FontInstance,
         key: &GlyphKey,
     ) -> Option<GlyphDimensions> {
-        self.get_ct_font(font.font_key, font.size)
+        self.get_ct_font(font.font_key, font.size, &font.variations)
             .and_then(|ref ct_font| {
                 let glyph = key.index as CGGlyph;
                 let (x_offset, y_offset) = font.get_subpx_offset(key);
@@ -306,7 +427,7 @@ impl FontContext {
         font: &FontInstance,
         key: &GlyphKey,
     ) -> Option<RasterizedGlyph> {
-        let ct_font = match self.get_ct_font(font.font_key, font.size) {
+        let ct_font = match self.get_ct_font(font.font_key, font.size, &font.variations) {
             Some(font) => font,
             None => return Some(RasterizedGlyph::blank()),
         };

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -8,7 +8,7 @@ use api::{ColorF, FontRenderMode, SubpixelDirection};
 use api::{DevicePoint, DeviceUintRect, DeviceUintSize};
 use api::{Epoch, FontInstance, FontInstanceKey, FontKey, FontTemplate};
 use api::{ExternalImageData, ExternalImageType};
-use api::{FontInstanceOptions, FontInstancePlatformOptions};
+use api::{FontInstanceOptions, FontInstancePlatformOptions, FontVariation};
 use api::{GlyphDimensions, GlyphKey, IdNamespace};
 use api::{ImageData, ImageDescriptor, ImageKey, ImageRendering};
 use api::{TileOffset, TileSize};
@@ -303,6 +303,7 @@ impl ResourceCache {
                         instance.glyph_size,
                         instance.options,
                         instance.platform_options,
+                        instance.variations,
                     );
                 }
                 ResourceUpdate::DeleteFontInstance(instance) => {
@@ -334,6 +335,7 @@ impl ResourceCache {
         glyph_size: Au,
         options: Option<FontInstanceOptions>,
         platform_options: Option<FontInstancePlatformOptions>,
+        variations: Vec<FontVariation>,
     ) {
         let mut render_mode = FontRenderMode::Subpixel;
         let mut subpx_dir = SubpixelDirection::Horizontal;
@@ -350,6 +352,7 @@ impl ResourceCache {
             render_mode,
             subpx_dir,
             platform_options,
+            variations,
         );
         self.resources.font_instances.insert(instance_key, instance);
     }

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -4,7 +4,8 @@
 
 use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint};
 use {DeviceUintRect, DeviceUintSize, FontInstanceKey, FontKey, GlyphDimensions, GlyphKey};
-use {FontInstance, FontInstanceOptions, FontInstancePlatformOptions, NativeFontHandle, WorldPoint};
+use {FontInstance, FontInstanceOptions, FontInstancePlatformOptions, FontVariation,
+     NativeFontHandle, WorldPoint};
 use {ImageData, ImageDescriptor, ImageKey, LayoutPoint, LayoutSize, LayoutTransform,
      LayoutVector2D};
 use app_units::Au;
@@ -94,6 +95,7 @@ impl ResourceUpdates {
         glyph_size: Au,
         options: Option<FontInstanceOptions>,
         platform_options: Option<FontInstancePlatformOptions>,
+        variations: Vec<FontVariation>,
     ) {
         self.updates
             .push(ResourceUpdate::AddFontInstance(AddFontInstance {
@@ -102,6 +104,7 @@ impl ResourceUpdates {
                 glyph_size,
                 options,
                 platform_options,
+                variations,
             }));
     }
 
@@ -147,6 +150,7 @@ pub struct AddFontInstance {
     pub glyph_size: Au,
     pub options: Option<FontInstanceOptions>,
     pub platform_options: Option<FontInstancePlatformOptions>,
+    pub variations: Vec<FontVariation>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/webrender_api/src/color.rs
+++ b/webrender_api/src/color.rs
@@ -60,7 +60,7 @@ impl Hash for ColorF {
 }
 
 // FIXME: remove this when Rust 1.21 is stable (float_bits_conv)
-trait ToBits {
+pub trait ToBits {
     fn _to_bits(self) -> u32;
 }
 impl ToBits for f32 {

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use {ColorF, ColorU, IdNamespace, LayoutPoint};
+use {ColorF, ColorU, IdNamespace, LayoutPoint, ToBits};
 use app_units::Au;
 #[cfg(target_os = "macos")]
 use core_foundation::string::CFString;
@@ -14,6 +14,8 @@ use dwrote::FontDescriptor;
 use serde::de::{self, Deserialize, Deserializer};
 #[cfg(target_os = "macos")]
 use serde::ser::{Serialize, Serializer};
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 
@@ -161,6 +163,36 @@ impl Into<f64> for SubpixelOffset {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialOrd, Deserialize, Serialize)]
+pub struct FontVariation {
+    pub tag: u32,
+    pub value: f32,
+}
+
+impl Ord for FontVariation {
+    fn cmp(&self, other: &FontVariation) -> Ordering {
+        self.tag.cmp(&other.tag)
+            .then(self.value._to_bits().cmp(&other.value._to_bits()))
+    }
+}
+
+impl PartialEq for FontVariation {
+    fn eq(&self, other: &FontVariation) -> bool {
+        self.tag == other.tag &&
+        self.value._to_bits() == other.value._to_bits()
+    }
+}
+
+impl Eq for FontVariation {}
+
+impl Hash for FontVariation {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.tag.hash(state);
+        self.value._to_bits().hash(state);
+    }
+}
+
+#[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {
     pub render_mode: FontRenderMode,
@@ -193,6 +225,7 @@ pub struct FontInstance {
     pub render_mode: FontRenderMode,
     pub subpx_dir: SubpixelDirection,
     pub platform_options: Option<FontInstancePlatformOptions>,
+    pub variations: Vec<FontVariation>,
 }
 
 impl FontInstance {
@@ -203,6 +236,7 @@ impl FontInstance {
         render_mode: FontRenderMode,
         subpx_dir: SubpixelDirection,
         platform_options: Option<FontInstancePlatformOptions>,
+        variations: Vec<FontVariation>,
     ) -> FontInstance {
         // In alpha/mono mode, the color of the font is irrelevant.
         // Forcing it to black in those cases saves rasterizing glyphs
@@ -218,6 +252,7 @@ impl FontInstance {
             render_mode,
             subpx_dir,
             platform_options,
+            variations,
         }
     }
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -236,6 +236,7 @@ impl Wrench {
             FontRenderMode::Alpha,
             SubpixelDirection::Horizontal,
             None,
+            Vec::new(),
         );
         let mut keys = Vec::new();
         for glyph_index in &indices {
@@ -368,7 +369,7 @@ impl Wrench {
     pub fn add_font_instance(&mut self, font_key: FontKey, size: Au) -> FontInstanceKey {
         let key = self.api.generate_font_instance_key();
         let mut update = ResourceUpdates::new();
-        update.add_font_instance(key, font_key, size, None, None);
+        update.add_font_instance(key, font_key, size, None, None, Vec::new());
         self.api.update_resources(update);
         key
     }


### PR DESCRIPTION
This adds support for font variations in an effort to correct the problem identified in https://github.com/servo/webrender/issues/1655 and https://bugzilla.mozilla.org/show_bug.cgi?id=1397458

Apple system fonts may use font variations internally to identify modifications of a base raw font for styling, namely bold. To correctly supply these fonts to WebRender, we need to not only send over the raw font, but any internal font variation information. This makes this possible to receive it on the WebRender side, in cooperation with changes on the Gecko side to supply it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1714)
<!-- Reviewable:end -->
