### PR TITLE
Make subpixel positioning match that of Gecko.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -289,10 +289,14 @@ Glyph fetch_glyph(int specific_prim_address,
         case SUBPX_DIR_NONE:
             break;
         case SUBPX_DIR_HORIZONTAL:
-            glyph.x = trunc(glyph.x);
+            // Glyphs positioned [-0.125, 0.125] get a
+            // subpx position of zero. So include that
+            // offset in the glyph position to ensure
+            // we truncate to the correct whole position.
+            glyph.x = trunc(glyph.x + 0.125);
             break;
         case SUBPX_DIR_VERTICAL:
-            glyph.y = trunc(glyph.y);
+            glyph.y = trunc(glyph.y + 0.125);
             break;
     }
 


### PR DESCRIPTION
Simplify the quantization function, and add unit tests.

Modify the shader to correctly add the glyph subpixel offset
before truncating the value.

With these changes, the glyph rendering is pixel-perfect with
Gecko in all the test cases I checked.

Fixes #1270.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1715)
<!-- Reviewable:end -->
