### PR TITLE
Add support for hit testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ version = "0.52.0"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -119,6 +119,66 @@ impl ClipScrollTree {
             .unwrap_or(self.topmost_scrolling_node_id())
     }
 
+    pub fn is_point_clipped_in_for_node(
+        &self,
+        point: WorldPoint,
+        node_id: &ClipId,
+        cache: &mut FastHashMap<ClipId, Option<LayerPoint>>,
+        clip_store: &ClipStore
+    ) -> bool {
+        if let Some(point) = cache.get(node_id) {
+            return point.is_some();
+        }
+
+        let node = self.nodes.get(node_id).unwrap();
+        let parent_clipped_in = match node.parent {
+            None => true, // This is the root node.
+            Some(ref parent_id) => {
+                self.is_point_clipped_in_for_node(point, parent_id, cache, clip_store)
+            }
+        };
+
+        if !parent_clipped_in {
+            cache.insert(*node_id, None);
+            return false;
+        }
+
+        let transform = node.world_viewport_transform;
+        let transformed_point = match transform.inverse() {
+            Some(inverted) => inverted.transform_point2d(&point),
+            None => {
+                cache.insert(*node_id, None);
+                return false;
+            }
+        };
+
+        let point_in_layer = transformed_point - node.local_viewport_rect.origin.to_vector();
+        let clip_info = match node.node_type {
+            NodeType::Clip(ref info) => info,
+            _ => {
+                cache.insert(*node_id, Some(point_in_layer));
+                return true;
+            }
+        };
+
+        if !node.local_clip_rect.contains(&transformed_point) {
+            cache.insert(*node_id, None);
+            return false;
+        }
+
+        let point_in_clips = transformed_point - clip_info.clip_rect.origin.to_vector();
+        for &(ref clip, _) in clip_store.get(&clip_info.clip_sources).clips() {
+            if !clip.contains(&point_in_clips) {
+                cache.insert(*node_id, None);
+                return false;
+            }
+        }
+
+        cache.insert(*node_id, Some(point_in_layer));
+
+        true
+    }
+
     pub fn get_scroll_node_state(&self) -> Vec<ScrollLayerState> {
         let mut result = vec![];
         for (id, node) in self.nodes.iter() {
@@ -342,8 +402,14 @@ impl ClipScrollTree {
         origin_in_parent_reference_frame: LayerVector2D,
         pipeline_id: PipelineId,
         parent_id: Option<ClipId>,
+        root_for_pipeline: bool,
     ) -> ClipId {
-        let reference_frame_id = self.generate_new_clip_id(pipeline_id);
+        let reference_frame_id = if root_for_pipeline {
+            ClipId::root_reference_frame(pipeline_id)
+        } else {
+            self.generate_new_clip_id(pipeline_id)
+        };
+
         let node = ClipScrollNode::new_reference_frame(
             parent_id,
             rect,
@@ -461,5 +527,16 @@ impl ClipScrollTree {
         if !self.nodes.is_empty() {
             self.print_node(&self.root_reference_frame_id, pt, clip_store);
         }
+    }
+
+    pub fn make_node_relative_point_absolute(
+        &self,
+        pipeline_id: Option<PipelineId>,
+        point: &LayerPoint
+    ) -> WorldPoint {
+        pipeline_id.and_then(|id| self.nodes.get(&ClipId::root_reference_frame(id)))
+                   .map(|node| node.world_viewport_transform.transform_point2d(point))
+                   .unwrap_or_else(|| WorldPoint::new(point.x, point.y))
+
     }
 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderRadius, ExtendMode, FontRenderMode, GlyphInstance, GradientStop};
-use api::{BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntSize, DevicePoint};
-use api::{device_length, FontInstance, LayerVector2D, LineOrientation, LineStyle};
-use api::{GlyphKey, LayerToWorldTransform, TileOffset, YuvColorSpace, YuvFormat};
-use api::{ImageKey, ImageRendering, ItemRange, LayerPoint, LayerRect, LayerSize, TextShadow};
+use api::{BorderRadius, BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect, DeviceIntSize};
+use api::{DevicePoint, ExtendMode, FontInstance, FontRenderMode, GlyphInstance, GlyphKey};
+use api::{GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerRect};
+use api::{LayerSize, LayerToWorldTransform, LayerVector2D, LineOrientation, LineStyle, TextShadow};
+use api::{TileOffset, YuvColorSpace, YuvFormat, device_length};
 use app_units::Au;
 use border::BorderCornerInstance;
 use clip::{ClipMode, ClipSourcesHandle, ClipStore};
@@ -144,6 +144,10 @@ pub struct PrimitiveMetadata {
     pub local_rect: LayerRect,
     pub local_clip_rect: LayerRect,
     pub is_backface_visible: bool,
+
+    /// A tag used to identify this primitive outside of WebRender. This is
+    /// used for returning useful data during hit testing.
+    pub tag: Option<ItemTag>,
 }
 
 #[derive(Debug)]
@@ -862,6 +866,7 @@ impl PrimitiveStore {
         local_clip_rect: &LayerRect,
         is_backface_visible: bool,
         clip_sources: ClipSourcesHandle,
+        tag: Option<ItemTag>,
         container: PrimitiveContainer,
     ) -> PrimitiveIndex {
         let prim_index = self.cpu_metadata.len();
@@ -879,6 +884,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_rectangles.push(rect);
@@ -896,6 +902,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_lines.push(line);
@@ -912,6 +919,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_text_runs.push(text_cpu);
@@ -928,6 +936,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_text_shadows.push(text_shadow);
@@ -944,6 +953,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_images.push(image_cpu);
@@ -960,6 +970,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_yuv_images.push(image_cpu);
@@ -976,6 +987,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_borders.push(border_cpu);
@@ -992,6 +1004,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_gradients.push(gradient_cpu);
@@ -1009,6 +1022,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_gradients.push(gradient_cpu);
@@ -1026,6 +1040,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_radial_gradients.push(radial_gradient_cpu);
@@ -1042,6 +1057,7 @@ impl PrimitiveStore {
                     local_rect: *local_rect,
                     local_clip_rect: *local_clip_rect,
                     is_backface_visible: is_backface_visible,
+                    tag,
                 };
 
                 self.cpu_box_shadows.push(box_shadow);

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -331,6 +331,12 @@ impl RenderBackend {
                     DocumentOp::ScrolledNop
                 }
             }
+            DocumentMsg::HitTest(pipeline_id, point, flags, tx) => {
+                profile_scope!("HitTest");
+                let result = doc.frame.hit_test(pipeline_id, point, flags);
+                tx.send(result).unwrap();
+                DocumentOp::Nop
+            }
             DocumentMsg::ScrollNodeWithId(origin, id, clamp) => {
                 profile_scope!("ScrollNodeWithScrollId");
                 let _timer = profile_counters.total_time.timer();

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderRadius, ComplexClipRegion, LayoutRect};
-use api::{DeviceIntRect, DevicePoint, DeviceRect, DeviceSize};
-use api::{LayerRect, LayerToWorldTransform, WorldPoint3D};
-use euclid::{Point2D, Rect, Size2D};
-use euclid::{TypedPoint2D, TypedRect, TypedSize2D, TypedTransform2D, TypedTransform3D};
+use api::{BorderRadius, ComplexClipRegion, DeviceIntRect, DevicePoint, DeviceRect, DeviceSize};
+use api::{LayerRect, LayerToWorldTransform, LayoutRect, WorldPoint3D};
+use euclid::{Point2D, Rect, Size2D, TypedPoint2D, TypedRect, TypedSize2D, TypedTransform2D};
+use euclid::TypedTransform3D;
 use num_traits::Zero;
 use std::f32::consts::FRAC_1_SQRT_2;
 

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -12,6 +12,7 @@ ipc = ["ipc-channel"]
 [dependencies]
 app_units = "0.5.6"
 bincode = "0.8"
+bitflags = "0.9"
 byteorder = "1.0"
 euclid = "0.15"
 fxhash = "0.2.1"

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint};
-use {DeviceUintRect, DeviceUintSize, FontInstanceKey, FontKey, GlyphDimensions, GlyphKey};
-use {FontInstance, FontInstanceOptions, FontInstancePlatformOptions, FontVariation,
-     NativeFontHandle, WorldPoint};
-use {ImageData, ImageDescriptor, ImageKey, LayoutPoint, LayoutSize, LayoutTransform,
-     LayoutVector2D};
+use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint, DeviceUintRect};
+use {DeviceUintSize, FontInstance, FontInstanceKey, FontInstanceOptions};
+use {FontInstancePlatformOptions, FontKey, FontVariation, GlyphDimensions, GlyphKey, ImageData};
+use {ImageDescriptor, ImageKey, ItemTag, LayoutPoint, LayoutSize, LayoutTransform, LayoutVector2D};
+use {NativeFontHandle, WorldPoint};
 use app_units::Au;
 use channel::{self, MsgSender, Payload, PayloadSender, PayloadSenderHelperMethods};
 use std::cell::Cell;
@@ -143,6 +142,33 @@ pub enum AddFont {
     Native(FontKey, NativeFontHandle),
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct HitTestItem {
+    /// The pipeline that the display item that was hit belongs to.
+    pub pipeline: PipelineId,
+
+    /// The tag of the hit display item.
+    pub tag: ItemTag,
+
+    /// The hit point in the coordinate space of the "viewport" of the display item. The
+    /// viewport is the scroll node formed by the root reference frame of the display item's
+    /// pipeline.
+    pub point_in_viewport: LayoutPoint,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct HitTestResult {
+    pub items: Vec<HitTestItem>,
+}
+
+bitflags! {
+    #[derive(Deserialize, Serialize)]
+    pub struct HitTestFlags: u8 {
+        const FIND_ALL = 0b00000001;
+        const POINT_RELATIVE_TO_PIPELINE_VIEWPORT = 0b00000010;
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AddFontInstance {
     pub key: FontInstanceKey,
@@ -155,6 +181,7 @@ pub struct AddFontInstance {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub enum DocumentMsg {
+    HitTest(Option<PipelineId>, WorldPoint, HitTestFlags, MsgSender<HitTestResult>),
     SetDisplayList {
         list_descriptor: BuiltDisplayListDescriptor,
         epoch: Epoch,
@@ -187,6 +214,7 @@ impl fmt::Debug for DocumentMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
             DocumentMsg::SetDisplayList { .. } => "DocumentMsg::SetDisplayList",
+            DocumentMsg::HitTest(..) => "DocumentMsg::HitTest",
             DocumentMsg::SetPageZoom(..) => "DocumentMsg::SetPageZoom",
             DocumentMsg::SetPinchZoom(..) => "DocumentMsg::SetPinchZoom",
             DocumentMsg::SetPan(..) => "DocumentMsg::SetPan",
@@ -610,6 +638,18 @@ impl RenderApi {
             document_id,
             DocumentMsg::ScrollNodeWithId(origin, id, clamp),
         );
+    }
+
+    /// Does a hit test as the given point
+    pub fn hit_test(&self,
+                    document_id: DocumentId,
+                    pipeline_id: Option<PipelineId>,
+                    point: WorldPoint,
+                    flags: HitTestFlags)
+                    -> HitTestResult {
+        let (tx, rx) = channel::msg_channel().unwrap();
+        self.send(document_id, DocumentMsg::HitTest(pipeline_id, point, flags, tx));
+        rx.recv().unwrap()
     }
 
     pub fn set_page_zoom(&self, document_id: DocumentId, page_zoom: ZoomFactor) {

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -38,6 +38,13 @@ impl ClipAndScrollInfo {
     }
 }
 
+/// A tag that can be used to identify items during hit testing. If the tag
+/// is missing then the item doesn't take part in hit testing at all. This
+/// is composed of two numbers. In Servo, the first is an identifier while the
+/// second is used to select the cursor that should be used during mouse
+/// movement.
+pub type ItemTag = (u64, u8);
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct DisplayItem {
     pub item: SpecificDisplayItem,
@@ -50,6 +57,7 @@ pub struct PrimitiveInfo<T> {
     pub rect: TypedRect<f32, T>,
     pub local_clip: LocalClip,
     pub is_backface_visible: bool,
+    pub tag: Option<ItemTag>,
 }
 
 impl LayerPrimitiveInfo {
@@ -68,6 +76,7 @@ impl LayerPrimitiveInfo {
             rect: rect,
             local_clip: clip,
             is_backface_visible: true,
+            tag: None,
         }
     }
 }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -343,6 +343,7 @@ impl<'a, 'b> DisplayItemRef<'a, 'b> {
             rect: info.rect.translate(&offset),
             local_clip: info.local_clip.create_with_offset(offset),
             is_backface_visible: info.is_backface_visible,
+            tag: info.tag,
         }
     }
 
@@ -997,6 +998,7 @@ impl DisplayListBuilder {
             rect: content_rect,
             local_clip: LocalClip::from(clip_rect),
             is_backface_visible: true,
+            tag: None,
         };
 
         self.push_item(item, &info);

--- a/webrender_api/src/lib.rs
+++ b/webrender_api/src/lib.rs
@@ -7,6 +7,8 @@
 
 extern crate app_units;
 extern crate bincode;
+#[macro_use]
+extern crate bitflags;
 extern crate byteorder;
 #[cfg(feature = "nightly")]
 extern crate core;


### PR DESCRIPTION
This adds a new API point for doing hit testing against the display
list. This version supports the features Servo needs to do hist
testing, except for text index support (which will come in a later PR).

Fixes #1575.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1744)
<!-- Reviewable:end -->
