### PR TITLE
Handle non-invertible transforms in ray_intersects_node

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -463,7 +463,11 @@ impl ClipScrollNode {
     }
 
     pub fn ray_intersects_node(&self, cursor: &WorldPoint) -> bool {
-        let inv = self.world_viewport_transform.inverse().unwrap();
+        let inv = match self.world_viewport_transform.inverse() {
+            Some(inv) => inv,
+            None => return false,
+        };
+
         let z0 = -10000.0;
         let z1 = 10000.0;
 


### PR DESCRIPTION
Currently the code does not properly handle the non-invertible case
here. Since non-invertible matrices do not render contents we can
safely return false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1745)
<!-- Reviewable:end -->
