### PR TITLE
Support platform specific reftests.

### DIFF
--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -20,4 +20,4 @@ fuzzy(1,100) == decorations-suite.yaml decorations-suite.png
 fuzzy(1,160) == shadow-grey.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 # enable when synthetic-italics implemented on mac
-# != synthetic-italics.yaml synthetic-italics-ref.yaml
+platform(linux) != synthetic-italics.yaml synthetic-italics-ref.yaml


### PR DESCRIPTION
Enable the synthetics italics reftest on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1752)
<!-- Reviewable:end -->
