### PR TITLE
Move content_size to ScrollingState and store a scrolling size

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -76,9 +76,6 @@ pub enum NodeType {
 /// Contains information common among all types of ClipScrollTree nodes.
 #[derive(Debug)]
 pub struct ClipScrollNode {
-    /// Size of the content inside the scroll region (in logical pixels)
-    pub content_size: LayerSize,
-
     /// Viewing rectangle in the coordinate system of the parent reference frame.
     pub local_viewport_rect: LayerRect,
 
@@ -128,7 +125,6 @@ impl ClipScrollNode {
         scroll_sensitivity: ScrollSensitivity,
     ) -> ClipScrollNode {
         ClipScrollNode {
-            content_size: *content_size,
             local_viewport_rect: *frame_rect,
             local_clip_rect: *frame_rect,
             combined_local_viewport_rect: LayerRect::zero(),
@@ -138,13 +134,18 @@ impl ClipScrollNode {
             parent: Some(parent_id),
             children: Vec::new(),
             pipeline_id,
-            node_type: NodeType::ScrollFrame(ScrollingState::new(scroll_sensitivity)),
+            node_type: NodeType::ScrollFrame(ScrollingState::new(
+                scroll_sensitivity,
+                LayerSize::new(
+                    (content_size.width - frame_rect.size.width).max(0.0),
+                    (content_size.height - frame_rect.size.height).max(0.0)
+                )
+            )),
         }
     }
 
     pub fn new(pipeline_id: PipelineId, parent_id: ClipId, clip_info: ClipInfo) -> ClipScrollNode {
         ClipScrollNode {
-            content_size: clip_info.clip_rect.size,
             local_viewport_rect: clip_info.clip_rect,
             local_clip_rect: clip_info.clip_rect,
             combined_local_viewport_rect: LayerRect::zero(),
@@ -161,7 +162,6 @@ impl ClipScrollNode {
     pub fn new_reference_frame(
         parent_id: Option<ClipId>,
         local_viewport_rect: &LayerRect,
-        content_size: LayerSize,
         transform: &LayerToScrollTransform,
         origin_in_parent_reference_frame: LayerVector2D,
         pipeline_id: PipelineId,
@@ -172,7 +172,6 @@ impl ClipScrollNode {
         };
 
         ClipScrollNode {
-            content_size,
             local_viewport_rect: *local_viewport_rect,
             local_clip_rect: *local_viewport_rect,
             combined_local_viewport_rect: LayerRect::zero(),
@@ -193,7 +192,6 @@ impl ClipScrollNode {
         pipeline_id: PipelineId,
     ) -> ClipScrollNode {
         ClipScrollNode {
-            content_size: frame_rect.size,
             local_viewport_rect: frame_rect,
             local_clip_rect: frame_rect,
             combined_local_viewport_rect: LayerRect::zero(),
@@ -227,8 +225,9 @@ impl ClipScrollNode {
     }
 
     pub fn set_scroll_origin(&mut self, origin: &LayerPoint, clamp: ScrollClamping) -> bool {
-        let scrollable_height = self.scrollable_height();
-        let scrollable_width = self.scrollable_width();
+        let scrollable_size = self.scrollable_size();
+        let scrollable_width = scrollable_size.width;
+        let scrollable_height = scrollable_size.height;
 
         let scrolling = match self.node_type {
             NodeType::ScrollFrame(ref mut scrolling) => scrolling,
@@ -366,18 +365,15 @@ impl ClipScrollNode {
         sticky_offset
     }
 
-    pub fn scrollable_height(&self) -> f32 {
-        self.content_size.height - self.local_viewport_rect.size.height
+    pub fn scrollable_size(&self) -> LayerSize {
+        match self.node_type {
+           NodeType:: ScrollFrame(state) => state.scrollable_size,
+            _ => LayerSize::zero(),
+        }
     }
 
-    pub fn scrollable_width(&self) -> f32 {
-        self.content_size.width - self.local_viewport_rect.size.width
-    }
 
     pub fn scroll(&mut self, scroll_location: ScrollLocation, phase: ScrollEventPhase) -> bool {
-        let scrollable_width = self.scrollable_width();
-        let scrollable_height = self.scrollable_height();
-
         let scrolling = match self.node_type {
             NodeType::ScrollFrame(ref mut scrolling) => scrolling,
             _ => return false,
@@ -399,8 +395,7 @@ impl ClipScrollNode {
                 return true;
             }
             ScrollLocation::End => {
-                let end_pos = self.local_viewport_rect.size.height - self.content_size.height;
-
+                let end_pos = -scrolling.scrollable_size.height;
                 if scrolling.offset.y.round() <= end_pos {
                     // Nothing to do on this layer.
                     return false;
@@ -411,9 +406,8 @@ impl ClipScrollNode {
             }
         };
 
-        let overscroll_amount = scrolling.overscroll_amount(scrollable_width, scrollable_height);
-        let overscrolling =
-            CAN_OVERSCROLL && (overscroll_amount.x != 0.0 || overscroll_amount.y != 0.0);
+        let overscroll_amount = scrolling.overscroll_amount();
+        let overscrolling = CAN_OVERSCROLL && (overscroll_amount != LayerVector2D::zero());
         if overscrolling {
             if overscroll_amount.x != 0.0 {
                 delta.x /= overscroll_amount.x.abs()
@@ -423,6 +417,8 @@ impl ClipScrollNode {
             }
         }
 
+        let scrollable_width = scrolling.scrollable_size.width;
+        let scrollable_height = scrolling.scrollable_size.height;
         let is_unscrollable = scrollable_width <= 0. && scrollable_height <= 0.;
         let original_layer_scroll_offset = scrolling.offset;
 
@@ -474,9 +470,10 @@ impl ClipScrollNode {
         let p0 = inv.transform_point3d(&cursor.extend(z0));
         let p1 = inv.transform_point3d(&cursor.extend(z1));
 
-        if self.scrollable_width() <= 0. && self.scrollable_height() <= 0. {
+        if self.scrollable_size() == LayerSize::zero() {
             return false;
         }
+
         ray_intersects_rect(
             p0.to_untyped(),
             p1.to_untyped(),
@@ -493,11 +490,7 @@ impl ClipScrollNode {
 
     pub fn is_overscrolling(&self) -> bool {
         match self.node_type {
-            NodeType::ScrollFrame(ref scrolling) => {
-                let overscroll_amount =
-                    scrolling.overscroll_amount(self.scrollable_width(), self.scrollable_height());
-                overscroll_amount.x != 0.0 || overscroll_amount.y != 0.0
-            }
+            NodeType::ScrollFrame(ref state) => state.overscroll_amount() != LayerVector2D::zero(),
             _ => false,
         }
     }
@@ -511,11 +504,17 @@ pub struct ScrollingState {
     pub bouncing_back: bool,
     pub should_handoff_scroll: bool,
     pub scroll_sensitivity: ScrollSensitivity,
+
+    /// Amount that this ScrollFrame can scroll in both directions.
+    pub scrollable_size: LayerSize,
+
 }
 
 /// Manages scrolling offset, overscroll state, etc.
 impl ScrollingState {
-    pub fn new(scroll_sensitivity: ScrollSensitivity) -> ScrollingState {
+    pub fn new(scroll_sensitivity: ScrollSensitivity,
+               scrollable_size: LayerSize
+    ) -> ScrollingState {
         ScrollingState {
             offset: LayerVector2D::zero(),
             spring: Spring::at(LayerPoint::zero(), STIFFNESS, DAMPING),
@@ -523,6 +522,7 @@ impl ScrollingState {
             bouncing_back: false,
             should_handoff_scroll: false,
             scroll_sensitivity,
+            scrollable_size,
         }
     }
 
@@ -547,23 +547,19 @@ impl ScrollingState {
         }
     }
 
-    pub fn overscroll_amount(
-        &self,
-        scrollable_width: f32,
-        scrollable_height: f32,
-    ) -> LayerVector2D {
+    pub fn overscroll_amount(&self) -> LayerVector2D {
         let overscroll_x = if self.offset.x > 0.0 {
             -self.offset.x
-        } else if self.offset.x < -scrollable_width {
-            -scrollable_width - self.offset.x
+        } else if self.offset.x < -self.scrollable_size.width {
+            -self.scrollable_size.width - self.offset.x
         } else {
             0.0
         };
 
         let overscroll_y = if self.offset.y > 0.0 {
             -self.offset.y
-        } else if self.offset.y < -scrollable_height {
-            -scrollable_height - self.offset.y
+        } else if self.offset.y < -self.scrollable_size.height {
+            -self.scrollable_size.height - self.offset.y
         } else {
             0.0
         };

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -413,7 +413,6 @@ impl ClipScrollTree {
         let node = ClipScrollNode::new_reference_frame(
             parent_id,
             rect,
-            rect.size,
             transform,
             origin_in_parent_reference_frame,
             pipeline_id,
@@ -481,6 +480,7 @@ impl ClipScrollTree {
             }
             NodeType::ScrollFrame(scrolling_info) => {
                 pt.new_level(format!("ScrollFrame"));
+                pt.add_item(format!("scrollable_size: {:?}", scrolling_info.scrollable_size));
                 pt.add_item(format!("scroll.offset: {:?}", scrolling_info.offset));
             }
             NodeType::StickyFrame(sticky_frame_info) => {
@@ -489,7 +489,6 @@ impl ClipScrollTree {
             }
         }
 
-        pt.add_item(format!("content_size: {:?}", node.content_size));
         pt.add_item(format!(
             "local_viewport_rect: {:?}",
             node.local_viewport_rect

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1937,7 +1937,7 @@ impl FrameBuilder {
             // Invalidate what's in the cache so it will get rebuilt.
             gpu_cache.invalidate(&metadata.gpu_location);
 
-            let scrollable_distance = clip_scroll_node.scrollable_height();
+            let scrollable_distance = clip_scroll_node.scrollable_size().height;
 
             if scrollable_distance <= 0.0 {
                 metadata.local_clip_rect.size = LayerSize::zero();


### PR DESCRIPTION
This is only used for scroll frames, so it doesn't make sense to have
it on the shared data structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1763)
<!-- Reviewable:end -->
