### PR TITLE
Cull primitives with invalid dimensions, to avoid overflow later.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1075,6 +1075,12 @@ impl PrimitiveStore {
             let metadata = &mut self.cpu_metadata[prim_index.0];
             metadata.screen_rect = None;
 
+            if metadata.local_rect.size.width <= 0.0 ||
+               metadata.local_rect.size.height <= 0.0 {
+                warn!("invalid primitive rect {:?}", metadata.local_rect);
+                return None;
+            }
+
             if !metadata.is_backface_visible &&
                prim_context.packed_layer.transform.is_backface_visible() {
                 return None;


### PR DESCRIPTION
Primitives with invalid dimensions can cause overflow and general
badness in the texture and render task allocators. Detect them
and ensure they are not considered visible.

Fixes https://github.com/servo/servo/issues/18655

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1768)
<!-- Reviewable:end -->
