### PR TITLE
Add reftest for text-shadow with clipped out contents

### DIFF
--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -11,6 +11,7 @@
 != shadow-cover-1.yaml shadow-cover-2.yaml
 != shadow-many.yaml shadow.yaml
 != shadow-complex.yaml shadow-many.yaml
+!= shadow-clipped-text.yaml blank.yaml
 != non-opaque.yaml non-opaque-notref.yaml
 == decorations.yaml decorations-ref.yaml
 fuzzy(1,100) == decorations-suite.yaml decorations-suite.png

--- a/wrench/reftests/text/shadow-clipped-text.yaml
+++ b/wrench/reftests/text/shadow-clipped-text.yaml
@@ -1,0 +1,22 @@
+--- # tests that shadows still render even if the associated text is clipped out
+root:
+  items:
+    - type: scroll-frame
+      bounds: [14, 18, 10, 5]
+      content-size: [10, 5]
+      items:
+        -
+          type: "text-shadow"
+          bounds: [11, 20, 100, 100]
+          blur-radius: 3
+          offset: [0, 0]
+          color: black
+        -
+          bounds: [14, 23, 100, 100]
+          glyphs: [55]
+          offsets: [16, 43]
+          size: 18
+          color: black
+          font: "VeraBd.ttf"
+        -
+          type: "pop-text-shadow"


### PR DESCRIPTION
This is a minimal test-case for #1779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1786)
<!-- Reviewable:end -->
