### PR TITLE
Fix some calculation errors for ps_split_composite and make_polygon.

### DIFF
--- a/webrender/res/ps_split_composite.glsl
+++ b/webrender/res/ps_split_composite.glsl
@@ -38,11 +38,15 @@ void main(void) {
     CompositeInstance ci = fetch_composite_instance();
     SplitGeometry geometry = fetch_split_geometry(ci.user_data0);
     AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
+    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+
+    vec2 dest_origin = dest_task.render_target_origin -
+                       dest_task.screen_space_origin;
 
     vec3 world_pos = bilerp(geometry.points[0], geometry.points[1],
                             geometry.points[3], geometry.points[2],
                             aPosition.y, aPosition.x);
-    vec4 final_pos = vec4(world_pos.xy * uDevicePixelRatio, ci.z, 1.0);
+    vec4 final_pos = vec4((world_pos.xy + dest_origin) * uDevicePixelRatio, ci.z, 1.0);
 
     gl_Position = uTransform * final_pos;
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1606,6 +1606,12 @@ pub struct StackingContext {
     /// This is a temporary hack while we don't support subpixel AA
     /// on transparent stacking contexts.
     pub allow_subpixel_aa: bool,
+
+    /// Indicate that if any pritimive contained in this stacking context.
+    pub has_any_primitive: bool,
+
+    /// Union of all stacking context bounds of all children.
+    pub children_sc_bounds: LayerRect,
 }
 
 impl StackingContext {
@@ -1638,6 +1644,8 @@ impl StackingContext {
             is_visible: false,
             is_backface_visible,
             allow_subpixel_aa,
+            has_any_primitive: false,
+            children_sc_bounds: LayerRect::zero(),
         }
     }
 

--- a/wrench/reftests/split/intermediate-1-ref.yaml
+++ b/wrench/reftests/split/intermediate-1-ref.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: 8 36 100 100
+      color: green
+    - type: rect
+      bounds: 108 36 100 100
+      color: blue
+    - type: rect
+      bounds: 208 36 100 100
+      color: yellow

--- a/wrench/reftests/split/intermediate-1.yaml
+++ b/wrench/reftests/split/intermediate-1.yaml
@@ -1,0 +1,38 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: 8 36 300 100
+      color: red
+    - type: stacking-context
+      transform-style: preserve-3d
+      transform: translate(8, 36, 0)
+      items:
+        - type: stacking-context
+          transform-style: preserve-3d
+          items:
+            - type: rect
+              bounds: 0 0 100 100
+              color: green
+        - type: stacking-context # flat, intermediate surface
+          items:
+            - type: stacking-context
+              transform: translate(100, 0, 0)
+              transform-style: preserve-3d
+              items:
+                - type: stacking-context
+                  transform-style: preserve-3d
+                  items:
+                    - type: rect
+                      bounds: 0 0 100 100
+                      color: blue
+                - type: stacking-context
+                  transform: translate(100, 0, 0)
+                  transform-style: preserve-3d
+                  items:
+                    - type: stacking-context
+                      transform-style: preserve-3d
+                      items:
+                        - type: rect
+                          bounds: 0 0 100 100
+                          color: yellow

--- a/wrench/reftests/split/intermediate-2.yaml
+++ b/wrench/reftests/split/intermediate-2.yaml
@@ -1,0 +1,34 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: 8 36 300 100
+      color: red
+    - type: stacking-context
+      transform-style: preserve-3d
+      transform: translate(8, 36, 0)
+      items:
+        - type: stacking-context
+          transform-style: preserve-3d
+          items:
+            - type: rect
+              bounds: 0 0 100 100
+              color: green
+        - type: stacking-context
+          items:
+            - type: stacking-context
+              transform: translate(100, 0, 0)
+              items:
+                - type: rect
+                  bounds: 0 0 100 100
+                  color: blue
+                - type: stacking-context
+                  transform: translate(100, 0, 0)
+                  transform-style: preserve-3d
+                  items:
+                    - type: stacking-context
+                      transform-style: preserve-3d
+                      items:
+                        - type: rect
+                          bounds: 0 0 100 100
+                          color: yellow

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -3,4 +3,6 @@
 == nested.yaml nested-ref.yaml
 == nested-preserve3d-crash.yaml nested-preserve3d-crash.yaml
 == perspective-clipping.yaml perspective-clipping-ref.yaml
+== intermediate-1.yaml intermediate-1-ref.yaml
+== intermediate-2.yaml intermediate-1-ref.yaml
 #== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences


### PR DESCRIPTION
There are some bugs when we have a transform-style:flat in the middle of transform-style:preserve-3d. So I fixed it by following changes.

1. ps_split_composite shader did not take position of dest_task into
account.
2. make_polygon didn't work if isolated_items_bounds is empty.

r? kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1787)
<!-- Reviewable:end -->
