### PR TITLE
Allow webrender_api callers to explicitly specify the parent when def…

### DIFF
--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -986,10 +986,35 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator,
     {
+        let parent_id = self.clip_stack.last().unwrap().scroll_node_id;
+        self.define_scroll_frame_with_parent(
+            id,
+            parent_id,
+            content_rect,
+            clip_rect,
+            complex_clips,
+            image_mask,
+            scroll_sensitivity)
+    }
+
+    pub fn define_scroll_frame_with_parent<I>(
+        &mut self,
+        id: Option<ClipId>,
+        parent_id: ClipId,
+        content_rect: LayoutRect,
+        clip_rect: LayoutRect,
+        complex_clips: I,
+        image_mask: Option<ImageMask>,
+        scroll_sensitivity: ScrollSensitivity,
+    ) -> ClipId
+    where
+        I: IntoIterator<Item = ComplexClipRegion>,
+        I::IntoIter: ExactSizeIterator,
+    {
         let id = self.generate_clip_id(id);
         let item = SpecificDisplayItem::ScrollFrame(ScrollFrameDisplayItem {
             id: id,
-            parent_id: self.clip_stack.last().unwrap().scroll_node_id,
+            parent_id: parent_id,
             image_mask: image_mask,
             scroll_sensitivity,
         });
@@ -1017,10 +1042,31 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator,
     {
+        let parent_id = self.clip_stack.last().unwrap().scroll_node_id;
+        self.define_clip_with_parent(
+            id,
+            parent_id,
+            clip_rect,
+            complex_clips,
+            image_mask)
+    }
+
+    pub fn define_clip_with_parent<I>(
+        &mut self,
+        id: Option<ClipId>,
+        parent_id: ClipId,
+        clip_rect: LayoutRect,
+        complex_clips: I,
+        image_mask: Option<ImageMask>,
+    ) -> ClipId
+    where
+        I: IntoIterator<Item = ComplexClipRegion>,
+        I::IntoIter: ExactSizeIterator,
+    {
         let id = self.generate_clip_id(id);
         let item = SpecificDisplayItem::Clip(ClipDisplayItem {
             id,
-            parent_id: self.clip_stack.last().unwrap().scroll_node_id,
+            parent_id: parent_id,
             image_mask: image_mask,
         });
 


### PR DESCRIPTION
…ining a new clip or scroll frame.

This will allow us to use these APIs with less pushing and popping of
ancestor clips onto the stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1796)
<!-- Reviewable:end -->
