### PR TITLE
Use panic=abort instead of panic=unwind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
 
 [profile.release]
 debug = true
+panic = "abort"


### PR DESCRIPTION
This is the same mode as Gecko uses and will get better codegen
once https://github.com/rust-lang/rust/pull/45012 has landed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1825)
<!-- Reviewable:end -->
