### PR TITLE
Introduce ClipChain

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -2,16 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, LayerPixel, LayerPoint, LayerRect, LayerSize};
+use api::{ClipId, DeviceIntRect, LayerPixel, LayerPoint, LayerRect, LayerSize};
 use api::{LayerToScrollTransform, LayerToWorldTransform, LayerVector2D, PipelineId};
 use api::{ScrollClamping, ScrollEventPhase, ScrollLocation, ScrollSensitivity, StickyFrameInfo};
 use api::WorldPoint;
 use clip::{ClipRegion, ClipSources, ClipSourcesHandle, ClipStore};
-use clip_scroll_tree::TransformUpdateState;
+use clip_scroll_tree::{CoordinateSystemId, TransformUpdateState};
 use geometry::ray_intersects_rect;
-use spring::{Spring, DAMPING, STIFFNESS};
-use tiling::PackedLayerIndex;
-use util::MatrixHelpers;
+use gpu_cache::GpuCache;
+use render_task::{ClipChain, ClipChainNode, ClipWorkItem};
+use resource_cache::ResourceCache;
+use spring::{DAMPING, STIFFNESS, Spring};
+use std::rc::Rc;
+use tiling::{PackedLayer, PackedLayerIndex};
+use util::{MatrixHelpers, MaxRect};
 
 #[cfg(target_os = "macos")]
 const CAN_OVERSCROLL: bool = true;
@@ -27,6 +31,9 @@ pub struct ClipInfo {
     /// The packed layer index for this node, which is used to render a clip mask
     /// for it, if necessary.
     pub packed_layer_index: PackedLayerIndex,
+
+    /// Whether or not this clip node automatically creates a mask.
+    pub is_masking: bool,
 }
 
 impl ClipInfo {
@@ -35,9 +42,13 @@ impl ClipInfo {
         packed_layer_index: PackedLayerIndex,
         clip_store: &mut ClipStore,
     ) -> ClipInfo {
+        let clip_sources = ClipSources::from(clip_region);
+        let is_masking = clip_sources.is_masking();
+
         ClipInfo {
-            clip_sources: clip_store.insert(ClipSources::from(clip_region)),
+            clip_sources: clip_store.insert(clip_sources),
             packed_layer_index,
+            is_masking,
         }
     }
 }
@@ -102,9 +113,43 @@ pub struct ClipScrollNode {
 
     /// Whether or not this node is a reference frame.
     pub node_type: NodeType,
+
+    /// The node in the chain of clips that are necessary to clip display items
+    /// that have this ClipScrollNode as their clip parent. This will be used to
+    /// generate clip tasks.
+    pub clip_chain_node: ClipChain,
+
+    /// The intersected outer bounds of the clips for this node.
+    pub combined_clip_outer_bounds: DeviceIntRect,
+
+    /// The axis-aligned coordinate system id of this node.
+    pub coordinate_system_id: CoordinateSystemId,
 }
 
 impl ClipScrollNode {
+    fn new(
+        pipeline_id: PipelineId,
+        parent_id: Option<ClipId>,
+        rect: &LayerRect,
+        node_type: NodeType
+    ) -> ClipScrollNode {
+        ClipScrollNode {
+            local_viewport_rect: *rect,
+            local_clip_rect: *rect,
+            combined_local_viewport_rect: LayerRect::zero(),
+            world_viewport_transform: LayerToWorldTransform::identity(),
+            world_content_transform: LayerToWorldTransform::identity(),
+            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
+            parent: parent_id,
+            children: Vec::new(),
+            pipeline_id,
+            node_type: node_type,
+            clip_chain_node: None,
+            combined_clip_outer_bounds: DeviceIntRect::max_rect(),
+            coordinate_system_id: CoordinateSystemId(0),
+        }
+    }
+
     pub fn new_scroll_frame(
         pipeline_id: PipelineId,
         parent_id: ClipId,
@@ -112,24 +157,15 @@ impl ClipScrollNode {
         content_size: &LayerSize,
         scroll_sensitivity: ScrollSensitivity,
     ) -> ClipScrollNode {
-        ClipScrollNode {
-            local_viewport_rect: *frame_rect,
-            local_clip_rect: *frame_rect,
-            combined_local_viewport_rect: LayerRect::zero(),
-            world_viewport_transform: LayerToWorldTransform::identity(),
-            world_content_transform: LayerToWorldTransform::identity(),
-            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
-            parent: Some(parent_id),
-            children: Vec::new(),
-            pipeline_id,
-            node_type: NodeType::ScrollFrame(ScrollingState::new(
-                scroll_sensitivity,
-                LayerSize::new(
-                    (content_size.width - frame_rect.size.width).max(0.0),
-                    (content_size.height - frame_rect.size.height).max(0.0)
-                )
-            )),
-        }
+        let node_type = NodeType::ScrollFrame(ScrollingState::new(
+            scroll_sensitivity,
+            LayerSize::new(
+                (content_size.width - frame_rect.size.width).max(0.0),
+                (content_size.height - frame_rect.size.height).max(0.0)
+            )
+        ));
+
+        Self::new(pipeline_id, Some(parent_id), frame_rect, node_type)
     }
 
     pub fn new_clip_node(
@@ -138,23 +174,12 @@ impl ClipScrollNode {
         clip_info: ClipInfo,
         clip_rect: LayerRect,
     ) -> ClipScrollNode {
-        ClipScrollNode {
-            local_viewport_rect: clip_rect,
-            local_clip_rect: clip_rect,
-            combined_local_viewport_rect: LayerRect::zero(),
-            world_viewport_transform: LayerToWorldTransform::identity(),
-            world_content_transform: LayerToWorldTransform::identity(),
-            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
-            parent: Some(parent_id),
-            children: Vec::new(),
-            pipeline_id,
-            node_type: NodeType::Clip(clip_info),
-        }
+        Self::new(pipeline_id, Some(parent_id), &clip_rect, NodeType::Clip(clip_info))
     }
 
     pub fn new_reference_frame(
         parent_id: Option<ClipId>,
-        local_viewport_rect: &LayerRect,
+        frame_rect: &LayerRect,
         transform: &LayerToScrollTransform,
         origin_in_parent_reference_frame: LayerVector2D,
         pipeline_id: PipelineId,
@@ -163,19 +188,7 @@ impl ClipScrollNode {
             transform: *transform,
             origin_in_parent_reference_frame,
         };
-
-        ClipScrollNode {
-            local_viewport_rect: *local_viewport_rect,
-            local_clip_rect: *local_viewport_rect,
-            combined_local_viewport_rect: LayerRect::zero(),
-            world_viewport_transform: LayerToWorldTransform::identity(),
-            world_content_transform: LayerToWorldTransform::identity(),
-            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
-            parent: parent_id,
-            children: Vec::new(),
-            pipeline_id,
-            node_type: NodeType::ReferenceFrame(info),
-        }
+        Self::new(pipeline_id, parent_id, frame_rect, NodeType::ReferenceFrame(info))
     }
 
     pub fn new_sticky_frame(
@@ -184,18 +197,8 @@ impl ClipScrollNode {
         sticky_frame_info: StickyFrameInfo,
         pipeline_id: PipelineId,
     ) -> ClipScrollNode {
-        ClipScrollNode {
-            local_viewport_rect: frame_rect,
-            local_clip_rect: frame_rect,
-            combined_local_viewport_rect: LayerRect::zero(),
-            world_viewport_transform: LayerToWorldTransform::identity(),
-            world_content_transform: LayerToWorldTransform::identity(),
-            reference_frame_relative_scroll_offset: LayerVector2D::zero(),
-            parent: Some(parent_id),
-            children: Vec::new(),
-            pipeline_id,
-            node_type: NodeType::StickyFrame(sticky_frame_info, LayerVector2D::zero()),
-        }
+        let node_type = NodeType::StickyFrame(sticky_frame_info, LayerVector2D::zero());
+        Self::new(pipeline_id, Some(parent_id), &frame_rect, node_type)
     }
 
 
@@ -255,7 +258,79 @@ impl ClipScrollNode {
         true
     }
 
-    pub fn update_transform(&mut self, state: &TransformUpdateState) {
+    pub fn update_clip_work_item(
+        &mut self,
+        state: &mut TransformUpdateState,
+        screen_rect: &DeviceIntRect,
+        device_pixel_ratio: f32,
+        packed_layers: &mut Vec<PackedLayer>,
+        clip_store: &mut ClipStore,
+        resource_cache: &mut ResourceCache,
+        gpu_cache: &mut GpuCache,
+    ) {
+        self.coordinate_system_id = state.current_coordinate_system_id;
+
+        let current_clip_chain = state.parent_clip_chain.clone();
+        let clip_info = match self.node_type {
+            NodeType::Clip(ref mut info) if info.is_masking => info,
+            _ => {
+                self.clip_chain_node = current_clip_chain;
+                self.combined_clip_outer_bounds = state.combined_outer_clip_bounds;
+                return;
+            }
+        };
+
+        // The coordinates of the mask are relative to the origin of the node itself,
+        // so we need to account for that origin in the transformation we assign to
+        // the packed layer.
+        let transform = self.world_viewport_transform
+            .pre_translate(self.local_viewport_rect.origin.to_vector().to_3d());
+
+        let packed_layer = &mut packed_layers[clip_info.packed_layer_index.0];
+        if packed_layer.set_transform(transform) {
+            // Meanwhile, the combined viewport rect is relative to the reference frame, so
+            // we move it into the local coordinate system of the node.
+            let local_viewport_rect = self.combined_local_viewport_rect
+                .translate(&-self.local_viewport_rect.origin.to_vector());
+
+            packed_layer.set_rect(
+                &local_viewport_rect,
+                screen_rect,
+                device_pixel_ratio,
+            );
+        }
+
+        let clip_sources = clip_store.get_mut(&clip_info.clip_sources);
+        clip_sources.update(
+            &transform,
+            gpu_cache,
+            resource_cache,
+            device_pixel_ratio,
+        );
+
+        let outer_bounds = clip_sources.bounds.outer.as_ref().map_or_else(
+            DeviceIntRect::zero,
+            |rect| rect.device_rect
+        );
+
+        self.combined_clip_outer_bounds = outer_bounds.intersection(
+            &state.combined_outer_clip_bounds).unwrap_or_else(DeviceIntRect::zero);
+
+        // TODO: Combine rectangles in the same axis-aligned clip space here?
+        self.clip_chain_node = Some(Rc::new(ClipChainNode {
+            work_item: ClipWorkItem {
+                layer_index: clip_info.packed_layer_index,
+                clip_sources: clip_info.clip_sources.weak(),
+                coordinate_system_id: state.current_coordinate_system_id,
+            },
+            prev: current_clip_chain,
+        }));
+
+        state.combined_outer_clip_bounds = self.combined_clip_outer_bounds;
+        state.parent_clip_chain = self.clip_chain_node.clone();
+    }
+
+    pub fn update_transform(&mut self, state: &mut TransformUpdateState) {
         // We calculate this here to avoid a double-borrow later.
         let sticky_offset = self.calculate_sticky_offset(
             &state.nearest_scrolling_ancestor_offset,
@@ -315,6 +390,45 @@ impl ClipScrollNode {
         let scroll_offset = self.scroll_offset();
         self.world_content_transform = self.world_viewport_transform
             .pre_translate(scroll_offset.to_3d());
+
+        // The transformation we are passing is the transformation of the parent
+        // reference frame and the offset is the accumulated offset of all the nodes
+        // between us and the parent reference frame. If we are a reference frame,
+        // we need to reset both these values.
+        match self.node_type {
+            NodeType::ReferenceFrame(ref info) => {
+                state.parent_reference_frame_transform = self.world_viewport_transform;
+                state.parent_combined_viewport_rect = self.combined_local_viewport_rect;
+                state.parent_accumulated_scroll_offset = LayerVector2D::zero();
+                state.nearest_scrolling_ancestor_viewport =
+                    state.nearest_scrolling_ancestor_viewport
+                       .translate(&info.origin_in_parent_reference_frame);
+
+                if !info.transform.preserves_2d_axis_alignment() {
+                    state.current_coordinate_system_id = state.next_coordinate_system_id;
+                    state.next_coordinate_system_id = state.next_coordinate_system_id.next();
+                }
+            },
+            NodeType::Clip(..) => {
+                state.parent_combined_viewport_rect = self.combined_local_viewport_rect;
+            },
+            NodeType::ScrollFrame(ref scrolling) => {
+                state.parent_combined_viewport_rect =
+                        self.combined_local_viewport_rect.translate(&-scrolling.offset);
+                state.parent_accumulated_scroll_offset =
+                    scrolling.offset + state.parent_accumulated_scroll_offset;
+                state.nearest_scrolling_ancestor_offset = scrolling.offset;
+                state.nearest_scrolling_ancestor_viewport = self.local_viewport_rect;
+            }
+            NodeType::StickyFrame(_, sticky_offset) => {
+                // We don't translate the combined rect by the sticky offset, because sticky
+                // offsets actually adjust the node position itself, whereas scroll offsets
+                // only apply to contents inside the node.
+                state.parent_combined_viewport_rect = self.combined_local_viewport_rect;
+                state.parent_accumulated_scroll_offset =
+                    sticky_offset + state.parent_accumulated_scroll_offset;
+            }
+        }
     }
 
     fn calculate_sticky_offset(

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -1095,36 +1095,13 @@ impl Frame {
         }
     }
 
-    pub fn build(
+    pub fn build_renderer_frame(
         &mut self,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         pipelines: &FastHashMap<PipelineId, ScenePipeline>,
         device_pixel_ratio: f32,
         pan: LayerPoint,
-        output_pipelines: &FastHashSet<PipelineId>,
-        texture_cache_profile: &mut TextureCacheProfileCounters,
-        gpu_cache_profile: &mut GpuCacheProfileCounters,
-    ) -> RendererFrame {
-        self.clip_scroll_tree.update_all_node_transforms(pan);
-        let frame = self.build_frame(
-            resource_cache,
-            gpu_cache,
-            pipelines,
-            device_pixel_ratio,
-            output_pipelines,
-            texture_cache_profile,
-            gpu_cache_profile,
-        );
-        frame
-    }
-
-    fn build_frame(
-        &mut self,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
-        pipelines: &FastHashMap<PipelineId, ScenePipeline>,
-        device_pixel_ratio: f32,
         output_pipelines: &FastHashSet<PipelineId>,
         texture_cache_profile: &mut TextureCacheProfileCounters,
         gpu_cache_profile: &mut GpuCacheProfileCounters,
@@ -1138,6 +1115,7 @@ impl Frame {
                 &mut self.clip_scroll_tree,
                 pipelines,
                 device_pixel_ratio,
+                pan,
                 output_pipelines,
                 texture_cache_profile,
                 gpu_cache_profile,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -16,7 +16,7 @@ use app_units::Au;
 use border::ImageBorderSegment;
 use clip::{ClipMode, ClipRegion, ClipSource, ClipSources, ClipStore, Contains};
 use clip_scroll_node::{ClipInfo, ClipScrollNode, NodeType};
-use clip_scroll_tree::ClipScrollTree;
+use clip_scroll_tree::{ClipScrollTree, CoordinateSystemId};
 use euclid::{SideOffsets2D, TypedTransform3D, vec2, vec3};
 use frame::FrameId;
 use gpu_cache::GpuCache;
@@ -29,8 +29,8 @@ use prim_store::{PrimitiveContainer, PrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_task::{AlphaRenderItem, ClipWorkItem, RenderTask};
-use render_task::{RenderTaskId, RenderTaskLocation, RenderTaskTree};
+use render_task::{AlphaRenderItem, ClipChain, RenderTask, RenderTaskId, RenderTaskLocation};
+use render_task::RenderTaskTree;
 use resource_cache::ResourceCache;
 use scene::ScenePipeline;
 use std::{mem, usize, f32, i32};
@@ -38,8 +38,7 @@ use tiling::{ClipScrollGroup, ClipScrollGroupIndex, CompositeOps, Frame};
 use tiling::{ContextIsolation, StackingContextIndex};
 use tiling::{PackedLayer, PackedLayerIndex, PrimitiveFlags, PrimitiveRunCmd, RenderPass};
 use tiling::{RenderTargetContext, ScrollbarPrimitive, StackingContext};
-use util::{self, pack_as_float, recycle_vec, subtract_rect};
-use util::{MatrixHelpers, RectHelpers};
+use util::{self, RectHelpers, pack_as_float, recycle_vec, subtract_rect};
 
 /// Construct a polygon from stacking context boundaries.
 /// `anchor` here is an index that's going to be preserved in all the
@@ -143,15 +142,10 @@ pub struct PrimitiveContext<'a> {
     pub packed_layer_index: PackedLayerIndex,
     pub packed_layer: &'a PackedLayer,
     pub device_pixel_ratio: f32,
-
-    // Clip items that apply for this primitive run.
-    // In the future, we'll build these once at the
-    // start of the frame when updating the
-    // clip-scroll tree.
-    pub current_clip_stack: Vec<ClipWorkItem>,
+    pub clip_chain: ClipChain,
     pub clip_bounds: DeviceIntRect,
     pub clip_id: ClipId,
-
+    pub coordinate_system_id: CoordinateSystemId,
     pub display_list: &'a BuiltDisplayList,
 }
 
@@ -160,68 +154,22 @@ impl<'a> PrimitiveContext<'a> {
         packed_layer_index: PackedLayerIndex,
         packed_layer: &'a PackedLayer,
         clip_id: ClipId,
-        screen_rect: &DeviceIntRect,
-        clip_scroll_tree: &ClipScrollTree,
-        clip_store: &ClipStore,
+        clip_chain: ClipChain,
+        clip_bounds: DeviceIntRect,
+        coordinate_system_id: CoordinateSystemId,
         device_pixel_ratio: f32,
         display_list: &'a BuiltDisplayList,
-    ) -> Option<Self> {
-
-        let mut current_clip_stack = Vec::new();
-        let mut clip_bounds = *screen_rect;
-        let mut current_id = Some(clip_id);
-        // Indicates if the next non-reference-frame that we encounter needs to have its
-        // local combined clip rectangle backed into the clip mask.
-        let mut next_node_needs_region_mask = false;
-        while let Some(id) = current_id {
-            let node = &clip_scroll_tree.nodes.get(&id).unwrap();
-            current_id = node.parent;
-
-            let clip = match node.node_type {
-                NodeType::ReferenceFrame(ref info) => {
-                    // if the transform is non-aligned, bake the next LCCR into the clip mask
-                    next_node_needs_region_mask |= !info.transform.preserves_2d_axis_alignment();
-                    continue;
-                }
-                NodeType::Clip(ref clip) => clip,
-                NodeType::StickyFrame(..) | NodeType::ScrollFrame(..) => {
-                    continue;
-                }
-            };
-
-            let clip_sources = clip_store.get(&clip.clip_sources);
-            if !clip_sources.is_masking() {
-                continue;
-            }
-
-            // apply the outer device bounds of the clip stack
-            if let Some(ref outer) = clip_sources.bounds.outer {
-                clip_bounds = match clip_bounds.intersection(&outer.device_rect) {
-                    Some(rect) => rect,
-                    None => return None,
-                }
-            }
-
-            //TODO-LCCR: bake a single LCCR instead of all aligned rects?
-            current_clip_stack.push(ClipWorkItem {
-                layer_index: clip.packed_layer_index,
-                clip_sources: clip.clip_sources.weak(),
-                apply_rectangles: next_node_needs_region_mask,
-            });
-            next_node_needs_region_mask = false;
-        }
-
-        current_clip_stack.reverse();
-
-        Some(PrimitiveContext {
+    ) -> Self {
+        PrimitiveContext {
             packed_layer_index,
             packed_layer,
-            current_clip_stack,
+            clip_chain,
             clip_bounds,
+            coordinate_system_id,
             device_pixel_ratio,
             clip_id,
             display_list,
-        })
+        }
     }
 }
 
@@ -388,6 +336,7 @@ impl FrameBuilder {
             clip_node_id: info.clip_node_id(),
             packed_layer_index,
             screen_bounding_rect: None,
+            coordinate_system_id: CoordinateSystemId(0),
         });
 
         group_id
@@ -1698,7 +1647,6 @@ impl FrameBuilder {
         resource_cache: &mut ResourceCache,
         pipelines: &FastHashMap<PipelineId, ScenePipeline>,
         clip_scroll_tree: &ClipScrollTree,
-        screen_rect: &DeviceIntRect,
         device_pixel_ratio: f32,
         profile_counters: &mut FrameProfileCounters,
     ) -> bool {
@@ -1712,9 +1660,27 @@ impl FrameBuilder {
             }
         };
 
+        let (clip_chain, clip_bounds, coordinate_system_id) =
+            match clip_scroll_tree.nodes.get(&clip_and_scroll.clip_node_id()) {
+            Some(node) if node.combined_clip_outer_bounds != DeviceIntRect::zero() => {
+                let group_id = self.clip_scroll_group_indices[&clip_and_scroll];
+                (
+                    node.clip_chain_node.clone(),
+                    node.combined_clip_outer_bounds,
+                    self.clip_scroll_group_store[group_id].coordinate_system_id,
+                )
+            }
+            _ => {
+                let group_id = self.clip_scroll_group_indices[&clip_and_scroll];
+                self.clip_scroll_group_store[group_id].screen_bounding_rect = None;
+
+                debug!("{:?} of clipped out {:?}", base_prim_index, stacking_context_index);
+                return false;
+            }
+        };
+
+        let stacking_context = &mut self.stacking_context_store[stacking_context_index.0];
         let pipeline_id = {
-            let stacking_context =
-                &mut self.stacking_context_store[stacking_context_index.0];
             if !stacking_context.can_contribute_to_scene() {
                 return false;
             }
@@ -1732,8 +1698,6 @@ impl FrameBuilder {
             packed_layer_index
         );
 
-        let stacking_context =
-            &mut self.stacking_context_store[stacking_context_index.0];
         let packed_layer = &self.packed_layers[packed_layer_index.0];
         let display_list = &pipelines
             .get(&pipeline_id)
@@ -1748,21 +1712,12 @@ impl FrameBuilder {
             packed_layer_index,
             packed_layer,
             clip_and_scroll.clip_node_id(),
-            screen_rect,
-            clip_scroll_tree,
-            &self.clip_store,
+            clip_chain,
+            clip_bounds,
+            coordinate_system_id,
             device_pixel_ratio,
             display_list,
         );
-
-        let prim_context = match prim_context {
-            Some(prim_context) => prim_context,
-            None => {
-                let group_id = self.clip_scroll_group_indices[&clip_and_scroll];
-                self.clip_scroll_group_store[group_id].screen_bounding_rect = None;
-                return false
-            },
-        };
 
         debug!(
             "\tclip_bounds {:?}, layer_local_clip {:?}",
@@ -1853,52 +1808,6 @@ impl FrameBuilder {
         }
     }
 
-    fn recalculate_clip_scroll_nodes(
-        &mut self,
-        clip_scroll_tree: &mut ClipScrollTree,
-        gpu_cache: &mut GpuCache,
-        resource_cache: &mut ResourceCache,
-        screen_rect: &DeviceIntRect,
-        device_pixel_ratio: f32
-    ) {
-        for (_, ref mut node) in clip_scroll_tree.nodes.iter_mut() {
-            let node_clip_info = match node.node_type {
-                NodeType::Clip(ref mut clip_info) => clip_info,
-                _ => continue,
-            };
-
-            let packed_layer_index = node_clip_info.packed_layer_index;
-            let packed_layer = &mut self.packed_layers[packed_layer_index.0];
-
-            // The coordinates of the mask are relative to the origin of the node itself,
-            // so we need to account for that origin in the transformation we assign to
-            // the packed layer.
-            let transform = node.world_viewport_transform
-                .pre_translate(node.local_viewport_rect.origin.to_vector().to_3d());
-
-            if packed_layer.set_transform(transform) {
-                // Meanwhile, the combined viewport rect is relative to the reference frame, so
-                // we move it into the local coordinate system of the node.
-                let local_viewport_rect = node.combined_local_viewport_rect
-                    .translate(&-node.local_viewport_rect.origin.to_vector());
-
-                packed_layer.set_rect(
-                    &local_viewport_rect,
-                    screen_rect,
-                    device_pixel_ratio,
-                );
-            }
-
-            let clip_sources = self.clip_store.get_mut(&node_clip_info.clip_sources);
-            clip_sources.update(
-                &transform,
-                gpu_cache,
-                resource_cache,
-                device_pixel_ratio,
-            );
-        }
-    }
-
     fn recalculate_clip_scroll_groups(
         &mut self,
         clip_scroll_tree: &ClipScrollTree,
@@ -1937,6 +1846,8 @@ impl FrameBuilder {
                 device_pixel_ratio,
             );
 
+            group.coordinate_system_id = scroll_node.coordinate_system_id;
+
             debug!(
                 "\t\tlocal viewport {:?} screen bound {:?}",
                 local_viewport_rect,
@@ -1960,13 +1871,6 @@ impl FrameBuilder {
     ) {
         profile_scope!("cull");
 
-        self.recalculate_clip_scroll_nodes(
-            clip_scroll_tree,
-            gpu_cache,
-            resource_cache,
-            screen_rect,
-            device_pixel_ratio
-        );
         self.recalculate_clip_scroll_groups(
             clip_scroll_tree,
             screen_rect,
@@ -1990,7 +1894,6 @@ impl FrameBuilder {
                         resource_cache,
                         pipelines,
                         clip_scroll_tree,
-                        screen_rect,
                         device_pixel_ratio,
                         profile_counters,
                     );
@@ -2360,6 +2263,7 @@ impl FrameBuilder {
         clip_scroll_tree: &mut ClipScrollTree,
         pipelines: &FastHashMap<PipelineId, ScenePipeline>,
         device_pixel_ratio: f32,
+        pan: LayerPoint,
         output_pipelines: &FastHashSet<PipelineId>,
         texture_cache_profile: &mut TextureCacheProfileCounters,
         gpu_cache_profile: &mut GpuCacheProfileCounters,
@@ -2380,6 +2284,16 @@ impl FrameBuilder {
                 self.screen_size.width as i32,
                 self.screen_size.height as i32,
             ),
+        );
+
+        clip_scroll_tree.update_all_node_transforms(
+            &screen_rect,
+            device_pixel_ratio,
+            &mut self.packed_layers,
+            &mut self.clip_store,
+            resource_cache,
+            gpu_cache,
+            pan
         );
 
         self.update_scroll_bars(clip_scroll_tree, gpu_cache);

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -103,7 +103,7 @@ impl Document {
             self.pan.x as f32 / accumulated_scale_factor,
             self.pan.y as f32 / accumulated_scale_factor,
         );
-        self.frame.build(
+        self.frame.build_renderer_frame(
             resource_cache,
             gpu_cache,
             &self.scene.pipelines,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -9,6 +9,7 @@ use api::{LayerToWorldTransform, MixBlendMode, PipelineId, PropertyBinding, Tran
 use api::{LayerVector2D, TileOffset, WorldToLayerTransform, YuvColorSpace, YuvFormat};
 use border::{BorderCornerInstance, BorderCornerSide};
 use clip::{ClipSource, ClipStore};
+use clip_scroll_tree::CoordinateSystemId;
 use device::Texture;
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle, GpuCacheUpdateList};
 use gpu_types::{BlurDirection, BlurInstance, BoxShadowCacheInstance, ClipMaskInstance};
@@ -812,11 +813,13 @@ impl ClipBatcher {
         &mut self,
         task_address: RenderTaskAddress,
         clips: &[ClipWorkItem],
+        coordinate_system_id: CoordinateSystemId,
         resource_cache: &ResourceCache,
         gpu_cache: &GpuCache,
         geometry_kind: MaskGeometryKind,
         clip_store: &ClipStore,
     ) {
+        let mut coordinate_system_id = coordinate_system_id;
         for work_item in clips.iter() {
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
@@ -845,12 +848,15 @@ impl ClipBatcher {
                                 ..instance
                             });
                     }
-                    ClipSource::Rectangle(..) => if work_item.apply_rectangles {
-                        self.rectangles.push(ClipMaskInstance {
-                            clip_data_address: gpu_address,
-                            segment: MaskSegment::All as i32,
-                            ..instance
-                        });
+                    ClipSource::Rectangle(..) => {
+                        if work_item.coordinate_system_id != coordinate_system_id {
+                            self.rectangles.push(ClipMaskInstance {
+                                clip_data_address: gpu_address,
+                                segment: MaskSegment::All as i32,
+                                ..instance
+                            });
+                            coordinate_system_id = work_item.coordinate_system_id;
+                        }
                     },
                     ClipSource::RoundedRectangle(..) => match geometry_kind {
                         MaskGeometryKind::Default => {
@@ -1305,6 +1311,7 @@ impl RenderTarget for AlphaRenderTarget {
                 self.clip_batcher.add(
                     task_address,
                     &task_info.clips,
+                    task_info.coordinate_system_id,
                     &ctx.resource_cache,
                     gpu_cache,
                     task_info.geometry_kind,
@@ -1686,6 +1693,7 @@ pub struct ClipScrollGroup {
     pub clip_node_id: ClipId,
     pub packed_layer_index: PackedLayerIndex,
     pub screen_bounding_rect: Option<(TransformedRectKind, DeviceIntRect)>,
+    pub coordinate_system_id: CoordinateSystemId,
 }
 
 impl ClipScrollGroup {


### PR DESCRIPTION
Clip chains are a linked list of ClipWorkItems that are used to avoid
having to recalculate the stack of clips necessary to render items when
switching between different ClipScrollNodes. The ClipChains are
calculated once on a per node basis during update_transform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1833)
<!-- Reviewable:end -->
