### PR TITLE
Fix nested clips in sticky frames

### DIFF
--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -10,4 +10,5 @@
 == clip-and-scroll-property.yaml clip-and-scroll-property-ref.yaml
 == translate-nested.yaml translate-nested-ref.yaml
 == sticky.yaml sticky-ref.yaml
+== sticky-nested.yaml sticky-ref.yaml
 == sibling-hidden-clip.yaml sibling-hidden-clip-ref.yaml

--- a/wrench/reftests/scrolling/sticky-nested.yaml
+++ b/wrench/reftests/scrolling/sticky-nested.yaml
@@ -1,0 +1,215 @@
+root:
+  items:
+    # This is a scroll frame with an out-of-viewport rect that should be pushed into the
+    # viewport by its "bottom" sticky constraint.
+    - type: scroll-frame
+      bounds: [10, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [10, 60, 50, 50]
+        sticky-info:
+          bottom: [0, -500]
+        items:
+        - type: clip
+          bounds: [10, 60, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [10, 60, 50, 50]
+            color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [70, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [70, 10, 50, 50]
+        sticky-info:
+          top: [0, 500]
+        items:
+        - type: clip
+          bounds: [70, 10, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [70, 10, 50, 50]
+            color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [10, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [60, 70, 50, 50]
+        sticky-info:
+          right: [0, -500]
+        items:
+        - type: clip
+          bounds: [60, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [60, 70, 50, 50]
+            color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [70, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [70, 70, 50, 50]
+        sticky-info:
+          left: [0, 500]
+        items:
+        - type: clip
+          bounds: [70, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [70, 70, 50, 50]
+            color: green
+
+    # The same tests, but this time with a margin.
+    - type: scroll-frame
+      bounds: [130, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [130, 60, 50, 50]
+        sticky-info:
+          bottom: [10, -500]
+        items:
+        - type: clip
+          bounds: [130, 60, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [130, 60, 50, 50]
+            color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [190, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [190, 10, 50, 50]
+        sticky-info:
+          top: [10, 500]
+        items:
+        - type: clip
+          bounds: [190, 10, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [190, 10, 50, 50]
+            color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [130, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [180, 70, 50, 50]
+        sticky-info:
+          right: [10, -500]
+        items:
+        - type: clip
+          bounds: [180, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [180, 70, 50, 50]
+            color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [190, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [190, 70, 50, 50]
+        sticky-info:
+          left: [10, 500]
+        items:
+        - type: clip
+          bounds: [190, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [190, 70, 50, 50]
+            color: green
+
+    # The same tests, but this time with a limit.
+    - type: scroll-frame
+      bounds: [250, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [250, 60, 50, 50]
+        sticky-info:
+          bottom: [0, -25]
+        items:
+        - type: clip
+          bounds: [250, 60, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [250, 60, 50, 50]
+            color: green
+    # Do the same thing, but now for the "top" constraint.
+    - type: scroll-frame
+      bounds: [310, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 50]
+      items:
+      - type: sticky-frame
+        bounds: [310, 10, 50, 50]
+        sticky-info:
+          top: [0, 25]
+        items:
+        - type: clip
+          bounds: [310, 10, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [310, 10, 50, 50]
+            color: green
+    # Do the same thing, but now for the "right" constraint.
+    - type: scroll-frame
+      bounds: [250, 70, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: sticky-frame
+        bounds: [300, 70, 50, 50]
+        sticky-info:
+          right: [0, -25]
+        items:
+        - type: clip
+          bounds: [300, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [300, 70, 50, 50]
+            color: green
+    # Do the same thing, but now for the "left" constraint.
+    - type: scroll-frame
+      bounds: [310, 70, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [50, 0]
+      items:
+      - type: sticky-frame
+        bounds: [310, 70, 50, 50]
+        sticky-info:
+          left: [0, 25]
+        items:
+        - type: clip
+          bounds: [310, 70, 50, 50]
+          content-size: [100, 100]
+          items:
+          - type: rect
+            bounds: [310, 70, 50, 50]
+            color: green


### PR DESCRIPTION
Pass on sticky offsets as scrolling offsets in a way that ensures that
nested clips move properly with their parent sticky frame.

Fixes #1777.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1845)
<!-- Reviewable:end -->
