### PR TITLE
Fix diacritic glyphs on Linux.

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -278,12 +278,6 @@ impl FontContext {
     ) -> Option<GlyphDimensions> {
         let metrics = unsafe { &(*slot).metrics };
 
-        // If there's no advance, no need to consider this glyph
-        // for layout.
-        if metrics.horiAdvance == 0 {
-            return None
-        }
-
         let advance = metrics.horiAdvance as f32 / 64.0;
         match unsafe { (*slot).format } {
             FT_Glyph_Format::FT_GLYPH_FORMAT_BITMAP => {

--- a/wrench/reftests/text/diacritics-ref.yaml
+++ b/wrench/reftests/text/diacritics-ref.yaml
@@ -1,0 +1,6 @@
+root:
+  items:
+    - text: "x"
+      origin: 20 30
+      size: 20
+      font: "FreeSans.ttf"

--- a/wrench/reftests/text/diacritics.yaml
+++ b/wrench/reftests/text/diacritics.yaml
@@ -1,0 +1,6 @@
+root:
+  items:
+    - text: "x̂"
+      origin: 20 30
+      size: 20
+      font: "FreeSans.ttf"

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -32,3 +32,4 @@ fuzzy(1,2) platform(linux) == colors.yaml colors-subpx.png
 platform(linux) options(disable-subpixel) == border-radius.yaml border-radius-alpha.png
 platform(linux) == border-radius.yaml border-radius-subpx.png
 options(disable-aa) == transparent-no-aa.yaml transparent-no-aa-ref.yaml
+!= diacritics.yaml diacritics-ref.yaml


### PR DESCRIPTION
Diacritic glyphs have a valid width and height, but a
zero advance. Previously we were discarding these but
they are valid glyphs. The code also checks for a width
and height of 0 below, which catches non-printable glyphs
such as spaces.

Fixes #1846.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1868)
<!-- Reviewable:end -->
