### PR TITLE
Fix plane splitting precision error.

### DIFF
--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -5,4 +5,5 @@
 == perspective-clipping.yaml perspective-clipping-ref.yaml
 == intermediate-1.yaml intermediate-1-ref.yaml
 == intermediate-2.yaml intermediate-1-ref.yaml
+== split-intersect1.yaml split-intersect1-ref.yaml
 #== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences

--- a/wrench/reftests/split/split-intersect1-ref.yaml
+++ b/wrench/reftests/split/split-intersect1-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+    - type: stacking-context
+      items:
+        - type: stacking-context
+          items:
+            - type: rect
+              bounds: 50 0 50 100
+              color: red
+        - type: stacking-context
+          items:
+            - type: rect
+              bounds: 0 0 50 100
+              color: green

--- a/wrench/reftests/split/split-intersect1.yaml
+++ b/wrench/reftests/split/split-intersect1.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+    - type: stacking-context
+      transform-style: preserve-3d
+      items:
+        - type: stacking-context
+          items:
+            - type: rect
+              bounds: 0 0 100 100
+              color: red
+        - type: stacking-context
+          transform: rotate-y(0.1)
+          bounds: 0 0 100 100
+          items:
+            - type: rect
+              bounds: 0 0 100 100
+              color: green


### PR DESCRIPTION
We use f32 for plane splitting calculation. But f32 would have some precision error. I use f64 instead to prevent precision error.

r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1869)
<!-- Reviewable:end -->
