### PR TITLE
Add routes to publish pulse messages

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -66,6 +66,8 @@ tasks:
           servo-tidy &&
           (cd wrench && python headless.py reftest) &&
           (cd wrench && cargo build --release --features=debugger)
+    routes:
+      - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.linux-release"
   - metadata:
       name: Linux debug tests
       description: Runs debug-mode WebRender CI stuff on a Linux TC worker
@@ -97,6 +99,8 @@ tasks:
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
           (cargo test --all --verbose)
+    routes:
+      - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.linux-debug"
   # For the OS X jobs we use a pool of machines that we are managing, because
   # Mozilla releng doesn't have any spare OS X machines for us at this time.
   # Talk to :kats or :jrmuizel if you need more details about this. The machines
@@ -136,6 +140,8 @@ tasks:
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
           (cargo test --all --verbose)
+    routes:
+      - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.osx-release"
   - metadata:
       name: OS X debug tests
       description: Runs debug-mode WebRender CI stuff on a OS X TC worker
@@ -165,3 +171,5 @@ tasks:
           export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&
           (cd wrench && python headless.py reftest) &&
           (cd wrench && cargo build --release --features=debugger)
+    routes:
+      - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.osx-debug"


### PR DESCRIPTION
This will cause the CI tasks to be indexed, which makes them easily
viewable at https://tools.taskcluster.net/index/garbage.webrender.ci/
But more importantly, it will cause TaskCluster to send pulse messages
when these tasks are completed, which we can listen for. One way is to
use the pulse inspector at https://tools.taskcluster.net/pulse-inspector
with the route "#.webrender.#" on the following exchanges:
  exchange/taskcluster-queue/v1/task-completed (for successful tasks)
  exchange/taskcluster-queue/v1/task-failed (for failed tasks)
  exchange/taskcluster-queue/v1/task-exception (for taskcluster errors)
We can also listen for these in any program using the pulse API (e.g.
via the mozillapulse python library).
This can eventually be used to notify bors/homu if the test jobs succeed
so it can merge without waiting for the slower travis runs to complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1871)
<!-- Reviewable:end -->
