### PR TITLE
Fix aa clamping for transparent text

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1248,7 +1248,7 @@ impl FrameBuilder {
         // We defer this until after fast-shadows so that shadows of transparent text
         // get subpixel-aa
         if color.a != 1.0 {
-            prim.font.render_mode = FontRenderMode::Alpha;
+            prim.font.render_mode = prim.font.render_mode.limit_by(FontRenderMode::Alpha);
         }
 
         // Create (and add to primitive store) the primitive that will be

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -31,3 +31,4 @@ fuzzy(1,4) platform(linux) options(disable-subpixel) == colors.yaml colors-alpha
 fuzzy(1,2) platform(linux) == colors.yaml colors-subpx.png
 platform(linux) options(disable-subpixel) == border-radius.yaml border-radius-alpha.png
 platform(linux) == border-radius.yaml border-radius-subpx.png
+options(disable-aa) == transparent-no-aa.yaml transparent-no-aa-ref.yaml

--- a/wrench/reftests/text/transparent-no-aa-ref.yaml
+++ b/wrench/reftests/text/transparent-no-aa-ref.yaml
@@ -1,0 +1,17 @@
+---
+root: 
+  items: 
+        - 
+          type: "shadow"
+          bounds: [0, 0, 200, 200]
+          offset: [0, 0]
+          blur-radius: 0
+          color: [0, 0, 0, 0.5]
+        - 
+          text: "hello everybody"
+          origin: [10, 20]
+          size: 18
+          color: [0, 0, 0, 0]
+          font: "VeraBd.ttf"
+        - 
+          type: "pop-all-shadows"

--- a/wrench/reftests/text/transparent-no-aa.yaml
+++ b/wrench/reftests/text/transparent-no-aa.yaml
@@ -1,0 +1,9 @@
+---
+root: 
+  items: 
+        - 
+          text: "hello everybody"
+          origin: [10, 20]
+          size: 18
+          color: [0, 0, 0, 0.5]
+          font: "VeraBd.ttf"

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -29,6 +29,7 @@ const PLATFORM: &str = "mac";
 const PLATFORM: &str = "other";
 
 const OPTION_DISABLE_SUBPX: &str = "disable-subpixel";
+const OPTION_DISABLE_AA: &str = "disable-aa";
 
 pub struct ReftestOptions {
     // These override values that are lower.
@@ -212,6 +213,9 @@ impl ReftestManifest {
                         let (_, args, _) = parse_function(options);
                         if args.iter().any(|arg| arg == &OPTION_DISABLE_SUBPX) {
                             font_render_mode = Some(FontRenderMode::Alpha);
+                        }
+                        if args.iter().any(|arg| arg == &OPTION_DISABLE_AA) {
+                            font_render_mode = Some(FontRenderMode::Mono);
                         }
                     }
                     "==" => {


### PR DESCRIPTION
My previous patch accidentally resulted in upgrading mono to alpha.

Currently causing two failures in the linux CI since it uses Mono everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1873)
<!-- Reviewable:end -->
