### PR TITLE
Allow resource updates to affect pipeline epochs.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -222,6 +222,10 @@ impl Frame {
             .finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
     }
 
+    pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {
+        self.pipeline_epoch_map.insert(pipeline_id, epoch);
+    }
+
     fn flatten_clip<'a>(
         &mut self,
         context: &mut FlattenContext,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -297,6 +297,17 @@ impl RenderBackend {
 
                 DocumentOp::Built
             }
+            DocumentMsg::UpdatePipelineResources { resources, pipeline_id, epoch } => {
+                profile_scope!("UpdateResources");
+
+                self.resource_cache
+                    .update_resources(resources, &mut profile_counters.resources);
+
+                doc.scene.update_epoch(pipeline_id, epoch);
+                doc.frame.update_epoch(pipeline_id, epoch);
+
+                DocumentOp::Nop
+            }
             DocumentMsg::SetRootPipeline(pipeline_id) => {
                 profile_scope!("SetRootPipeline");
 

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -133,6 +133,12 @@ impl Scene {
         }
         self.pipelines.remove(&pipeline_id);
     }
+
+    pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {
+        if let Some(pipeline) = self.pipelines.get_mut(&pipeline_id) {
+            pipeline.epoch = epoch;
+        }
+    }
 }
 
 pub trait FilterOpHelpers {


### PR DESCRIPTION
This adds `DocumentMsg::UpdatePipelineResources` which allows updating resources *and* update a pipeline's epoch (useful when the resources being updated are as meaningful as layout updates, for gecko this is typically image updates).

This doesn't remove the global (as in not associated to a given pipeline) `UpdateResources` message because it is easier for servo to keep using that one for now and even for gecko there are several cases where the global resource updates message is a better fir like adding fonts and cleaning up after a pipeline is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1883)
<!-- Reviewable:end -->
