### PR TITLE
Include point relative to the item in HitTest result

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1625,6 +1625,7 @@ impl FrameBuilder {
                     pipeline: clip_and_scroll.clip_node_id().pipeline_id(),
                     tag: item.tag,
                     point_in_viewport,
+                    point_relative_to_item: point_in_layer - item.rect.origin.to_vector(),
                 });
                 if !flags.contains(FIND_ALL) {
                     return result;

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -154,6 +154,10 @@ pub struct HitTestItem {
     /// viewport is the scroll node formed by the root reference frame of the display item's
     /// pipeline.
     pub point_in_viewport: LayoutPoint,
+
+    /// The coordinates of the original hit test point relative to the origin of this item.
+    /// This is useful for calculating things like text offsets in the client.
+    pub point_relative_to_item: LayoutPoint,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]


### PR DESCRIPTION
This will allow Servo to calculate the character index in text fields
during hit testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1884)
<!-- Reviewable:end -->
