### PR TITLE
Make push_text accept an iterator, to avoid copies in gecko

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -313,7 +313,7 @@ impl Example for App {
             let info = LayoutPrimitiveInfo::new(text_bounds);
             builder.push_text(
                 &info,
-                &glyphs,
+                glyphs.iter().cloned(),
                 font_instance_key,
                 ColorF::new(1.0, 1.0, 0.0, 1.0),
                 None,

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -809,23 +809,26 @@ impl DisplayListBuilder {
         self.push_item(item, info);
     }
 
-    pub fn push_text(
+    pub fn push_text<I>(
         &mut self,
         info: &LayoutPrimitiveInfo,
-        glyphs: &[GlyphInstance],
+        mut glyphs: I,
         font_key: FontInstanceKey,
         color: ColorF,
         glyph_options: Option<GlyphOptions>,
-    ) {
+    ) where 
+        I: ExactSizeIterator<Item=GlyphInstance>,
+    {
         let item = SpecificDisplayItem::Text(TextDisplayItem {
             color,
             font_key,
             glyph_options,
         });
 
-        for split_glyphs in glyphs.chunks(MAX_TEXT_RUN_LENGTH) {
+        // Consumed in chunks to avoid problems in the backend
+        while glyphs.len() > 0 {
             self.push_item(item, info);
-            self.push_iter(split_glyphs);
+            self.push_iter(glyphs.by_ref().take(MAX_TEXT_RUN_LENGTH));
         }
     }
 

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -990,7 +990,7 @@ impl YamlFrameReader {
         };
         info.rect = rect;
 
-        dl.push_text(&info, &glyphs, font_instance_key, color, None);
+        dl.push_text(&info, glyphs.iter().cloned(), font_instance_key, color, None);
     }
 
     fn handle_iframe(


### PR DESCRIPTION
This will probably be a **[breaking change]** for servo/gecko, but trivially fixed as seen in the wrench/example case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1885)
<!-- Reviewable:end -->
