### PR TITLE
Remove redundant nested cfg statements

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -707,7 +707,6 @@ impl<T> GpuProfiler<T> {
     where
         T: NamedTag,
     {
-        #[cfg(feature = "query")]
         self.frames[self.next_frame].add_marker(tag)
     }
 
@@ -715,12 +714,10 @@ impl<T> GpuProfiler<T> {
     where
         T: NamedTag,
     {
-        #[cfg(feature = "query")]
         self.frames[self.next_frame].add_sampler(tag)
     }
 
     pub fn done_sampler(&mut self) {
-        #[cfg(feature = "query")]
         self.frames[self.next_frame].done_sampler()
     }
 }


### PR DESCRIPTION
Since the entire impl is wrapped in the same cfg, it seems unnecessary to put it inside the function bodies as well. This causes cbindgen to fail when parsing the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1887)
<!-- Reviewable:end -->
