### PR TITLE
Remove `heapsize` dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,7 +1095,6 @@ dependencies = [
  "core-graphics 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -15,7 +15,6 @@ bitflags = "1.0"
 bincode = "0.9"
 byteorder = "1.0"
 euclid = "0.15"
-heapsize = ">= 0.3.6, < 0.5"
 ipc-channel = {version = "0.9", optional = true}
 serde = { version = "1.0", features = ["rc", "derive"] }
 time = "0.1"

--- a/webrender_api/src/color.rs
+++ b/webrender_api/src/color.rs
@@ -16,7 +16,6 @@ pub struct ColorF {
     pub b: f32,
     pub a: f32,
 }
-known_heap_size!(0, ColorF);
 
 impl ColorF {
     /// Constructs a new `ColorF` from its components.

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -337,7 +337,6 @@ pub struct GradientStop {
     pub offset: f32,
     pub color: ColorF,
 }
-known_heap_size!(0, GradientStop);
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RadialGradient {
@@ -376,8 +375,6 @@ pub enum ScrollPolicy {
     Scrollable = 0,
     Fixed = 1,
 }
-
-known_heap_size!(0, ScrollPolicy);
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -699,21 +696,3 @@ impl ClipId {
         }
     }
 }
-
-macro_rules! define_empty_heap_size_of {
-    ($name:ident) => {
-        impl ::heapsize::HeapSizeOf for $name {
-            fn heap_size_of_children(&self) -> usize { 0 }
-        }
-    }
-}
-
-define_empty_heap_size_of!(ClipAndScrollInfo);
-define_empty_heap_size_of!(ClipId);
-define_empty_heap_size_of!(ImageKey);
-define_empty_heap_size_of!(LocalClip);
-define_empty_heap_size_of!(MixBlendMode);
-define_empty_heap_size_of!(RepeatMode);
-define_empty_heap_size_of!(ScrollSensitivity);
-define_empty_heap_size_of!(StickySideConstraint);
-define_empty_heap_size_of!(TransformStyle);

--- a/webrender_api/src/lib.rs
+++ b/webrender_api/src/lib.rs
@@ -13,8 +13,6 @@ extern crate byteorder;
 #[cfg(feature = "nightly")]
 extern crate core;
 extern crate euclid;
-#[macro_use]
-extern crate heapsize;
 #[cfg(feature = "ipc")]
 extern crate ipc_channel;
 #[macro_use]


### PR DESCRIPTION
The `heapsize` crate is being deprecated in favour of the `malloc_size_of`
crate within Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1900)
<!-- Reviewable:end -->
