### PR TITLE
Pass the dirty rect down into the blob image

### DIFF
--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use webrender::api::{self, DisplayListBuilder, DocumentId, LayoutSize, PipelineId, RenderApi,
-                     ResourceUpdates};
+use webrender::api::{self, DeviceUintRect, DisplayListBuilder, DocumentId, LayoutSize, PipelineId,
+                     RenderApi, ResourceUpdates};
 
 // This example shows how to implement a very basic BlobImageRenderer that can only render
 // a checkerboard pattern.
@@ -145,7 +145,7 @@ impl api::BlobImageRenderer for CheckerboardRenderer {
             .insert(key, Arc::new(deserialize_blob(&cmds[..]).unwrap()));
     }
 
-    fn update(&mut self, key: api::ImageKey, cmds: api::BlobImageData) {
+    fn update(&mut self, key: api::ImageKey, cmds: api::BlobImageData, _dirty_rect: Option<DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
         self.image_cmds

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -430,7 +430,7 @@ impl ResourceCache {
                 self.blob_image_renderer
                     .as_mut()
                     .unwrap()
-                    .update(image_key, mem::replace(blob, BlobImageData::new()));
+                    .update(image_key, mem::replace(blob, BlobImageData::new()), dirty_rect);
             }
 
             ImageResource {

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -151,7 +151,7 @@ pub trait BlobImageResources {
 pub trait BlobImageRenderer: Send {
     fn add(&mut self, key: ImageKey, data: BlobImageData, tiling: Option<TileSize>);
 
-    fn update(&mut self, key: ImageKey, data: BlobImageData);
+    fn update(&mut self, key: ImageKey, data: BlobImageData, dirty_rect: Option<DeviceUintRect>);
 
     fn delete(&mut self, key: ImageKey);
 

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -105,7 +105,7 @@ impl BlobImageRenderer for CheckerboardRenderer {
             .insert(key, deserialize_blob(&cmds[..]).unwrap());
     }
 
-    fn update(&mut self, key: ImageKey, cmds: BlobImageData) {
+    fn update(&mut self, key: ImageKey, cmds: BlobImageData, _dirty_rect: Option<DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
         self.image_cmds


### PR DESCRIPTION
This lets us know which area of the image has changed and is useful
for merging the old blob data and the new blob data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1903)
<!-- Reviewable:end -->
