### PR TITLE
Require immutable, threadsafe render notifier at renderer initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.52.1",
+ "webrender 0.53.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1050,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "angle 0.5.0 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1079,13 +1079,13 @@ dependencies = [
  "servo-glutin 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.52.1",
+ "webrender_api 0.53.0",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.52.1"
+version = "0.53.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -125,12 +125,10 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
     };
 
     let size = DeviceUintSize::new(width, height);
-    let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), opts).unwrap();
+    let notifier = Box::new(Notifier::new(window.create_window_proxy()));
+    let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), notifier, opts).unwrap();
     let api = sender.create_api();
     let document_id = api.add_document(size);
-
-    let notifier = Box::new(Notifier::new(window.create_window_proxy()));
-    renderer.set_render_notifier(notifier);
 
     if let Some(external_image_handler) = example.get_external_image_handler() {
         renderer.set_external_image_handler(external_image_handler);

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -22,12 +22,18 @@ impl Notifier {
 }
 
 impl RenderNotifier for Notifier {
-    fn new_frame_ready(&mut self) {
+    fn clone(&self) -> Box<RenderNotifier> {
+        Box::new(Notifier {
+            window_proxy: self.window_proxy.clone(),
+        })
+    }
+
+    fn new_frame_ready(&self) {
         #[cfg(not(target_os = "android"))]
         self.window_proxy.wakeup_event_loop();
     }
 
-    fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {
+    fn new_scroll_frame_ready(&self, _composite_needed: bool) {
         #[cfg(not(target_os = "android"))]
         self.window_proxy.wakeup_event_loop();
     }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -145,7 +145,7 @@ pub struct RenderBackend {
     frame_config: FrameBuilderConfig,
     documents: FastHashMap<DocumentId, Document>,
 
-    notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
+    notifier: Arc<Mutex<Box<RenderNotifier>>>,
     recorder: Option<Box<ApiRecordingReceiver>>,
 
     enable_render_on_scroll: bool,
@@ -160,7 +160,7 @@ impl RenderBackend {
         default_device_pixel_ratio: f32,
         texture_cache: TextureCache,
         workers: Arc<ThreadPool>,
-        notifier: Arc<Mutex<Option<Box<RenderNotifier>>>>,
+        notifier: Arc<Mutex<Box<RenderNotifier>>>,
         frame_config: FrameBuilderConfig,
         recorder: Option<Box<ApiRecordingReceiver>>,
         blob_image_renderer: Option<Box<BlobImageRenderer>>,
@@ -445,7 +445,7 @@ impl RenderBackend {
                 }
                 Err(..) => {
                     let notifier = self.notifier.lock();
-                    notifier.unwrap().as_mut().unwrap().shut_down();
+                    notifier.unwrap().shut_down();
                     break;
                 }
             };
@@ -512,7 +512,7 @@ impl RenderBackend {
                 }
                 ApiMsg::ExternalEvent(evt) => {
                     let notifier = self.notifier.lock();
-                    notifier.unwrap().as_mut().unwrap().external_event(evt);
+                    notifier.unwrap().external_event(evt);
                 }
                 ApiMsg::ClearNamespace(namespace_id) => {
                     self.resource_cache.clear_namespace(namespace_id);
@@ -540,8 +540,6 @@ impl RenderBackend {
                     self.notifier
                         .lock()
                         .unwrap()
-                        .as_mut()
-                        .unwrap()
                         .new_frame_ready();
                 }
                 ApiMsg::DebugCommand(option) => {
@@ -558,11 +556,11 @@ impl RenderBackend {
                     };
                     self.result_tx.send(msg).unwrap();
                     let notifier = self.notifier.lock();
-                    notifier.unwrap().as_mut().unwrap().new_frame_ready();
+                    notifier.unwrap().new_frame_ready();
                 }
                 ApiMsg::ShutDown => {
                     let notifier = self.notifier.lock();
-                    notifier.unwrap().as_mut().unwrap().shut_down();
+                    notifier.unwrap().shut_down();
                     break;
                 }
             }
@@ -597,8 +595,6 @@ impl RenderBackend {
         notifier
             .as_mut()
             .unwrap()
-            .as_mut()
-            .unwrap()
             .new_frame_ready();
     }
 
@@ -609,8 +605,6 @@ impl RenderBackend {
         //           cleaner way to do this, or use the OnceMutex on crates.io?
         let mut notifier = self.notifier.lock();
         notifier
-            .as_mut()
-            .unwrap()
             .as_mut()
             .unwrap()
             .new_scroll_frame_ready(composite_needed);

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -23,7 +23,7 @@ use scene::Scene;
 #[cfg(feature = "debugger")]
 use serde_json;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::sync::mpsc::Sender;
 use std::u32;
 use texture_cache::TextureCache;
@@ -145,7 +145,7 @@ pub struct RenderBackend {
     frame_config: FrameBuilderConfig,
     documents: FastHashMap<DocumentId, Document>,
 
-    notifier: Arc<Mutex<Box<RenderNotifier>>>,
+    notifier: Box<RenderNotifier>,
     recorder: Option<Box<ApiRecordingReceiver>>,
 
     enable_render_on_scroll: bool,
@@ -160,7 +160,7 @@ impl RenderBackend {
         default_device_pixel_ratio: f32,
         texture_cache: TextureCache,
         workers: Arc<ThreadPool>,
-        notifier: Arc<Mutex<Box<RenderNotifier>>>,
+        notifier: Box<RenderNotifier>,
         frame_config: FrameBuilderConfig,
         recorder: Option<Box<ApiRecordingReceiver>>,
         blob_image_renderer: Option<Box<BlobImageRenderer>>,
@@ -444,8 +444,7 @@ impl RenderBackend {
                     msg
                 }
                 Err(..) => {
-                    let notifier = self.notifier.lock();
-                    notifier.unwrap().shut_down();
+                    self.notifier.shut_down();
                     break;
                 }
             };
@@ -511,8 +510,7 @@ impl RenderBackend {
                     self.documents.remove(&document_id);
                 }
                 ApiMsg::ExternalEvent(evt) => {
-                    let notifier = self.notifier.lock();
-                    notifier.unwrap().external_event(evt);
+                    self.notifier.external_event(evt);
                 }
                 ApiMsg::ClearNamespace(namespace_id) => {
                     self.resource_cache.clear_namespace(namespace_id);
@@ -537,10 +535,7 @@ impl RenderBackend {
                     // We use new_frame_ready to wake up the renderer and get the
                     // resource updates processed, but the UpdateResources message
                     // will cancel rendering the frame.
-                    self.notifier
-                        .lock()
-                        .unwrap()
-                        .new_frame_ready();
+                    self.notifier.new_frame_ready();
                 }
                 ApiMsg::DebugCommand(option) => {
                     let msg = match option {
@@ -555,12 +550,10 @@ impl RenderBackend {
                         _ => ResultMsg::DebugCommand(option),
                     };
                     self.result_tx.send(msg).unwrap();
-                    let notifier = self.notifier.lock();
-                    notifier.unwrap().new_frame_ready();
+                    self.notifier.new_frame_ready();
                 }
                 ApiMsg::ShutDown => {
-                    let notifier = self.notifier.lock();
-                    notifier.unwrap().shut_down();
+                    self.notifier.shut_down();
                     break;
                 }
             }
@@ -587,27 +580,11 @@ impl RenderBackend {
     ) {
         self.publish_frame(document_id, frame, profile_counters);
 
-        // TODO(gw): This is kindof bogus to have to lock the notifier
-        //           each time it's used. This is due to some nastiness
-        //           in initialization order for Servo. Perhaps find a
-        //           cleaner way to do this, or use the OnceMutex on crates.io?
-        let mut notifier = self.notifier.lock();
-        notifier
-            .as_mut()
-            .unwrap()
-            .new_frame_ready();
+        self.notifier.new_frame_ready();
     }
 
-    fn notify_compositor_of_new_scroll_frame(&mut self, composite_needed: bool) {
-        // TODO(gw): This is kindof bogus to have to lock the notifier
-        //           each time it's used. This is due to some nastiness
-        //           in initialization order for Servo. Perhaps find a
-        //           cleaner way to do this, or use the OnceMutex on crates.io?
-        let mut notifier = self.notifier.lock();
-        notifier
-            .as_mut()
-            .unwrap()
-            .new_scroll_frame_ready(composite_needed);
+    fn notify_compositor_of_new_scroll_frame(&self, composite_needed: bool) {
+        self.notifier.new_scroll_frame_ready(composite_needed);
     }
 
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -55,7 +55,7 @@ use std::f32;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use texture_cache::TextureCache;
@@ -930,18 +930,14 @@ struct PrimitiveShader {
 }
 
 struct FileWatcher {
-    notifier: Arc<Mutex<Box<RenderNotifier>>>,
+    notifier: Box<RenderNotifier>,
     result_tx: Sender<ResultMsg>,
 }
 
 impl FileWatcherHandler for FileWatcher {
     fn file_changed(&self, path: PathBuf) {
         self.result_tx.send(ResultMsg::RefreshShader(path)).ok();
-        let mut notifier = self.notifier.lock();
-        notifier
-            .as_mut()
-            .unwrap()
-            .new_frame_ready();
+        self.notifier.new_frame_ready();
     }
 }
 
@@ -1238,12 +1234,11 @@ impl Renderer {
         let (result_tx, result_rx) = channel();
         let gl_type = gl.get_type();
 
-        let notifier = Arc::new(Mutex::new(notifier));
         let debug_server = DebugServer::new(api_tx.clone());
 
         let file_watch_handler = FileWatcher {
             result_tx: result_tx.clone(),
-            notifier: Arc::clone(&notifier),
+            notifier: notifier.clone(),
         };
 
         let mut device = Device::new(
@@ -1654,7 +1649,7 @@ impl Renderer {
 
         device.end_frame();
 
-        let backend_notifier = Arc::clone(&notifier);
+        let backend_notifier = notifier.clone();
 
         let default_font_render_mode = match (options.enable_aa, options.enable_subpixel_aa) {
             (true, true) => FontRenderMode::Subpixel,

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.52.1"
+version = "0.53.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -873,10 +873,11 @@ pub struct DynamicProperties {
 }
 
 pub trait RenderNotifier: Send {
-    fn new_frame_ready(&mut self);
-    fn new_scroll_frame_ready(&mut self, composite_needed: bool);
-    fn external_event(&mut self, _evt: ExternalEvent) {
+    fn clone(&self) -> Box<RenderNotifier>;
+    fn new_frame_ready(&self);
+    fn new_scroll_frame_ready(&self, composite_needed: bool);
+    fn external_event(&self, _evt: ExternalEvent) {
         unimplemented!()
     }
-    fn shut_down(&mut self) {}
+    fn shut_down(&self) {}
 }

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -63,6 +63,7 @@ use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::rc::Rc;
+use std::sync::mpsc::{channel, Sender, Receiver};
 use webrender::api::*;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
@@ -278,6 +279,21 @@ fn make_window(
     wrapper
 }
 
+fn create_notifier() -> (Box<RenderNotifier>, Receiver<()>) {
+    // setup a notifier so we can wait for frames to be finished
+    struct Notifier {
+        tx: Sender<()>,
+    };
+    impl RenderNotifier for Notifier {
+        fn new_frame_ready(&mut self) {
+            self.tx.send(()).unwrap();
+        }
+        fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
+    }
+    let (tx, rx) = channel();
+    (Box::new(Notifier { tx: tx }), rx)
+}
+
 fn main() {
     #[cfg(feature = "logging")]
     env_logger::init().unwrap();
@@ -321,6 +337,17 @@ fn main() {
     let dp_ratio = dp_ratio.unwrap_or(window.hidpi_factor());
     let (width, height) = window.get_inner_size_pixels();
     let dim = DeviceUintSize::new(width, height);
+
+    let needs_frame_notifier = ["perf", "reftest", "png", "rawtest"]
+        .iter()
+        .any(|s| args.subcommand_matches(s).is_some());
+    let (notifier, rx) = if needs_frame_notifier {
+        let (notifier, rx) = create_notifier();
+        (Some(notifier), Some(rx))
+    } else {
+        (None, None)
+    };
+
     let mut wrench = Wrench::new(
         &mut window,
         res_path,
@@ -333,6 +360,7 @@ fn main() {
         args.is_present("verbose"),
         args.is_present("no_scissor"),
         args.is_present("no_batch"),
+        notifier,
     );
 
     let mut thing = if let Some(subargs) = args.subcommand_matches("show") {
@@ -341,12 +369,12 @@ fn main() {
         Box::new(BinaryFrameReader::new_from_args(subargs)) as Box<WrenchThing>
     } else if let Some(subargs) = args.subcommand_matches("png") {
         let reader = YamlFrameReader::new_from_args(subargs);
-        png::png(&mut wrench, &mut window, reader);
+        png::png(&mut wrench, &mut window, reader, rx.unwrap());
         wrench.renderer.deinit();
         return;
     } else if let Some(subargs) = args.subcommand_matches("reftest") {
         let (w, h) = window.get_inner_size_pixels();
-        let harness = ReftestHarness::new(&mut wrench, &mut window);
+        let harness = ReftestHarness::new(&mut wrench, &mut window, rx.unwrap());
         let base_manifest = Path::new("reftests/reftest.list");
         let specific_reftest = subargs.value_of("REFTEST").map(|x| Path::new(x));
         let mut reftest_options = ReftestOptions::default();
@@ -358,7 +386,7 @@ fn main() {
         return;
     } else if let Some(_) = args.subcommand_matches("rawtest") {
         {
-            let harness = RawtestHarness::new(&mut wrench, &mut window);
+            let harness = RawtestHarness::new(&mut wrench, &mut window, rx.unwrap());
             harness.run();
         }
         wrench.renderer.deinit();
@@ -367,7 +395,7 @@ fn main() {
         // Perf mode wants to benchmark the total cost of drawing
         // a new displaty list each frame.
         wrench.rebuild_display_lists = true;
-        let harness = PerfHarness::new(&mut wrench, &mut window);
+        let harness = PerfHarness::new(&mut wrench, &mut window, rx.unwrap());
         let base_manifest = Path::new("benchmarks/benchmarks.list");
         let filename = subargs.value_of("filename").unwrap();
         harness.run(base_manifest, filename);

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -279,17 +279,25 @@ fn make_window(
     wrapper
 }
 
-fn create_notifier() -> (Box<RenderNotifier>, Receiver<()>) {
-    // setup a notifier so we can wait for frames to be finished
-    struct Notifier {
-        tx: Sender<()>,
-    };
-    impl RenderNotifier for Notifier {
-        fn new_frame_ready(&mut self) {
-            self.tx.send(()).unwrap();
-        }
-        fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
+struct Notifier {
+    tx: Sender<()>,
+}
+
+// setup a notifier so we can wait for frames to be finished
+impl RenderNotifier for Notifier {
+    fn clone(&self) -> Box<RenderNotifier> {
+        Box::new(Notifier {
+            tx: self.tx.clone(),
+        })
     }
+
+    fn new_frame_ready(&self) {
+        self.tx.send(()).unwrap();
+    }
+    fn new_scroll_frame_ready(&self, _composite_needed: bool) {}
+}
+
+fn create_notifier() -> (Box<RenderNotifier>, Receiver<()>) {
     let (tx, rx) = channel();
     (Box::new(Notifier { tx: tx }), rx)
 }

--- a/wrench/src/perf.rs
+++ b/wrench/src/perf.rs
@@ -9,8 +9,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{channel, Receiver, Sender};
-use webrender::api::*;
+use std::sync::mpsc::Receiver;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
@@ -128,22 +127,7 @@ pub struct PerfHarness<'a> {
 }
 
 impl<'a> PerfHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper) -> PerfHarness<'a> {
-        // setup a notifier so we can wait for frames to be finished
-        struct Notifier {
-            tx: Sender<()>,
-        };
-        impl RenderNotifier for Notifier {
-            fn new_frame_ready(&mut self) {
-                self.tx.send(()).unwrap();
-            }
-            fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
-        }
-        let (tx, rx) = channel();
-        wrench
-            .renderer
-            .set_render_notifier(Box::new(Notifier { tx: tx }));
-
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> PerfHarness<'a> {
         PerfHarness { wrench, window, rx }
     }
 

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -4,7 +4,7 @@
 
 use WindowWrapper;
 use blob;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::Receiver;
 use webrender::api::*;
 use wrench::Wrench;
 
@@ -15,22 +15,7 @@ pub struct RawtestHarness<'a> {
 }
 
 impl<'a> RawtestHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper) -> RawtestHarness<'a> {
-        // setup a notifier so we can wait for frames to be finished
-        struct Notifier {
-            tx: Sender<()>,
-        };
-        impl RenderNotifier for Notifier {
-            fn new_frame_ready(&mut self) {
-                self.tx.send(()).unwrap();
-            }
-            fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
-        }
-        let (tx, rx) = channel();
-        wrench
-            .renderer
-            .set_render_notifier(Box::new(Notifier { tx: tx }));
-
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> RawtestHarness<'a> {
         RawtestHarness {
             wrench: wrench,
             rx: rx,

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -14,7 +14,7 @@ use std::fmt::{Display, Error, Formatter};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::Receiver;
 use webrender::api::*;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
@@ -259,22 +259,7 @@ pub struct ReftestHarness<'a> {
     rx: Receiver<()>,
 }
 impl<'a> ReftestHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper) -> ReftestHarness<'a> {
-        // setup a notifier so we can wait for frames to be finished
-        struct Notifier {
-            tx: Sender<()>,
-        };
-        impl RenderNotifier for Notifier {
-            fn new_frame_ready(&mut self) {
-                self.tx.send(()).unwrap();
-            }
-            fn new_scroll_frame_ready(&mut self, _composite_needed: bool) {}
-        }
-        let (tx, rx) = channel();
-        wrench
-            .renderer
-            .set_render_notifier(Box::new(Notifier { tx: tx }));
-
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> ReftestHarness<'a> {
         ReftestHarness { wrench, window, rx }
     }
 


### PR DESCRIPTION
This addresses one of the top intermittent test failures in Servo and cleans up an awkward part of the renderer API. Instead of storing an optional notifier inside of a shared mutex, we require that the notifier is cloneable and is responsible for its own mutation requirements. This puts the onus on the implementation of a particular notifier to deal with threadsafety concerns, rather than making all consumers pay for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1904)
<!-- Reviewable:end -->
