### PR TITLE
Only respect the text color's alpha component for Bitmap glyphs.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1155,10 +1155,17 @@ impl FrameBuilder {
             }
         }
 
+        let color = match font.render_mode {
+            FontRenderMode::Bitmap => ColorF::new(1.0, 1.0, 1.0, color.a),
+            FontRenderMode::Subpixel |
+            FontRenderMode::Alpha |
+            FontRenderMode::Mono => *color,
+        };
+
         let prim_font = FontInstance::new(
             font.font_key,
             font.size,
-            *color,
+            color,
             render_mode,
             font.subpx_dir,
             font.platform_options,


### PR DESCRIPTION
Fixes #1780.
Fixes #1876.

This restores a chunk of code that was added in #1754 and removed in #1816, with the difference that I use `color.a` as the alpha component instead of `1.0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1905)
<!-- Reviewable:end -->
