### PR TITLE
Add a script to run reftests and spawn reftest analyzer.

### DIFF
--- a/wrench/reftest-debugger.py
+++ b/wrench/reftest-debugger.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import subprocess
+
+with open('reftest.log', "w") as out:
+    try:
+        subprocess.check_call(['./headless.py', 'reftest'], stdout=out)
+        print("All tests passed.")
+    except subprocess.CalledProcessError as ex:
+        subprocess.check_call(['firefox', 'reftest-analyzer.xhtml#logurl=reftest.log'])


### PR DESCRIPTION
This probably only works on Linux, and will need some changes
to support running on Mac and Windows.

Fixes #1863.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1907)
<!-- Reviewable:end -->
