### PR TITLE
Use premultiplied blending for rectangle primitives.

### DIFF
--- a/webrender/res/ps_rectangle.glsl
+++ b/webrender/res/ps_rectangle.glsl
@@ -49,6 +49,6 @@ void main(void) {
 #ifdef WR_FEATURE_CLIP
     alpha = min(alpha, do_clip());
 #endif
-    oFragColor = vColor * vec4(1.0, 1.0, 1.0, alpha);
+    oFragColor = vColor * alpha;
 }
 #endif

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -160,7 +160,7 @@ pub struct RectanglePrimitive {
 
 impl ToGpuBlocks for RectanglePrimitive {
     fn write_gpu_blocks(&self, mut request: GpuDataRequest) {
-        request.push(self.color);
+        request.push(self.color.premultiplied());
     }
 }
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -62,6 +62,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
                     FontRenderMode::Bitmap => BlendMode::PremultipliedAlpha,
                 }
             }
+            PrimitiveKind::Rectangle |
             PrimitiveKind::Image |
             PrimitiveKind::AlignedGradient |
             PrimitiveKind::AngleGradient |
@@ -71,7 +72,10 @@ impl AlphaBatchHelpers for PrimitiveStore {
             } else {
                 BlendMode::None
             },
-            _ => if needs_blending {
+            PrimitiveKind::YuvImage |
+            PrimitiveKind::Border |
+            PrimitiveKind::Line |
+            PrimitiveKind::Brush => if needs_blending {
                 BlendMode::Alpha
             } else {
                 BlendMode::None


### PR DESCRIPTION
It would be nice to drop unpremultiplied blending completely at some point. This change goes one step on the way there.

r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1914)
<!-- Reviewable:end -->
