### PR TITLE
Switch ps_cache_image to be a brush shader.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -4,6 +4,13 @@
 
 #ifdef WR_VERTEX_SHADER
 
+void brush_vs(
+    int prim_address,
+    vec2 local_pos,
+    RectWithSize local_rect,
+    ivec2 user_data
+);
+
 // Whether this brush is being drawn on a Picture
 // task (new) or an alpha batch task (legacy).
 // Can be removed once everything uses pictures.
@@ -102,7 +109,7 @@ void main(void) {
         //           shaders that don't clip in the future,
         //           but it's reasonable to assume that one
         //           implies the other, for now.
-#ifdef WR_FEATURE_ALPHA
+#ifdef WR_FEATURE_ALPHA_PASS
         write_clip(
             vi.screen_pos,
             clip_area
@@ -121,11 +128,14 @@ void main(void) {
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
+
+vec4 brush_fs();
+
 void main(void) {
     // Run the specific brush FS code to output the color.
     vec4 color = brush_fs();
 
-#ifdef WR_FEATURE_ALPHA
+#ifdef WR_FEATURE_ALPHA_PASS
     // Apply the clip mask
     color *= do_clip();
 #endif

--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -2,14 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-varying vec2 vLocalPos;
-flat varying vec4 vLocalRect;
-
 #ifdef WR_VERTEX_SHADER
+
+// Whether this brush is being drawn on a Picture
+// task (new) or an alpha batch task (legacy).
+// Can be removed once everything uses pictures.
+#define BRUSH_FLAG_USES_PICTURE     (1 << 0)
 
 struct BrushInstance {
     int picture_address;
     int prim_address;
+    int layer_address;
+    int clip_address;
+    int z;
+    int flags;
+    ivec2 user_data;
 };
 
 BrushInstance load_brush() {
@@ -17,6 +24,11 @@ BrushInstance load_brush() {
 
     bi.picture_address = aData0.x;
     bi.prim_address = aData0.y;
+    bi.layer_address = aData0.z;
+    bi.clip_address = aData0.w;
+    bi.z = aData1.x;
+    bi.flags = aData1.y;
+    bi.user_data = aData1.zw;
 
     return bi;
 }
@@ -44,36 +56,79 @@ void main(void) {
     // Load the brush instance from vertex attributes.
     BrushInstance brush = load_brush();
 
-    // Fetch the dynamic picture that we are drawing on.
-    PictureTask pic_task = fetch_picture_task(brush.picture_address);
-
     // Load the geometry for this brush. For now, this is simply the
     // local rect of the primitive. In the future, this will support
     // loading segment rects, and other rect formats (glyphs).
     PrimitiveGeometry geom = fetch_primitive_geometry(brush.prim_address);
 
-    // Write the (p0,p1) form of the primitive rect and the local position
-    // of this vertex. Specific brush shaders can use this information to
-    // interpolate texture coordinates etc.
-    vLocalRect = vec4(geom.local_rect.p0, geom.local_rect.p0 + geom.local_rect.size);
+    vec2 device_pos, local_pos;
+    RectWithSize local_rect = geom.local_rect;
 
-    // Right now - pictures only support local positions. In the future, this
-    // will be expanded to support transform picture types (the common kind).
-    vec2 pos = pic_task.target_rect.p0 + aPosition.xy * pic_task.target_rect.size;
-    vLocalPos = aPosition.xy * pic_task.target_rect.size / uDevicePixelRatio;
+    if ((brush.flags & BRUSH_FLAG_USES_PICTURE) != 0) {
+        // Fetch the dynamic picture that we are drawing on.
+        PictureTask pic_task = fetch_picture_task(brush.picture_address);
+
+        // Right now - pictures only support local positions. In the future, this
+        // will be expanded to support transform picture types (the common kind).
+        device_pos = pic_task.target_rect.p0 + aPosition.xy * pic_task.target_rect.size;
+        local_pos = aPosition.xy * pic_task.target_rect.size / uDevicePixelRatio;
+
+        // Write the final position transformed by the orthographic device-pixel projection.
+        gl_Position = uTransform * vec4(device_pos, 0.0, 1.0);
+    } else {
+        AlphaBatchTask alpha_task = fetch_alpha_batch_task(brush.picture_address);
+        Layer layer = fetch_layer(brush.layer_address);
+        ClipArea clip_area = fetch_clip_area(brush.clip_address);
+
+        // Write the normal vertex information out.
+        // TODO(gw): Support transform types in brushes. For now,
+        //           the old cache image shader didn't support
+        //           them yet anyway, so we're not losing any
+        //           existing functionality.
+        VertexInfo vi = write_vertex(
+            geom.local_rect,
+            geom.local_clip_rect,
+            float(brush.z),
+            layer,
+            alpha_task,
+            geom.local_rect
+        );
+
+        local_pos = vi.local_pos;
+
+        // For brush instances in the alpha pass, always write
+        // out clip information.
+        // TODO(gw): It's possible that we might want alpha
+        //           shaders that don't clip in the future,
+        //           but it's reasonable to assume that one
+        //           implies the other, for now.
+#ifdef WR_FEATURE_ALPHA
+        write_clip(
+            vi.screen_pos,
+            clip_area
+        );
+#endif
+    }
 
     // Run the specific brush VS code to write interpolators.
-    brush_vs(brush.prim_address, vLocalRect);
-
-    // Write the final position transformed by the orthographic device-pixel projection.
-    gl_Position = uTransform * vec4(pos, 0.0, 1.0);
+    brush_vs(
+        brush.prim_address + VECS_PER_PRIM_HEADER,
+        local_pos,
+        local_rect,
+        brush.user_data
+    );
 }
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
 void main(void) {
     // Run the specific brush FS code to output the color.
-    vec4 color = brush_fs(vLocalPos, vLocalRect);
+    vec4 color = brush_fs();
+
+#ifdef WR_FEATURE_ALPHA
+    // Apply the clip mask
+    color *= do_clip();
+#endif
 
     // TODO(gw): Handle pre-multiply common code here as required.
     oFragColor = color;

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include shared,prim_shared
+#include shared,prim_shared,brush
 
 varying vec3 vUv;
 flat varying vec4 vUvBounds;
 
-#if defined WR_FEATURE_ALPHA
+#if defined WR_FEATURE_ALPHA_TARGET
 flat varying vec4 vColor;
 #endif
 
@@ -27,7 +27,7 @@ void brush_vs(
     RenderTaskData child_task = fetch_render_task(user_data.x);
     vUv.z = child_task.data1.x;
 
-#if defined WR_FEATURE_COLOR
+#if defined WR_FEATURE_COLOR_TARGET
     vec2 texture_size = vec2(textureSize(sColor0, 0).xy);
 #else
     Picture pic = fetch_picture(prim_address);
@@ -53,7 +53,7 @@ void brush_vs(
 vec4 brush_fs() {
     vec2 uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
 
-#if defined WR_FEATURE_COLOR
+#if defined WR_FEATURE_COLOR_TARGET
     vec4 color = texture(sColor0, vec3(uv, vUv.z));
 #else
     vec4 color = vColor * texture(sColor1, vec3(uv, vUv.z)).r;
@@ -62,5 +62,3 @@ vec4 brush_fs() {
     return color;
 }
 #endif
-
-#include brush

--- a/webrender/res/brush_mask.glsl
+++ b/webrender/res/brush_mask.glsl
@@ -9,6 +9,8 @@ flat varying vec4 vClipCenter_Radius_TL;
 flat varying vec4 vClipCenter_Radius_TR;
 flat varying vec4 vClipCenter_Radius_BR;
 flat varying vec4 vClipCenter_Radius_BL;
+flat varying vec4 vLocalRect;
+varying vec2 vLocalPos;
 
 #ifdef WR_VERTEX_SHADER
 
@@ -25,31 +27,45 @@ BrushPrimitive fetch_brush_primitive(int address) {
     return BrushPrimitive(data[0].x, data[1].xy, data[1].zw, data[2].xy, data[2].zw);
 }
 
-void brush_vs(int prim_address, vec4 prim_rect) {
+void brush_vs(
+    int prim_address,
+    vec2 local_pos,
+    RectWithSize local_rect,
+    ivec2 user_data
+) {
     // Load the specific primitive.
-    BrushPrimitive prim = fetch_brush_primitive(prim_address + 2);
+    BrushPrimitive prim = fetch_brush_primitive(prim_address);
 
     // Write clip parameters
     vClipMode = prim.clip_mode;
+
+    // TODO(gw): In the future, when brush primitives may be segment rects
+    //           we need to account for that here, and differentiate between
+    //           the segment rect (geometry) amd the primitive rect (which
+    //           defines where the clip radii are relative to).
+    vec4 prim_rect = vec4(local_rect.p0, local_rect.p0 + local_rect.size);
 
     vClipCenter_Radius_TL = vec4(prim_rect.xy + prim.radius_tl, prim.radius_tl);
     vClipCenter_Radius_TR = vec4(prim_rect.zy + vec2(-prim.radius_tr.x, prim.radius_tr.y), prim.radius_tr);
     vClipCenter_Radius_BR = vec4(prim_rect.zw - prim.radius_br, prim.radius_br);
     vClipCenter_Radius_BL = vec4(prim_rect.xw + vec2(prim.radius_bl.x, -prim.radius_bl.y), prim.radius_bl);
+
+    vLocalRect = prim_rect;
+    vLocalPos = local_pos;
 }
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-vec4 brush_fs(vec2 local_pos, vec4 local_rect) {
+vec4 brush_fs() {
     // TODO(gw): The mask code below is super-inefficient. Once we
     // start using primitive segments in brush shaders, this can
     // be made much faster.
     float d = 0.0;
     // Check if in valid clip region.
-    if (local_pos.x >= local_rect.x && local_pos.x < local_rect.z &&
-        local_pos.y >= local_rect.y && local_pos.y < local_rect.w) {
+    if (vLocalPos.x >= vLocalRect.x && vLocalPos.x < vLocalRect.z &&
+        vLocalPos.y >= vLocalRect.y && vLocalPos.y < vLocalRect.w) {
         // Apply ellipse clip on each corner.
-        d = rounded_rect(local_pos,
+        d = rounded_rect(vLocalPos,
                          vClipCenter_Radius_TL,
                          vClipCenter_Radius_TR,
                          vClipCenter_Radius_BR,

--- a/webrender/res/brush_mask.glsl
+++ b/webrender/res/brush_mask.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include shared,prim_shared,ellipse
+#include shared,prim_shared,ellipse,brush
 
 flat varying float vClipMode;
 flat varying vec4 vClipCenter_Radius_TL;
@@ -75,5 +75,3 @@ vec4 brush_fs() {
     return vec4(mix(d, 1.0 - d, vClipMode));
 }
 #endif
-
-#include brush

--- a/webrender/res/cs_blur.glsl
+++ b/webrender/res/cs_blur.glsl
@@ -29,7 +29,7 @@ void main(void) {
     vec4 src_rect = src_task.data0;
     vec4 target_rect = task.data0;
 
-#if defined WR_FEATURE_COLOR
+#if defined WR_FEATURE_COLOR_TARGET
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0).xy);
 #else
     vec2 texture_size = vec2(textureSize(sCacheA8, 0).xy);
@@ -69,7 +69,7 @@ void main(void) {
 
 #ifdef WR_FRAGMENT_SHADER
 
-#if defined WR_FEATURE_COLOR
+#if defined WR_FEATURE_COLOR_TARGET
 #define SAMPLE_TYPE vec4
 #define SAMPLE_TEXTURE(uv)  texture(sCacheRGBA8, uv)
 #else

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -154,38 +154,14 @@ pub const BRUSH_FLAG_USES_PICTURE: i32 = (1 << 0);
 //           a u16 type.
 #[repr(C)]
 pub struct BrushInstance {
-    picture_address: RenderTaskAddress,
-    prim_address: GpuCacheAddress,
-    layer_address: PackedLayerAddress,
-    clip_task_address: RenderTaskAddress,
-    z: i32,
-    flags: i32,
-    user_data0: i32,
-    user_data1: i32,
-}
-
-impl BrushInstance {
-    pub fn new(
-        picture_address: RenderTaskAddress,
-        prim_address: GpuCacheAddress,
-        layer_address: PackedLayerAddress,
-        clip_task_address: RenderTaskAddress,
-        z: i32,
-        flags: i32,
-        user_data0: i32,
-        user_data1: i32,
-    ) -> BrushInstance {
-        BrushInstance {
-            picture_address,
-            prim_address,
-            layer_address: layer_address.into(),
-            clip_task_address,
-            z,
-            flags,
-            user_data0,
-            user_data1,
-        }
-    }
+    pub picture_address: RenderTaskAddress,
+    pub prim_address: GpuCacheAddress,
+    pub layer_address: PackedLayerAddress,
+    pub clip_task_address: RenderTaskAddress,
+    pub z: i32,
+    pub flags: i32,
+    pub user_data0: i32,
+    pub user_data1: i32,
 }
 
 impl From<BrushInstance> for PrimitiveInstance {

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -140,20 +140,50 @@ impl From<CompositePrimitiveInstance> for PrimitiveInstance {
     }
 }
 
+// Whether this brush is being drawn on a Picture
+// task (new) or an alpha batch task (legacy).
+// Can be removed once everything uses pictures.
+pub const BRUSH_FLAG_USES_PICTURE: i32 = (1 << 0);
+
+// TODO(gw): While we are comverting things over, we
+//           need to have the instance be the same
+//           size as an old PrimitiveInstance. In the
+//           future, we can compress this vertex
+//           format a lot - e.g. z, render task
+//           addresses etc can reasonably become
+//           a u16 type.
 #[repr(C)]
 pub struct BrushInstance {
     picture_address: RenderTaskAddress,
     prim_address: GpuCacheAddress,
+    layer_address: PackedLayerAddress,
+    clip_task_address: RenderTaskAddress,
+    z: i32,
+    flags: i32,
+    user_data0: i32,
+    user_data1: i32,
 }
 
 impl BrushInstance {
     pub fn new(
         picture_address: RenderTaskAddress,
-        prim_address: GpuCacheAddress
+        prim_address: GpuCacheAddress,
+        layer_address: PackedLayerAddress,
+        clip_task_address: RenderTaskAddress,
+        z: i32,
+        flags: i32,
+        user_data0: i32,
+        user_data1: i32,
     ) -> BrushInstance {
         BrushInstance {
             picture_address,
             prim_address,
+            layer_address: layer_address.into(),
+            clip_task_address,
+            z,
+            flags,
+            user_data0,
+            user_data1,
         }
     }
 }
@@ -164,12 +194,12 @@ impl From<BrushInstance> for PrimitiveInstance {
             data: [
                 instance.picture_address.0 as i32,
                 instance.prim_address.as_int(),
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
+                instance.layer_address.0,
+                instance.clip_task_address.0 as i32,
+                instance.z,
+                instance.flags,
+                instance.user_data0,
+                instance.user_data1,
             ]
         }
     }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -61,7 +61,7 @@ use std::thread;
 use texture_cache::TextureCache;
 use thread_profiler::{register_thread_with_profiler, write_profile};
 use tiling::{AlphaRenderTarget, ColorRenderTarget, RenderTargetKind};
-use tiling::{BatchKey, BatchKind, Frame, RenderTarget, TransformBatchKind};
+use tiling::{BatchKey, BatchKind, BrushBatchKind, Frame, RenderTarget, TransformBatchKind};
 use time::precise_time_ns;
 use util::TransformedRectKind;
 
@@ -70,6 +70,10 @@ pub const MAX_VERTEX_TEXTURE_WIDTH: usize = 1024;
 const GPU_TAG_BRUSH_MASK: GpuProfileTag = GpuProfileTag {
     label: "B_Mask",
     color: debug_colors::BLACK,
+};
+const GPU_TAG_BRUSH_IMAGE: GpuProfileTag = GpuProfileTag {
+    label: "B_Image",
+    color: debug_colors::SILVER,
 };
 const GPU_TAG_CACHE_CLIP: GpuProfileTag = GpuProfileTag {
     label: "C_Clip",
@@ -147,10 +151,6 @@ const GPU_TAG_PRIM_BORDER_EDGE: GpuProfileTag = GpuProfileTag {
     label: "BorderEdge",
     color: debug_colors::LAVENDER,
 };
-const GPU_TAG_PRIM_CACHE_IMAGE: GpuProfileTag = GpuProfileTag {
-    label: "CacheImage",
-    color: debug_colors::SILVER,
-};
 const GPU_TAG_BLUR: GpuProfileTag = GpuProfileTag {
     label: "Blur",
     color: debug_colors::VIOLET,
@@ -177,6 +177,11 @@ impl BatchKind {
             BatchKind::HardwareComposite => "HardwareComposite",
             BatchKind::SplitComposite => "SplitComposite",
             BatchKind::Blend => "Blend",
+            BatchKind::Brush(kind) => {
+                match kind {
+                    BrushBatchKind::Image(..) => "Brush (Image)",
+                }
+            }
             BatchKind::Transformable(_, kind) => match kind {
                 TransformBatchKind::Rectangle(..) => "Rectangle",
                 TransformBatchKind::TextRun => "TextRun",
@@ -190,7 +195,6 @@ impl BatchKind {
                 TransformBatchKind::AlignedGradient => "AlignedGradient",
                 TransformBatchKind::AngleGradient => "AngleGradient",
                 TransformBatchKind::RadialGradient => "RadialGradient",
-                TransformBatchKind::CacheImage(..) => "CacheImage",
                 TransformBatchKind::BorderCorner => "BorderCorner",
                 TransformBatchKind::BorderEdge => "BorderEdge",
                 TransformBatchKind::Line => "Line",
@@ -835,6 +839,7 @@ impl VertexDataTexture {
 
 const TRANSFORM_FEATURE: &str = "TRANSFORM";
 const CLIP_FEATURE: &str = "CLIP";
+const ALPHA_FEATURE: &str = "ALPHA";
 
 enum ShaderKind {
     Primitive,
@@ -927,6 +932,77 @@ impl LazilyCompiledShader {
 struct PrimitiveShader {
     simple: LazilyCompiledShader,
     transform: LazilyCompiledShader,
+}
+
+// A brush shader supports two modes:
+// opaque:
+//   Used for completely opaque primitives,
+//   or inside segments of partially
+//   opaque primitives. Assumes no need
+//   for clip masks, AA etc.
+// alpha:
+//   Used for brush primitives in the alpha
+//   pass. Assumes that AA should be applied
+//   along the primitive edge, and also that
+//   clip mask is present.
+struct BrushShader {
+    opaque: LazilyCompiledShader,
+    alpha: LazilyCompiledShader,
+}
+
+impl BrushShader {
+    fn new(
+        name: &'static str,
+        device: &mut Device,
+        features: &[&'static str],
+        precache: bool,
+    ) -> Result<BrushShader, ShaderError> {
+        let opaque = try!{
+            LazilyCompiledShader::new(ShaderKind::Brush,
+                                      name,
+                                      features,
+                                      device,
+                                      precache)
+        };
+
+        let mut alpha_features = features.to_vec();
+        alpha_features.push(ALPHA_FEATURE);
+
+        let alpha = try!{
+            LazilyCompiledShader::new(ShaderKind::Brush,
+                                      name,
+                                      &alpha_features,
+                                      device,
+                                      precache)
+        };
+
+        Ok(BrushShader { opaque, alpha })
+    }
+
+    fn bind<M>(
+        &mut self,
+        device: &mut Device,
+        blend_mode: BlendMode,
+        projection: &Transform3D<f32>,
+        mode: M,
+        renderer_errors: &mut Vec<RendererError>,
+    ) where M: Into<ShaderMode> {
+        match blend_mode {
+            BlendMode::None => {
+                self.opaque.bind(device, projection, mode, renderer_errors)
+            }
+            BlendMode::Alpha |
+            BlendMode::PremultipliedAlpha |
+            BlendMode::Subpixel => {
+                self.alpha.bind(device, projection, mode, renderer_errors)
+            }
+        }
+    }
+
+    fn deinit(self, device: &mut Device) {
+        self.opaque.deinit(device);
+        self.alpha.deinit(device);
+    }
 }
 
 struct FileWatcher {
@@ -1096,7 +1172,11 @@ pub struct Renderer {
     cs_line: LazilyCompiledShader,
     cs_blur_a8: LazilyCompiledShader,
     cs_blur_rgba8: LazilyCompiledShader,
+
+    // Brush shaders
     brush_mask: LazilyCompiledShader,
+    brush_image_rgba8: BrushShader,
+    brush_image_a8: BrushShader,
 
     /// These are "cache clip shaders". These shaders are used to
     /// draw clip instances into the cached clip mask. The results
@@ -1122,8 +1202,6 @@ pub struct Renderer {
     ps_gradient: PrimitiveShader,
     ps_angle_gradient: PrimitiveShader,
     ps_radial_gradient: PrimitiveShader,
-    ps_cache_image_rgba8: PrimitiveShader,
-    ps_cache_image_a8: PrimitiveShader,
     ps_line: PrimitiveShader,
 
     ps_blend: LazilyCompiledShader,
@@ -1294,6 +1372,20 @@ impl Renderer {
                                       &[],
                                       &mut device,
                                       options.precache_shaders)
+        };
+
+        let brush_image_a8 = try!{
+            BrushShader::new("brush_image",
+                             &mut device,
+                             &["ALPHA"],
+                             options.precache_shaders)
+        };
+
+        let brush_image_rgba8 = try!{
+            BrushShader::new("brush_image",
+                             &mut device,
+                             &["COLOR"],
+                             options.precache_shaders)
         };
 
         let cs_blur_a8 = try!{
@@ -1478,20 +1570,6 @@ impl Renderer {
                                  } else {
                                     &[]
                                  },
-                                 options.precache_shaders)
-        };
-
-        let ps_cache_image_a8 = try!{
-            PrimitiveShader::new("ps_cache_image",
-                                 &mut device,
-                                 &["ALPHA"],
-                                 options.precache_shaders)
-        };
-
-        let ps_cache_image_rgba8 = try!{
-            PrimitiveShader::new("ps_cache_image",
-                                 &mut device,
-                                 &["COLOR"],
                                  options.precache_shaders)
         };
 
@@ -1712,6 +1790,8 @@ impl Renderer {
             cs_blur_a8,
             cs_blur_rgba8,
             brush_mask,
+            brush_image_rgba8,
+            brush_image_a8,
             cs_clip_rectangle,
             cs_clip_border,
             cs_clip_image,
@@ -1725,8 +1805,6 @@ impl Renderer {
             ps_gradient,
             ps_angle_gradient,
             ps_radial_gradient,
-            ps_cache_image_rgba8,
-            ps_cache_image_a8,
             ps_blend,
             ps_hw_composite,
             ps_split_composite,
@@ -2344,6 +2422,34 @@ impl Renderer {
                     .bind(&mut self.device, projection, 0, &mut self.renderer_errors);
                 GPU_TAG_PRIM_BLEND
             }
+            BatchKind::Brush(brush_kind) => {
+                match brush_kind {
+                    BrushBatchKind::Image(target_kind) => {
+                        match target_kind {
+                            RenderTargetKind::Alpha => {
+                                self.brush_image_a8.bind(
+                                    &mut self.device,
+                                    key.blend_mode,
+                                    projection,
+                                    0,
+                                    &mut self.renderer_errors,
+                                );
+                            }
+                            RenderTargetKind::Color => {
+                                self.brush_image_rgba8.bind(
+                                    &mut self.device,
+                                    key.blend_mode,
+                                    projection,
+                                    0,
+                                    &mut self.renderer_errors,
+                                );
+                            }
+                        }
+
+                        GPU_TAG_BRUSH_IMAGE
+                    }
+                }
+            }
             BatchKind::Transformable(transform_kind, batch_kind) => match batch_kind {
                 TransformBatchKind::Rectangle(needs_clipping) => {
                     debug_assert!(
@@ -2464,29 +2570,6 @@ impl Renderer {
                         &mut self.renderer_errors,
                     );
                     GPU_TAG_PRIM_RADIAL_GRADIENT
-                }
-                TransformBatchKind::CacheImage(target_kind) => {
-                    match target_kind {
-                        RenderTargetKind::Alpha => {
-                            self.ps_cache_image_a8.bind(
-                                &mut self.device,
-                                transform_kind,
-                                projection,
-                                0,
-                                &mut self.renderer_errors,
-                            );
-                        }
-                        RenderTargetKind::Color => {
-                            self.ps_cache_image_rgba8.bind(
-                                &mut self.device,
-                                transform_kind,
-                                projection,
-                                0,
-                                &mut self.renderer_errors,
-                            );
-                        }
-                    }
-                    GPU_TAG_PRIM_CACHE_IMAGE
                 }
             },
         };
@@ -3495,6 +3578,8 @@ impl Renderer {
         self.cs_blur_a8.deinit(&mut self.device);
         self.cs_blur_rgba8.deinit(&mut self.device);
         self.brush_mask.deinit(&mut self.device);
+        self.brush_image_rgba8.deinit(&mut self.device);
+        self.brush_image_a8.deinit(&mut self.device);
         self.cs_clip_rectangle.deinit(&mut self.device);
         self.cs_clip_image.deinit(&mut self.device);
         self.cs_clip_border.deinit(&mut self.device);
@@ -3519,8 +3604,6 @@ impl Renderer {
         self.ps_gradient.deinit(&mut self.device);
         self.ps_angle_gradient.deinit(&mut self.device);
         self.ps_radial_gradient.deinit(&mut self.device);
-        self.ps_cache_image_rgba8.deinit(&mut self.device);
-        self.ps_cache_image_a8.deinit(&mut self.device);
         self.ps_line.deinit(&mut self.device);
         self.ps_blend.deinit(&mut self.device);
         self.ps_hw_composite.deinit(&mut self.device);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -14,6 +14,7 @@ use device::Texture;
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle, GpuCacheUpdateList};
 use gpu_types::{BlurDirection, BlurInstance, BrushInstance, ClipMaskInstance};
 use gpu_types::{CompositePrimitiveInstance, PrimitiveInstance, SimplePrimitiveInstance};
+use gpu_types::{BRUSH_FLAG_USES_PICTURE};
 use internal_types::{FastHashMap, SourceTexture};
 use internal_types::BatchTextures;
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
@@ -583,13 +584,22 @@ impl AlphaRenderItem {
                         let cache_task_id = picture.render_task_id.expect("no render task!");
                         let cache_task_address = render_tasks.get_task_address(cache_task_id);
                         let textures = BatchTextures::render_target_cache();
-                        let kind = BatchKind::Transformable(
-                            transform_kind,
-                            TransformBatchKind::CacheImage(picture.target_kind()),
+                        let kind = BatchKind::Brush(
+                            BrushBatchKind::Image(picture.target_kind()),
                         );
                         let key = BatchKey::new(kind, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(key, item_bounding_rect);
-                        batch.push(base_instance.build(0, cache_task_address.0 as i32, 0));
+                        let instance = BrushInstance::new(
+                            task_address,
+                            prim_cache_address,
+                            packed_layer_index.into(),
+                            clip_task_address,
+                            z,
+                            0,
+                            cache_task_address.0 as i32,
+                            0,
+                        );
+                        batch.push(PrimitiveInstance::from(instance));
                     }
                     PrimitiveKind::AlignedGradient => {
                         let gradient_cpu =
@@ -1338,7 +1348,21 @@ impl RenderTarget for AlphaRenderTarget {
 
                                 match sub_metadata.prim_kind {
                                     PrimitiveKind::Brush => {
-                                        let instance = BrushInstance::new(task_index, sub_prim_address);
+                                        let instance = BrushInstance::new(
+                                            task_index,
+                                            sub_prim_address,
+                                            // TODO(gw): In the future, when brush
+                                            //           primitives on picture backed
+                                            //           tasks support clip masks and
+                                            //           transform primitives, these
+                                            //           will need to be filled out!
+                                            PackedLayerIndex(0).into(),
+                                            RenderTaskAddress(0),
+                                            0,
+                                            BRUSH_FLAG_USES_PICTURE,
+                                            0,
+                                            0,
+                                        );
                                         self.rect_cache_prims.push(PrimitiveInstance::from(instance));
                                     }
                                     _ => {
@@ -1543,10 +1567,14 @@ pub enum TransformBatchKind {
     AlignedGradient,
     AngleGradient,
     RadialGradient,
-    CacheImage(RenderTargetKind),
     BorderCorner,
     BorderEdge,
     Line,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum BrushBatchKind {
+    Image(RenderTargetKind)
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -1560,6 +1588,7 @@ pub enum BatchKind {
     SplitComposite,
     Blend,
     Transformable(TransformedRectKind, TransformBatchKind),
+    Brush(BrushBatchKind),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -589,16 +589,16 @@ impl AlphaRenderItem {
                         );
                         let key = BatchKey::new(kind, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(key, item_bounding_rect);
-                        let instance = BrushInstance::new(
-                            task_address,
-                            prim_cache_address,
-                            packed_layer_index.into(),
+                        let instance = BrushInstance {
+                            picture_address: task_address,
+                            prim_address: prim_cache_address,
+                            layer_address: packed_layer_index.into(),
                             clip_task_address,
                             z,
-                            0,
-                            cache_task_address.0 as i32,
-                            0,
-                        );
+                            flags: 0,
+                            user_data0: cache_task_address.0 as i32,
+                            user_data1: 0,
+                        };
                         batch.push(PrimitiveInstance::from(instance));
                     }
                     PrimitiveKind::AlignedGradient => {
@@ -1348,21 +1348,21 @@ impl RenderTarget for AlphaRenderTarget {
 
                                 match sub_metadata.prim_kind {
                                     PrimitiveKind::Brush => {
-                                        let instance = BrushInstance::new(
-                                            task_index,
-                                            sub_prim_address,
+                                        let instance = BrushInstance {
+                                            picture_address: task_index,
+                                            prim_address: sub_prim_address,
                                             // TODO(gw): In the future, when brush
                                             //           primitives on picture backed
                                             //           tasks support clip masks and
                                             //           transform primitives, these
                                             //           will need to be filled out!
-                                            PackedLayerIndex(0).into(),
-                                            RenderTaskAddress(0),
-                                            0,
-                                            BRUSH_FLAG_USES_PICTURE,
-                                            0,
-                                            0,
-                                        );
+                                            layer_address: PackedLayerIndex(0).into(),
+                                            clip_task_address: RenderTaskAddress(0),
+                                            z: 0,
+                                            flags: BRUSH_FLAG_USES_PICTURE,
+                                            user_data0: 0,
+                                            user_data1: 0,
+                                        };
                                         self.rect_cache_prims.push(PrimitiveInstance::from(instance));
                                     }
                                     _ => {

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -67,10 +67,6 @@ const SHADERS: &[Shader] = &[
         features: PRIM_FEATURES,
     },
     Shader {
-        name: "ps_cache_image",
-        features: &["COLOR", "ALPHA"],
-    },
-    Shader {
         name: "ps_blend",
         features: PRIM_FEATURES,
     },
@@ -106,6 +102,10 @@ const SHADERS: &[Shader] = &[
     Shader {
         name: "brush_mask",
         features: &[],
+    },
+    Shader {
+        name: "brush_image",
+        features: &["COLOR", "ALPHA"],
     },
 ];
 

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -105,7 +105,7 @@ const SHADERS: &[Shader] = &[
     },
     Shader {
         name: "brush_image",
-        features: &["COLOR", "ALPHA"],
+        features: &["COLOR_TARGET", "ALPHA_TARGET"],
     },
 ];
 


### PR DESCRIPTION
This starts to expand on how the brush shader works, and
converts one of the simplest primitive shaders over to use it.

The fundamental difference between a primitive and brush shader is:

Primitive shaders have two versions: transform and axis-aligned.

Brush shaders have an opaque and alpha version. In the future,
the opaque brush shader can run on a transformed primitive to
handle the inner part of the primitive which doesn't need AA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1919)
<!-- Reviewable:end -->
