### PR TITLE
Add a ClearRectangle item type.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -8,7 +8,7 @@ use clip::ClipSource;
 use ellipse::Ellipse;
 use frame_builder::FrameBuilder;
 use gpu_cache::GpuDataRequest;
-use prim_store::{BorderPrimitiveCpu, PrimitiveContainer, TexelRect};
+use prim_store::{BorderPrimitiveCpu, RectangleContent, PrimitiveContainer, TexelRect};
 use tiling::PrimitiveFlags;
 use util::{lerp, pack_as_float};
 
@@ -385,7 +385,7 @@ impl FrameBuilder {
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    &border.top.color,
+                    &RectangleContent::Fill(border.top.color),
                     PrimitiveFlags::None,
                 );
             }
@@ -398,7 +398,7 @@ impl FrameBuilder {
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    &border.left.color,
+                    &RectangleContent::Fill(border.left.color),
                     PrimitiveFlags::None,
                 );
             }
@@ -411,7 +411,7 @@ impl FrameBuilder {
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    &border.right.color,
+                    &RectangleContent::Fill(border.right.color),
                     PrimitiveFlags::None,
                 );
             }
@@ -424,7 +424,7 @@ impl FrameBuilder {
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    &border.bottom.color,
+                    &RectangleContent::Fill(border.bottom.color),
                     PrimitiveFlags::None,
                 );
             }

--- a/webrender/src/box_shadow.rs
+++ b/webrender/src/box_shadow.rs
@@ -7,8 +7,8 @@ use api::{BorderRadius, BoxShadowClipMode, LayoutSize, LayerPrimitiveInfo};
 use api::{ClipMode, ComplexClipRegion, LocalClip, ClipAndScrollInfo};
 use clip::ClipSource;
 use frame_builder::FrameBuilder;
-use prim_store::{PrimitiveContainer, RectanglePrimitive, BrushPrimitive};
-use prim_store::{BrushMaskKind, BrushKind};
+use prim_store::{PrimitiveContainer, RectangleContent, RectanglePrimitive};
+use prim_store::{BrushMaskKind, BrushKind, BrushPrimitive};
 use picture::PicturePrimitive;
 use util::RectHelpers;
 
@@ -103,7 +103,7 @@ impl FrameBuilder {
                 &fast_info,
                 clips,
                 PrimitiveContainer::Rectangle(RectanglePrimitive {
-                    color: *color,
+                    content: RectangleContent::Fill(*color),
                 }),
             );
         } else {

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1877,6 +1877,11 @@ impl Device {
         self.gl.blend_equation(gl::FUNC_ADD);
     }
 
+    pub fn set_blend_mode_premultiplied_dest_out(&self) {
+        self.gl.blend_func(gl::ZERO, gl::ONE_MINUS_SRC_ALPHA);
+        self.gl.blend_equation(gl::FUNC_ADD);
+    }
+
     pub fn set_blend_mode_alpha(&self) {
         self.gl.blend_func_separate(
             gl::SRC_ALPHA,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -27,7 +27,7 @@ use prim_store::{TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
 use prim_store::{PrimitiveContainer, PrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
-use prim_store::{RectanglePrimitive, TextRunPrimitiveCpu};
+use prim_store::{RectangleContent, RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_task::{AlphaRenderItem, ClearMode, ClipChain, RenderTask, RenderTaskId, RenderTaskLocation};
 use render_task::RenderTaskTree;
@@ -599,17 +599,18 @@ impl FrameBuilder {
         &mut self,
         clip_and_scroll: ClipAndScrollInfo,
         info: &LayerPrimitiveInfo,
-        color: &ColorF,
+        content: &RectangleContent,
         flags: PrimitiveFlags,
     ) {
-        let prim = RectanglePrimitive { color: *color };
-
-        // Don't add transparent rectangles to the draw list, but do consider them for hit
-        // testing. This allows specifying invisible hit testing areas.
-        if color.a == 0.0 {
-            self.add_primitive_to_hit_testing_list(info, clip_and_scroll);
-            return;
+        if let &RectangleContent::Fill(ColorF{a, ..}) = content {
+            if a == 0.0 {
+                // Don't add transparent rectangles to the draw list, but do consider them for hit
+                // testing. This allows specifying invisible hit testing areas.
+                self.add_primitive_to_hit_testing_list(info, clip_and_scroll);
+                return;
+            }
         }
+        let prim = RectanglePrimitive { content: *content };
 
         let prim_index = self.add_primitive(
             clip_and_scroll,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -710,6 +710,7 @@ impl ToDebugString for SpecificDisplayItem {
             SpecificDisplayItem::YuvImage(..) => String::from("yuv_image"),
             SpecificDisplayItem::Text(..) => String::from("text"),
             SpecificDisplayItem::Rectangle(..) => String::from("rectangle"),
+            SpecificDisplayItem::ClearRectangle => String::from("clear_rectangle"),
             SpecificDisplayItem::Line(..) => String::from("line"),
             SpecificDisplayItem::Gradient(..) => String::from("gradient"),
             SpecificDisplayItem::RadialGradient(..) => String::from("radial_gradient"),

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -636,6 +636,7 @@ pub enum BlendMode {
     None,
     Alpha,
     PremultipliedAlpha,
+    PremultipliedDestOut,
     Subpixel,
 }
 
@@ -1007,6 +1008,7 @@ impl BrushShader {
             }
             BlendMode::Alpha |
             BlendMode::PremultipliedAlpha |
+            BlendMode::PremultipliedDestOut |
             BlendMode::Subpixel => {
                 self.alpha.bind(device, projection, mode, renderer_errors)
             }
@@ -2475,6 +2477,7 @@ impl Renderer {
                         !needs_clipping || match key.blend_mode {
                             BlendMode::Alpha |
                             BlendMode::PremultipliedAlpha |
+                            BlendMode::PremultipliedDestOut |
                             BlendMode::Subpixel => true,
                             BlendMode::None => false,
                         }
@@ -2817,6 +2820,7 @@ impl Renderer {
                         BlendMode::None => ColorF::new(0.3, 0.3, 0.3, 1.0),
                         BlendMode::Alpha => ColorF::new(0.0, 0.9, 0.1, 1.0),
                         BlendMode::PremultipliedAlpha => ColorF::new(0.0, 0.3, 0.7, 1.0),
+                        BlendMode::PremultipliedDestOut => ColorF::new(0.6, 0.2, 0.0, 1.0),
                         BlendMode::Subpixel => ColorF::new(0.5, 0.0, 0.4, 1.0),
                     }.into();
                     for item_rect in &batch.item_rects {
@@ -2893,7 +2897,7 @@ impl Renderer {
                                 self.device
                                     .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
                             }
-                            BlendMode::Alpha | BlendMode::None => {
+                            BlendMode::Alpha | BlendMode::PremultipliedDestOut | BlendMode::None => {
                                 unreachable!("bug: bad blend mode for text");
                             }
                         }
@@ -2914,6 +2918,10 @@ impl Renderer {
                                 BlendMode::PremultipliedAlpha => {
                                     self.device.set_blend(true);
                                     self.device.set_blend_mode_premultiplied_alpha();
+                                }
+                                BlendMode::PremultipliedDestOut => {
+                                    self.device.set_blend(true);
+                                    self.device.set_blend_mode_premultiplied_dest_out();
                                 }
                                 BlendMode::Subpixel => {
                                     unreachable!("bug: subpx text handled earlier");

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -91,6 +91,7 @@ pub enum SpecificDisplayItem {
     ScrollFrame(ScrollFrameDisplayItem),
     StickyFrame(StickyFrameDisplayItem),
     Rectangle(RectangleDisplayItem),
+    ClearRectangle,
     Line(LineDisplayItem),
     Text(TextDisplayItem),
     Image(ImageDisplayItem),

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -791,6 +791,10 @@ impl DisplayListBuilder {
         self.push_item(item, info);
     }
 
+    pub fn push_clear_rect(&mut self, info: &LayoutPrimitiveInfo) {
+        self.push_item(SpecificDisplayItem::ClearRectangle, info);
+    }
+
     pub fn push_line(
         &mut self,
         info: &LayoutPrimitiveInfo,

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -562,6 +562,18 @@ impl YamlFrameReader {
         dl.push_rect(&info, color);
     }
 
+    fn handle_clear_rect(
+        &mut self,
+        dl: &mut DisplayListBuilder,
+        item: &Yaml,
+        info: &mut LayoutPrimitiveInfo,
+    ) {
+        info.rect = item["bounds"]
+            .as_rect()
+            .expect("clear-rect type must have bounds");
+        dl.push_clear_rect(&info);
+    }
+
     fn handle_line(
         &mut self,
         dl: &mut DisplayListBuilder,
@@ -1085,6 +1097,7 @@ impl YamlFrameReader {
             info.is_backface_visible = item["backface-visible"].as_bool().unwrap_or(true);;
             match item_type {
                 "rect" => self.handle_rect(dl, item, &mut info),
+                "clear-rect" => self.handle_clear_rect(dl, item, &mut info),
                 "line" => self.handle_line(dl, item, &mut info),
                 "image" => self.handle_image(dl, wrench, item, &mut info),
                 "text" | "glyphs" => self.handle_text(dl, wrench, item, &mut info),

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -623,6 +623,9 @@ impl YamlFrameWriter {
                     str_node(&mut v, "type", "rect");
                     color_node(&mut v, "color", item.color);
                 }
+                ClearRectangle => {
+                    str_node(&mut v, "type", "clear-rect");;
+                }
                 Line(item) => {
                     str_node(&mut v, "type", "line");
                     if let LineStyle::Wavy = item.style {


### PR DESCRIPTION
Fixes #1926.

I haven't extensively tested this yet. This draws ClearRectangle items as Rectangle primitives with opaque black and operator destination out.
I'm not really sure how to optimize the case where we don't need blending, because the color is set on the primitive before we decide how to blend it. But if there's no blending, we need to set the color to transparent black instead of opaque black.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1929)
<!-- Reviewable:end -->
