### PR TITLE
Add auto crop when generating PNG reftest images.

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -631,7 +631,7 @@ fn main() {
             gl::UNSIGNED_BYTE,
         );
 
-        save_flipped("screenshot.png", &pixels, size);
+        save_flipped("screenshot.png", pixels, size);
     }
 
     wrench.renderer.deinit();

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -388,7 +388,7 @@ impl<'a> ReftestHarness<'a> {
         let write_debug_images = false;
         if write_debug_images {
             let debug_path = filename.with_extension("yaml.png");
-            save_flipped(debug_path, &pixels, size);
+            save_flipped(debug_path, pixels.clone(), size);
         }
 
         reader.deinit(self.wrench);


### PR DESCRIPTION
When using the PNG command, if a PNG with the same filename
already exists, read the dimensions from that and crop the
new file to those dimensions.

This means:
 * To create a full size image, or a new image size, delete the
   existing file.
 * Common case - the file size will be cropped to existing size.
 * When creating a new image, crop it manually to set the default
   size.

Fixes #1934.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1936)
<!-- Reviewable:end -->
