### PR TITLE
remember GlyphFormat in glyph cache and pass to text run shader

### DIFF
--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -27,6 +27,10 @@
 // Vertex shader attributes and uniforms
 //======================================================================================
 #ifdef WR_VERTEX_SHADER
+    // A generic uniform that shaders can optionally use to configure
+    // an operation mode for this batch.
+    uniform int uMode;
+
     // Uniform inputs
     uniform mat4 uTransform;       // Orthographic projection
     uniform float uDevicePixelRatio;

--- a/webrender/src/glyph_cache.rs
+++ b/webrender/src/glyph_cache.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{DevicePoint, DeviceUintSize, FontInstance, GlyphKey};
+use glyph_rasterizer::GlyphFormat;
 use internal_types::FastHashMap;
 use resource_cache::ResourceClassCache;
 use std::sync::Arc;
@@ -14,6 +15,7 @@ pub struct CachedGlyphInfo {
     pub size: DeviceUintSize,
     pub offset: DevicePoint,
     pub scale: f32,
+    pub format: GlyphFormat,
 }
 
 pub type GlyphKeyCache = ResourceClassCache<GlyphKey, Option<CachedGlyphInfo>>;

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -6,6 +6,7 @@ use api::{FontInstance, FontInstancePlatformOptions, FontKey, FontRenderMode};
 use api::{ColorU, GlyphDimensions, GlyphKey, SubpixelDirection};
 use dwrote;
 use gamma_lut::{Color as ColorLut, GammaLut};
+use glyph_rasterizer::{GlyphFormat, RasterizedGlyph};
 use internal_types::FastHashMap;
 use std::sync::Arc;
 
@@ -27,15 +28,6 @@ pub struct FontContext {
 // DirectWrite is safe to use on multiple threads and non-shareable resources are
 // all hidden inside their font context.
 unsafe impl Send for FontContext {}
-
-pub struct RasterizedGlyph {
-    pub top: f32,
-    pub left: f32,
-    pub width: u32,
-    pub height: u32,
-    pub scale: f32,
-    pub bytes: Vec<u8>,
-}
 
 fn dwrite_texture_type(render_mode: FontRenderMode) -> dwrote::DWRITE_TEXTURE_TYPE {
     match render_mode {
@@ -375,6 +367,7 @@ impl FontContext {
             width: width as u32,
             height: height as u32,
             scale: 1.0,
+            format: GlyphFormat::from(font.render_mode),
             bytes: rgba_pixels,
         })
     }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -587,7 +587,7 @@ impl TextRunPrimitiveCpu {
     }
 
     fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
-        request.push(ColorF::from(self.font.color));
+        request.push(ColorF::from(self.font.color).premultiplied());
         request.push([
             self.offset.x,
             self.offset.y,


### PR DESCRIPTION
When glyphs are rasterized, this makes sure the font backends output the actual format of the glyph. This is then passed down through fetch_glyphs into the shader, which can use this information to properly interpret things like color.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1945)
<!-- Reviewable:end -->
