### PR TITLE
Possible workaround for Intel GPU bug with nested structs

### DIFF
--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -96,7 +96,8 @@ ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
 
     vLocalBounds = vec4(clipped_local_rect.p0, clipped_local_rect.p0 + clipped_local_rect.size);
 
-    return ClipVertexInfo(layer_pos.xyw, actual_pos, clipped_local_rect);
+    ClipVertexInfo vi = ClipVertexInfo(layer_pos.xyw, actual_pos, clipped_local_rect);
+    return vi;
 }
 
 #endif //WR_VERTEX_SHADER

--- a/webrender/res/cs_clip_image.glsl
+++ b/webrender/res/cs_clip_image.glsl
@@ -16,7 +16,9 @@ struct ImageMaskData {
 
 ImageMaskData fetch_mask_data(ivec2 address) {
     vec4 data = fetch_from_resource_cache_1_direct(address);
-    return ImageMaskData(RectWithSize(data.xy, data.zw));
+    RectWithSize local_rect = RectWithSize(data.xy, data.zw);
+    ImageMaskData mask_data = ImageMaskData(local_rect);
+    return mask_data;
 }
 
 void main(void) {

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -209,12 +209,19 @@ struct PictureTask {
 PictureTask fetch_picture_task(int address) {
     RenderTaskData task_data = fetch_render_task(address);
 
-    return PictureTask(
-        RectWithSize(task_data.data0.xy, task_data.data0.zw),
+    RectWithSize target_rect = RectWithSize(
+        task_data.data0.xy,
+        task_data.data0.zw
+    );
+
+    PictureTask task = PictureTask(
+        target_rect,
         task_data.data1.x,
         task_data.data1.yz,
         task_data.data2
     );
+
+    return task;
 }
 
 struct BlurTask {


### PR DESCRIPTION
Potentially fixes #1939

@NiLSPACE would you be able to test? I suspect just as simple `cd webrender && cargo run --example yuv` should be sufficient. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1949)
<!-- Reviewable:end -->
