### PR TITLE
Make UnsafeVecWriter faster

### DIFF
--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -491,6 +491,7 @@ impl<'a, 'b> Serialize for DisplayItemRef<'a, 'b> {
 struct UnsafeVecWriter(*mut u8);
 
 impl Write for UnsafeVecWriter {
+    #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         unsafe {
             ptr::copy_nonoverlapping(buf.as_ptr(), self.0, buf.len());
@@ -498,16 +499,36 @@ impl Write for UnsafeVecWriter {
         }
         Ok(buf.len())
     }
+
+    #[inline(always)]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        unsafe {
+            ptr::copy_nonoverlapping(buf.as_ptr(), self.0, buf.len());
+            self.0 = self.0.offset(buf.len() as isize);
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 struct SizeCounter(usize);
 
 impl<'a> Write for SizeCounter {
+    #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0 += buf.len();
         Ok(buf.len())
     }
+
+    #[inline(always)]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0 += buf.len();
+        Ok(())
+    }
+
+    #[inline(always)]
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 


### PR DESCRIPTION
I was seeing write() not being inlined as well as the default write_all() implementation. Neither of those are ever good things for us to have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1951)
<!-- Reviewable:end -->
