### PR TITLE
Remove isolation conflict log.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -365,13 +365,6 @@ impl FrameBuilder {
                 // must be drawn with a transparent background, unless the parent stacking context
                 // is the root of the page
                 let isolation = &mut self.stacking_context_store[parent_index.0].isolation;
-                if *isolation != ContextIsolation::None {
-                    error!(
-                        "Isolation conflict detected on {:?}: {:?}",
-                        parent_index,
-                        *isolation
-                    );
-                }
                 *isolation = ContextIsolation::Full;
             }
         }


### PR DESCRIPTION
This fixes #1955, there are some cases that a stacking context can contain multiple child stacking contexts with blend mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1956)
<!-- Reviewable:end -->
