### PR TITLE
Use primitive clip masks only, instead of sharing clip chain masks.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1191,7 +1191,7 @@ impl PrimitiveStore {
         // Try to create a mask if we may need to.
         let prim_clips = clip_store.get(&metadata.clip_sources);
         let is_axis_aligned = prim_context.packed_layer.transform.preserves_2d_axis_alignment();
-        let clip_task = if prim_clips.is_masking() {
+        let clip_task = if prim_context.clip_chain.is_some() || prim_clips.is_masking() {
             // Take into account the actual clip info of the primitive, and
             // mutate the current bounds accordingly.
             let mask_rect = match prim_clips.bounds.outer {
@@ -1205,35 +1205,24 @@ impl PrimitiveStore {
                 _ => prim_screen_rect,
             };
 
-            let extra_clip = Some(Rc::new(ClipChainNode {
-                work_item: ClipWorkItem {
-                    layer_index: prim_context.packed_layer_index,
-                    clip_sources: metadata.clip_sources.weak(),
-                    coordinate_system_id: prim_context.coordinate_system_id,
-                },
-                prev: None,
-            }));
+            let extra_clip = if prim_clips.is_masking() {
+                Some(Rc::new(ClipChainNode {
+                    work_item: ClipWorkItem {
+                        layer_index: prim_context.packed_layer_index,
+                        clip_sources: metadata.clip_sources.weak(),
+                        coordinate_system_id: prim_context.coordinate_system_id,
+                    },
+                    prev: None,
+                }))
+            } else {
+                None
+            };
 
             RenderTask::new_mask(
                 None,
                 mask_rect,
                 prim_context.clip_chain.clone(),
                 extra_clip,
-                prim_screen_rect,
-                clip_store,
-                is_axis_aligned,
-                prim_context.coordinate_system_id,
-            )
-        } else if prim_context.clip_chain.is_some() {
-            // If the primitive doesn't have a specific clip, key the task ID off the
-            // stacking context. This means that two primitives which are only clipped
-            // by the stacking context stack can share clip masks during render task
-            // assignment to targets.
-            RenderTask::new_mask(
-                Some(prim_context.clip_id),
-                prim_context.clip_bounds,
-                prim_context.clip_chain.clone(),
-                None,
                 prim_screen_rect,
                 clip_store,
                 is_axis_aligned,

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -286,6 +286,13 @@ impl Wrench {
             }
         }
 
+        // The platform font implementations don't always handle
+        // the exact dimensions used when subpixel AA is enabled
+        // on glyphs. As a workaround, inflate the bounds by
+        // 2 pixels on either side, to give a slightly less
+        // tight fitting bounding rect.
+        let bounding_rect = bounding_rect.inflate(2.0, 2.0);
+
         (indices, positions, bounding_rect)
     }
 


### PR DESCRIPTION
We're not getting any noticeable benefit from trying to share clip
masks. In fact, we are often seeing very significant slowdowns
since we over-estimate the size needed for a shared clip mask.

This change drops the GPU time in #1817 from 40ms to 7ms on
my machine - this is an extreme case, but it's faster in every
site that I tested on locally.

This is also a good simplification for upcoming changes, where
we will be more aggressively removing clip masks when they
are redundant, and drawing them in small segments where possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1960)
<!-- Reviewable:end -->
