### PR TITLE
Stop creating a root scrolling node

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -47,9 +47,10 @@ pub struct ClipScrollTree {
     /// this ID is not valid, which is indicated by ```node``` being empty.
     pub root_reference_frame_id: ClipId,
 
-    /// The root scroll node which is the first child of the root reference frame.
-    /// Initially this ID is not valid, which is indicated by ```nodes``` being empty.
-    pub topmost_scrolling_node_id: ClipId,
+    /// The topmost scrolling node that we have, which is decided by the first scrolling node
+    /// to be added to the tree. This is really only useful for Servo, so we should figure out
+    /// a good way to remove it in the future.
+    pub topmost_scrolling_node_id: Option<ClipId>,
 
     /// A set of pipelines which should be discarded the next time this
     /// tree is drained.
@@ -82,7 +83,7 @@ impl ClipScrollTree {
             pending_scroll_offsets: FastHashMap::default(),
             currently_scrolling_node_id: None,
             root_reference_frame_id: ClipId::root_reference_frame(dummy_pipeline),
-            topmost_scrolling_node_id: ClipId::root_scroll_node(dummy_pipeline),
+            topmost_scrolling_node_id: None,
             current_new_node_item: 1,
             pipelines_to_discard: FastHashSet::default(),
         }
@@ -93,13 +94,6 @@ impl ClipScrollTree {
         debug_assert!(!self.nodes.is_empty());
         debug_assert!(self.nodes.contains_key(&self.root_reference_frame_id));
         self.root_reference_frame_id
-    }
-
-    pub fn topmost_scrolling_node_id(&self) -> ClipId {
-        // TODO(mrobinson): We should eventually make this impossible to misuse.
-        debug_assert!(!self.nodes.is_empty());
-        debug_assert!(self.nodes.contains_key(&self.topmost_scrolling_node_id));
-        self.topmost_scrolling_node_id
     }
 
     pub fn collect_nodes_bouncing_back(&self) -> FastHashSet<ClipId> {
@@ -139,11 +133,6 @@ impl ClipScrollTree {
                 None
             }
         })
-    }
-
-    pub fn find_scrolling_node_at_point(&self, cursor: &WorldPoint) -> ClipId {
-        self.find_scrolling_node_at_point_in_node(cursor, self.root_reference_frame_id())
-            .unwrap_or(self.topmost_scrolling_node_id())
     }
 
     pub fn is_point_clipped_in_for_node(
@@ -261,11 +250,17 @@ impl ClipScrollTree {
             return false;
         }
 
-        let clip_id = match (
-            phase,
-            self.find_scrolling_node_at_point(&cursor),
-            self.currently_scrolling_node_id,
-        ) {
+        let topmost_scrolling_node_id = match self.topmost_scrolling_node_id {
+            Some(id) => id,
+            None => return false,
+        };
+
+        let scrolling_node = self.find_scrolling_node_at_point_in_node(
+            &cursor,
+            self.root_reference_frame_id()
+        ).unwrap_or(topmost_scrolling_node_id);;
+
+        let clip_id = match (phase, scrolling_node, self.currently_scrolling_node_id) {
             (ScrollEventPhase::Start, scroll_node_at_point_id, _) => {
                 self.currently_scrolling_node_id = Some(scroll_node_at_point_id);
                 scroll_node_at_point_id
@@ -283,7 +278,6 @@ impl ClipScrollTree {
             (_, _, None) => return false,
         };
 
-        let topmost_scrolling_node_id = self.topmost_scrolling_node_id();
         let non_root_overscroll = if clip_id != topmost_scrolling_node_id {
             self.nodes.get(&clip_id).unwrap().is_overscrolling()
         } else {
@@ -486,6 +480,10 @@ impl ClipScrollTree {
     }
 
     pub fn add_node(&mut self, node: ClipScrollNode, id: ClipId) {
+        if let NodeType::ScrollFrame(..) = node.node_type {
+            self.topmost_scrolling_node_id.get_or_insert(id);
+        }
+
         // When the parent node is None this means we are adding the root.
         match node.parent {
             Some(parent_id) => self.nodes.get_mut(&parent_id).unwrap().add_child(id),

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -77,7 +77,7 @@ impl<'a> FlattenContext<'a> {
         &mut self,
         traversal: &mut BuiltDisplayListIter<'a>,
         pipeline_id: PipelineId,
-        content_size: &LayoutSize,
+        frame_size: &LayoutSize,
     ) {
         self.builder.push_stacking_context(
             &LayerVector2D::zero(),
@@ -96,11 +96,11 @@ impl<'a> FlattenContext<'a> {
 
         // For the root pipeline, there's no need to add a full screen rectangle
         // here, as it's handled by the framebuffer clear.
-        let clip_id = ClipId::root_scroll_node(pipeline_id);
+        let clip_id = ClipId::root_reference_frame(pipeline_id);
         if self.scene.root_pipeline_id != Some(pipeline_id) {
             if let Some(pipeline) = self.scene.pipelines.get(&pipeline_id) {
                 if let Some(bg_color) = pipeline.background_color {
-                    let root_bounds = LayerRect::new(LayerPoint::zero(), *content_size);
+                    let root_bounds = LayerRect::new(LayerPoint::zero(), *frame_size);
                     let info = LayerPrimitiveInfo::new(root_bounds);
                     self.builder.add_solid_rectangle(
                         ClipAndScrollInfo::simple(clip_id),
@@ -119,12 +119,14 @@ impl<'a> FlattenContext<'a> {
             let scrollbar_rect = LayerRect::new(LayerPoint::zero(), LayerSize::new(10.0, 70.0));
             let info = LayerPrimitiveInfo::new(scrollbar_rect);
 
-            self.builder.add_solid_rectangle(
-                ClipAndScrollInfo::simple(clip_id),
-                &info,
-                &DEFAULT_SCROLLBAR_COLOR,
-                PrimitiveFlags::Scrollbar(self.clip_scroll_tree.topmost_scrolling_node_id(), 4.0),
-            );
+            if let Some(node_id) = self.clip_scroll_tree.topmost_scrolling_node_id {
+                self.builder.add_solid_rectangle(
+                    ClipAndScrollInfo::simple(clip_id),
+                    &info,
+                    &DEFAULT_SCROLLBAR_COLOR,
+                    PrimitiveFlags::Scrollbar(node_id, 4.0),
+                );
+            }
         }
 
         self.builder.pop_stacking_context();
@@ -339,7 +341,7 @@ impl<'a> FlattenContext<'a> {
         let iframe_rect = LayerRect::new(LayerPoint::zero(), bounds.size);
         let origin = reference_frame_relative_offset + bounds.origin.to_vector();
         let transform = LayerToScrollTransform::create_translation(origin.x, origin.y, 0.0);
-        let iframe_reference_frame_id = self.builder.push_reference_frame(
+        self.builder.push_reference_frame(
             Some(clip_id),
             pipeline_id,
             &iframe_rect,
@@ -349,20 +351,10 @@ impl<'a> FlattenContext<'a> {
             self.clip_scroll_tree,
         );
 
-        self.builder.add_scroll_frame(
-            ClipId::root_scroll_node(pipeline_id),
-            iframe_reference_frame_id,
-            pipeline_id,
-            &iframe_rect,
-            &pipeline.content_size,
-            ScrollSensitivity::ScriptAndInputEvents,
-            self.clip_scroll_tree,
-        );
-
         self.flatten_root(
             &mut pipeline.display_list.iter(),
             pipeline_id,
-            &pipeline.content_size,
+            &bounds.size,
         );
 
         self.builder.pop_reference_frame();
@@ -668,7 +660,6 @@ impl<'a> FlattenContext<'a> {
             color,
             PrimitiveFlags::None,
         );
-
         for clipped_rect in &clipped_rects {
             let mut info = info.clone();
             info.rect = *clipped_rect;
@@ -1095,7 +1086,6 @@ impl FrameContext {
             roller.builder.push_root(
                 root_pipeline_id,
                 &root_pipeline.viewport_size,
-                &root_pipeline.content_size,
                 roller.clip_scroll_tree,
             );
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -468,9 +468,10 @@ impl FrameBuilder {
             root_node.local_clip_rect = viewport_clip;
         }
 
-        let clip_id = clip_scroll_tree.topmost_scrolling_node_id();
-        if let Some(root_node) = clip_scroll_tree.nodes.get_mut(&clip_id) {
-            root_node.local_clip_rect = viewport_clip;
+        if let Some(clip_id) = clip_scroll_tree.topmost_scrolling_node_id {
+            if let Some(root_node) = clip_scroll_tree.nodes.get_mut(&clip_id) {
+                root_node.local_clip_rect = viewport_clip;
+            }
         }
     }
 
@@ -478,7 +479,6 @@ impl FrameBuilder {
         &mut self,
         pipeline_id: PipelineId,
         viewport_size: &LayerSize,
-        content_size: &LayerSize,
         clip_scroll_tree: &mut ClipScrollTree,
     ) -> ClipId {
         let viewport_rect = LayerRect::new(LayerPoint::zero(), *viewport_size);
@@ -493,20 +493,7 @@ impl FrameBuilder {
             clip_scroll_tree,
         );
 
-        let topmost_scrolling_node_id = ClipId::root_scroll_node(pipeline_id);
-        clip_scroll_tree.topmost_scrolling_node_id = topmost_scrolling_node_id;
-
-        self.add_scroll_frame(
-            topmost_scrolling_node_id,
-            clip_scroll_tree.root_reference_frame_id,
-            pipeline_id,
-            &viewport_rect,
-            content_size,
-            ScrollSensitivity::ScriptAndInputEvents,
-            clip_scroll_tree,
-        );
-
-        topmost_scrolling_node_id
+        clip_scroll_tree.root_reference_frame_id
     }
 
     pub fn add_clip_node(

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -681,19 +681,15 @@ pub enum ClipId {
 }
 
 impl ClipId {
-    pub fn root_scroll_node(pipeline_id: PipelineId) -> ClipId {
-        ClipId::Clip(0, pipeline_id)
-    }
-
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ClipId {
         ClipId::DynamicallyAddedNode(0, pipeline_id)
     }
 
     pub fn new(id: u64, pipeline_id: PipelineId) -> ClipId {
-        // We do this because it is very easy to create accidentally create something that
-        // seems like a root scroll node, but isn't one.
+        // We do this because it is very easy to accidentally create something that
+        // seems like the root node, but isn't one.
         if id == 0 {
-            return ClipId::root_scroll_node(pipeline_id);
+            return ClipId::root_reference_frame(pipeline_id);
         }
 
         ClipId::ClipExternalId(id, pipeline_id)
@@ -714,9 +710,9 @@ impl ClipId {
         }
     }
 
-    pub fn is_root_scroll_node(&self) -> bool {
+    pub fn is_root(&self) -> bool {
         match *self {
-            ClipId::Clip(0, _) => true,
+            ClipId::DynamicallyAddedNode(0, _) => true,
             _ => false,
         }
     }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -657,7 +657,7 @@ impl DisplayListBuilder {
             data: Vec::with_capacity(capacity),
             pipeline_id,
             clip_stack: vec![
-                ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id)),
+                ClipAndScrollInfo::simple(ClipId::root_reference_frame(pipeline_id)),
             ],
             next_clip_id: FIRST_CLIP_ID,
             builder_start_time: start_time,

--- a/wrench/reftests/scrolling/fixed-position.yaml
+++ b/wrench/reftests/scrolling/fixed-position.yaml
@@ -1,23 +1,10 @@
 root:
-  bounds: [0, 0, 1024, 10000]
-  scroll-offset: [0, 100]
   items:
-    # This stacking context should not scroll out of view because it is fixed position.
-    - type: stacking-context
-      bounds: [0, 0, 50, 50]
-      scroll-policy: fixed
+    - type: scroll-frame
+      bounds: [0, 0, 500, 500]
+      scroll-offset: [0, 100]
       items:
-        - type: rect
-          bounds: [0, 0, 50, 50]
-          color: green
-    # Even though there is a fixed position stacking context, it should scroll,
-    # because it is fixed relative to its reference frame. The reference frame
-    # of this stacking context is the stacking context parent because it has
-    # a transformation.
-    - type: stacking-context
-      bounds: [0, 0, 50, 50]
-      transform: translate(60, 100)
-      items:
+        # This stacking context should not scroll out of view because it is fixed position.
         - type: stacking-context
           bounds: [0, 0, 50, 50]
           scroll-policy: fixed
@@ -25,41 +12,56 @@ root:
             - type: rect
               bounds: [0, 0, 50, 50]
               color: green
-    # This is similar to the previous case, but ensures that this still works
-    # even with an identity transform.
-    - type: stacking-context
-      bounds: [120, 0, 50, 200]
-      transform: translate(0, 0)
-      items:
+        # Even though there is a fixed position stacking context, it should scroll,
+        # because it is fixed relative to its reference frame. The reference frame
+        # of this stacking context is the stacking context parent because it has
+        # a transformation.
         - type: stacking-context
-          bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
+          bounds: [0, 0, 50, 50]
+          transform: translate(60, 100)
           items:
-            - type: rect
-              bounds: [0, 100, 50, 50]
-              color: green
-    # This is similar to the previous case, but for perspective.
-    - type: stacking-context
-      bounds: [180, 0, 50, 200]
-      perspective: 1
-      items:
-        - type: stacking-context
-          bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
-          items:
-            - type: rect
-              bounds: [0, 100, 50, 50]
-              color: green
-    # This is similar to the previous case, but since the perspective is
-    # 0 (equivalent to none), it shouldn't scroll.
-    - type: stacking-context
-      bounds: [240, 0, 50, 200]
-      perspective: 0
-      items:
-        - type: stacking-context
-          bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
-          items:
-            - type: rect
+            - type: stacking-context
               bounds: [0, 0, 50, 50]
-              color: green
+              scroll-policy: fixed
+              items:
+                - type: rect
+                  bounds: [0, 0, 50, 50]
+                  color: green
+        # This is similar to the previous case, but ensures that this still works
+        # even with an identity transform.
+        - type: stacking-context
+          bounds: [120, 0, 50, 200]
+          transform: translate(0, 0)
+          items:
+            - type: stacking-context
+              bounds: [0, 0, 50, 200]
+              scroll-policy: fixed
+              items:
+                - type: rect
+                  bounds: [0, 100, 50, 50]
+                  color: green
+        # This is similar to the previous case, but for perspective.
+        - type: stacking-context
+          bounds: [180, 0, 50, 200]
+          perspective: 1
+          items:
+            - type: stacking-context
+              bounds: [0, 0, 50, 200]
+              scroll-policy: fixed
+              items:
+                - type: rect
+                  bounds: [0, 100, 50, 50]
+                  color: green
+        # This is similar to the previous case, but since the perspective is
+        # 0 (equivalent to none), it shouldn't scroll.
+        - type: stacking-context
+          bounds: [240, 0, 50, 200]
+          perspective: 0
+          items:
+            - type: stacking-context
+              bounds: [0, 0, 50, 200]
+              scroll-policy: fixed
+              items:
+                - type: rect
+                  bounds: [0, 0, 50, 50]
+                  color: green

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -3,7 +3,6 @@
 == fixed-position.yaml fixed-position-ref.yaml
 == nested-scroll-offset.yaml nested-scroll-offset-ref.yaml
 == out-of-bounds-scroll.yaml out-of-bounds-scroll-ref.yaml
-== root-scroll.yaml root-scroll-ref.yaml
 == scroll-layer-with-mask.yaml scroll-layer-with-mask-ref.yaml
 == scroll-layer.yaml scroll-layer-ref.yaml
 == simple.yaml simple-ref.yaml

--- a/wrench/reftests/scrolling/root-scroll-ref.yaml
+++ b/wrench/reftests/scrolling/root-scroll-ref.yaml
@@ -1,6 +1,0 @@
-root:
-  bounds: [0, 0, 1024, 10000]
-  items:
-    - type: rect
-      bounds: [10, 10, 50, 50]
-      color: green

--- a/wrench/reftests/scrolling/root-scroll.yaml
+++ b/wrench/reftests/scrolling/root-scroll.yaml
@@ -1,7 +1,0 @@
-root:
-  bounds: [0, 0, 1024, 10000]
-  scroll-offset: [0, 100]
-  items:
-    - type: rect
-      bounds: [10, 110, 50, 50]
-      color: green

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -244,7 +244,7 @@ impl YamlFrameReader {
 
                 let mut dl = DisplayListBuilder::new(pipeline_id, content_size);
                 let mut info = LayoutPrimitiveInfo::new(LayoutRect::zero());
-                self.add_stacking_context_from_yaml(&mut dl, wrench, pipeline, true, &mut info);
+                self.add_stacking_context_from_yaml(&mut dl, wrench, pipeline, &mut info);
                 self.display_lists.push(dl.finalize());
             }
         }
@@ -253,7 +253,7 @@ impl YamlFrameReader {
         let content_size = self.get_root_size_from_yaml(wrench, &yaml["root"]);
         let mut dl = DisplayListBuilder::new(wrench.root_pipeline_id, content_size);
         let mut info = LayoutPrimitiveInfo::new(LayoutRect::zero());
-        self.add_stacking_context_from_yaml(&mut dl, wrench, &yaml["root"], true, &mut info);
+        self.add_stacking_context_from_yaml(&mut dl, wrench, &yaml["root"], &mut info);
         self.display_lists.push(dl.finalize());
     }
 
@@ -1097,7 +1097,7 @@ impl YamlFrameReader {
                 "box-shadow" => self.handle_box_shadow(dl, item, &mut info),
                 "iframe" => self.handle_iframe(dl, item, &mut info),
                 "stacking-context" => {
-                    self.add_stacking_context_from_yaml(dl, wrench, item, false, &mut info)
+                    self.add_stacking_context_from_yaml(dl, wrench, item, &mut info)
                 }
                 "shadow" => self.handle_push_shadow(dl, item, &mut info),
                 "pop-all-shadows" => self.handle_pop_all_shadows(dl),
@@ -1245,7 +1245,6 @@ impl YamlFrameReader {
         dl: &mut DisplayListBuilder,
         wrench: &mut Wrench,
         yaml: &Yaml,
-        is_root: bool,
         info: &mut LayoutPrimitiveInfo,
     ) {
         let default_bounds = LayoutRect::new(LayoutPoint::zero(), wrench.window_size_f32());
@@ -1277,14 +1276,6 @@ impl YamlFrameReader {
         let scroll_policy = yaml["scroll-policy"]
             .as_scroll_policy()
             .unwrap_or(ScrollPolicy::Scrollable);
-
-        if is_root {
-            if let Some(size) = yaml["scroll-offset"].as_point() {
-                let id = ClipId::root_scroll_node(dl.pipeline_id);
-                self.scroll_offsets
-                    .insert(id, LayerPoint::new(size.x, size.y));
-            }
-        }
 
         let filters = yaml["filters"].as_vec_filter_op().unwrap_or(vec![]);
         info.rect = bounds;

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1100,7 +1100,7 @@ impl ClipIdMapper {
     }
 
     fn map_id(&self, id: &ClipId) -> usize {
-        if id.is_root_scroll_node() {
+        if id.is_root() {
             return 0;
         }
         *self.hash_map.get(id).unwrap()


### PR DESCRIPTION
This is used by Servo, but not by Gecko, so we move the creation into
Servo itself. As part of the transition, we keep
topmost_scrolling_node_id, with the plan of removing it in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1962)
<!-- Reviewable:end -->
