### PR TITLE
Set the subpixel text mask's alpha so that drawing text on transparency doesn't create black boxes.

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -612,12 +612,15 @@ impl FontContext {
                         pixel[2] = 255 - pixel[2];
                     }
 
-                    pixel[3] = match font.render_mode {
-                        FontRenderMode::Subpixel => 255,
-                        _ => {
-                            pixel[0]
-                        }
-                    }; // end match
+                    // Set alpha to the value of the green channel. For grayscale
+                    // text, all three channels have the same value anyway.
+                    // For subpixel text, the mask's alpha only makes a difference
+                    // when computing the destination alpha on destination pixels
+                    // that are not completely opaque. Picking an alpha value
+                    // that's somehow based on the mask at least ensures that text
+                    // blending doesn't modify the destination alpha on pixels where
+                    // the mask is entirely zero.
+                    pixel[3] = pixel[1];
                 } // end row
             } // end height
 


### PR DESCRIPTION
Drawing subpixel text to non-opaque destinations isn't really supported, but in some cases we do it anyway. One of those cases will be the Firefox tab bar on macOS as soon as we start putting a `ClearRect` primitive in there, in order to support vibrancy.

This patch is basically a quick hack to get rid of the black boxes in that case. The resulting subpixel AA will only look correct if the destination surface is later composited on top of a black background. But that's the case for the Firefox tab bar anyway (the dark vibrancy is close to black), so we're lucky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1965)
<!-- Reviewable:end -->
