### PR TITLE
cleanup of subpixel glyph format

### DIFF
--- a/webrender/src/gamma_lut.rs
+++ b/webrender/src/gamma_lut.rs
@@ -295,82 +295,41 @@ impl GammaLut {
         table
     }
 
-    // Skia normally preblends based on what the text color is.
-    // If we can't do that, use Skia default colors.
-    pub fn preblend_default_colors_bgra(&self, pixels: &mut [u8], width: usize, height: usize) {
-        let preblend_color = ColorU::new(0x7f, 0x80, 0x7f, 0xff);
-        self.preblend_bgra(pixels, width, height, preblend_color);
-    }
-
-    fn replace_pixels_bgra(&self, pixels: &mut [u8], width: usize, height: usize,
-                           table_r: &[u8; 256], table_g: &[u8; 256], table_b: &[u8; 256]) {
-         for y in 0..height {
-            let current_height = y * width * 4;
-
-            for pixel in pixels[current_height..current_height + (width * 4)].chunks_mut(4) {
-                pixel[0] = table_b[pixel[0] as usize];
-                pixel[1] = table_g[pixel[1] as usize];
-                pixel[2] = table_r[pixel[2] as usize];
-                // Don't touch alpha
-            }
-        }
-    }
-
-    // Mostly used by windows and GlyphRunAnalysis::GetAlphaTexture
-    fn replace_pixels_rgb(&self, pixels: &mut [u8], width: usize, height: usize,
-                          table_r: &[u8; 256], table_g: &[u8; 256], table_b: &[u8; 256]) {
-         for y in 0..height {
-            let current_height = y * width * 3;
-
-            for pixel in pixels[current_height..current_height + (width * 3)].chunks_mut(3) {
-                pixel[0] = table_r[pixel[0] as usize];
-                pixel[1] = table_g[pixel[1] as usize];
-                pixel[2] = table_b[pixel[2] as usize];
-            }
-        }
-    }
-
     // Assumes pixels are in BGRA format. Assumes pixel values are in linear space already.
-    pub fn preblend_bgra(&self, pixels: &mut [u8], width: usize, height: usize, color: ColorU) {
+    pub fn preblend(&self, pixels: &mut [u8], color: ColorU) {
         let table_r = self.get_table(color.r);
         let table_g = self.get_table(color.g);
         let table_b = self.get_table(color.b);
 
-        self.replace_pixels_bgra(pixels, width, height, table_r, table_g, table_b);
-    }
-
-    // Assumes pixels are in RGB format. Assumes pixel values are in linear space already. NOTE:
-    // there is no alpha here.
-    pub fn preblend_rgb(&self, pixels: &mut [u8], width: usize, height: usize, color: ColorU) {
-        let table_r = self.get_table(color.r);
-        let table_g = self.get_table(color.g);
-        let table_b = self.get_table(color.b);
-
-        self.replace_pixels_rgb(pixels, width, height, table_r, table_g, table_b);
+        for pixel in pixels.chunks_mut(4) {
+            pixel[0] = table_b[pixel[0] as usize];
+            pixel[1] = table_g[pixel[1] as usize];
+            pixel[2] = table_r[pixel[2] as usize];
+            // Use green channel as a cheap grayscale approximation that won't disturb preblending.
+            pixel[3] = pixel[1];
+        }
     }
 
     #[cfg(target_os="macos")]
-    pub fn coregraphics_convert_to_linear_bgra(&self, pixels: &mut [u8], width: usize, height: usize) {
-        self.replace_pixels_bgra(pixels, width, height,
-                                 &self.cg_inverse_gamma,
-                                 &self.cg_inverse_gamma,
-                                 &self.cg_inverse_gamma);
+    pub fn coregraphics_convert_to_linear(&self, pixels: &mut [u8]) {
+        for pixel in pixels.chunks_mut(4) {
+            pixel[0] = self.cg_inverse_gamma[pixel[0] as usize];
+            pixel[1] = self.cg_inverse_gamma[pixel[1] as usize];
+            pixel[2] = self.cg_inverse_gamma[pixel[2] as usize];
+        }
     }
 
     // Assumes pixels are in BGRA format. Assumes pixel values are in linear space already.
-    pub fn preblend_grayscale_bgra(&self, pixels: &mut [u8], width: usize, height: usize, color: ColorU) {
+    pub fn preblend_grayscale(&self, pixels: &mut [u8], color: ColorU) {
         let table_g = self.get_table(color.g);
 
-         for y in 0..height {
-            let current_height = y * width * 4;
-
-            for pixel in pixels[current_height..current_height + (width * 4)].chunks_mut(4) {
-                let luminance = compute_luminance(pixel[2], pixel[1], pixel[0]);
-                pixel[0] = table_g[luminance as usize];
-                pixel[1] = table_g[luminance as usize];
-                pixel[2] = table_g[luminance as usize];
-                pixel[3] = table_g[luminance as usize];
-            }
+        for pixel in pixels.chunks_mut(4) {
+            let luminance = compute_luminance(pixel[2], pixel[1], pixel[0]);
+            let alpha = table_g[luminance as usize];
+            pixel[0] = alpha;
+            pixel[1] = alpha;
+            pixel[2] = alpha;
+            pixel[3] = alpha;
         }
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRect};
-use api::{DevicePoint, ExtendMode, FontInstance, FontRenderMode, GlyphInstance, GlyphKey};
+use api::{DevicePoint, ExtendMode, FontInstance, GlyphInstance, GlyphKey};
 use api::{GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerRect};
 use api::{ClipMode, LayerSize, LayerVector2D, LineOrientation, LineStyle};
 use api::{TileOffset, YuvColorSpace, YuvFormat};
@@ -554,26 +554,10 @@ pub struct TextRunPrimitiveCpu {
     pub glyph_gpu_blocks: Vec<GpuBlockData>,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum TextRunMode {
-    Normal,
-    Shadow,
-}
 
 impl TextRunPrimitiveCpu {
-    pub fn get_font(&self,
-                    run_mode: TextRunMode,
-                    device_pixel_ratio: f32,
-    ) -> FontInstance {
+    pub fn get_font(&self, device_pixel_ratio: f32) -> FontInstance {
         let mut font = self.font.clone();
-        match run_mode {
-            TextRunMode::Normal => {}
-            TextRunMode::Shadow => {
-                // Shadows never use subpixel AA, but need to respect the alpha/mono flag
-                // for reftests.
-                font.render_mode = font.render_mode.limit_by(FontRenderMode::Alpha);
-            }
-        };
         font.size = font.size.scale_by(device_pixel_ratio);
         font
     }
@@ -583,10 +567,9 @@ impl TextRunPrimitiveCpu {
         resource_cache: &mut ResourceCache,
         device_pixel_ratio: f32,
         display_list: &BuiltDisplayList,
-        run_mode: TextRunMode,
         gpu_cache: &mut GpuCache,
     ) {
-        let font = self.get_font(run_mode, device_pixel_ratio);
+        let font = self.get_font(device_pixel_ratio);
 
         // Cache the glyph positions, if not in the cache already.
         // TODO(gw): In the future, remove `glyph_instances`
@@ -1097,7 +1080,6 @@ impl PrimitiveStore {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
-        text_run_mode: TextRunMode,
     ) {
         let metadata = &mut self.cpu_metadata[prim_index.0];
         match metadata.prim_kind {
@@ -1116,7 +1098,6 @@ impl PrimitiveStore {
                     resource_cache,
                     prim_context.device_pixel_ratio,
                     prim_context.display_list,
-                    text_run_mode,
                     gpu_cache,
                 );
             }
@@ -1357,7 +1338,6 @@ impl PrimitiveStore {
                     resource_cache,
                     gpu_cache,
                     render_tasks,
-                    TextRunMode::Shadow,
                 );
             }
         }
@@ -1380,7 +1360,6 @@ impl PrimitiveStore {
             resource_cache,
             gpu_cache,
             render_tasks,
-            TextRunMode::Normal,
         );
 
         Some(geometry)

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -20,7 +20,7 @@ use internal_types::{FastHashMap, SourceTexture};
 use internal_types::BatchTextures;
 use picture::PictureKind;
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
-use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, RectangleContent, TextRunMode};
+use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, RectangleContent};
 use profiler::FrameProfileCounters;
 use render_task::{AlphaRenderItem, ClipWorkItem, MaskGeometryKind, MaskSegment};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKey, RenderTaskKind};
@@ -561,7 +561,7 @@ impl AlphaRenderItem {
                         let text_cpu =
                             &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
 
-                        let font = text_cpu.get_font(TextRunMode::Normal, ctx.device_pixel_ratio);
+                        let font = text_cpu.get_font(ctx.device_pixel_ratio);
 
                         ctx.resource_cache.fetch_glyphs(
                             font,
@@ -1236,7 +1236,7 @@ impl RenderTarget for ColorRenderTarget {
                                             [sub_metadata.cpu_prim_index.0];
                                         let text_run_cache_prims = &mut self.text_run_cache_prims;
 
-                                        let font = text.get_font(TextRunMode::Shadow, ctx.device_pixel_ratio);
+                                        let font = text.get_font(ctx.device_pixel_ratio);
 
                                         ctx.resource_cache.fetch_glyphs(
                                             font,

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -18,7 +18,7 @@ fuzzy(1,100) == decorations-suite.yaml decorations-suite.png
 == 1658.yaml 1658-ref.yaml
 == split-batch.yaml split-batch-ref.yaml
 == shadow-red.yaml shadow-red-ref.yaml
-fuzzy(1,644) == shadow-grey.yaml shadow-grey-ref.yaml
+fuzzy(1,735) == shadow-grey.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 == shadow-atomic.yaml shadow-atomic-ref.yaml
 options(disable-aa) == shadow-ordering.yaml shadow-ordering-ref.yaml


### PR DESCRIPTION
This initially started as an idea between Markus and I to just store the grayscale value in the alpha channel of subpixel glyphs on all platforms (not just macOS). That, unfortunately, led to digging up a number of bugs and inconsistencies in the glyph code surrounding the subpixel glyph format, making this more of an omnibus patch to clean that all up.

Among the things addressed:
1) DWrite subpixel layout was reversed - now fixed to be BGRA. Gamma lut code simplified now that all backends are consistently BGRA.
2) FreeType bitmap code wasn't advancing destination row.
3) All platforms now output alpha for subpixel, so that we no longer need to limit text shadows to alpha format, so text shadows should generate faster and use less memory now.
4) Removed all the TextRunMode::Shadow junk since it is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1969)
<!-- Reviewable:end -->
