### PR TITLE
Ensure that HitTest and GetScrollState are not serialized.

### DIFF
--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::ApiMsg;
+use api::{ApiMsg, DocumentMsg};
 use bincode::{serialize, Infinite};
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::any::TypeId;
@@ -65,8 +65,14 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
     match *msg {
         ApiMsg::UpdateResources(..) |
         ApiMsg::AddDocument { .. } |
-        ApiMsg::UpdateDocument(..) |
         ApiMsg::DeleteDocument(..) => true,
+        ApiMsg::UpdateDocument(_, ref msg) => {
+            match *msg {
+                DocumentMsg::GetScrollNodeState(..) |
+                DocumentMsg::HitTest(..) => false,
+                _ => true,
+            }
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
These contain Sender objects that can't be serialized. These
messages are used by Servo and were preventing binary
recordings from working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/1991)
<!-- Reviewable:end -->
