### PR TITLE
Refactor / prep work for storing primitive runs in Picture structs.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -25,7 +25,7 @@ use picture::{PicturePrimitive};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
-use prim_store::{PrimitiveContainer, PrimitiveIndex};
+use prim_store::{PrimitiveContainer, PrimitiveIndex, PrimitiveRun};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{RectangleContent, RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
@@ -263,24 +263,24 @@ impl FrameBuilder {
     ) {
         match self.cmds.last_mut().unwrap() {
             &mut PrimitiveRunCmd::PrimitiveRun(
-                run_prim_index,
-                ref mut count,
-                run_clip_and_scroll,
-            ) => if run_clip_and_scroll == clip_and_scroll &&
-                run_prim_index.0 + *count == prim_index.0
+                ref mut run,
+            ) => if run.clip_and_scroll == clip_and_scroll &&
+                run.base_prim_index.0 + run.count == prim_index.0
             {
-                *count += 1;
+                run.count += 1;
                 return;
             },
             &mut PrimitiveRunCmd::PushStackingContext(..) |
             &mut PrimitiveRunCmd::PopStackingContext => {}
         }
 
-        self.cmds.push(PrimitiveRunCmd::PrimitiveRun(
-            prim_index,
-            1,
+        let run = PrimitiveRun {
+            base_prim_index: prim_index,
+            count: 1,
             clip_and_scroll,
-        ));
+        };
+
+        self.cmds.push(PrimitiveRunCmd::PrimitiveRun(run));
     }
 
     /// Convenience interface that creates a primitive entry and adds it
@@ -1337,9 +1337,7 @@ impl FrameBuilder {
 
     fn handle_primitive_run(
         &mut self,
-        base_prim_index: PrimitiveIndex,
-        prim_count: usize,
-        clip_and_scroll: ClipAndScrollInfo,
+        run: &PrimitiveRun,
         render_tasks: &mut RenderTaskTree,
         gpu_cache: &mut GpuCache,
         resource_cache: &mut ResourceCache,
@@ -1347,20 +1345,20 @@ impl FrameBuilder {
         clip_scroll_tree: &ClipScrollTree,
         device_pixel_ratio: f32,
         profile_counters: &mut FrameProfileCounters,
-    ) -> bool {
+    ) {
         let stacking_context_index = *self.stacking_context_stack.last().unwrap();
-        let scroll_node = &clip_scroll_tree.nodes[&clip_and_scroll.scroll_node_id];
-        let clip_node = &clip_scroll_tree.nodes[&clip_and_scroll.clip_node_id()];
+        let scroll_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.scroll_node_id];
+        let clip_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.clip_node_id()];
 
         if clip_node.combined_clip_outer_bounds == DeviceIntRect::zero() {
-            debug!("{:?} of clipped out {:?}", base_prim_index, stacking_context_index);
-            return false;
+            debug!("{:?} of clipped out {:?}", run.base_prim_index, stacking_context_index);
+            return;
         }
 
         let stacking_context = &mut self.stacking_context_store[stacking_context_index.0];
         let pipeline_id = {
             if !stacking_context.can_contribute_to_scene() {
-                return false;
+                return;
             }
 
             // At least one primitive in this stacking context is visible, so the stacking
@@ -1371,7 +1369,7 @@ impl FrameBuilder {
 
         debug!(
             "\t{:?} of {:?}",
-            base_prim_index,
+            run.base_prim_index,
             stacking_context_index,
         );
 
@@ -1381,7 +1379,7 @@ impl FrameBuilder {
             .display_list;
 
         if !stacking_context.is_backface_visible && scroll_node.world_content_transform.is_backface_visible() {
-            return false;
+            return;
         }
 
         let prim_context = PrimitiveContext::new(
@@ -1391,30 +1389,26 @@ impl FrameBuilder {
             scroll_node,
         );
 
-        for i in 0 .. prim_count {
-            let prim_index = PrimitiveIndex(base_prim_index.0 + i);
+        let result = self.prim_store.prepare_prim_run(
+            run,
+            &prim_context,
+            gpu_cache,
+            resource_cache,
+            render_tasks,
+            &mut self.clip_store,
+        );
 
-            if let Some(prim_geom) = self.prim_store.prepare_prim_for_render(
-                prim_index,
-                &prim_context,
-                resource_cache,
-                gpu_cache,
-                render_tasks,
-                &mut self.clip_store,
-            ) {
-                stacking_context.screen_bounds = stacking_context
-                    .screen_bounds
-                    .union(&prim_geom.device_rect);
-                stacking_context.isolated_items_bounds = stacking_context
-                    .isolated_items_bounds
-                    .union(&prim_geom.local_rect);
-                stacking_context.has_any_primitive = true;
+        if result.visible_primitives > 0 {
+            stacking_context.screen_bounds = stacking_context
+                .screen_bounds
+                .union(&result.device_rect);
+            stacking_context.isolated_items_bounds = stacking_context
+                .isolated_items_bounds
+                .union(&result.local_rect);
+            stacking_context.has_any_primitive = true;
 
-                profile_counters.visible_primitives.inc();
-            }
+            profile_counters.visible_primitives.add(result.visible_primitives);
         }
-
-        true //visible
     }
 
     fn handle_pop_stacking_context(
@@ -1496,11 +1490,9 @@ impl FrameBuilder {
                 PrimitiveRunCmd::PushStackingContext(stacking_context_index) => {
                     self.handle_push_stacking_context(stacking_context_index)
                 }
-                PrimitiveRunCmd::PrimitiveRun(prim_index, prim_count, clip_and_scroll) => {
+                PrimitiveRunCmd::PrimitiveRun(ref run) => {
                     self.handle_primitive_run(
-                        prim_index,
-                        prim_count,
-                        clip_and_scroll,
+                        run,
                         render_tasks,
                         gpu_cache,
                         resource_cache,
@@ -1840,19 +1832,19 @@ impl FrameBuilder {
                         current_task = prev_task;
                     }
                 }
-                PrimitiveRunCmd::PrimitiveRun(first_prim_index, prim_count, clip_and_scroll) => {
+                PrimitiveRunCmd::PrimitiveRun(ref run) => {
                     let stacking_context_index = *sc_stack.last().unwrap();
                     if !self.stacking_context_store[stacking_context_index.0].is_visible {
                         continue;
                     }
 
-                    debug!("\trun of {} items", prim_count);
+                    debug!("\trun of {} items", run.count);
 
-                    let scroll_node = &clip_scroll_tree.nodes[&clip_and_scroll.scroll_node_id];
-                    let clip_node = &clip_scroll_tree.nodes[&clip_and_scroll.clip_node_id()];
+                    let scroll_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.scroll_node_id];
+                    let clip_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.clip_node_id()];
 
-                    for i in 0 .. prim_count {
-                        let prim_index = PrimitiveIndex(first_prim_index.0 + i);
+                    for i in 0 .. run.count {
+                        let prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
 
                         if self.prim_store.cpu_metadata[prim_index.0].screen_rect.is_some() {
                             self.prim_store

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -7,7 +7,7 @@ use api::{BoxShadowClipMode, LayerPoint, LayerRect, LayerSize, Shadow};
 use box_shadow::BLUR_SAMPLE_SCALE;
 use frame_builder::PrimitiveContext;
 use gpu_cache::GpuDataRequest;
-use prim_store::PrimitiveIndex;
+use prim_store::{PrimitiveIndex, PrimitiveRun};
 use render_task::{ClearMode, RenderTask, RenderTaskId, RenderTaskTree};
 use tiling::RenderTargetKind;
 
@@ -20,13 +20,6 @@ use tiling::RenderTargetKind;
  * A configuration describing how to draw the primitives on
    this picture (e.g. in screen space or local space).
  */
-
-#[derive(Clone, Debug)]
-pub struct PrimitiveRun {
-    pub prim_index: PrimitiveIndex,
-    pub count: usize,
-    pub clip_and_scroll: ClipAndScrollInfo,
-}
 
 #[derive(Debug)]
 pub enum PictureKind {
@@ -112,14 +105,14 @@ impl PicturePrimitive {
 
         if let Some(ref mut run) = self.prim_runs.last_mut() {
             if run.clip_and_scroll == clip_and_scroll &&
-               run.prim_index.0 + run.count == prim_index.0 {
+               run.base_prim_index.0 + run.count == prim_index.0 {
                 run.count += 1;
                 return;
             }
         }
 
         self.prim_runs.push(PrimitiveRun {
-            prim_index,
+            base_prim_index: prim_index,
             count: 1,
             clip_and_scroll,
         });

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{BorderRadius, BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRe
 use api::{DevicePoint, ExtendMode, FontInstance, GlyphInstance, GlyphKey};
 use api::{GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerRect};
 use api::{ClipMode, LayerSize, LayerVector2D, LineOrientation, LineStyle};
-use api::{TileOffset, YuvColorSpace, YuvFormat};
+use api::{ClipAndScrollInfo, TileOffset, YuvColorSpace, YuvFormat};
 use border::BorderCornerInstance;
 use clip::{ClipSourcesHandle, ClipStore, Geometry};
 use frame_builder::PrimitiveContext;
@@ -19,6 +19,20 @@ use resource_cache::{ImageProperties, ResourceCache};
 use std::{mem, usize};
 use std::rc::Rc;
 use util::{pack_as_float, recycle_vec, MatrixHelpers, TransformedRect, TransformedRectKind};
+
+#[derive(Clone, Debug)]
+pub struct PrimitiveRun {
+    pub base_prim_index: PrimitiveIndex,
+    pub count: usize,
+    pub clip_and_scroll: ClipAndScrollInfo,
+}
+
+#[derive(Debug)]
+pub struct PrimitiveRunResult {
+    pub local_rect: LayerRect,
+    pub device_rect: DeviceIntRect,
+    pub visible_primitives: usize,
+}
 
 #[derive(Debug, Copy, Clone)]
 pub struct PrimitiveOpacity {
@@ -1333,7 +1347,7 @@ impl PrimitiveStore {
         //           avoid borrow checker issues.
         for run in dependent_primitives {
             for i in 0 .. run.count {
-                let sub_prim_index = PrimitiveIndex(run.prim_index.0 + i);
+                let sub_prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
 
                 self.prepare_prim_for_render_inner(
                     sub_prim_index,
@@ -1367,8 +1381,42 @@ impl PrimitiveStore {
 
         Some(geometry)
     }
-}
 
+    pub fn prepare_prim_run(
+        &mut self,
+        run: &PrimitiveRun,
+        prim_context: &PrimitiveContext,
+        gpu_cache: &mut GpuCache,
+        resource_cache: &mut ResourceCache,
+        render_tasks: &mut RenderTaskTree,
+        clip_store: &mut ClipStore,
+    ) -> PrimitiveRunResult {
+        let mut result = PrimitiveRunResult {
+            local_rect: LayerRect::zero(),
+            device_rect: DeviceIntRect::zero(),
+            visible_primitives: 0,
+        };
+
+        for i in 0 .. run.count {
+            let prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
+
+            if let Some(prim_geom) = self.prepare_prim_for_render(
+                prim_index,
+                prim_context,
+                resource_cache,
+                gpu_cache,
+                render_tasks,
+                clip_store,
+            ) {
+                result.local_rect = result.local_rect.union(&prim_geom.local_rect);
+                result.device_rect = result.device_rect.union(&prim_geom.device_rect);
+                result.visible_primitives += 1;
+            }
+        }
+
+        result
+    }
+}
 
 //Test for one clip region contains another
 trait InsideTest<T> {

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderRadiusKind, ClipAndScrollInfo, ClipId, ColorF, DeviceIntPoint, ImageKey};
+use api::{BorderRadiusKind, ClipId, ColorF, DeviceIntPoint, ImageKey};
 use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize};
 use api::{ExternalImageType, FilterOp, FontRenderMode, ImageRendering, LayerRect};
 use api::{MixBlendMode, PipelineId, PropertyBinding, TransformStyle};
@@ -20,7 +20,7 @@ use internal_types::{FastHashMap, SourceTexture};
 use internal_types::BatchTextures;
 use picture::PictureKind;
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
-use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, RectangleContent};
+use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, PrimitiveRun, RectangleContent};
 use profiler::FrameProfileCounters;
 use render_task::{AlphaRenderItem, ClipWorkItem, MaskGeometryKind, MaskSegment};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKey, RenderTaskKind};
@@ -121,7 +121,7 @@ pub struct ScrollbarPrimitive {
 pub enum PrimitiveRunCmd {
     PushStackingContext(StackingContextIndex),
     PopStackingContext,
-    PrimitiveRun(PrimitiveIndex, usize, ClipAndScrollInfo),
+    PrimitiveRun(PrimitiveRun),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -1245,7 +1245,7 @@ impl RenderTarget for ColorRenderTarget {
 
                         for run in &prim.prim_runs {
                             for i in 0 .. run.count {
-                                let sub_prim_index = PrimitiveIndex(run.prim_index.0 + i);
+                                let sub_prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
 
                                 let sub_metadata = ctx.prim_store.get_metadata(sub_prim_index);
                                 let sub_prim_address =
@@ -1414,7 +1414,7 @@ impl RenderTarget for AlphaRenderTarget {
 
                         for run in &prim.prim_runs {
                             for i in 0 .. run.count {
-                                let sub_prim_index = PrimitiveIndex(run.prim_index.0 + i);
+                                let sub_prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
 
                                 let sub_metadata = ctx.prim_store.get_metadata(sub_prim_index);
                                 let sub_prim_address =


### PR DESCRIPTION
This shouldn't have any effect on the existing functionality, it
just starts restructuring the code in a way that will allow us
to walk the tree of Picture structs and prepare primitive runs
from each Picture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2004)
<!-- Reviewable:end -->
