### PR TITLE
Fix some issues with scrollbars

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -10,7 +10,6 @@ use ellipse::Ellipse;
 use frame_builder::FrameBuilder;
 use gpu_cache::GpuDataRequest;
 use prim_store::{BorderPrimitiveCpu, RectangleContent, PrimitiveContainer, TexelRect};
-use tiling::PrimitiveFlags;
 use util::{lerp, pack_as_float};
 
 #[repr(u8)]
@@ -388,7 +387,7 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     RectangleContent::Fill(border.top.color),
-                    PrimitiveFlags::None,
+                    None,
                 );
             }
             if left_edge == BorderEdgeKind::Solid {
@@ -401,7 +400,7 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     RectangleContent::Fill(border.left.color),
-                    PrimitiveFlags::None,
+                    None,
                 );
             }
             if right_edge == BorderEdgeKind::Solid {
@@ -414,7 +413,7 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     RectangleContent::Fill(border.right.color),
-                    PrimitiveFlags::None,
+                    None,
                 );
             }
             if bottom_edge == BorderEdgeKind::Solid {
@@ -427,7 +426,7 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     RectangleContent::Fill(border.bottom.color),
-                    PrimitiveFlags::None,
+                    None,
                 );
             }
         } else {

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -34,12 +34,14 @@ use render_task::RenderTaskTree;
 use resource_cache::ResourceCache;
 use scene::ScenePipeline;
 use std::{mem, usize, f32, i32};
-use tiling::{CompositeOps, Frame};
-use tiling::{ContextIsolation, RenderTargetKind, StackingContextIndex};
-use tiling::{PrimitiveFlags, PrimitiveRunCmd, RenderPass};
-use tiling::{RenderTargetContext, ScrollbarPrimitive, StackingContext};
+use tiling::{CompositeOps, ContextIsolation, Frame, PrimitiveRunCmd, RenderPass};
+use tiling::{RenderTargetContext, RenderTargetKind, ScrollbarPrimitive, StackingContext};
+use tiling::StackingContextIndex;
 use util::{self, pack_as_float, RectHelpers, recycle_vec};
 use box_shadow::BLUR_SAMPLE_SCALE;
+
+#[derive(Debug)]
+pub struct ScrollbarInfo(pub ClipId, pub LayerRect);
 
 /// Construct a polygon from stacking context boundaries.
 /// `anchor` here is an index that's going to be preserved in all the
@@ -565,7 +567,7 @@ impl FrameBuilder {
         clip_and_scroll: ClipAndScrollInfo,
         info: &LayerPrimitiveInfo,
         content: RectangleContent,
-        flags: PrimitiveFlags,
+        scrollbar_info: Option<ScrollbarInfo>,
     ) {
         if let RectangleContent::Fill(ColorF{a, ..}) = content {
             if a == 0.0 {
@@ -587,15 +589,12 @@ impl FrameBuilder {
             PrimitiveContainer::Rectangle(prim),
         );
 
-        match flags {
-            PrimitiveFlags::None => {}
-            PrimitiveFlags::Scrollbar(clip_id, border_radius) => {
-                self.scrollbar_prims.push(ScrollbarPrimitive {
-                    prim_index,
-                    clip_id,
-                    border_radius,
-                });
-            }
+        if let Some(ScrollbarInfo(clip_id, frame_rect)) = scrollbar_info {
+            self.scrollbar_prims.push(ScrollbarPrimitive {
+                prim_index,
+                clip_id,
+                frame_rect,
+            });
         }
     }
 
@@ -1515,45 +1514,31 @@ impl FrameBuilder {
     }
 
     fn update_scroll_bars(&mut self, clip_scroll_tree: &ClipScrollTree, gpu_cache: &mut GpuCache) {
-        let distance_from_edge = 8.0;
+        static SCROLLBAR_PADDING: f32 = 8.0;
 
         for scrollbar_prim in &self.scrollbar_prims {
             let metadata = &mut self.prim_store.cpu_metadata[scrollbar_prim.prim_index.0];
-            let clip_scroll_node = &clip_scroll_tree.nodes[&scrollbar_prim.clip_id];
+            let scroll_frame = &clip_scroll_tree.nodes[&scrollbar_prim.clip_id];
 
             // Invalidate what's in the cache so it will get rebuilt.
             gpu_cache.invalidate(&metadata.gpu_location);
 
-            let scrollable_distance = clip_scroll_node.scrollable_size().height;
-
+            let scrollable_distance = scroll_frame.scrollable_size().height;
             if scrollable_distance <= 0.0 {
                 metadata.local_clip_rect.size = LayerSize::zero();
                 continue;
             }
+            let amount_scrolled = -scroll_frame.scroll_offset().y / scrollable_distance;
 
-            let scroll_offset = clip_scroll_node.scroll_offset();
-            let f = -scroll_offset.y / scrollable_distance;
+            let frame_rect = scrollbar_prim.frame_rect;
+            let min_y = frame_rect.origin.y + SCROLLBAR_PADDING;
+            let max_y = frame_rect.origin.y + frame_rect.size.height -
+                (SCROLLBAR_PADDING + metadata.local_rect.size.height);
 
-            let min_y = clip_scroll_node.local_viewport_rect.origin.y - scroll_offset.y +
-                distance_from_edge;
-
-            let max_y = clip_scroll_node.local_viewport_rect.origin.y +
-                clip_scroll_node.local_viewport_rect.size.height -
-                scroll_offset.y - metadata.local_rect.size.height -
-                distance_from_edge;
-
-            metadata.local_rect.origin.x = clip_scroll_node.local_viewport_rect.origin.x +
-                clip_scroll_node.local_viewport_rect.size.width -
-                metadata.local_rect.size.width -
-                distance_from_edge;
-
-            metadata.local_rect.origin.y = util::lerp(min_y, max_y, f);
+            metadata.local_rect.origin.x = frame_rect.origin.x + frame_rect.size.width -
+                (metadata.local_rect.size.width + SCROLLBAR_PADDING);
+            metadata.local_rect.origin.y = util::lerp(min_y, max_y, amount_scrolled);
             metadata.local_clip_rect = metadata.local_rect;
-
-            // TODO(gw): The code to set / update border clips on scroll bars
-            //           has been broken for a long time, so I've removed it
-            //           for now. We can re-add that code once the clips
-            //           data is moved over to the GPU cache!
         }
     }
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -112,7 +112,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
 pub struct ScrollbarPrimitive {
     pub clip_id: ClipId,
     pub prim_index: PrimitiveIndex,
-    pub border_radius: f32,
+    pub frame_rect: LayerRect,
 }
 
 #[derive(Debug)]
@@ -120,12 +120,6 @@ pub enum PrimitiveRunCmd {
     PushStackingContext(StackingContextIndex),
     PopStackingContext,
     PrimitiveRun(PrimitiveRun),
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum PrimitiveFlags {
-    None,
-    Scrollbar(ClipId, f32),
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Scrollbars would scroll horizontally instead of sticking to the edge of
the frame and were also not visible at all on iframes. This change fixes
those issues by adding them to the containing reference frame. As part
of this change, iframe background colors are also attached to the
reference frame and only painted over the frame rect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2018)
<!-- Reviewable:end -->
