### PR TITLE
Clean up update_transform a bit

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -325,7 +325,7 @@ impl ClipScrollTree {
             .scroll(scroll_location, phase)
     }
 
-    pub fn update_all_node_transforms(
+    pub fn update_tree(
         &mut self,
         screen_rect: &DeviceIntRect,
         device_pixel_ratio: f32,
@@ -357,7 +357,7 @@ impl ClipScrollTree {
             current_coordinate_system_id: CoordinateSystemId(0),
             next_coordinate_system_id: CoordinateSystemId(0).next(),
         };
-        self.update_node_transform(
+        self.update_node(
             root_reference_frame_id,
             &mut state,
             device_pixel_ratio,
@@ -368,7 +368,7 @@ impl ClipScrollTree {
         );
     }
 
-    fn update_node_transform(
+    fn update_node(
         &mut self,
         layer_id: ClipId,
         state: &mut TransformUpdateState,
@@ -387,12 +387,9 @@ impl ClipScrollTree {
                 None => return,
             };
 
-            node.update_transform(
+            node.update(
                 &mut state,
-                node_data
-            );
-            node.update_clip_work_item(
-                &mut state,
+                node_data,
                 device_pixel_ratio,
                 clip_store,
                 resource_cache,
@@ -403,7 +400,7 @@ impl ClipScrollTree {
         };
 
         for child_layer_id in node_children {
-            self.update_node_transform(
+            self.update_node(
                 child_layer_id,
                 &mut state,
                 device_pixel_ratio,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1842,7 +1842,12 @@ impl FrameBuilder {
                             self.prim_store
                                 .add_render_tasks_for_prim(prim_index, &mut current_task);
                             let item =
-                                AlphaRenderItem::Primitive(clip_node.id, scroll_node.id, prim_index, next_z);
+                                AlphaRenderItem::Primitive(
+                                    clip_node.node_data_index,
+                                    scroll_node.node_data_index,
+                                    prim_index,
+                                    next_z
+                                );
                             current_task.as_alpha_batch_mut().items.push(item);
                             next_z += 1;
                         }
@@ -1889,7 +1894,7 @@ impl FrameBuilder {
 
         let mut node_data = Vec::new();
 
-        clip_scroll_tree.update_all_node_transforms(
+        clip_scroll_tree.update_tree(
             &screen_rect,
             device_pixel_ratio,
             &mut self.clip_store,

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -31,7 +31,7 @@ pub struct BlurInstance {
 #[repr(C)]
 pub struct ClipMaskInstance {
     pub render_task_address: RenderTaskAddress,
-    pub scroll_node_id: ClipScrollNodeIndex,
+    pub scroll_node_data_index: ClipScrollNodeIndex,
     pub segment: i32,
     pub clip_data_address: GpuCacheAddress,
     pub resource_address: GpuCacheAddress,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1257,7 +1257,7 @@ impl PrimitiveStore {
             let extra_clip = if prim_clips.has_clips() {
                 Some(Rc::new(ClipChainNode {
                     work_item: ClipWorkItem {
-                        scroll_node_id: prim_context.scroll_node.id,
+                        scroll_node_data_index: prim_context.scroll_node.node_data_index,
                         clip_sources: metadata.clip_sources.weak(),
                         coordinate_system_id: prim_context.scroll_node.coordinate_system_id,
                     },

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -204,7 +204,7 @@ pub enum MaskGeometryKind {
 
 #[derive(Debug, Clone)]
 pub struct ClipWorkItem {
-    pub scroll_node_id: ClipScrollNodeIndex,
+    pub scroll_node_data_index: ClipScrollNodeIndex,
     pub clip_sources: ClipSourcesWeakHandle,
     pub coordinate_system_id: CoordinateSystemId,
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -875,7 +875,7 @@ impl ClipBatcher {
         for work_item in clips.iter() {
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
-                scroll_node_id: work_item.scroll_node_id,
+                scroll_node_data_index: work_item.scroll_node_data_index,
                 segment: 0,
                 clip_data_address: GpuCacheAddress::invalid(),
                 resource_address: GpuCacheAddress::invalid(),


### PR DESCRIPTION
Rename these methods since it's been a long time since they just update
the transform. Also, move some of the code around a bit in
ClipSrollNode to more strongly enforce the proper call order. Finally,
rename ClipScrollNode::id to ClipScrollNode::node_data_index to better
match what it is and avoid confusion with ClipId.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2019)
<!-- Reviewable:end -->
