### PR TITLE
Remove ClipInfo

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -245,7 +245,8 @@ impl ClipSources {
         }
     }
 
-    pub fn is_masking(&self) -> bool {
+    /// Whether or not this ClipSources has any clips (does any clipping).
+    pub fn has_clips(&self) -> bool {
         !self.clips.is_empty()
     }
 }

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -180,8 +180,8 @@ impl ClipScrollTree {
         };
 
         let point_in_layer = transformed_point - node.local_viewport_rect.origin.to_vector();
-        let clip_info = match node.node_type {
-            NodeType::Clip(ref info) => info,
+        let clip_sources_handle = match node.node_type {
+            NodeType::Clip(ref clip_sources_handle) => clip_sources_handle,
             _ => {
                 cache.insert(*node_id, Some(point_in_layer));
                 return true;
@@ -194,7 +194,7 @@ impl ClipScrollTree {
         }
 
         let point_in_clips = transformed_point - node.local_clip_rect.origin.to_vector();
-        for &(ref clip, _) in clip_store.get(&clip_info.clip_sources).clips() {
+        for &(ref clip, _) in clip_store.get(&clip_sources_handle).clips() {
             if !clip.contains(&point_in_clips) {
                 cache.insert(*node_id, None);
                 return false;
@@ -507,11 +507,11 @@ impl ClipScrollTree {
         let node = self.nodes.get(id).unwrap();
 
         match node.node_type {
-            NodeType::Clip(ref info) => {
+            NodeType::Clip(ref clip_sources_handle) => {
                 pt.new_level("Clip".to_owned());
 
                 pt.add_item(format!("id: {:?}", id));
-                let clips = clip_store.get(&info.clip_sources).clips();
+                let clips = clip_store.get(&clip_sources_handle).clips();
                 pt.new_level(format!("Clip Sources [{}]", clips.len()));
                 for source in clips {
                     pt.add_item(format!("{:?}", source));

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -15,8 +15,8 @@ use api::{WorldPixel, WorldPoint, YuvColorSpace, YuvData, device_length};
 use app_units::Au;
 use border::ImageBorderSegment;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore, Contains};
-use clip_scroll_node::{ClipInfo, ClipScrollNode, NodeType};
-use clip_scroll_tree::{ClipScrollTree};
+use clip_scroll_node::{ClipScrollNode, NodeType};
+use clip_scroll_tree::ClipScrollTree;
 use euclid::{SideOffsets2D, TypedTransform3D, vec2, vec3};
 use frame::FrameId;
 use gpu_cache::GpuCache;
@@ -473,11 +473,12 @@ impl FrameBuilder {
         clip_scroll_tree: &mut ClipScrollTree,
     ) {
         let clip_rect = clip_region.main;
-        let clip_info = ClipInfo::new(
-            clip_region,
-            &mut self.clip_store,
-        );
-        let node = ClipScrollNode::new_clip_node(pipeline_id, parent_id, clip_info, clip_rect);
+        let clip_sources = ClipSources::from(clip_region);
+        debug_assert!(clip_sources.has_clips());
+
+        let handle = self.clip_store.insert(clip_sources);
+
+        let node = ClipScrollNode::new_clip_node(pipeline_id, parent_id, handle, clip_rect);
         clip_scroll_tree.add_node(node, new_node_id);
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1236,7 +1236,8 @@ impl PrimitiveStore {
         let prim_clips = clip_store.get(&metadata.clip_sources);
         let is_axis_aligned = transform.transform_kind() == TransformedRectKind::AxisAligned;
 
-        let clip_task = if prim_context.clip_node.clip_chain_node.is_some() || prim_clips.is_masking() {
+        let has_clips = prim_context.clip_node.clip_chain_node.is_some() || prim_clips.has_clips();
+        let clip_task = if has_clips {
             // Take into account the actual clip info of the primitive, and
             // mutate the current bounds accordingly.
             let mask_rect = match prim_clips.bounds.outer {
@@ -1250,7 +1251,7 @@ impl PrimitiveStore {
                 _ => prim_screen_rect,
             };
 
-            let extra_clip = if prim_clips.is_masking() {
+            let extra_clip = if prim_clips.has_clips() {
                 Some(Rc::new(ClipChainNode {
                     work_item: ClipWorkItem {
                         scroll_node_id: prim_context.scroll_node.id,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -399,7 +399,7 @@ impl RenderTask {
                 let clip_info = clip_store
                     .get_opt(&node.work_item.clip_sources)
                     .expect("bug: clip item should exist");
-                debug_assert!(clip_info.is_masking());
+                debug_assert!(clip_info.has_clips());
 
                 match clip_info.bounds.inner {
                     Some(ref inner) if !inner.device_rect.is_empty() => {


### PR DESCRIPTION
Since Clip nodes always have clips in their ClipSources, the is_masking
member isn't necessary in ClipInfo. Since only one member remains,
we just store the ClipSourcesHandle and remove ClipInfo entirely. We
also rename ClipSources::is_masking() to ClipSources::has_clips()
because it is possible that a ClipSources may not be rendered to a mask
if the clip is rectangular. This can make the previous name of the
method misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2020)
<!-- Reviewable:end -->
