### PR TITLE
Relax the isolation conflict log.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -323,7 +323,7 @@ impl FrameBuilder {
                 // must be drawn with a transparent background, unless the parent stacking context
                 // is the root of the page
                 let isolation = &mut self.stacking_context_store[parent_index.0].isolation;
-                if *isolation != ContextIsolation::None {
+                if *isolation == ContextIsolation::Items {
                     error!(
                         "Isolation conflict detected on {:?}: {:?}",
                         parent_index,


### PR DESCRIPTION
In #1955, we discussed about removing error log in [1], but it might break the code logic if we overwrite the isolation ContextIsolation::Items with ContextIsolation::Full.

Could we relax the condition here which keep the logic above and allow a stacking context to contain multiple child stacking contexts with blend mode?

r? @kvark

[1] https://github.com/servo/webrender/blob/4b8493d6bdc64d2d83202ac15b06b0d4b14c6e76/webrender/src/frame_builder.rs#L369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2042)
<!-- Reviewable:end -->
