### PR TITLE
Add a couple of simple opaque drawing optimizations.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1688,7 +1688,10 @@ impl FrameBuilder {
         // Do the allocations now, assigning each tile's tasks to a render
         // pass and target as required.
         for index in 0 .. required_pass_count {
-            passes.push(RenderPass::new(index == required_pass_count - 1));
+            passes.push(RenderPass::new(
+                index == required_pass_count - 1,
+                screen_rect.size,
+            ));
         }
 
         render_tasks.assign_to_passes(main_render_task_id, passes.len() - 1, &mut passes);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1388,11 +1388,21 @@ impl FrameBuilder {
     ) {
         let sub_rect_block = sub_rect.unwrap_or(TexelRect::invalid()).into();
 
+        // If the tile spacing is the same as the rect size,
+        // then it is effectively zero. We use this later on
+        // in prim_store to detect if an image can be considered
+        // opaque.
+        let tile_spacing = if *tile_spacing == info.rect.size {
+            LayerSize::zero()
+        } else {
+            *tile_spacing
+        };
+
         let prim_cpu = ImagePrimitiveCpu {
             image_key,
             image_rendering,
             tile_offset: tile,
-            tile_spacing: *tile_spacing,
+            tile_spacing,
             gpu_blocks: [
                 [
                     stretch_size.width,


### PR DESCRIPTION
1) When detecting if an image is opaque, WR will check if the
   tile_spacing field is non-zero. If so, it assumes that there
   will be some transparent pixels and uses the alpha pass.
   However, Gecko typically supplies the tile_spacing size to be
   equal to the size of the image rect. This case was not being
   detected as opaque compatible. As a result, every image in
   the Gecko integration was being drawn in the alpha pass.

2) When adding primitives to opaque batches, we would previously
   look for any batch in the existing list to add it to. However,
   when a large primitive is encountered, it's typically more
   efficient to break the batch in order to get much better
   z-buffer efficiency. Now, any opaque primitive which is more
   than 1/4 of the screen size will force a batch break.

Example performance difference on my HD4600 on CNN.com:

From:

  GPU time: 5.6ms
  Opaque coverage: 1.72
  Alpha coverage: 1.32

To:

  GPU time: 3.4ms
  Opaque coverage: 1.07
  Alpha coverage: 1.01

So this relatively small optimization can save a lot of memory
bandwidth and pixel overdraw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2046)
<!-- Reviewable:end -->
