### PR TITLE
DocumentAPI support on the Renderer side

### DIFF
--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -35,7 +35,7 @@ impl Example for App {
         _api: &RenderApi,
         builder: &mut DisplayListBuilder,
         _resources: &mut ResourceUpdates,
-        _layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -185,16 +185,19 @@ struct App {
 }
 
 impl Example for App {
+    // Make this the only example to test all shaders for compile errors.
+    const PRECACHE_SHADERS: bool = true;
+
     fn render(
         &mut self,
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        layout_size: LayoutSize,
+        _: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
-        let bounds = LayoutRect::new(LayoutPoint::zero(), layout_size);
+        let bounds = LayoutRect::new(LayoutPoint::zero(), builder.content_size());
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use webrender::api::{self, DeviceUintRect, DisplayListBuilder, DocumentId, LayoutSize, PipelineId,
-                     RenderApi, ResourceUpdates};
+use webrender::api::{self,
+    DisplayListBuilder, DocumentId, PipelineId, RenderApi, ResourceUpdates};
 
 // This example shows how to implement a very basic BlobImageRenderer that can only render
 // a checkerboard pattern.
@@ -145,7 +145,7 @@ impl api::BlobImageRenderer for CheckerboardRenderer {
             .insert(key, Arc::new(deserialize_blob(&cmds[..]).unwrap()));
     }
 
-    fn update(&mut self, key: api::ImageKey, cmds: api::BlobImageData, _dirty_rect: Option<DeviceUintRect>) {
+    fn update(&mut self, key: api::ImageKey, cmds: api::BlobImageData, _dirty_rect: Option<api::DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
         self.image_cmds
@@ -227,7 +227,7 @@ impl Example for App {
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        layout_size: LayoutSize,
+        _framebuffer_size: api::DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
@@ -247,7 +247,7 @@ impl Example for App {
             None,
         );
 
-        let bounds = api::LayoutRect::new(api::LayoutPoint::zero(), layout_size);
+        let bounds = api::LayoutRect::new(api::LayoutPoint::zero(), builder.content_size());
         let info = api::LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
@@ -278,15 +278,6 @@ impl Example for App {
         );
 
         builder.pop_stacking_context();
-    }
-
-    fn on_event(
-        &mut self,
-        _event: glutin::Event,
-        _api: &RenderApi,
-        _document_id: DocumentId,
-    ) -> bool {
-        false
     }
 }
 

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate env_logger;
+extern crate euclid;
 
 use gleam::gl;
 use glutin;
@@ -28,17 +29,13 @@ impl RenderNotifier for Notifier {
         })
     }
 
-    fn wakeup(&self) {
+    fn wake_up(&self) {
         #[cfg(not(target_os = "android"))]
         self.window_proxy.wakeup_event_loop();
     }
 
-    fn new_document_ready(&self, _: DocumentId) {
-        self.wakeup();
-    }
-
-    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
-        self.wakeup();
+    fn new_document_ready(&self, _: DocumentId, _scrolled: bool, _composite_needed: bool) {
+        self.wake_up();
     }
 }
 
@@ -65,16 +62,20 @@ impl HandyDandyRectBuilder for (i32, i32) {
 }
 
 pub trait Example {
+    const TITLE: &'static str = "WebRender Sample App";
+    const PRECACHE_SHADERS: bool = false;
     fn render(
         &mut self,
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        layout_size: LayoutSize,
+        framebuffer_size: DeviceUintSize,
         pipeline_id: PipelineId,
         document_id: DocumentId,
     );
-    fn on_event(&mut self, event: glutin::Event, api: &RenderApi, document_id: DocumentId) -> bool;
+    fn on_event(&mut self, glutin::Event, &RenderApi, DocumentId) -> bool {
+        false
+    }
     fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
         None
     }
@@ -84,10 +85,14 @@ pub trait Example {
     ) -> Option<Box<webrender::OutputImageHandler>> {
         None
     }
-    fn draw_custom(&self, _gl: &gl::Gl) {}
+    fn draw_custom(&self, _gl: &gl::Gl) {
+    }
 }
 
-pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOptions>) {
+pub fn main_wrapper<E: Example>(
+    example: &mut E,
+    options: Option<webrender::RendererOptions>,
+) {
     env_logger::init().unwrap();
 
     let args: Vec<String> = env::args().collect();
@@ -98,7 +103,7 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
     };
 
     let window = glutin::WindowBuilder::new()
-        .with_title("WebRender Sample App")
+        .with_title(E::TITLE)
         .with_multitouch()
         .with_gl(glutin::GlRequest::GlThenGles {
             opengl_version: (3, 2),
@@ -122,22 +127,26 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
 
     println!("OpenGL version {}", gl.get_string(gl::VERSION));
     println!("Shader resource path: {:?}", res_path);
-
-    let (width, height) = window.get_inner_size_pixels().unwrap();
+    let device_pixel_ratio = window.hidpi_factor();
+    println!("Device pixel ratio: {}", device_pixel_ratio);
 
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,
         debug: true,
-        precache_shaders: true,
-        device_pixel_ratio: window.hidpi_factor(),
+        precache_shaders: E::PRECACHE_SHADERS,
+        device_pixel_ratio,
+        clear_color: Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
         ..options.unwrap_or(webrender::RendererOptions::default())
     };
 
-    let size = DeviceUintSize::new(width, height);
+    let framebuffer_size = {
+        let (width, height) = window.get_inner_size_pixels().unwrap();
+        DeviceUintSize::new(width, height)
+    };
     let notifier = Box::new(Notifier::new(window.create_window_proxy()));
     let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), notifier, opts).unwrap();
     let api = sender.create_api();
-    let document_id = api.add_document(size, 0);
+    let document_id = api.add_document(framebuffer_size, 0);
 
     if let Some(external_image_handler) = example.get_external_image_handler() {
         renderer.set_external_image_handler(external_image_handler);
@@ -147,10 +156,8 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
     }
 
     let epoch = Epoch(0);
-    let root_background_color = ColorF::new(0.3, 0.0, 0.0, 1.0);
-
     let pipeline_id = PipelineId(0, 0);
-    let layout_size = LayoutSize::new(width as f32, height as f32);
+    let layout_size = framebuffer_size.to_f32() / euclid::ScaleFactor::new(device_pixel_ratio);
     let mut builder = DisplayListBuilder::new(pipeline_id, layout_size);
     let mut resources = ResourceUpdates::new();
 
@@ -158,15 +165,15 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
         &api,
         &mut builder,
         &mut resources,
-        layout_size,
+        framebuffer_size,
         pipeline_id,
         document_id,
     );
     api.set_display_list(
         document_id,
         epoch,
-        Some(root_background_color),
-        LayoutSize::new(width as f32, height as f32),
+        None,
+        layout_size,
         builder.finalize(),
         true,
         resources,
@@ -177,10 +184,7 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
     'outer: for event in window.wait_events() {
         let mut events = Vec::new();
         events.push(event);
-
-        for event in window.poll_events() {
-            events.push(event);
-        }
+        events.extend(window.poll_events());
 
         for event in events {
             match event {
@@ -235,9 +239,10 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
                     _,
                     Some(glutin::VirtualKeyCode::Key1),
                 ) => {
-                    api.set_window_parameters(document_id,
-                        size,
-                        DeviceUintRect::new(DeviceUintPoint::zero(), size),
+                    api.set_window_parameters(
+                        document_id,
+                        framebuffer_size,
+                        DeviceUintRect::new(DeviceUintPoint::zero(), framebuffer_size),
                         1.0
                     );
                 }
@@ -246,9 +251,10 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
                     _,
                     Some(glutin::VirtualKeyCode::Key2),
                 ) => {
-                    api.set_window_parameters(document_id,
-                        size,
-                        DeviceUintRect::new(DeviceUintPoint::zero(), size),
+                    api.set_window_parameters(
+                        document_id,
+                        framebuffer_size,
+                        DeviceUintRect::new(DeviceUintPoint::zero(), framebuffer_size),
                         2.0
                     );
                 }
@@ -267,15 +273,15 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
                         &api,
                         &mut builder,
                         &mut resources,
-                        layout_size,
+                        framebuffer_size,
                         pipeline_id,
                         document_id,
                     );
                     api.set_display_list(
                         document_id,
                         epoch,
-                        Some(root_background_color),
-                        LayoutSize::new(width as f32, height as f32),
+                        None,
+                        layout_size,
                         builder.finalize(),
                         true,
                         resources,
@@ -286,7 +292,7 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
         }
 
         renderer.update();
-        renderer.render(DeviceUintSize::new(width, height)).unwrap();
+        renderer.render(framebuffer_size).unwrap();
         example.draw_custom(&*gl);
         window.swap_buffers().ok();
     }

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -28,14 +28,17 @@ impl RenderNotifier for Notifier {
         })
     }
 
-    fn new_frame_ready(&self) {
+    fn wakeup(&self) {
         #[cfg(not(target_os = "android"))]
         self.window_proxy.wakeup_event_loop();
     }
 
-    fn new_scroll_frame_ready(&self, _composite_needed: bool) {
-        #[cfg(not(target_os = "android"))]
-        self.window_proxy.wakeup_event_loop();
+    fn new_document_ready(&self, _: DocumentId) {
+        self.wakeup();
+    }
+
+    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
+        self.wakeup();
     }
 }
 
@@ -134,7 +137,7 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
     let notifier = Box::new(Notifier::new(window.create_window_proxy()));
     let (mut renderer, sender) = webrender::Renderer::new(gl.clone(), notifier, opts).unwrap();
     let api = sender.create_api();
-    let document_id = api.add_document(size);
+    let document_id = api.add_document(size, 0);
 
     if let Some(external_image_handler) = example.get_external_image_handler() {
         renderer.set_external_image_handler(external_image_handler);

--- a/webrender/examples/document.rs
+++ b/webrender/examples/document.rs
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate euclid;
+extern crate gleam;
+extern crate glutin;
+extern crate webrender;
+
+#[path = "common/boilerplate.rs"]
+mod boilerplate;
+
+use boilerplate::Example;
+use euclid::ScaleFactor;
+use webrender::api::*;
+
+// This example creates multiple documents overlapping each other with
+// specified layer indices.
+
+struct Document {
+    id: DocumentId,
+    pipeline_id: PipelineId,
+    content_rect: LayoutRect,
+    color: ColorF,
+}
+
+struct App {
+    documents: Vec<Document>,
+}
+
+impl App {
+    fn init(
+        &mut self,
+        api: &RenderApi,
+        framebuffer_size: DeviceUintSize,
+        device_pixel_ratio: f32,
+    ) {
+        let init_data = vec![
+            (
+                PipelineId(1, 0),
+                -1,
+                ColorF::new(0.0, 1.0, 0.0, 1.0),
+                DeviceUintPoint::new(0, 0),
+            ),
+            (
+                PipelineId(2, 0),
+                -2,
+                ColorF::new(1.0, 1.0, 0.0, 1.0),
+                DeviceUintPoint::new(200, 0),
+            ),
+            (
+                PipelineId(3, 0),
+                -3,
+                ColorF::new(1.0, 0.0, 0.0, 1.0),
+                DeviceUintPoint::new(200, 200),
+            ),
+            (
+                PipelineId(4, 0),
+                -4,
+                ColorF::new(1.0, 0.0, 1.0, 1.0),
+                DeviceUintPoint::new(0, 200),
+            ),
+        ];
+
+        for (pipeline_id, layer, color, offset) in init_data {
+            let size = DeviceUintSize::new(250, 250);
+            let bounds = DeviceUintRect::new(offset, size);
+
+            let document_id = api.add_document(size, layer);
+            api.set_window_parameters(document_id,
+                framebuffer_size,
+                bounds,
+                1.0
+            );
+            api.set_root_pipeline(document_id, pipeline_id);
+
+            self.documents.push(Document {
+                id: document_id,
+                pipeline_id,
+                content_rect: bounds.to_f32() / ScaleFactor::new(device_pixel_ratio),
+                color,
+            });
+        }
+    }
+}
+
+impl Example for App {
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        base_builder: &mut DisplayListBuilder,
+        _: &mut ResourceUpdates,
+        framebuffer_size: DeviceUintSize,
+        _: PipelineId,
+        _: DocumentId,
+    ) {
+        if self.documents.is_empty() {
+            let device_pixel_ratio = framebuffer_size.width as f32 /
+                base_builder.content_size().width;
+            // this is the first run, hack around the boilerplate,
+            // which assumes an example only needs one document
+            self.init(api, framebuffer_size, device_pixel_ratio);
+        }
+
+        for doc in &self.documents {
+            let mut builder = DisplayListBuilder::new(
+                doc.pipeline_id,
+                doc.content_rect.size,
+            );
+            let local_rect = LayoutRect::new(
+                LayoutPoint::zero(),
+                doc.content_rect.size,
+            );
+
+            builder.push_stacking_context(
+                &LayoutPrimitiveInfo::new(doc.content_rect),
+                ScrollPolicy::Fixed,
+                None,
+                TransformStyle::Flat,
+                None,
+                MixBlendMode::Normal,
+                Vec::new(),
+            );
+            builder.push_rect(
+                &LayoutPrimitiveInfo::new(local_rect),
+                doc.color,
+            );
+            builder.pop_stacking_context();
+
+            api.set_display_list(
+                doc.id,
+                Epoch(0),
+                None,
+                doc.content_rect.size,
+                builder.finalize(),
+                true,
+                ResourceUpdates::new(),
+            );
+
+            api.generate_frame(doc.id, None);
+        }
+    }
+}
+
+fn main() {
+    let mut app = App {
+        documents: Vec::new(),
+    };
+    boilerplate::main_wrapper(&mut app, None);
+}

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -56,7 +56,7 @@ impl Example for App {
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         _resources: &mut ResourceUpdates,
-        _layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         document_id: DocumentId,
     ) {
@@ -144,15 +144,6 @@ impl Example for App {
         gl.delete_vertex_arrays(&[vao]);
         gl.delete_buffers(&[vbo]);
         gl.delete_program(pid);
-    }
-
-    fn on_event(
-        &mut self,
-        _event: glutin::Event,
-        _api: &RenderApi,
-        _document_id: DocumentId,
-    ) -> bool {
-        false
     }
 
     fn get_output_image_handler(

--- a/webrender/examples/iframe.rs
+++ b/webrender/examples/iframe.rs
@@ -24,7 +24,7 @@ impl Example for App {
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         _resources: &mut ResourceUpdates,
-        _layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         pipeline_id: PipelineId,
         document_id: DocumentId,
     ) {
@@ -74,15 +74,6 @@ impl Example for App {
         builder.push_rect(&info, ColorF::new(1.0, 0.0, 0.0, 1.0));
         builder.push_iframe(&info, sub_pipeline_id);
         builder.pop_stacking_context();
-    }
-
-    fn on_event(
-        &mut self,
-        _event: glutin::Event,
-        _api: &RenderApi,
-        _document_id: DocumentId,
-    ) -> bool {
-        false
     }
 }
 

--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -24,7 +24,7 @@ impl Example for App {
         _api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        _layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -24,11 +24,13 @@ impl Example for App {
         _api: &RenderApi,
         builder: &mut DisplayListBuilder,
         _resources: &mut ResourceUpdates,
-        layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
-        let info = LayoutPrimitiveInfo::new(LayoutRect::new(LayoutPoint::zero(), layout_size));
+        let info = LayoutPrimitiveInfo::new(
+            LayoutRect::new(LayoutPoint::zero(), builder.content_size())
+        );
         builder.push_stacking_context(
             &info,
             ScrollPolicy::Scrollable,

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -86,7 +86,7 @@ impl Example for App {
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        _layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -170,11 +170,11 @@ impl Example for App {
         api: &RenderApi,
         builder: &mut DisplayListBuilder,
         resources: &mut ResourceUpdates,
-        layout_size: LayoutSize,
+        _framebuffer_size: DeviceUintSize,
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
-        let bounds = LayoutRect::new(LayoutPoint::zero(), layout_size);
+        let bounds = LayoutRect::new(LayoutPoint::zero(), builder.content_size());
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -803,8 +803,8 @@ impl<'a> Device<'a> {
             self.gl.viewport(
                 0,
                 0,
-                dimensions.width as gl::GLint,
-                dimensions.height as gl::GLint,
+                dimensions.width as _,
+                dimensions.height as _,
             );
         }
     }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -588,7 +588,8 @@ pub struct Device<'a> {
     bound_draw_fbo: FBOId,
     default_read_fbo: gl::GLuint,
     default_draw_fbo: gl::GLuint,
-    device_pixel_ratio: f32,
+
+    pub device_pixel_ratio: f32,
 
     // HW or API capabilties
     capabilities: Capabilities,
@@ -696,10 +697,9 @@ impl<'a> Device<'a> {
         }
     }
 
-    pub fn begin_frame(&mut self, device_pixel_ratio: f32) -> FrameId {
+    pub fn begin_frame(&mut self) -> FrameId {
         debug_assert!(!self.inside_frame);
         self.inside_frame = true;
-        self.device_pixel_ratio = device_pixel_ratio;
 
         // Retrive the currently set FBO.
         let default_read_fbo = self.gl.get_integer_v(gl::READ_FRAMEBUFFER_BINDING);

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -1024,6 +1024,7 @@ impl<'a> FlattenContext<'a> {
 /// Frame context contains the information required to update
 /// (e.g. scroll) a renderer frame builder (`FrameBuilder`).
 pub struct FrameContext {
+    window_size: DeviceUintSize,
     clip_scroll_tree: ClipScrollTree,
     pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
     id: FrameId,
@@ -1033,6 +1034,7 @@ pub struct FrameContext {
 impl FrameContext {
     pub fn new(config: FrameBuilderConfig) -> Self {
         FrameContext {
+            window_size: DeviceUintSize::zero(),
             pipeline_epoch_map: FastHashMap::default(),
             clip_scroll_tree: ClipScrollTree::new(),
             id: FrameId(0),
@@ -1104,6 +1106,7 @@ impl FrameContext {
         if window_size.width == 0 || window_size.height == 0 {
             error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
         }
+        self.window_size = window_size;
 
         let old_scrolling_states = self.reset();
 
@@ -1119,7 +1122,7 @@ impl FrameContext {
                 scene,
                 builder: FrameBuilder::new(
                     old_builder,
-                    window_size,
+                    inner_rect,
                     background_color,
                     self.frame_builder_config,
                 ),
@@ -1195,6 +1198,7 @@ impl FrameContext {
             self.id,
             &mut self.clip_scroll_tree,
             pipelines,
+            self.window_size,
             device_pixel_ratio,
             pan,
             texture_cache_profile,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -4,8 +4,8 @@
 
 use api::{BorderDetails, BorderDisplayItem, BuiltDisplayList};
 use api::{ClipAndScrollInfo, ClipId, ColorF, PropertyBinding};
-use api::{DeviceIntPoint, DeviceUintRect, DeviceUintSize};
-use api::{ExtendMode, FontRenderMode, LayoutTransform};
+use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize};
+use api::{DocumentLayer, ExtendMode, FontRenderMode, LayoutTransform};
 use api::{GlyphInstance, GlyphOptions, GradientStop, HitTestFlags, HitTestItem, HitTestResult};
 use api::{ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerPrimitiveInfo, LayerRect};
 use api::{LayerSize, LayerToScrollTransform, LayerVector2D, LayoutVector2D, LineOrientation};
@@ -93,7 +93,7 @@ impl HitTestingItem {
 
 pub struct HitTestingRun(Vec<HitTestingItem>, ClipAndScrollInfo);
 
-/// A builder structure for `RendererFrame`
+/// A builder structure for `tiling::Frame`
 pub struct FrameBuilder {
     screen_rect: DeviceUintRect,
     background_color: Option<ColorF>,
@@ -1631,6 +1631,7 @@ impl FrameBuilder {
         pipelines: &FastHashMap<PipelineId, ScenePipeline>,
         window_size: DeviceUintSize,
         device_pixel_ratio: f32,
+        layer: DocumentLayer,
         pan: LayerPoint,
         texture_cache_profile: &mut TextureCacheProfileCounters,
         gpu_cache_profile: &mut GpuCacheProfileCounters,
@@ -1697,7 +1698,7 @@ impl FrameBuilder {
         for index in 0 .. required_pass_count {
             passes.push(RenderPass::new(
                 index == required_pass_count - 1,
-                screen_rect.size,
+                self.screen_rect.size.to_i32(),
             ));
         }
 
@@ -1740,6 +1741,7 @@ impl FrameBuilder {
             inner_rect: self.screen_rect,
             device_pixel_ratio,
             background_color: self.background_color,
+            layer,
             profile_counters,
             passes,
             node_data,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -29,7 +29,7 @@ use prim_store::{PrimitiveContainer, PrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{RectangleContent, RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_task::{ClearMode, RenderTask, RenderTaskTree};
+use render_task::{ClearMode, RenderTask, RenderTaskId, RenderTaskTree};
 use resource_cache::ResourceCache;
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
@@ -147,41 +147,46 @@ impl<'a> PrimitiveContext<'a> {
 }
 
 impl FrameBuilder {
-    pub fn new(
-        previous: Option<Self>,
+    pub fn empty() -> Self {
+        FrameBuilder {
+            hit_testing_runs: Vec::new(),
+            shadow_prim_stack: Vec::new(),
+            pending_shadow_contents: Vec::new(),
+            scrollbar_prims: Vec::new(),
+            reference_frame_stack: Vec::new(),
+            picture_stack: Vec::new(),
+            sc_stack: Vec::new(),
+            prim_store: PrimitiveStore::new(),
+            clip_store: ClipStore::new(),
+            screen_rect: DeviceUintRect::zero(),
+            background_color: None,
+            config: FrameBuilderConfig {
+                enable_scrollbars: false,
+                default_font_render_mode: FontRenderMode::Mono,
+                debug: false,
+            },
+        }
+    }
+
+    pub fn recycle(
+        self,
         screen_rect: DeviceUintRect,
         background_color: Option<ColorF>,
         config: FrameBuilderConfig,
     ) -> Self {
-        match previous {
-            Some(prev) => FrameBuilder {
-                hit_testing_runs: recycle_vec(prev.hit_testing_runs),
-                shadow_prim_stack: recycle_vec(prev.shadow_prim_stack),
-                pending_shadow_contents: recycle_vec(prev.pending_shadow_contents),
-                scrollbar_prims: recycle_vec(prev.scrollbar_prims),
-                reference_frame_stack: recycle_vec(prev.reference_frame_stack),
-                picture_stack: recycle_vec(prev.picture_stack),
-                sc_stack: recycle_vec(prev.sc_stack),
-                prim_store: prev.prim_store.recycle(),
-                clip_store: prev.clip_store.recycle(),
-                screen_rect,
-                background_color,
-                config,
-            },
-            None => FrameBuilder {
-                hit_testing_runs: Vec::new(),
-                shadow_prim_stack: Vec::new(),
-                pending_shadow_contents: Vec::new(),
-                scrollbar_prims: Vec::new(),
-                reference_frame_stack: Vec::new(),
-                picture_stack: Vec::new(),
-                sc_stack: Vec::new(),
-                prim_store: PrimitiveStore::new(),
-                clip_store: ClipStore::new(),
-                screen_rect,
-                background_color,
-                config,
-            },
+        FrameBuilder {
+            hit_testing_runs: recycle_vec(self.hit_testing_runs),
+            shadow_prim_stack: recycle_vec(self.shadow_prim_stack),
+            pending_shadow_contents: recycle_vec(self.pending_shadow_contents),
+            scrollbar_prims: recycle_vec(self.scrollbar_prims),
+            reference_frame_stack: recycle_vec(self.reference_frame_stack),
+            picture_stack: recycle_vec(self.picture_stack),
+            sc_stack: recycle_vec(self.sc_stack),
+            prim_store: self.prim_store.recycle(),
+            clip_store: self.clip_store.recycle(),
+            screen_rect,
+            background_color,
+            config,
         }
     }
 
@@ -1520,7 +1525,7 @@ impl FrameBuilder {
         }
 
         result.items.dedup();
-        return result;
+        result
     }
 
     /// Compute the contribution (bounding rectangles, and resources) of layers and their
@@ -1535,8 +1540,12 @@ impl FrameBuilder {
         profile_counters: &mut FrameProfileCounters,
         device_pixel_ratio: f32,
         scene_properties: &SceneProperties,
-    ) {
+    ) -> Option<RenderTaskId> {
         profile_scope!("cull");
+
+        if self.prim_store.cpu_pictures.is_empty() {
+            return None
+        }
 
         // The root picture is always the first one added.
         let prim_run_cmds = mem::replace(&mut self.prim_store.cpu_pictures[0].runs, Vec::new());
@@ -1591,6 +1600,7 @@ impl FrameBuilder {
         );
 
         pic.render_task_id = Some(render_tasks.add(root_render_task));
+        pic.render_task_id
     }
 
     fn update_scroll_bars(&mut self, clip_scroll_tree: &ClipScrollTree, gpu_cache: &mut GpuCache) {
@@ -1668,7 +1678,7 @@ impl FrameBuilder {
 
         let mut render_tasks = RenderTaskTree::new();
 
-        self.build_layer_screen_rects_and_cull_layers(
+        let main_render_task_id = self.build_layer_screen_rects_and_cull_layers(
             clip_scroll_tree,
             pipelines,
             resource_cache,
@@ -1679,30 +1689,30 @@ impl FrameBuilder {
             scene_properties,
         );
 
-        let main_render_task_id = self.prim_store
-            .cpu_pictures[0]
-            .render_task_id
-            .expect("bug: no root render task!");
-
-        let mut required_pass_count = 0;
-        render_tasks.max_depth(main_render_task_id, 0, &mut required_pass_count);
-
+        let mut passes = Vec::new();
         resource_cache.block_until_all_resources_added(gpu_cache, texture_cache_profile);
 
-        let mut deferred_resolves = vec![];
+        if let Some(main_render_task_id) = main_render_task_id {
+            let mut required_pass_count = 0;
+            render_tasks.max_depth(main_render_task_id, 0, &mut required_pass_count);
 
-        let mut passes = Vec::new();
+            // Do the allocations now, assigning each tile's tasks to a render
+            // pass and target as required.
+            for index in 0 .. required_pass_count {
+                passes.push(RenderPass::new(
+                    index == required_pass_count - 1,
+                    self.screen_rect.size.to_i32(),
+                ));
+            }
 
-        // Do the allocations now, assigning each tile's tasks to a render
-        // pass and target as required.
-        for index in 0 .. required_pass_count {
-            passes.push(RenderPass::new(
-                index == required_pass_count - 1,
-                self.screen_rect.size.to_i32(),
-            ));
+            render_tasks.assign_to_passes(
+                main_render_task_id,
+                required_pass_count - 1,
+                &mut passes,
+            );
         }
 
-        render_tasks.assign_to_passes(main_render_task_id, passes.len() - 1, &mut passes);
+        let mut deferred_resolves = vec![];
 
         for pass in &mut passes {
             let ctx = RenderTargetContext {

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -148,14 +148,14 @@ pub struct RenderedDocument {
     /// The layers that are currently affected by the over-scrolling animation.
     pub layers_bouncing_back: FastHashSet<ClipId>,
 
-    pub frame: Option<tiling::Frame>,
+    pub frame: tiling::Frame,
 }
 
 impl RenderedDocument {
     pub fn new(
         pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
         layers_bouncing_back: FastHashSet<ClipId>,
-        frame: Option<tiling::Frame>,
+        frame: tiling::Frame,
     ) -> Self {
         RenderedDocument {
             pipeline_epoch_map,

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -140,7 +140,7 @@ impl TextureUpdateList {
 }
 
 /// Mostly wraps a tiling::Frame, adding a bit of extra information.
-pub struct RendererFrame {
+pub struct RenderedDocument {
     /// The last rendered epoch for each pipeline present in the frame.
     /// This information is used to know if a certain transformation on the layout has
     /// been rendered, which is necessary for reftests.
@@ -151,13 +151,13 @@ pub struct RendererFrame {
     pub frame: Option<tiling::Frame>,
 }
 
-impl RendererFrame {
+impl RenderedDocument {
     pub fn new(
         pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
         layers_bouncing_back: FastHashSet<ClipId>,
         frame: Option<tiling::Frame>,
     ) -> Self {
-        RendererFrame {
+        RenderedDocument {
             pipeline_epoch_map,
             layers_bouncing_back,
             frame,
@@ -174,9 +174,9 @@ pub enum ResultMsg {
     DebugCommand(DebugCommand),
     DebugOutput(DebugOutput),
     RefreshShader(PathBuf),
-    NewFrame(
+    PublishDocument(
         DocumentId,
-        RendererFrame,
+        RenderedDocument,
         TextureUpdateList,
         BackendProfileCounters,
     ),

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -303,6 +303,7 @@ impl ProfileCounter for AverageTimeProfileCounter {
 }
 
 
+#[derive(Clone)]
 pub struct FrameProfileCounters {
     pub total_primitives: IntProfileCounter,
     pub visible_primitives: IntProfileCounter,
@@ -818,11 +819,6 @@ impl Profiler {
         self.draw_counters(
             &[
                 &renderer_profile.frame_counter,
-                &frame_profile.total_primitives,
-                &frame_profile.visible_primitives,
-                &frame_profile.passes,
-                &frame_profile.color_targets,
-                &frame_profile.alpha_targets,
                 &backend_profile.resources.gpu_cache.allocated_rows,
                 &backend_profile.resources.gpu_cache.allocated_blocks,
             ],
@@ -862,6 +858,20 @@ impl Profiler {
             debug_renderer,
             true,
         );
+
+        for frame_profile in frame_profiles {
+            self.draw_counters(
+                &[
+                    &frame_profile.total_primitives,
+                    &frame_profile.visible_primitives,
+                    &frame_profile.passes,
+                    &frame_profile.color_targets,
+                    &frame_profile.alpha_targets,
+                ],
+                debug_renderer,
+                true,
+            );
+        }
 
         self.draw_counters(
             &[&renderer_profile.draw_calls, &renderer_profile.vertices],

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -794,7 +794,7 @@ impl Profiler {
 
     pub fn draw_profile(
         &mut self,
-        frame_profile: &FrameProfileCounters,
+        frame_profiles: &[FrameProfileCounters],
         backend_profile: &BackendProfileCounters,
         renderer_profile: &RendererProfileCounters,
         renderer_timers: &mut RendererProfileTimers,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -7,7 +7,7 @@ use api::{ApiMsg, BlobImageRenderer, BuiltDisplayList, DebugCommand, DeviceIntPo
 use api::{BuiltDisplayListIter, SpecificDisplayItem};
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize};
 use api::{DocumentId, DocumentLayer, DocumentMsg};
-use api::{HitTestResult, IdNamespace, LayerPoint, PipelineId, RenderNotifier};
+use api::{IdNamespace, LayerPoint, PipelineId, RenderNotifier};
 use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
 #[cfg(feature = "debugger")]
@@ -34,6 +34,7 @@ use time::precise_time_ns;
 struct Document {
     scene: Scene,
     frame_ctx: FrameContext,
+    // the `Option` here is only to deal with borrow checker
     frame_builder: Option<FrameBuilder>,
     window_size: DeviceUintSize,
     inner_rect: DeviceUintRect,
@@ -69,7 +70,7 @@ impl Document {
         Document {
             scene: Scene::new(),
             frame_ctx: FrameContext::new(config),
-            frame_builder: None,
+            frame_builder: Some(FrameBuilder::empty()),
             window_size,
             inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), window_size),
             layer,
@@ -90,8 +91,9 @@ impl Document {
 
     fn build_scene(&mut self, resource_cache: &mut ResourceCache) {
         let accumulated_scale_factor = self.accumulated_scale_factor();
-        self.frame_builder = self.frame_ctx.create(
-            self.frame_builder.take(),
+        // this code is why we have `Option`, which is never `None`
+        let frame_builder = self.frame_ctx.create(
+            self.frame_builder.take().unwrap(),
             &self.scene,
             resource_cache,
             self.window_size,
@@ -99,6 +101,7 @@ impl Document {
             accumulated_scale_factor,
             &self.output_pipelines,
         );
+        self.frame_builder = Some(frame_builder);
     }
 
     fn render(
@@ -112,25 +115,18 @@ impl Document {
             self.pan.x as f32 / accumulated_scale_factor,
             self.pan.y as f32 / accumulated_scale_factor,
         );
-        match self.frame_builder {
-            Some(ref mut builder) => {
-                self.frame_ctx.build_rendered_document(
-                    builder,
-                    resource_cache,
-                    gpu_cache,
-                    &self.scene.pipelines,
-                    accumulated_scale_factor,
-                    self.layer,
-                    pan,
-                    &mut resource_profile.texture_cache,
-                    &mut resource_profile.gpu_cache,
-                    &self.scene.properties,
-                )
-            }
-            None => {
-                self.frame_ctx.get_rendered_document()
-            }
-        }
+        self.frame_ctx.build_rendered_document(
+            self.frame_builder.as_mut().unwrap(),
+            resource_cache,
+            gpu_cache,
+            &self.scene.pipelines,
+            accumulated_scale_factor,
+            self.layer,
+            pan,
+            &mut resource_profile.texture_cache,
+            &mut resource_profile.gpu_cache,
+            &self.scene.properties,
+        )
     }
 }
 
@@ -366,13 +362,11 @@ impl RenderBackend {
             }
             DocumentMsg::HitTest(pipeline_id, point, flags, tx) => {
                 profile_scope!("HitTest");
-                let result = match doc.frame_builder {
-                    Some(ref builder) => {
-                        let cst = doc.frame_ctx.get_clip_scroll_tree();
-                        builder.hit_test(cst, pipeline_id, point, flags)
-                    },
-                    None => HitTestResult::default(),
-                };
+                let cst = doc.frame_ctx.get_clip_scroll_tree();
+                let result = doc.frame_builder
+                    .as_ref()
+                    .unwrap()
+                    .hit_test(cst, pipeline_id, point, flags);
                 tx.send(result).unwrap();
                 DocumentOp::Nop
             }
@@ -547,7 +541,7 @@ impl RenderBackend {
                         cancel_rendering: true,
                     };
                     self.result_tx.send(msg).unwrap();
-                    self.notifier.wakeup();
+                    self.notifier.wake_up();
                 }
                 ApiMsg::DebugCommand(option) => {
                     let msg = match option {
@@ -562,7 +556,7 @@ impl RenderBackend {
                         _ => ResultMsg::DebugCommand(option),
                     };
                     self.result_tx.send(msg).unwrap();
-                    self.notifier.wakeup();
+                    self.notifier.wake_up();
                 }
                 ApiMsg::ShutDown => {
                     self.notifier.shut_down();
@@ -592,7 +586,7 @@ impl RenderBackend {
     ) {
         self.publish_document(document_id, document, profile_counters);
 
-        self.notifier.new_document_ready(document_id);
+        self.notifier.new_document_ready(document_id, false, true);
     }
 
     fn notify_compositor_of_new_scroll_document(
@@ -600,7 +594,7 @@ impl RenderBackend {
         document_id: DocumentId,
         composite_needed: bool,
     ) {
-        self.notifier.new_scroll_document_ready(document_id, composite_needed);
+        self.notifier.new_document_ready(document_id, true, composite_needed);
     }
 
 
@@ -683,11 +677,10 @@ impl RenderBackend {
 
             // TODO(gw): Restructure the storage of clip-scroll tree, clip store
             //           etc so this isn't so untidy.
-            if let Some(ref frame_builder) = doc.frame_builder {
-                doc.frame_ctx
-                    .get_clip_scroll_tree()
-                    .print_with(&frame_builder.clip_store, &mut builder);
-            }
+            let clip_store = &doc.frame_builder.as_ref().unwrap().clip_store;
+            doc.frame_ctx
+                .get_clip_scroll_tree()
+                .print_with(clip_store, &mut builder);
 
             debug_root.add(builder.build());
         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -10,7 +10,7 @@
 //! [renderer]: struct.Renderer.html
 
 use api::{channel, BlobImageRenderer, FontRenderMode};
-use api::{ColorF, Epoch, PipelineId, RenderApiSender, RenderNotifier};
+use api::{ColorF, DocumentId, Epoch, PipelineId, RenderApiSender, RenderNotifier};
 use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DeviceUintRect, DeviceUintSize};
 use api::{ExternalImageId, ExternalImageType, ImageFormat};
 use api::{YUV_COLOR_SPACES, YUV_FORMATS};
@@ -1212,7 +1212,7 @@ pub struct Renderer<'a> {
     pending_texture_updates: Vec<TextureUpdateList>,
     pending_gpu_cache_updates: Vec<GpuCacheUpdateList>,
     pending_shader_updates: Vec<PathBuf>,
-    current_frame: Option<RendererFrame>,
+    active_frames: FastHashMap<DocumentId, RendererFrame>,
 
     // These are "cache shaders". These shaders are used to
     // draw intermediate results to cache targets. The results
@@ -1399,8 +1399,7 @@ impl<'a> Renderer<'a> {
 
         register_thread_with_profiler("Compositor".to_owned());
 
-        // device-pixel ratio doesn't matter here - we are just creating resources.
-        device.begin_frame(1.0);
+        device.begin_frame();
 
         let cs_text_run = try!{
             LazilyCompiledShader::new(ShaderKind::Cache(VertexArrayKind::Primitive),
@@ -1845,18 +1844,20 @@ impl<'a> Renderer<'a> {
                 if let Some(ref thread_listener) = *thread_listener_for_render_backend {
                     thread_listener.thread_started(&thread_name);
                 }
-                let mut backend = RenderBackend::new(api_rx,
-                                                     payload_rx,
-                                                     payload_tx_for_backend,
-                                                     result_tx,
-                                                     device_pixel_ratio,
-                                                     texture_cache,
-                                                     workers,
-                                                     backend_notifier,
-                                                     config,
-                                                     recorder,
-                                                     blob_image_renderer,
-                                                     enable_render_on_scroll);
+                let mut backend = RenderBackend::new(
+                    api_rx,
+                    payload_rx,
+                    payload_tx_for_backend,
+                    result_tx,
+                    device_pixel_ratio,
+                    texture_cache,
+                    workers,
+                    backend_notifier,
+                    config,
+                    recorder,
+                    blob_image_renderer,
+                    enable_render_on_scroll,
+                );
                 backend.run(backend_profile_counters);
                 if let Some(ref thread_listener) = *thread_listener_for_render_backend {
                     thread_listener.thread_stopped(&thread_name);
@@ -1871,7 +1872,7 @@ impl<'a> Renderer<'a> {
             result_rx,
             debug_server,
             device,
-            current_frame: None,
+            active_frames: FastHashMap::default(),
             pending_texture_updates: Vec::new(),
             pending_gpu_cache_updates: Vec::new(),
             pending_shader_updates: Vec::new(),
@@ -1987,7 +1988,7 @@ impl<'a> Renderer<'a> {
         while let Ok(msg) = self.result_rx.try_recv() {
             match msg {
                 ResultMsg::NewFrame(
-                    _document_id,
+                    document_id,
                     mut frame,
                     texture_update_list,
                     profile_counters,
@@ -2009,7 +2010,7 @@ impl<'a> Renderer<'a> {
                         self.pipeline_epoch_map.insert(*pipeline_id, *epoch);
                     }
 
-                    self.current_frame = Some(frame);
+                    self.active_frames.insert(document_id, frame);
                 }
                 ResultMsg::UpdateResources {
                     updates,
@@ -2019,10 +2020,10 @@ impl<'a> Renderer<'a> {
                     self.update_texture_cache();
                     // If we receive a NewFrame message followed by this one within
                     // the same update we need ot cancel the frame because we might
-                    // have deleted the resources in use in the frame dut to a memory
+                    // have deleted the resources in use in the frame due to a memory
                     // pressure event.
                     if cancel_rendering {
-                        self.current_frame = None;
+                        self.active_frames.clear();
                     }
                 }
                 ResultMsg::RefreshShader(path) => {
@@ -2052,10 +2053,12 @@ impl<'a> Renderer<'a> {
     fn get_passes_for_debugger(&self) -> String {
         let mut debug_passes = debug_server::PassList::new();
 
-        if let Some(frame) = self.current_frame
-            .as_ref()
-            .and_then(|frame| frame.frame.as_ref())
-        {
+        for rendered_frame in self.active_frames.values() {
+            let frame = match rendered_frame.frame {
+                Some(ref frame) => frame,
+                None => continue,
+            };
+
             for pass in &frame.passes {
                 let mut debug_pass = debug_server::Pass::new();
 
@@ -2233,120 +2236,124 @@ impl<'a> Renderer<'a> {
     pub fn render(&mut self, framebuffer_size: DeviceUintSize) -> Result<(), Vec<RendererError>> {
         profile_scope!("render");
 
-        if let Some(mut frame) = self.current_frame.take() {
-            if let Some(ref mut frame) = frame.frame {
-                let mut profile_timers = RendererProfileTimers::new();
-                let profile_samplers = {
-                    let _gm = self.gpu_profile.start_marker("build samples");
-                    // Block CPU waiting for last frame's GPU profiles to arrive.
-                    // In general this shouldn't block unless heavily GPU limited.
-                    let (gpu_frame_id, timers, samplers) = self.gpu_profile.build_samples();
+        if !self.active_frames.values().any(|rendered_frame| rendered_frame.frame.is_some()) {
+            self.last_time = precise_time_ns();
+            return Ok(())
+        }
 
-                    if self.max_recorded_profiles > 0 {
-                        while self.gpu_profiles.len() >= self.max_recorded_profiles {
-                            self.gpu_profiles.pop_front();
-                        }
-                        self.gpu_profiles
-                            .push_back(GpuProfile::new(gpu_frame_id, &timers));
-                    }
-                    profile_timers.gpu_samples = timers;
-                    samplers
-                };
+        let mut frame_profiles = Vec::new();
+        let mut profile_timers = RendererProfileTimers::new();
 
-                let cpu_frame_id = profile_timers.cpu_time.profile(|| {
-                    let cpu_frame_id = {
-                        let _gm = self.gpu_profile.start_marker("begin frame");
-                        let frame_id = self.device.begin_frame(frame.device_pixel_ratio);
-                        self.gpu_profile.begin_frame(frame_id);
+        let profile_samplers = {
+            let _gm = self.gpu_profile.start_marker("build samples");
+            // Block CPU waiting for last frame's GPU profiles to arrive.
+            // In general this shouldn't block unless heavily GPU limited.
+            let (gpu_frame_id, timers, samplers) = self.gpu_profile.build_samples();
 
-                        self.device.disable_scissor();
-                        self.device.disable_depth();
-                        self.device.set_blend(false);
-                        //self.update_shaders();
+            if self.max_recorded_profiles > 0 {
+                while self.gpu_profiles.len() >= self.max_recorded_profiles {
+                    self.gpu_profiles.pop_front();
+                }
+                self.gpu_profiles
+                    .push_back(GpuProfile::new(gpu_frame_id, &timers));
+            }
+            profile_timers.gpu_samples = timers;
+            samplers
+        };
 
-                        self.update_texture_cache();
 
-                        self.update_gpu_cache(frame);
+        let cpu_frame_id = profile_timers.cpu_time.profile(|| {
+            let _gm = GpuMarker::new(self.device.rc_gl(), "begin frame");
+            let frame_id = self.device.begin_frame();
+            self.gpu_profile.begin_frame(frame_id);
 
-                        self.device.bind_texture(
-                            TextureSampler::ResourceCache,
-                            &self.gpu_cache_texture.texture,
-                        );
+            self.device.disable_scissor();
+            self.device.disable_depth();
+            self.device.set_blend(false);
+            //self.update_shaders();
 
-                        frame_id
-                    };
+            self.update_texture_cache();
 
+            self.device.bind_texture(
+                TextureSampler::ResourceCache,
+                &self.gpu_cache_texture.texture,
+            );
+
+            frame_id
+        });
+
+        profile_timers.cpu_time.profile(|| {
+            //Note: another borrowck dance
+            let mut active_frames = mem::replace(&mut self.active_frames, FastHashMap::default());
+
+            for rendered_frame in active_frames.values_mut() {
+                if let Some(ref mut frame) = rendered_frame.frame {
+                    self.device.device_pixel_ratio = frame.device_pixel_ratio;
+                    self.update_gpu_cache(frame);
                     self.draw_tile_frame(frame, framebuffer_size, cpu_frame_id);
-
-                    self.gpu_profile.end_frame();
-                    cpu_frame_id
-                });
-
-                let current_time = precise_time_ns();
-                let ns = current_time - self.last_time;
-                self.profile_counters.frame_time.set(ns);
-
-                if self.max_recorded_profiles > 0 {
-                    while self.cpu_profiles.len() >= self.max_recorded_profiles {
-                        self.cpu_profiles.pop_front();
+                    if self.debug_flags.contains(DebugFlags::PROFILER_DBG) {
+                        frame_profiles.push(frame.profile_counters.clone());
                     }
-                    let cpu_profile = CpuProfile::new(
-                        cpu_frame_id,
-                        self.backend_profile_counters.total_time.get(),
-                        profile_timers.cpu_time.get(),
-                        self.profile_counters.draw_calls.get(),
-                    );
-                    self.cpu_profiles.push_back(cpu_profile);
                 }
-
-                if self.debug_flags.contains(DebugFlags::PROFILER_DBG) {
-                    let _gm = self.gpu_profile.start_marker("profile");
-                    let screen_fraction = 1.0 / //TODO: take device/pixel ratio into equation?
-                        (framebuffer_size.width as f32 * framebuffer_size.height as f32);
-                    self.profiler.draw_profile(
-                        &frame.profile_counters,
-                        &self.backend_profile_counters,
-                        &self.profile_counters,
-                        &mut profile_timers,
-                        &profile_samplers,
-                        screen_fraction,
-                        &mut self.debug,
-                    );
-                }
-
-                self.profile_counters.reset();
-                self.profile_counters.frame_counter.inc();
-
-                {
-                    let _gm = self.gpu_profile.start_marker("debug");
-                    let debug_size = DeviceUintSize::new(
-                        framebuffer_size.width as u32,
-                        framebuffer_size.height as u32,
-                    );
-                    self.debug.render(&mut self.device, &debug_size);
-                }
-                {
-                    let _gm = self.gpu_profile.start_marker("end frame");
-                    self.device.end_frame();
-                }
-                self.last_time = current_time;
             }
 
-            // Restore frame - avoid borrow checker!
-            self.current_frame = Some(frame);
+            self.active_frames = active_frames;
+        });
+
+        let current_time = precise_time_ns();
+        let ns = current_time - self.last_time;
+        self.profile_counters.frame_time.set(ns);
+
+        if self.max_recorded_profiles > 0 {
+            while self.cpu_profiles.len() >= self.max_recorded_profiles {
+                self.cpu_profiles.pop_front();
+            }
+            let cpu_profile = CpuProfile::new(
+                cpu_frame_id,
+                self.backend_profile_counters.total_time.get(),
+                profile_timers.cpu_time.get(),
+                self.profile_counters.draw_calls.get(),
+            );
+            self.cpu_profiles.push_back(cpu_profile);
         }
-        if !self.renderer_errors.is_empty() {
-            let errors = mem::replace(&mut self.renderer_errors, Vec::new());
-            return Err(errors);
+
+        if self.debug_flags.contains(DebugFlags::PROFILER_DBG) {
+            //TODO: take device/pixel ratio into equation?
+            let screen_fraction = 1.0 / framebuffer_size.to_f32().area();
+            self.profiler.draw_profile(
+                &mut self.device,
+                &frame_profiles,
+                &self.backend_profile_counters,
+                &self.profile_counters,
+                &mut profile_timers,
+                &profile_samplers,
+                screen_fraction,
+                &mut self.debug,
+            );
         }
-        Ok(())
+
+        self.profile_counters.reset();
+        self.profile_counters.frame_counter.inc();
+
+        self.debug.render(&mut self.device, &framebuffer_size);
+        profile_timers.cpu_time.profile(|| {
+            let _gm = GpuMarker::new(self.device.rc_gl(), "end frame");
+            self.gpu_profile.end_frame();
+            self.device.end_frame();
+        });
+        self.last_time = current_time;
+
+        if self.renderer_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(mem::replace(&mut self.renderer_errors, Vec::new()))
+        }
     }
 
     pub fn layers_are_bouncing_back(&self) -> bool {
-        match self.current_frame {
-            None => false,
-            Some(ref current_frame) => !current_frame.layers_bouncing_back.is_empty(),
-        }
+        self.active_frames
+            .values()
+            .any(|rendered_frame| !rendered_frame.layers_bouncing_back.is_empty())
     }
 
     fn update_gpu_cache(&mut self, frame: &mut Frame) {
@@ -3773,7 +3780,7 @@ impl<'a> Renderer<'a> {
     // De-initialize the Renderer safely, assuming the GL is still alive and active.
     pub fn deinit(mut self) {
         //Note: this is a fake frame, only needed because texture deletion is require to happen inside a frame
-        self.device.begin_frame(1.0);
+        self.device.begin_frame();
         self.gpu_cache_texture.deinit(&mut self.device);
         if let Some(dither_matrix_texture) = self.dither_matrix_texture {
             self.device.delete_texture(dither_matrix_texture);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadiusKind, ClipId, ColorF, DeviceIntPoint, ImageKey};
-use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintSize};
+use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
 use api::{ExternalImageType, FilterOp, FontRenderMode, ImageRendering, LayerRect};
 use api::{MixBlendMode, PipelineId};
 use api::{TileOffset, YuvColorSpace, YuvFormat};
@@ -1994,6 +1994,7 @@ impl CompositeOps {
 /// and presented to the renderer.
 pub struct Frame {
     pub window_size: DeviceUintSize,
+    pub inner_rect: DeviceUintRect,
     pub background_color: Option<ColorF>,
     pub device_pixel_ratio: f32,
     pub passes: Vec<RenderPass>,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -4,8 +4,8 @@
 
 use api::{BorderRadiusKind, ClipId, ColorF, DeviceIntPoint, ImageKey};
 use api::{DeviceIntRect, DeviceIntSize, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
-use api::{ExternalImageType, FilterOp, FontRenderMode, ImageRendering, LayerRect};
-use api::{MixBlendMode, PipelineId};
+use api::{DocumentLayer, ExternalImageType, FilterOp, FontRenderMode, ImageRendering};
+use api::{LayerRect, MixBlendMode, PipelineId};
 use api::{TileOffset, YuvColorSpace, YuvFormat};
 use api::{LayerToWorldTransform, WorldPixel};
 use border::{BorderCornerInstance, BorderCornerSide};
@@ -1978,10 +1978,10 @@ pub struct CompositeOps {
 }
 
 impl CompositeOps {
-    pub fn new(filters: Vec<FilterOp>, mix_blend_mode: Option<MixBlendMode>) -> CompositeOps {
+    pub fn new(filters: Vec<FilterOp>, mix_blend_mode: Option<MixBlendMode>) -> Self {
         CompositeOps {
             filters,
-            mix_blend_mode: mix_blend_mode,
+            mix_blend_mode,
         }
     }
 
@@ -1996,6 +1996,7 @@ pub struct Frame {
     pub window_size: DeviceUintSize,
     pub inner_rect: DeviceUintRect,
     pub background_color: Option<ColorF>,
+    pub layer: DocumentLayer,
     pub device_pixel_ratio: f32,
     pub passes: Vec<RenderPass>,
     pub profile_counters: FrameProfileCounters,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 pub type TileSize = u16;
+/// Documents are rendered in the ascending order of their associated layer values.
 pub type DocumentLayer = i8;
 
 /// The resource updates for a given transaction (they must be applied in the same frame).
@@ -885,9 +886,8 @@ pub struct DynamicProperties {
 
 pub trait RenderNotifier: Send {
     fn clone(&self) -> Box<RenderNotifier>;
-    fn wakeup(&self);
-    fn new_document_ready(&self, DocumentId);
-    fn new_scroll_document_ready(&self, DocumentId, composite_needed: bool);
+    fn wake_up(&self);
+    fn new_document_ready(&self, DocumentId, scrolled: bool, composite_needed: bool);
     fn external_event(&self, _evt: ExternalEvent) {
         unimplemented!()
     }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 pub type TileSize = u16;
+pub type DocumentLayer = i8;
 
 /// The resource updates for a given transaction (they must be applied in the same frame).
 #[derive(Clone, Deserialize, Serialize)]
@@ -278,7 +279,7 @@ pub enum ApiMsg {
     /// Adds a new document namespace.
     CloneApi(MsgSender<IdNamespace>),
     /// Adds a new document with given initial size.
-    AddDocument(DocumentId, DeviceUintSize),
+    AddDocument(DocumentId, DeviceUintSize, DocumentLayer),
     /// A message targeted at a particular document.
     UpdateDocument(DocumentId, DocumentMsg),
     /// Deletes an existing document.
@@ -420,11 +421,11 @@ impl RenderApi {
         RenderApiSender::new(self.api_sender.clone(), self.payload_sender.clone())
     }
 
-    pub fn add_document(&self, initial_size: DeviceUintSize) -> DocumentId {
+    pub fn add_document(&self, initial_size: DeviceUintSize, layer: DocumentLayer) -> DocumentId {
         let new_id = self.next_unique_id();
         let document_id = DocumentId(self.namespace_id, new_id);
 
-        let msg = ApiMsg::AddDocument(document_id, initial_size);
+        let msg = ApiMsg::AddDocument(document_id, initial_size, layer);
         self.api_sender.send(msg).unwrap();
 
         document_id
@@ -569,7 +570,7 @@ impl RenderApi {
     /// # use webrender_api::{DeviceUintSize, PipelineId, RenderApiSender};
     /// # fn example(sender: RenderApiSender) {
     /// let api = sender.create_api();
-    /// let document_id = api.add_document(DeviceUintSize::zero());
+    /// let document_id = api.add_document(DeviceUintSize::zero(), 0);
     /// let pipeline_id = PipelineId(0, 0);
     /// api.set_root_pipeline(document_id, pipeline_id);
     /// # }
@@ -588,8 +589,8 @@ impl RenderApi {
     /// Supplies a new frame to WebRender.
     ///
     /// Non-blocking, it notifies a worker process which processes the display list.
-    /// When it's done and a RenderNotifier has been set in `webrender::Renderer`,
-    /// [new_frame_ready()][notifier] gets called.
+    /// When it's done and a `RenderNotifier` has been set in `webrender::Renderer`,
+    /// [new_document_ready()][notifier] gets called.
     ///
     /// Note: Scrolling doesn't require an own Frame.
     ///
@@ -608,7 +609,7 @@ impl RenderApi {
     /// * `resources`: A set of resource updates that must be applied at the same time as the
     ///                display list.
     ///
-    /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
+    /// [notifier]: trait.RenderNotifier.html#tymethod.new_document_ready
     pub fn set_display_list(
         &self,
         document_id: DocumentId,
@@ -884,8 +885,9 @@ pub struct DynamicProperties {
 
 pub trait RenderNotifier: Send {
     fn clone(&self) -> Box<RenderNotifier>;
-    fn new_frame_ready(&self);
-    fn new_scroll_frame_ready(&self, composite_needed: bool);
+    fn wakeup(&self);
+    fn new_document_ready(&self, DocumentId);
+    fn new_scroll_document_ready(&self, DocumentId, composite_needed: bool);
     fn external_event(&self, _evt: ExternalEvent) {
         unimplemented!()
     }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -533,7 +533,7 @@ impl<'a> Write for SizeCounter {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
-/// Serializes a value assuming the Serialize impl has a stable size across two 
+/// Serializes a value assuming the Serialize impl has a stable size across two
 /// invocations.
 ///
 /// If this assumption is incorrect, the result will be Undefined Behaviour. This
@@ -557,7 +557,7 @@ fn serialize_fast<T: Serialize>(vec: &mut Vec<u8>, e: &T) {
     debug_assert_eq!(((w.0 as usize) - (vec.as_ptr() as usize)), vec.len());
 }
 
-/// Serializes an iterator, assuming: 
+/// Serializes an iterator, assuming:
 ///
 /// * The Clone impl is trivial (e.g. we're just memcopying a slice iterator)
 /// * The ExactSizeIterator impl is stable and correct across a Clone
@@ -719,6 +719,11 @@ impl DisplayListBuilder {
             content_size,
             save_state: None,
         }
+    }
+
+    /// Return the content size for this display list
+    pub fn content_size(&self) -> LayoutSize {
+        self.content_size
     }
 
     /// Saves the current display list state, so it may be `restore()`'d.

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -291,15 +291,14 @@ impl RenderNotifier for Notifier {
         })
     }
 
-    fn wakeup(&self) {
+    fn wake_up(&self) {
         self.tx.send(()).unwrap();
     }
 
-    fn new_document_ready(&self, _: DocumentId) {
-        self.tx.send(()).unwrap();
-    }
-
-    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
+    fn new_document_ready(&self, _: DocumentId, scrolled: bool, _composite_needed: bool) {
+        if !scrolled {
+            self.wake_up();
+        }
     }
 }
 

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -291,10 +291,16 @@ impl RenderNotifier for Notifier {
         })
     }
 
-    fn new_frame_ready(&self) {
+    fn wakeup(&self) {
         self.tx.send(()).unwrap();
     }
-    fn new_scroll_frame_ready(&self, _composite_needed: bool) {}
+
+    fn new_document_ready(&self, _: DocumentId) {
+        self.tx.send(()).unwrap();
+    }
+
+    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
+    }
 }
 
 fn create_notifier() -> (Box<RenderNotifier>, Receiver<()>) {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -73,7 +73,7 @@ impl RenderNotifier for Notifier {
         Box::new(Notifier(self.0.clone()))
     }
 
-    fn wakeup(&self) {
+    fn wake_up(&self) {
         let mut data = self.0.lock();
         let data = data.as_mut().unwrap();
         match data.timing_receiver.steal() {
@@ -98,15 +98,15 @@ impl RenderNotifier for Notifier {
         }
     }
 
-    fn new_document_ready(&self, _: DocumentId) {
-        self.wakeup();
-    }
-
-    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
-        let data = self.0.lock();
-        if let Some(ref window_proxy) = data.unwrap().window_proxy {
-            #[cfg(not(target_os = "android"))]
-            window_proxy.wakeup_event_loop();
+    fn new_document_ready(&self, _: DocumentId, scrolled: bool, _composite_needed: bool) {
+        if scrolled {
+            let data = self.0.lock();
+            if let Some(ref window_proxy) = data.unwrap().window_proxy {
+                #[cfg(not(target_os = "android"))]
+                window_proxy.wakeup_event_loop();
+            }
+        } else {
+            self.wake_up();
         }
     }
 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -56,7 +56,7 @@ impl NotifierData {
         window_proxy: Option<WindowProxy>,
         timing_receiver: chase_lev::Stealer<time::SteadyTime>,
         verbose: bool,
-    ) -> NotifierData {
+    ) -> Self {
         NotifierData {
             window_proxy,
             frames_notified: 0,
@@ -73,7 +73,7 @@ impl RenderNotifier for Notifier {
         Box::new(Notifier(self.0.clone()))
     }
 
-    fn new_frame_ready(&self) {
+    fn wakeup(&self) {
         let mut data = self.0.lock();
         let data = data.as_mut().unwrap();
         match data.timing_receiver.steal() {
@@ -98,7 +98,11 @@ impl RenderNotifier for Notifier {
         }
     }
 
-    fn new_scroll_frame_ready(&self, _composite_needed: bool) {
+    fn new_document_ready(&self, _: DocumentId) {
+        self.wakeup();
+    }
+
+    fn new_scroll_document_ready(&self, _: DocumentId, _composite_needed: bool) {
         let data = self.0.lock();
         if let Some(ref window_proxy) = data.unwrap().window_proxy {
             #[cfg(not(target_os = "android"))]
@@ -193,7 +197,7 @@ impl<'a> Wrench<'a> {
 
         let (renderer, sender) = webrender::Renderer::new(window.clone_gl(), notifier, opts).unwrap();
         let api = sender.create_api();
-        let document_id = api.add_document(size);
+        let document_id = api.add_document(size, 0);
 
         let graphics_api = renderer.get_graphics_api_info();
 


### PR DESCRIPTION
This is a second batch of changes related to Document API, following #1509.

The idea is to allow Gecko to have separate documents for the chrome UI, page content, and bottom status bar, as opposed to using different pipelines in the same document. This change would allow minimal scene rebuilds per frame when UI is affected.

WIP TODO:
- [x] strict ordering API: https://github.com/servo/webrender/pull/2050/commits/532bff555393533e30e58b5d326b2759a7655aa5
- [x] Servo patch and test runs: https://github.com/kvark/servo/commit/0263fa8919d2737e09091f1ac71a8d517692261a
- [x] Firefox patch and try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=f939fbdab0231e6328061c12903db0c45847dd18
  - ~~`box-shadow/boxshadow-skiprect.html`~~ (from #1943)
  - ~~`css-filter-chains/moz-element.html`~~ (same as in #2053)
  - ~~`transform/animate-layer-scale-inherit-1.html`~~ (from #2043)
- [x] example
- [x] `FrameBuilder` and `RenderedDocument` refactor
https://tools.taskcluster.net/groups/DEvThfCaQWmt5Hp806GDLg/tasks/VLCZI7hVTQCc1xrDR3PgOQ/details#
- [x] review comments

cc  @glennw  @mstange @jrmuizel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2050)
<!-- Reviewable:end -->
