### PR TITLE
 Remove AlphaBatchTask, and introduce start of raster mode. 

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -62,7 +62,8 @@ void main(void) {
 
         // Right now - pictures only support local positions. In the future, this
         // will be expanded to support transform picture types (the common kind).
-        device_pos = pic_task.target_rect.p0 + uDevicePixelRatio * (local_pos - pic_task.content_origin);
+        device_pos = pic_task.common_data.task_rect.p0 +
+                     uDevicePixelRatio * (local_pos - pic_task.content_origin);
 
         // Write the final position transformed by the orthographic device-pixel projection.
         gl_Position = uTransform * vec4(device_pos, 0.0, 1.0);

--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -11,10 +11,8 @@ void brush_vs(
     ivec2 user_data
 );
 
-// Whether this brush is being drawn on a Picture
-// task (new) or an alpha batch task (legacy).
-// Can be removed once everything uses pictures.
-#define BRUSH_FLAG_USES_PICTURE     (1 << 0)
+#define RASTERIZATION_MODE_LOCAL_SPACE      0.0
+#define RASTERIZATION_MODE_SCREEN_SPACE     1.0
 
 struct BrushInstance {
     int picture_address;
@@ -54,9 +52,10 @@ void main(void) {
     vec2 device_pos, local_pos;
     RectWithSize local_rect = geom.local_rect;
 
-    if ((brush.flags & BRUSH_FLAG_USES_PICTURE) != 0) {
-        // Fetch the dynamic picture that we are drawing on.
-        PictureTask pic_task = fetch_picture_task(brush.picture_address);
+    // Fetch the dynamic picture that we are drawing on.
+    PictureTask pic_task = fetch_picture_task(brush.picture_address);
+
+    if (pic_task.rasterization_mode == RASTERIZATION_MODE_LOCAL_SPACE) {
 
         local_pos = local_rect.p0 + aPosition.xy * local_rect.size;
 
@@ -68,7 +67,6 @@ void main(void) {
         // Write the final position transformed by the orthographic device-pixel projection.
         gl_Position = uTransform * vec4(device_pos, 0.0, 1.0);
     } else {
-        AlphaBatchTask alpha_task = fetch_alpha_batch_task(brush.picture_address);
         Layer layer = fetch_layer(brush.clip_node_id, brush.scroll_node_id);
         ClipArea clip_area = fetch_clip_area(brush.clip_address);
 
@@ -82,7 +80,7 @@ void main(void) {
             geom.local_clip_rect,
             float(brush.z),
             layer,
-            alpha_task,
+            pic_task,
             geom.local_rect
         );
 

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -31,20 +31,20 @@ void brush_vs(
     //           we can expand this to support items from
     //           the normal texture cache and unify this
     //           with the normal image shader.
-    BlurTask task = fetch_blur_task(user_data.x);
-    vUv.z = task.render_target_layer_index;
+    BlurTask blur_task = fetch_blur_task(user_data.x);
+    vUv.z = blur_task.common_data.render_target_layer_index;
     vImageKind = user_data.y;
 
 #if defined WR_FEATURE_COLOR_TARGET
     vec2 texture_size = vec2(textureSize(sColor0, 0).xy);
 #else
     vec2 texture_size = vec2(textureSize(sColor1, 0).xy);
-    vColor = task.color;
+    vColor = blur_task.color;
 #endif
 
-    vec2 uv0 = task.target_rect.p0;
-    vec2 src_size = task.target_rect.size * task.scale_factor;
-    vec2 uv1 = uv0 + task.target_rect.size;
+    vec2 uv0 = blur_task.common_data.task_rect.p0;
+    vec2 src_size = blur_task.common_data.task_rect.size * blur_task.scale_factor;
+    vec2 uv1 = uv0 + blur_task.common_data.task_rect.size;
 
     // TODO(gw): In the future we'll probably draw these as segments
     //           with the brush shader. When that occurs, we can

--- a/webrender/res/clip_shared.glsl
+++ b/webrender/res/clip_shared.glsl
@@ -52,8 +52,8 @@ ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
                                       Layer layer,
                                       ClipArea area,
                                       int segment) {
-    vec2 outer_p0 = area.screen_origin_target_index.xy;
-    vec2 outer_p1 = outer_p0 + area.task_bounds.zw - area.task_bounds.xy;
+    vec2 outer_p0 = area.screen_origin;
+    vec2 outer_p1 = outer_p0 + area.common_data.task_rect.size;
     vec2 inner_p0 = area.inner_rect.xy;
     vec2 inner_p1 = area.inner_rect.zw;
 
@@ -86,7 +86,9 @@ ClipVertexInfo write_clip_tile_vertex(RectWithSize local_clip_rect,
     vec4 layer_pos = get_layer_pos(actual_pos / uDevicePixelRatio, layer);
 
     // compute the point position in side the layer, in CSS space
-    vec2 vertex_pos = actual_pos + area.task_bounds.xy - area.screen_origin_target_index.xy;
+    vec2 vertex_pos = actual_pos +
+                      area.common_data.task_rect.p0 -
+                      area.screen_origin;
 
     gl_Position = uTransform * vec4(vertex_pos, 0.0, 1);
 

--- a/webrender/res/cs_blur.glsl
+++ b/webrender/res/cs_blur.glsl
@@ -23,20 +23,20 @@ in int aBlurDirection;
 in vec4 aBlurRegion;
 
 void main(void) {
-    RenderTaskData task = fetch_render_task(aBlurRenderTaskAddress);
-    RenderTaskData src_task = fetch_render_task(aBlurSourceTaskAddress);
+    BlurTask blur_task = fetch_blur_task(aBlurRenderTaskAddress);
+    RenderTaskCommonData src_task = fetch_render_task_common_data(aBlurSourceTaskAddress);
 
-    vec4 src_rect = src_task.data0;
-    vec4 target_rect = task.data0;
+    RectWithSize src_rect = src_task.task_rect;
+    RectWithSize target_rect = blur_task.common_data.task_rect;
 
 #if defined WR_FEATURE_COLOR_TARGET
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0).xy);
 #else
     vec2 texture_size = vec2(textureSize(sCacheA8, 0).xy);
 #endif
-    vUv.z = src_task.data1.x;
-    vBlurRadius = int(3.0 * task.data1.y);
-    vSigma = task.data1.y;
+    vUv.z = src_task.render_target_layer_index;
+    vBlurRadius = int(3.0 * blur_task.blur_radius);
+    vSigma = blur_task.blur_radius;
 
     switch (aBlurDirection) {
         case DIR_HORIZONTAL:
@@ -47,20 +47,21 @@ void main(void) {
             break;
     }
 
-    vUvRect = vec4(src_rect.xy + vec2(0.5),
-                   src_rect.xy + src_rect.zw - vec2(0.5));
+    vUvRect = vec4(src_rect.p0 + vec2(0.5),
+                   src_rect.p0 + src_rect.size - vec2(0.5));
     vUvRect /= texture_size.xyxy;
 
     if (aBlurRegion.z > 0.0) {
         vec4 blur_region = aBlurRegion * uDevicePixelRatio;
-        src_rect = vec4(src_rect.xy + blur_region.xy, blur_region.zw);
-        target_rect = vec4(target_rect.xy + blur_region.xy, blur_region.zw);
+        src_rect = RectWithSize(src_rect.p0 + blur_region.xy, blur_region.zw);
+        target_rect.p0 = target_rect.p0 + blur_region.xy;
+        target_rect.size = blur_region.zw;
     }
 
-    vec2 pos = target_rect.xy + target_rect.zw * aPosition.xy;
+    vec2 pos = target_rect.p0 + target_rect.size * aPosition.xy;
 
-    vec2 uv0 = src_rect.xy / texture_size;
-    vec2 uv1 = (src_rect.xy + src_rect.zw) / texture_size;
+    vec2 uv0 = src_rect.p0 / texture_size;
+    vec2 uv1 = (src_rect.p0 + src_rect.size) / texture_size;
     vUv.xy = mix(uv0, uv1, aPosition.xy);
 
     gl_Position = uTransform * vec4(pos, 0.0, 1.0);

--- a/webrender/res/cs_clip_border.glsl
+++ b/webrender/res/cs_clip_border.glsl
@@ -128,8 +128,8 @@ void main(void) {
 
     // Position vertex within the render task area.
     vec2 final_pos = device_pos -
-                     area.screen_origin_target_index.xy +
-                     area.task_bounds.xy;
+                     area.screen_origin +
+                     area.common_data.task_rect.p0;
 
     // Calculate the local space position for this vertex.
     vec4 layer_pos = get_layer_pos(world_pos.xy, layer);

--- a/webrender/res/cs_text_run.glsl
+++ b/webrender/res/cs_text_run.glsl
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define PRIMITIVE_HAS_PICTURE_TASK
-
 #include shared,prim_shared
 
 varying vec3 vUv;

--- a/webrender/res/cs_text_run.glsl
+++ b/webrender/res/cs_text_run.glsl
@@ -32,7 +32,7 @@ void main(void) {
     // the glyph offset, relative to its primitive bounding rect.
     vec2 size = (res.uv_rect.zw - res.uv_rect.xy) * res.scale;
     vec2 local_pos = glyph.offset + vec2(res.offset.x, -res.offset.y) / uDevicePixelRatio;
-    vec2 origin = prim.task.target_rect.p0 +
+    vec2 origin = prim.task.common_data.task_rect.p0 +
                   uDevicePixelRatio * (local_pos - prim.task.content_origin);
     vec4 local_rect = vec4(origin, size);
 

--- a/webrender/res/ps_blend.glsl
+++ b/webrender/res/ps_blend.glsl
@@ -13,12 +13,12 @@ flat varying mat4 vColorMat;
 #ifdef WR_VERTEX_SHADER
 void main(void) {
     CompositeInstance ci = fetch_composite_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
+    PictureTask dest_task = fetch_picture_task(ci.render_task_index);
+    PictureTask src_task = fetch_picture_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.common_data.task_rect.p0 -
-                       dest_task.screen_space_origin +
-                       src_task.screen_space_origin;
+                       dest_task.content_origin +
+                       src_task.content_origin;
 
     vec2 local_pos = mix(dest_origin,
                          dest_origin + src_task.common_data.task_rect.size,

--- a/webrender/res/ps_blend.glsl
+++ b/webrender/res/ps_blend.glsl
@@ -16,20 +16,20 @@ void main(void) {
     AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
     AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
-    vec2 dest_origin = dest_task.render_target_origin -
+    vec2 dest_origin = dest_task.common_data.task_rect.p0 -
                        dest_task.screen_space_origin +
                        src_task.screen_space_origin;
 
     vec2 local_pos = mix(dest_origin,
-                         dest_origin + src_task.size,
+                         dest_origin + src_task.common_data.task_rect.size,
                          aPosition.xy);
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
-    vec2 st0 = src_task.render_target_origin;
-    vec2 st1 = src_task.render_target_origin + src_task.size;
+    vec2 st0 = src_task.common_data.task_rect.p0;
+    vec2 st1 = src_task.common_data.task_rect.p0 + src_task.common_data.task_rect.size;
 
-    vec2 uv = src_task.render_target_origin + aPosition.xy * src_task.size;
-    vUv = vec3(uv / texture_size, src_task.render_target_layer_index);
+    vec2 uv = src_task.common_data.task_rect.p0 + aPosition.xy * src_task.common_data.task_rect.size;
+    vUv = vec3(uv / texture_size, src_task.common_data.render_target_layer_index);
     vUvBounds = vec4(st0 + 0.5, st1 - 0.5) / texture_size.xyxy;
 
     vOp = ci.user_data0;

--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -11,13 +11,13 @@ flat varying int vOp;
 #ifdef WR_VERTEX_SHADER
 void main(void) {
     CompositeInstance ci = fetch_composite_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+    PictureTask dest_task = fetch_picture_task(ci.render_task_index);
     RenderTaskCommonData backdrop_task = fetch_render_task_common_data(ci.backdrop_task_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
+    PictureTask src_task = fetch_picture_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.common_data.task_rect.p0 -
-                       dest_task.screen_space_origin +
-                       src_task.screen_space_origin;
+                       dest_task.content_origin +
+                       src_task.content_origin;
 
     vec2 local_pos = mix(dest_origin,
                          dest_origin + src_task.common_data.task_rect.size,

--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -9,46 +9,29 @@ varying vec3 vUv1;
 flat varying int vOp;
 
 #ifdef WR_VERTEX_SHADER
-struct ReadbackTask {
-    vec2 render_target_origin;
-    vec2 size;
-    float render_target_layer_index;
-};
-
-ReadbackTask fetch_readback_task(int index) {
-    RenderTaskData data = fetch_render_task(index);
-
-    ReadbackTask task;
-    task.render_target_origin = data.data0.xy;
-    task.size = data.data0.zw;
-    task.render_target_layer_index = data.data1.x;
-
-    return task;
-}
-
 void main(void) {
     CompositeInstance ci = fetch_composite_instance();
     AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
-    ReadbackTask backdrop_task = fetch_readback_task(ci.backdrop_task_index);
+    RenderTaskCommonData backdrop_task = fetch_render_task_common_data(ci.backdrop_task_index);
     AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
-    vec2 dest_origin = dest_task.render_target_origin -
+    vec2 dest_origin = dest_task.common_data.task_rect.p0 -
                        dest_task.screen_space_origin +
                        src_task.screen_space_origin;
 
     vec2 local_pos = mix(dest_origin,
-                         dest_origin + src_task.size,
+                         dest_origin + src_task.common_data.task_rect.size,
                          aPosition.xy);
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
 
-    vec2 st0 = backdrop_task.render_target_origin / texture_size;
-    vec2 st1 = (backdrop_task.render_target_origin + backdrop_task.size) / texture_size;
+    vec2 st0 = backdrop_task.task_rect.p0 / texture_size;
+    vec2 st1 = (backdrop_task.task_rect.p0 + backdrop_task.task_rect.size) / texture_size;
     vUv0 = vec3(mix(st0, st1, aPosition.xy), backdrop_task.render_target_layer_index);
 
-    st0 = src_task.render_target_origin / texture_size;
-    st1 = (src_task.render_target_origin + src_task.size) / texture_size;
-    vUv1 = vec3(mix(st0, st1, aPosition.xy), src_task.render_target_layer_index);
+    st0 = src_task.common_data.task_rect.p0 / texture_size;
+    st1 = (src_task.common_data.task_rect.p0 + src_task.common_data.task_rect.size) / texture_size;
+    vUv1 = vec3(mix(st0, st1, aPosition.xy), src_task.common_data.render_target_layer_index);
 
     vOp = ci.user_data0;
 

--- a/webrender/res/ps_hardware_composite.glsl
+++ b/webrender/res/ps_hardware_composite.glsl
@@ -13,7 +13,7 @@ void main(void) {
     AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
     AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
 
-    vec2 dest_origin = dest_task.render_target_origin -
+    vec2 dest_origin = dest_task.common_data.task_rect.p0 -
                        dest_task.screen_space_origin +
                        vec2(ci.user_data0, ci.user_data1);
 
@@ -22,9 +22,9 @@ void main(void) {
                          aPosition.xy);
 
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
-    vec2 st0 = src_task.render_target_origin;
-    vec2 st1 = src_task.render_target_origin + src_task.size;
-    vUv = vec3(mix(st0, st1, aPosition.xy) / texture_size, src_task.render_target_layer_index);
+    vec2 st0 = src_task.common_data.task_rect.p0;
+    vec2 st1 = src_task.common_data.task_rect.p0 + src_task.common_data.task_rect.size;
+    vUv = vec3(mix(st0, st1, aPosition.xy) / texture_size, src_task.common_data.render_target_layer_index);
     vUvBounds = vec4(st0 + 0.5, st1 - 0.5) / texture_size.xyxy;
 
     gl_Position = uTransform * vec4(local_pos, ci.z, 1.0);

--- a/webrender/res/ps_hardware_composite.glsl
+++ b/webrender/res/ps_hardware_composite.glsl
@@ -10,11 +10,11 @@ flat varying vec4 vUvBounds;
 #ifdef WR_VERTEX_SHADER
 void main(void) {
     CompositeInstance ci = fetch_composite_instance();
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
+    PictureTask dest_task = fetch_picture_task(ci.render_task_index);
+    PictureTask src_task = fetch_picture_task(ci.src_task_index);
 
     vec2 dest_origin = dest_task.common_data.task_rect.p0 -
-                       dest_task.screen_space_origin +
+                       dest_task.content_origin +
                        vec2(ci.user_data0, ci.user_data1);
 
     vec2 local_pos = mix(dest_origin,

--- a/webrender/res/ps_line.glsl
+++ b/webrender/res/ps_line.glsl
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifdef WR_FEATURE_CACHE
-    #define PRIMITIVE_HAS_PICTURE_TASK
-#endif
-
 #include shared,prim_shared
 
 varying vec4 vColor;

--- a/webrender/res/ps_line.glsl
+++ b/webrender/res/ps_line.glsl
@@ -99,7 +99,7 @@ void main(void) {
     }
 
 #ifdef WR_FEATURE_CACHE
-    vec2 device_origin = prim.task.target_rect.p0 +
+    vec2 device_origin = prim.task.common_data.task_rect.p0 +
                          uDevicePixelRatio * (prim.local_rect.p0 - prim.task.content_origin);
     vec2 device_size = uDevicePixelRatio * prim.local_rect.size;
 

--- a/webrender/res/ps_split_composite.glsl
+++ b/webrender/res/ps_split_composite.glsl
@@ -37,11 +37,11 @@ vec3 bilerp(vec3 a, vec3 b, vec3 c, vec3 d, float s, float t) {
 void main(void) {
     CompositeInstance ci = fetch_composite_instance();
     SplitGeometry geometry = fetch_split_geometry(ci.user_data0);
-    AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
-    AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
+    PictureTask src_task = fetch_picture_task(ci.src_task_index);
+    PictureTask dest_task = fetch_picture_task(ci.render_task_index);
 
     vec2 dest_origin = dest_task.common_data.task_rect.p0 -
-                       dest_task.screen_space_origin;
+                       dest_task.content_origin;
 
     vec3 world_pos = bilerp(geometry.points[0], geometry.points[1],
                             geometry.points[3], geometry.points[2],
@@ -51,7 +51,7 @@ void main(void) {
     gl_Position = uTransform * final_pos;
 
     vec2 uv_origin = src_task.common_data.task_rect.p0;
-    vec2 uv_pos = uv_origin + world_pos.xy - src_task.screen_space_origin;
+    vec2 uv_pos = uv_origin + world_pos.xy - src_task.content_origin;
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
     vUv = vec3(uv_pos / texture_size, src_task.common_data.render_target_layer_index);
     vUvTaskBounds = vec4(uv_origin, uv_origin + src_task.common_data.task_rect.size) / texture_size.xyxy;

--- a/webrender/res/ps_split_composite.glsl
+++ b/webrender/res/ps_split_composite.glsl
@@ -40,7 +40,7 @@ void main(void) {
     AlphaBatchTask src_task = fetch_alpha_batch_task(ci.src_task_index);
     AlphaBatchTask dest_task = fetch_alpha_batch_task(ci.render_task_index);
 
-    vec2 dest_origin = dest_task.render_target_origin -
+    vec2 dest_origin = dest_task.common_data.task_rect.p0 -
                        dest_task.screen_space_origin;
 
     vec3 world_pos = bilerp(geometry.points[0], geometry.points[1],
@@ -50,12 +50,12 @@ void main(void) {
 
     gl_Position = uTransform * final_pos;
 
-    vec2 uv_origin = src_task.render_target_origin;
+    vec2 uv_origin = src_task.common_data.task_rect.p0;
     vec2 uv_pos = uv_origin + world_pos.xy - src_task.screen_space_origin;
     vec2 texture_size = vec2(textureSize(sCacheRGBA8, 0));
-    vUv = vec3(uv_pos / texture_size, src_task.render_target_layer_index);
-    vUvTaskBounds = vec4(uv_origin, uv_origin + src_task.size) / texture_size.xyxy;
-    vUvSampleBounds = vec4(uv_origin + 0.5, uv_origin + src_task.size - 0.5) / texture_size.xyxy;
+    vUv = vec3(uv_pos / texture_size, src_task.common_data.render_target_layer_index);
+    vUvTaskBounds = vec4(uv_origin, uv_origin + src_task.common_data.task_rect.size) / texture_size.xyxy;
+    vUvSampleBounds = vec4(uv_origin + 0.5, uv_origin + src_task.common_data.task_rect.size - 0.5) / texture_size.xyxy;
 }
 #endif
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -11,7 +11,7 @@ use api::{ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerPrimiti
 use api::{LayerSize, LayerToScrollTransform, LayerVector2D, LayoutVector2D, LineOrientation};
 use api::{LineStyle, LocalClip, PipelineId, RepeatMode};
 use api::{ScrollSensitivity, Shadow, TileOffset, TransformStyle};
-use api::{WorldPoint, YuvColorSpace, YuvData};
+use api::{PremultipliedColorF, WorldPoint, YuvColorSpace, YuvData};
 use app_units::Au;
 use border::ImageBorderSegment;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore, Contains, MAX_CLIP};
@@ -22,20 +22,19 @@ use frame::FrameId;
 use glyph_rasterizer::FontInstance;
 use gpu_cache::GpuCache;
 use internal_types::{FastHashMap, FastHashSet};
-use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
+use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, RasterizationMode};
 use prim_store::{TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
 use prim_store::{PrimitiveContainer, PrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{RectangleContent, RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_task::{RenderTask, RenderTaskLocation};
-use render_task::RenderTaskTree;
+use render_task::{ClearMode, RenderTask, RenderTaskTree};
 use resource_cache::ResourceCache;
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32, i32};
 use tiling::{CompositeOps, Frame};
-use tiling::{RenderPass};
+use tiling::{RenderPass, RenderTargetKind};
 use tiling::{RenderTargetContext, ScrollbarPrimitive};
 use util::{self, pack_as_float, RectHelpers, recycle_vec};
 
@@ -1579,11 +1578,15 @@ impl FrameBuilder {
         let pic = &mut self.prim_store.cpu_pictures[0];
         pic.runs = prim_run_cmds;
 
-        let root_render_task = RenderTask::new_alpha_batch(
-            DeviceIntPoint::zero(),
-            RenderTaskLocation::Fixed,
-            PrimitiveIndex(0),
+        let root_render_task = RenderTask::new_picture(
             None,
+            PrimitiveIndex(0),
+            RenderTargetKind::Color,
+            0.0,
+            0.0,
+            PremultipliedColorF::TRANSPARENT,
+            ClearMode::Transparent,
+            RasterizationMode::ScreenSpace,
             child_tasks,
         );
 

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -139,11 +139,6 @@ impl From<CompositePrimitiveInstance> for PrimitiveInstance {
     }
 }
 
-// Whether this brush is being drawn on a Picture
-// task (new) or an alpha batch task (legacy).
-// Can be removed once everything uses pictures.
-pub const BRUSH_FLAG_USES_PICTURE: i32 = (1 << 0);
-
 // TODO(gw): While we are comverting things over, we
 //           need to have the instance be the same
 //           size as an old PrimitiveInstance. In the

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -37,6 +37,15 @@ pub enum PictureCompositeMode {
     Blit,
 }
 
+/// Configure whether the primitives on this picture
+/// should be rasterized in screen space or local space.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum RasterizationMode {
+    LocalSpace = 0,
+    ScreenSpace = 1,
+}
+
 #[derive(Debug)]
 pub enum PictureKind {
     TextShadow {
@@ -95,9 +104,9 @@ pub struct PicturePrimitive {
     // unconditionally draw them.
     pub cull_children: bool,
 
-    // TODO(gw): Add a mode that specifies if this
-    //           picture should be rasterized in
-    //           screen-space or local-space.
+    /// Configure whether the primitives on this picture
+    /// should be rasterized in screen space or local space.
+    pub rasterization_kind: RasterizationMode,
 }
 
 impl PicturePrimitive {
@@ -113,6 +122,7 @@ impl PicturePrimitive {
             },
             pipeline_id,
             cull_children: false,
+            rasterization_kind: RasterizationMode::LocalSpace,
         }
     }
 
@@ -158,6 +168,7 @@ impl PicturePrimitive {
             },
             pipeline_id,
             cull_children: false,
+            rasterization_kind: RasterizationMode::LocalSpace,
         }
     }
 
@@ -181,6 +192,9 @@ impl PicturePrimitive {
             },
             pipeline_id,
             cull_children: true,
+            // TODO(gw): Make this configurable based on an
+            //           exposed API parameter in StackingContext.
+            rasterization_kind: RasterizationMode::ScreenSpace,
         }
     }
 
@@ -281,7 +295,7 @@ impl PicturePrimitive {
         prim_index: PrimitiveIndex,
         prim_context: &PrimitiveContext,
         render_tasks: &mut RenderTaskTree,
-        screen_rect: &DeviceIntRect,
+        prim_screen_rect: &DeviceIntRect,
         child_tasks: Vec<RenderTaskId>,
         parent_tasks: &mut Vec<RenderTaskId>,
     ) {
@@ -289,15 +303,19 @@ impl PicturePrimitive {
             PictureKind::Image {
                 ref mut readback_render_task_id,
                 composite_mode,
-                frame_output_pipeline_id,
                 ..
             } => {
                 match composite_mode {
                     Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {
-                        let picture_task = RenderTask::new_dynamic_alpha_batch(
-                            screen_rect,
+                        let picture_task = RenderTask::new_picture(
+                            Some(prim_screen_rect.size),
                             prim_index,
-                            None,
+                            RenderTargetKind::Color,
+                            prim_screen_rect.origin.x as f32,
+                            prim_screen_rect.origin.y as f32,
+                            PremultipliedColorF::TRANSPARENT,
+                            ClearMode::Transparent,
+                            self.rasterization_kind,
                             child_tasks,
                         );
 
@@ -319,14 +337,19 @@ impl PicturePrimitive {
                         self.render_task_id = Some(blur_render_task_id);
                     }
                     Some(PictureCompositeMode::MixBlend(..)) => {
-                        let picture_task = RenderTask::new_dynamic_alpha_batch(
-                            screen_rect,
+                        let picture_task = RenderTask::new_picture(
+                            Some(prim_screen_rect.size),
                             prim_index,
-                            None,
+                            RenderTargetKind::Color,
+                            prim_screen_rect.origin.x as f32,
+                            prim_screen_rect.origin.y as f32,
+                            PremultipliedColorF::TRANSPARENT,
+                            ClearMode::Transparent,
+                            self.rasterization_kind,
                             child_tasks,
                         );
 
-                        let readback_task_id = render_tasks.add(RenderTask::new_readback(*screen_rect));
+                        let readback_task_id = render_tasks.add(RenderTask::new_readback(*prim_screen_rect));
 
                         *readback_render_task_id = Some(readback_task_id);
                         parent_tasks.push(readback_task_id);
@@ -334,10 +357,15 @@ impl PicturePrimitive {
                         self.render_task_id = Some(render_tasks.add(picture_task));
                     }
                     Some(PictureCompositeMode::Filter(..)) | Some(PictureCompositeMode::Blit) => {
-                        let picture_task = RenderTask::new_dynamic_alpha_batch(
-                            screen_rect,
+                        let picture_task = RenderTask::new_picture(
+                            Some(prim_screen_rect.size),
                             prim_index,
-                            frame_output_pipeline_id,
+                            RenderTargetKind::Color,
+                            prim_screen_rect.origin.x as f32,
+                            prim_screen_rect.origin.y as f32,
+                            PremultipliedColorF::TRANSPARENT,
+                            ClearMode::Transparent,
+                            self.rasterization_kind,
                             child_tasks,
                         );
 
@@ -374,12 +402,15 @@ impl PicturePrimitive {
                 let blur_std_deviation = blur_radius.0 as f32 * 0.5;
 
                 let picture_task = RenderTask::new_picture(
-                    cache_size,
+                    Some(cache_size),
                     prim_index,
                     RenderTargetKind::Color,
-                    content_rect.origin,
+                    content_rect.origin.x,
+                    content_rect.origin.y,
                     color.premultiplied(),
                     ClearMode::Transparent,
+                    self.rasterization_kind,
+                    Vec::new(),
                 );
 
                 let picture_task_id = render_tasks.add(picture_task);
@@ -425,12 +456,15 @@ impl PicturePrimitive {
                 };
 
                 let picture_task = RenderTask::new_picture(
-                    cache_size,
+                    Some(cache_size),
                     prim_index,
                     RenderTargetKind::Alpha,
-                    content_rect.origin,
+                    content_rect.origin.x,
+                    content_rect.origin.y,
                     color.premultiplied(),
                     ClearMode::Zero,
+                    self.rasterization_kind,
+                    Vec::new(),
                 );
 
                 let picture_task_id = render_tasks.add(picture_task);

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -567,105 +567,92 @@ impl RenderTask {
         //           more type-safe. Although, it will always need
         //           to be kept in sync with the GLSL code anyway.
 
-        match self.kind {
+        let (data1, data2) = match self.kind {
             RenderTaskKind::Alpha(ref task) => {
-                let (target_rect, target_index) = self.get_target_rect();
-                RenderTaskData {
-                    data: [
-                        target_rect.origin.x as f32,
-                        target_rect.origin.y as f32,
-                        target_rect.size.width as f32,
-                        target_rect.size.height as f32,
+                (
+                    [
                         task.screen_origin.x as f32,
                         task.screen_origin.y as f32,
-                        target_index.0 as f32,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
+                        0.0
                     ],
-                }
+                    [
+                        0.0; 4
+                    ],
+                )
             }
             RenderTaskKind::Picture(ref task) => {
-                let (target_rect, target_index) = self.get_target_rect();
-                RenderTaskData {
-                    data: [
-                        target_rect.origin.x as f32,
-                        target_rect.origin.y as f32,
-                        target_rect.size.width as f32,
-                        target_rect.size.height as f32,
-                        target_index.0 as f32,
+                (
+                    [
                         task.content_origin.x,
                         task.content_origin.y,
-                        0.0,
+                        0.0
+                    ],
+                    [
                         task.color.r,
                         task.color.g,
                         task.color.b,
                         task.color.a,
                     ],
-                }
+                )
             }
             RenderTaskKind::CacheMask(ref task) => {
-                let (target_rect, target_index) = self.get_target_rect();
-                RenderTaskData {
-                    data: [
-                        target_rect.origin.x as f32,
-                        target_rect.origin.y as f32,
-                        (target_rect.origin.x + target_rect.size.width) as f32,
-                        (target_rect.origin.y + target_rect.size.height) as f32,
+                (
+                    [
                         task.actual_rect.origin.x as f32,
                         task.actual_rect.origin.y as f32,
-                        target_index.0 as f32,
                         0.0,
+                    ],
+                    [
                         task.inner_rect.origin.x as f32,
                         task.inner_rect.origin.y as f32,
                         (task.inner_rect.origin.x + task.inner_rect.size.width) as f32,
                         (task.inner_rect.origin.y + task.inner_rect.size.height) as f32,
                     ],
-                }
+                )
             }
             RenderTaskKind::VerticalBlur(ref task) |
             RenderTaskKind::HorizontalBlur(ref task) => {
-                let (target_rect, target_index) = self.get_target_rect();
-                RenderTaskData {
-                    data: [
-                        target_rect.origin.x as f32,
-                        target_rect.origin.y as f32,
-                        target_rect.size.width as f32,
-                        target_rect.size.height as f32,
-                        target_index.0 as f32,
+                (
+                    [
                         task.blur_std_deviation,
                         task.scale_factor,
                         0.0,
+                    ],
+                    [
                         task.color.r,
                         task.color.g,
                         task.color.b,
                         task.color.a,
                     ],
-                }
+                )
             }
             RenderTaskKind::Readback(..) |
-            RenderTaskKind::Scaling(..) => {
-                let (target_rect, target_index) = self.get_target_rect();
-                RenderTaskData {
-                    data: [
-                        target_rect.origin.x as f32,
-                        target_rect.origin.y as f32,
-                        target_rect.size.width as f32,
-                        target_rect.size.height as f32,
-                        target_index.0 as f32,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                        0.0,
-                    ],
-                }
+            RenderTaskKind::Scaling(..) |
+            RenderTaskKind::Alias(..) => {
+                (
+                    [0.0; 3],
+                    [0.0; 4],
+                )
             }
-            RenderTaskKind::Alias(..) => RenderTaskData { data: [0.0; 12] },
+        };
+
+        let (target_rect, target_index) = self.get_target_rect();
+
+        RenderTaskData {
+            data: [
+                target_rect.origin.x as f32,
+                target_rect.origin.y as f32,
+                target_rect.size.width as f32,
+                target_rect.size.height as f32,
+                target_index.0 as f32,
+                data1[0],
+                data1[1],
+                data1[2],
+                data2[0],
+                data2[1],
+                data2[2],
+                data2[3],
+            ]
         }
     }
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{ClipId, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use api::{LayerPoint, LayerRect};
-use api::{PipelineId, PremultipliedColorF};
+use api::{LayerPoint, LayerRect, PremultipliedColorF};
 use clip::{ClipSource, ClipSourcesWeakHandle, ClipStore};
 use clip_scroll_tree::CoordinateSystemId;
 use gpu_types::{ClipScrollNodeIndex};
+use picture::RasterizationMode;
 use prim_store::{PrimitiveIndex};
 use std::{cmp, usize, f32, i32};
 use std::rc::Rc;
@@ -150,15 +150,6 @@ pub enum RenderTaskLocation {
     Dynamic(Option<(DeviceIntPoint, RenderTargetIndex)>, DeviceIntSize),
 }
 
-#[derive(Debug)]
-pub struct AlphaRenderTask {
-    pub screen_origin: DeviceIntPoint,
-    pub prim_index: PrimitiveIndex,
-    // If this render task is a registered frame output, this
-    // contains the pipeline ID it maps to.
-    pub frame_output_pipeline_id: Option<PipelineId>,
-}
-
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub enum MaskSegment {
@@ -240,6 +231,7 @@ pub struct PictureTask {
     pub target_kind: RenderTargetKind,
     pub content_origin: LayerPoint,
     pub color: PremultipliedColorF,
+    pub rasterization_kind: RasterizationMode,
 }
 
 #[derive(Debug)]
@@ -258,7 +250,6 @@ pub struct RenderTaskData {
 
 #[derive(Debug)]
 pub enum RenderTaskKind {
-    Alpha(AlphaRenderTask),
     Picture(PictureTask),
     CacheMask(CacheMaskTask),
     VerticalBlur(BlurTask),
@@ -288,62 +279,32 @@ pub struct RenderTask {
 }
 
 impl RenderTask {
-    // TODO(gw): In the future we'll remove this
-    //           completely and convert everything
-    //           that is an alpha task to a Picture.
-    pub fn new_alpha_batch(
-        screen_origin: DeviceIntPoint,
-        location: RenderTaskLocation,
-        prim_index: PrimitiveIndex,
-        frame_output_pipeline_id: Option<PipelineId>,
-        children: Vec<RenderTaskId>,
-    ) -> Self {
-        RenderTask {
-            cache_key: None,
-            children,
-            location,
-            kind: RenderTaskKind::Alpha(AlphaRenderTask {
-                screen_origin,
-                prim_index,
-                frame_output_pipeline_id,
-            }),
-            clear_mode: ClearMode::Transparent,
-        }
-    }
-
-    pub fn new_dynamic_alpha_batch(
-        rect: &DeviceIntRect,
-        prim_index: PrimitiveIndex,
-        frame_output_pipeline_id: Option<PipelineId>,
-        children: Vec<RenderTaskId>,
-    ) -> Self {
-        let location = RenderTaskLocation::Dynamic(None, rect.size);
-        Self::new_alpha_batch(
-            rect.origin,
-            location,
-            prim_index,
-            frame_output_pipeline_id,
-            children,
-        )
-    }
-
     pub fn new_picture(
-        size: DeviceIntSize,
+        size: Option<DeviceIntSize>,
         prim_index: PrimitiveIndex,
         target_kind: RenderTargetKind,
-        content_origin: LayerPoint,
+        content_origin_x: f32,
+        content_origin_y: f32,
         color: PremultipliedColorF,
         clear_mode: ClearMode,
+        rasterization_kind: RasterizationMode,
+        children: Vec<RenderTaskId>,
     ) -> Self {
+        let location = match size {
+            Some(size) => RenderTaskLocation::Dynamic(None, size),
+            None => RenderTaskLocation::Fixed,
+        };
+
         RenderTask {
             cache_key: None,
-            children: Vec::new(),
-            location: RenderTaskLocation::Dynamic(None, size),
+            children,
+            location,
             kind: RenderTaskKind::Picture(PictureTask {
                 prim_index,
                 target_kind,
-                content_origin,
+                content_origin: LayerPoint::new(content_origin_x, content_origin_y),
                 color,
+                rasterization_kind,
             }),
             clear_mode,
         }
@@ -542,19 +503,6 @@ impl RenderTask {
         }
     }
 
-    pub fn as_alpha_batch<'a>(&'a self) -> &'a AlphaRenderTask {
-        match self.kind {
-            RenderTaskKind::Alpha(ref task) => task,
-            RenderTaskKind::Picture(..) |
-            RenderTaskKind::CacheMask(..) |
-            RenderTaskKind::VerticalBlur(..) |
-            RenderTaskKind::Readback(..) |
-            RenderTaskKind::HorizontalBlur(..) |
-            RenderTaskKind::Alias(..) |
-            RenderTaskKind::Scaling(..) => unreachable!(),
-        }
-    }
-
     // Write (up to) 8 floats of data specific to the type
     // of render task that is provided to the GPU shaders
     // via a vertex texture.
@@ -568,24 +516,12 @@ impl RenderTask {
         //           to be kept in sync with the GLSL code anyway.
 
         let (data1, data2) = match self.kind {
-            RenderTaskKind::Alpha(ref task) => {
-                (
-                    [
-                        task.screen_origin.x as f32,
-                        task.screen_origin.y as f32,
-                        0.0
-                    ],
-                    [
-                        0.0; 4
-                    ],
-                )
-            }
             RenderTaskKind::Picture(ref task) => {
                 (
                     [
                         task.content_origin.x,
                         task.content_origin.y,
-                        0.0
+                        task.rasterization_kind as u32 as f32,
                     ],
                     [
                         task.color.r,
@@ -693,7 +629,6 @@ impl RenderTask {
 
     pub fn target_kind(&self) -> RenderTargetKind {
         match self.kind {
-            RenderTaskKind::Alpha(..) |
             RenderTaskKind::Readback(..) => RenderTargetKind::Color,
 
             RenderTaskKind::CacheMask(..) => {
@@ -727,7 +662,6 @@ impl RenderTask {
     // if we decide that is useful.
     pub fn is_shared(&self) -> bool {
         match self.kind {
-            RenderTaskKind::Alpha(..) |
             RenderTaskKind::Picture(..) |
             RenderTaskKind::VerticalBlur(..) |
             RenderTaskKind::Readback(..) |

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -46,7 +46,7 @@ use rayon::Configuration as ThreadPoolConfig;
 use rayon::ThreadPool;
 use record::ApiRecordingReceiver;
 use render_backend::RenderBackend;
-use render_task::RenderTaskTree;
+use render_task::{RenderTaskKind, RenderTaskTree};
 #[cfg(feature = "debugger")]
 use serde_json;
 use std;
@@ -2671,8 +2671,14 @@ impl Renderer {
 
                 let (readback_rect, readback_layer) = readback.get_target_rect();
                 let (backdrop_rect, _) = backdrop.get_target_rect();
-                let backdrop_screen_origin = backdrop.as_alpha_batch().screen_origin;
-                let source_screen_origin = source.as_alpha_batch().screen_origin;
+                let backdrop_screen_origin = match backdrop.kind {
+                    RenderTaskKind::Picture(ref task_info) => task_info.content_origin,
+                    _ => panic!("bug: composite on non-picture?"),
+                };
+                let source_screen_origin = match source.kind {
+                    RenderTaskKind::Picture(ref task_info) => task_info.content_origin,
+                    _ => panic!("bug: composite on non-picture?"),
+                };
 
                 // Bind the FBO to blit the backdrop to.
                 // Called per-instance in case the layer (and therefore FBO)
@@ -2682,10 +2688,12 @@ impl Renderer {
                 self.device
                     .bind_draw_target(Some(cache_draw_target), Some(cache_texture_dimensions));
 
-                let src_x =
-                    backdrop_rect.origin.x - backdrop_screen_origin.x + source_screen_origin.x;
-                let src_y =
-                    backdrop_rect.origin.y - backdrop_screen_origin.y + source_screen_origin.y;
+                let src_x = backdrop_rect.origin.x -
+                            backdrop_screen_origin.x as i32 +
+                            source_screen_origin.x as i32;
+                let src_y = backdrop_rect.origin.y -
+                            backdrop_screen_origin.y as i32 +
+                            source_screen_origin.y as i32;
 
                 let dest_x = readback_rect.origin.x;
                 let dest_y = readback_rect.origin.y;


### PR DESCRIPTION
Most of the difficult work related to this was done in the
large picture PR that landed previously.

This removes the remnants of AlphaBatch tasks, and makes them
all run through Picture render tasks.

This also introduces the first part of the picture and shader
side support for selecting whether primitives on a given picture
are to be rasterized in screen space or a local space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2053)
<!-- Reviewable:end -->
