### PR TITLE
MacOS: core-graphics update to v12

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -47,5 +47,6 @@ dwrote = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.4"
-core-graphics = "0.9"
+core-graphics = "0.12"
 core-text = { version = "7.0", default-features = false }
+foreign-types = "0.3.0"

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -123,6 +123,8 @@ extern crate core_foundation;
 extern crate core_graphics;
 #[cfg(target_os = "macos")]
 extern crate core_text;
+#[cfg(target_os = "macos")]
+extern crate foreign_types;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 extern crate freetype;

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -244,7 +244,7 @@ fn new_ct_font_with_variations(cg_font: &CGFont, size: Au, variations: &[FontVar
             return ct_font;
         }
         let vals_dict = CFDictionary::from_CFType_pairs(&vals);
-        let cg_font = cg_font.create_copy_with_variations( &vals_dict );
+        let cg_font = cg_font.create_copy_from_variations( &vals_dict );
         match cg_font {
                 Ok(f) => return core_text::font::new_from_CGFont(&f, size.to_f64_px()),
                 Err(e) => return ct_font,

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -21,7 +21,7 @@ time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.4"
-core-graphics = "0.9"
+core-graphics = "0.12"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.4"


### PR DESCRIPTION
Webrender was updated to Core Graphics v12.
It is required for iOS support.
[Core-graphics's PR should be approved before this](https://github.com/servo/core-graphics-rs/pull/106)

Some Servos code should be changed for this version of webrender( [gfx component](https://github.com/servo/servo/blob/master/components/gfx/platform/macos/font_template.rs), in `pub fn ctfont(&self, pt_size: f64) -> Option<CTFont>` ), should I up version in Webrender's cargo?

@larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2056)
<!-- Reviewable:end -->
