### PR TITLE
Fix build breakage with current rustc:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,3 @@ members = [
 
 [profile.release]
 debug = true
-panic = "abort"


### PR DESCRIPTION
error: the crate `bitflags` is compiled with the panic strategy `abort` which is incompatible with this crate's strategy of `unwind`

error: aborting due to previous error

error: the crate `bitflags` is compiled with the panic strategy `abort` which is incompatible with this crate's strategy of `unwind`

error: aborting due to previous error

error: Could not compile `gleam`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2060)
<!-- Reviewable:end -->
