### PR TITLE
Remove lifetime parameter of Renderer

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -9,6 +9,7 @@ use euclid::Transform3D;
 use gleam::gl;
 use internal_types::RenderTargetMode;
 use internal_types::FastHashMap;
+use std::cell::RefCell;
 use std::fs::File;
 use std::io::Read;
 use std::iter::repeat;
@@ -487,7 +488,7 @@ pub struct VBOId(gl::GLuint);
 struct IBOId(gl::GLuint);
 
 #[derive(PartialEq, Eq, Hash, Debug)]
-struct ProgramSources {
+pub struct ProgramSources {
     renderer_name: String,
     vs_source: String,
     fs_source: String,
@@ -503,7 +504,7 @@ impl ProgramSources {
     }
 }
 
-struct ProgramBinary {
+pub struct ProgramBinary {
     binary: Vec<u8>,
     format: gl::GLenum,
 }
@@ -518,26 +519,16 @@ impl ProgramBinary {
 }
 
 pub struct ProgramCache {
-    binaries: FastHashMap<ProgramSources, ProgramBinary>,
+    pub binaries: RefCell<FastHashMap<ProgramSources, ProgramBinary>>,
 }
 
 impl ProgramCache {
-    pub fn new() -> Self {
-        ProgramCache {
-            binaries: FastHashMap::default(),
-        }
-    }
-
-    fn get(&self, sources: &ProgramSources) -> Option<&ProgramBinary> {
-      self.binaries.get(&sources)
-    }
-
-    fn contains(&self, sources: &ProgramSources) -> bool {
-      self.binaries.contains_key(&sources)
-    }
-
-    fn insert(&mut self, sources: ProgramSources, binary: ProgramBinary) {
-      self.binaries.insert(sources, binary);
+    pub fn new() -> Rc<Self> {
+        Rc::new(
+            ProgramCache {
+                binaries: RefCell::new(FastHashMap::default()),
+            }
+        )
     }
 }
 
@@ -577,7 +568,7 @@ pub enum ShaderError {
     Link(String, String),        // name, error message
 }
 
-pub struct Device<'a> {
+pub struct Device {
     gl: Rc<gl::Gl>,
     // device state
     bound_textures: [gl::GLuint; 16],
@@ -601,19 +592,19 @@ pub struct Device<'a> {
 
     max_texture_size: u32,
     renderer_name: String,
-    cached_programs: Option<&'a mut ProgramCache>,
+    cached_programs: Option<Rc<ProgramCache>>,
 
     // Frame counter. This is used to map between CPU
     // frames and GPU frames.
     frame_id: FrameId,
 }
 
-impl<'a> Device<'a> {
+impl Device {
     pub fn new(
         gl: Rc<gl::Gl>,
         resource_override_path: Option<PathBuf>,
         _file_changed_handler: Box<FileWatcherHandler>,
-        cached_programs: Option<&mut ProgramCache>,
+        cached_programs: Option<Rc<ProgramCache>>,
     ) -> Device {
         let max_texture_size = gl.get_integer_v(gl::MAX_TEXTURE_SIZE) as u32;
         let renderer_name = gl.get_string(gl::RENDERER);
@@ -654,7 +645,7 @@ impl<'a> Device<'a> {
         &self.gl
     }
 
-    pub fn update_program_cache(&mut self, cached_programs: &'a mut ProgramCache) {
+    pub fn update_program_cache(&mut self, cached_programs: Rc<ProgramCache>) {
         self.cached_programs = Some(cached_programs);
     }
 
@@ -1160,7 +1151,7 @@ impl<'a> Device<'a> {
         let mut loaded = false;
 
         if let Some(ref cached_programs) = self.cached_programs {
-            if let Some(binary) = cached_programs.get(&sources)
+            if let Some(binary) = cached_programs.binaries.borrow().get(&sources)
             {
                 self.gl.program_binary(pid, binary.format, &binary.binary);
 
@@ -1238,11 +1229,11 @@ impl<'a> Device<'a> {
             }
         }
 
-        if let Some(ref mut cached_programs) = self.cached_programs {
-            if !cached_programs.contains(&sources) {
+        if let Some(ref cached_programs) = self.cached_programs {
+            if !cached_programs.binaries.borrow().contains_key(&sources) {
                 let (buffer, format) = self.gl.get_program_binary(pid);
                 if buffer.len() > 0 {
-                  cached_programs.insert(sources, ProgramBinary::new(buffer, format));
+                  cached_programs.binaries.borrow_mut().insert(sources, ProgramBinary::new(buffer, format));
                 }
             }
         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1205,10 +1205,10 @@ struct FrameOutput {
 
 /// The renderer is responsible for submitting to the GPU the work prepared by the
 /// RenderBackend.
-pub struct Renderer<'a> {
+pub struct Renderer {
     result_rx: Receiver<ResultMsg>,
     debug_server: DebugServer,
-    device: Device<'a>,
+    device: Device,
     pending_texture_updates: Vec<TextureUpdateList>,
     pending_gpu_cache_updates: Vec<GpuCacheUpdateList>,
     pending_shader_updates: Vec<PathBuf>,
@@ -1335,7 +1335,7 @@ impl From<std::io::Error> for RendererError {
     }
 }
 
-impl<'a> Renderer<'a> {
+impl Renderer {
     /// Initializes webrender and creates a `Renderer` and `RenderApiSender`.
     ///
     /// # Examples
@@ -1973,7 +1973,7 @@ impl<'a> Renderer<'a> {
 
     // update the program cache with new binaries, e.g. when some of the lazy loaded
     // shader programs got activated in the mean time
-    pub fn update_program_cache(&mut self, cached_programs: &'a mut ProgramCache) {
+    pub fn update_program_cache(&mut self, cached_programs: Rc<ProgramCache>) {
         self.device.update_program_cache(cached_programs);
     }
 
@@ -3880,7 +3880,7 @@ pub trait ThreadListener {
     fn thread_stopped(&self, thread_name: &str);
 }
 
-pub struct RendererOptions<'a> {
+pub struct RendererOptions {
     pub device_pixel_ratio: f32,
     pub resource_override_path: Option<PathBuf>,
     pub enable_aa: bool,
@@ -3901,13 +3901,13 @@ pub struct RendererOptions<'a> {
     pub recorder: Option<Box<ApiRecordingReceiver>>,
     pub thread_listener: Option<Box<ThreadListener + Send + Sync>>,
     pub enable_render_on_scroll: bool,
-    pub cached_programs: Option<&'a mut ProgramCache>,
+    pub cached_programs: Option<Rc<ProgramCache>>,
     pub debug_flags: DebugFlags,
     pub renderer_id: Option<u64>,
 }
 
-impl<'a> Default for RendererOptions<'a> {
-    fn default() -> RendererOptions<'a> {
+impl Default for RendererOptions {
+    fn default() -> RendererOptions {
         RendererOptions {
             device_pixel_ratio: 1.0,
             resource_override_path: None,

--- a/wrench/src/perf.rs
+++ b/wrench/src/perf.rs
@@ -120,14 +120,14 @@ impl Profile {
     }
 }
 
-pub struct PerfHarness<'a, 'b> where 'b: 'a {
-    wrench: &'a mut Wrench<'b>,
+pub struct PerfHarness<'a> {
+    wrench: &'a mut Wrench,
     window: &'a mut WindowWrapper,
     rx: Receiver<()>,
 }
 
-impl<'a, 'b> PerfHarness<'a, 'b> {
-    pub fn new(wrench: &'a mut Wrench<'b>, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+impl<'a> PerfHarness<'a> {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
         PerfHarness { wrench, window, rx }
     }
 

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -8,14 +8,14 @@ use std::sync::mpsc::Receiver;
 use webrender::api::*;
 use wrench::Wrench;
 
-pub struct RawtestHarness<'a, 'b> where 'b: 'a {
-    wrench: &'a mut Wrench<'b>,
+pub struct RawtestHarness<'a> {
+    wrench: &'a mut Wrench,
     rx: Receiver<()>,
     window: &'a mut WindowWrapper,
 }
 
-impl<'a, 'b> RawtestHarness<'a, 'b> {
-    pub fn new(wrench: &'a mut Wrench<'b>, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+impl<'a> RawtestHarness<'a> {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
         RawtestHarness {
             wrench,
             rx,

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -253,13 +253,13 @@ impl ReftestManifest {
     }
 }
 
-pub struct ReftestHarness<'a, 'b> where 'b: 'a {
-    wrench: &'a mut Wrench<'b>,
+pub struct ReftestHarness<'a> {
+    wrench: &'a mut Wrench,
     window: &'a mut WindowWrapper,
     rx: Receiver<()>,
 }
-impl<'a, 'b> ReftestHarness<'a, 'b> {
-    pub fn new(wrench: &'a mut Wrench<'b>, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+impl<'a> ReftestHarness<'a> {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
         ReftestHarness { wrench, window, rx }
     }
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -116,11 +116,11 @@ pub trait WrenchThing {
     }
 }
 
-pub struct Wrench<'a> {
+pub struct Wrench {
     window_size: DeviceUintSize,
     device_pixel_ratio: f32,
 
-    pub renderer: webrender::Renderer<'a>,
+    pub renderer: webrender::Renderer,
     pub api: RenderApi,
     pub document_id: DocumentId,
     pub root_pipeline_id: PipelineId,
@@ -135,7 +135,7 @@ pub struct Wrench<'a> {
     pub frame_start_sender: chase_lev::Worker<time::SteadyTime>,
 }
 
-impl<'a> Wrench<'a> {
+impl Wrench {
     pub fn new(
         window: &mut WindowWrapper,
         shader_override_path: Option<PathBuf>,


### PR DESCRIPTION
In #2032, @glennw commented about the problem about lifetime parameter of Renderer. The lifetime parameter could cause a problem to merge to Servo.  This pull request addresses it. There could be another ways to address the problem.

cc @glennw @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2064)
<!-- Reviewable:end -->
