### PR TITLE
Use DebugFlags for time and sample queries.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -196,43 +196,36 @@ pub fn main_wrapper<E: Example>(
                     _,
                     Some(glutin::VirtualKeyCode::P),
                 ) => {
-                    let mut flags = renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::PROFILER_DBG);
-                    renderer.set_debug_flags(flags);
+                    renderer.toggle_debug_flags(webrender::DebugFlags::PROFILER_DBG);
                 }
                 glutin::Event::KeyboardInput(
                     glutin::ElementState::Pressed,
                     _,
                     Some(glutin::VirtualKeyCode::O),
                 ) => {
-                    let mut flags = renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::RENDER_TARGET_DBG);
-                    renderer.set_debug_flags(flags);
+                    renderer.toggle_debug_flags(webrender::DebugFlags::RENDER_TARGET_DBG);
                 }
                 glutin::Event::KeyboardInput(
                     glutin::ElementState::Pressed,
                     _,
                     Some(glutin::VirtualKeyCode::I),
                 ) => {
-                    let mut flags = renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::TEXTURE_CACHE_DBG);
-                    renderer.set_debug_flags(flags);
+                    renderer.toggle_debug_flags(webrender::DebugFlags::TEXTURE_CACHE_DBG);
                 }
                 glutin::Event::KeyboardInput(
                     glutin::ElementState::Pressed,
                     _,
                     Some(glutin::VirtualKeyCode::B),
                 ) => {
-                    let mut flags = renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::ALPHA_PRIM_DBG);
-                    renderer.set_debug_flags(flags);
+                    renderer.toggle_debug_flags(webrender::DebugFlags::ALPHA_PRIM_DBG);
                 }
                 glutin::Event::KeyboardInput(
                     glutin::ElementState::Pressed,
                     _,
                     Some(glutin::VirtualKeyCode::Q),
                 ) => {
-                    renderer.toggle_queries_enabled();
+                    renderer.toggle_debug_flags(webrender::DebugFlags::GPU_TIME_QUERIES
+                        | webrender::DebugFlags::GPU_SAMPLE_QUERIES);
                 }
                 glutin::Event::KeyboardInput(
                     glutin::ElementState::Pressed,

--- a/webrender/src/query.rs
+++ b/webrender/src/query.rs
@@ -214,14 +214,6 @@ impl<T> GpuProfiler<T> {
         }
     }
 
-    pub fn toggle_timers_enabled(&mut self) {
-        if self.frames[0].timers.set.is_empty() {
-            self.enable_timers();
-        } else {
-            self.disable_timers();
-        }
-    }
-
     pub fn enable_samplers(&mut self) {
         const MAX_SAMPLERS_PER_FRAME: i32 = 16;
         if cfg!(target_os = "macos") {
@@ -236,14 +228,6 @@ impl<T> GpuProfiler<T> {
     pub fn disable_samplers(&mut self) {
         for frame in &mut self.frames {
             frame.disable_samplers();
-        }
-    }
-
-    pub fn toggle_samplers_enabled(&mut self) {
-        if self.frames[0].samplers.set.is_empty() {
-            self.enable_samplers();
-        } else {
-            self.disable_samplers();
         }
     }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2283,11 +2283,6 @@ impl Renderer {
         }
     }
 
-    pub fn toggle_queries_enabled(&mut self) {
-        self.gpu_profile.toggle_timers_enabled();
-        self.gpu_profile.toggle_samplers_enabled();
-    }
-
     /// Set a callback for handling external images.
     pub fn set_external_image_handler(&mut self, handler: Box<ExternalImageHandler>) {
         self.external_image_handler = Some(handler);
@@ -3743,6 +3738,12 @@ impl Renderer {
     pub fn set_debug_flag(&mut self, flag: DebugFlags, enabled: bool) {
         let mut new_flags = self.debug_flags;
         new_flags.set(flag, enabled);
+        self.set_debug_flags(new_flags);
+    }
+
+    pub fn toggle_debug_flags(&mut self, toggle: DebugFlags) {
+        let mut new_flags = self.debug_flags;
+        new_flags.toggle(toggle);
         self.set_debug_flags(new_flags);
     }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1900,7 +1900,9 @@ impl Renderer {
         };
 
         let device_pixel_ratio = options.device_pixel_ratio;
-        let debug_flags = options.debug_flags;
+        // First set the flags to default and later call set_debug_flags to ensure any
+        // potential transition when enabling a flag is run.
+        let debug_flags = DebugFlags::default();
         let payload_tx_for_backend = payload_tx.clone();
         let recorder = options.recorder;
         let thread_listener = Arc::new(options.thread_listener);
@@ -1960,7 +1962,7 @@ impl Renderer {
         let gpu_cache_texture = CacheTexture::new(&mut device);
         let gpu_profile = GpuProfiler::new(Rc::clone(device.rc_gl()));
 
-        let renderer = Renderer {
+        let mut renderer = Renderer {
             result_rx,
             debug_server,
             device,
@@ -2025,6 +2027,8 @@ impl Renderer {
             texture_resolver,
             renderer_errors: Vec::new(),
         };
+
+        renderer.set_debug_flags(options.debug_flags);
 
         let sender = RenderApiSender::new(api_tx, payload_tx);
         Ok((renderer, sender))

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -65,6 +65,7 @@ use std::ptr;
 use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use webrender::api::*;
+use webrender::DebugFlags;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
@@ -586,27 +587,21 @@ fn main() {
                     break 'outer;
                 }
                 VirtualKeyCode::P => {
-                    let mut flags = wrench.renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::PROFILER_DBG);
-                    wrench.renderer.set_debug_flags(flags);
+                    wrench.renderer.toggle_debug_flags(DebugFlags::PROFILER_DBG);
                 }
                 VirtualKeyCode::O => {
-                    let mut flags = wrench.renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::RENDER_TARGET_DBG);
-                    wrench.renderer.set_debug_flags(flags);
+                    wrench.renderer.toggle_debug_flags(DebugFlags::RENDER_TARGET_DBG);
                 }
                 VirtualKeyCode::I => {
-                    let mut flags = wrench.renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::TEXTURE_CACHE_DBG);
-                    wrench.renderer.set_debug_flags(flags);
+                    wrench.renderer.toggle_debug_flags(DebugFlags::TEXTURE_CACHE_DBG);
                 }
                 VirtualKeyCode::B => {
-                    let mut flags = wrench.renderer.get_debug_flags();
-                    flags.toggle(webrender::DebugFlags::ALPHA_PRIM_DBG);
-                    wrench.renderer.set_debug_flags(flags);
+                    wrench.renderer.toggle_debug_flags(DebugFlags::ALPHA_PRIM_DBG);
                 }
                 VirtualKeyCode::Q => {
-                    wrench.renderer.toggle_queries_enabled();
+                    wrench.renderer.toggle_debug_flags(
+                        DebugFlags::GPU_TIME_QUERIES | DebugFlags::GPU_SAMPLE_QUERIES
+                    );
                 }
                 VirtualKeyCode::M => {
                     wrench.api.notify_memory_pressure();

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -64,8 +64,8 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender, Receiver};
-use webrender::api::*;
 use webrender::DebugFlags;
+use webrender::api::*;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use time;
 use webrender;
+use webrender::DebugFlags;
 use webrender::api::*;
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use {WindowWrapper, BLACK_COLOR, WHITE_COLOR};
@@ -169,14 +170,17 @@ impl Wrench {
             )) as Box<webrender::ApiRecordingReceiver>,
         });
 
+        let mut debug_flags = DebugFlags::default();
+        debug_flags.set(DebugFlags::DISABLE_BATCHING, no_batch);
+
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dp_ratio,
             resource_override_path: shader_override_path,
             recorder,
             enable_subpixel_aa: !no_subpixel_aa,
             debug,
+            debug_flags,
             enable_clear_scissor: !no_scissor,
-            enable_batcher: !no_batch,
             max_recorded_profiles: 16,
             blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new())),
             ..Default::default()


### PR DESCRIPTION
And also disabling batching while we are at it.
Debug flags make it easier to interface with gecko (no need to update the bindings or anything, we can even land the gecko glue before updating webrender). `flag_changed` will hopefully make it more convenient to use DebugFlags by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2072)
<!-- Reviewable:end -->
