### PR TITLE
Port the frame output example to use the Document API

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -76,14 +76,12 @@ pub trait Example {
     fn on_event(&mut self, glutin::Event, &RenderApi, DocumentId) -> bool {
         false
     }
-    fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
-        None
-    }
-    fn get_output_image_handler(
+    fn get_image_handlers(
         &mut self,
         _gl: &gl::Gl,
-    ) -> Option<Box<webrender::OutputImageHandler>> {
-        None
+    ) -> (Option<Box<webrender::ExternalImageHandler>>, 
+          Option<Box<webrender::OutputImageHandler>>) {
+        (None, None)
     }
     fn draw_custom(&self, _gl: &gl::Gl) {
     }
@@ -148,11 +146,14 @@ pub fn main_wrapper<E: Example>(
     let api = sender.create_api();
     let document_id = api.add_document(framebuffer_size, 0);
 
-    if let Some(external_image_handler) = example.get_external_image_handler() {
-        renderer.set_external_image_handler(external_image_handler);
-    }
-    if let Some(output_image_handler) = example.get_output_image_handler(&*gl) {
+    let (external, output) = example.get_image_handlers(&*gl);
+
+    if let Some(output_image_handler) = output {
         renderer.set_output_image_handler(output_image_handler);
+    }
+
+    if let Some(external_image_handler) = external {
+        renderer.set_external_image_handler(external_image_handler);
     }
 
     let epoch = Epoch(0);

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate euclid;
 extern crate gleam;
 extern crate glutin;
 extern crate webrender;
@@ -12,95 +13,96 @@ mod boilerplate;
 use boilerplate::{Example, HandyDandyRectBuilder};
 use gleam::gl;
 use webrender::api::*;
+use euclid::ScaleFactor;
 
 // This example demonstrates using the frame output feature to copy
 // the output of a WR framebuffer to a custom texture.
 
-const VS: &str = "#version 130
-    in vec2 aPos;out vec2 vUv;
-    void main() { vUv = aPos; gl_Position = vec4(aPos, 0.0, 1.0); }
-";
-const FS: &str = "#version 130
-    out vec4 oFragColor;
-    in vec2 vUv;
-    uniform sampler2D s;
-    void main() { oFragColor = texture(s, vUv); }
-";
+#[derive(Debug)]
+struct Document {
+    id: DocumentId,
+    pipeline_id: PipelineId,
+    content_rect: LayoutRect,
+    color: ColorF,
+}
+
 
 struct App {
-    iframe_pipeline_id: Option<PipelineId>,
-    texture_id: gl::GLuint,
+    external_image_key: Option<ImageKey>,
+    output_document: Option<Document>
 }
 
 struct OutputHandler {
-    texture_id: gl::GLuint,
+    texture_id: gl::GLuint
 }
 
-impl OutputHandler {
-    fn new(texture_id: gl::GLuint) -> OutputHandler {
-        OutputHandler { texture_id }
-    }
+struct ExternalHandler {
+    texture_id: gl::GLuint
 }
 
 impl webrender::OutputImageHandler for OutputHandler {
     fn lock(&mut self, _id: PipelineId) -> Option<(u32, DeviceIntSize)> {
-        Some((self.texture_id, DeviceIntSize::new(100, 100)))
+        Some((self.texture_id, DeviceIntSize::new(500, 500)))
     }
 
     fn unlock(&mut self, _id: PipelineId) {}
 }
 
-impl Example for App {
-    fn render(
+impl webrender::ExternalImageHandler for ExternalHandler {
+    fn lock(&mut self, _key: ExternalImageId, _channel_index: u8) -> webrender::ExternalImage {
+        webrender::ExternalImage {
+            u0: 0.0,
+            v0: 0.0,
+            u1: 1.0,
+            v1: 1.0,
+            source: webrender::ExternalImageSource::NativeTexture(self.texture_id),
+        }
+    }
+    fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {}
+}
+
+impl App {
+    fn init_output_document(
         &mut self,
         api: &RenderApi,
-        builder: &mut DisplayListBuilder,
-        _resources: &mut ResourceUpdates,
-        _framebuffer_size: DeviceUintSize,
-        _pipeline_id: PipelineId,
-        document_id: DocumentId,
+        framebuffer_size: DeviceUintSize,
+        device_pixel_ratio: f32,
     ) {
-        // Build the iframe display list on first render.
-        if self.iframe_pipeline_id.is_none() {
-            let epoch = Epoch(0);
-            let root_background_color = ColorF::new(0.0, 1.0, 0.0, 1.0);
+        // Generate the external image key that will be used to render the output document to the root document.
+        self.external_image_key = Some(api.generate_image_key());
+        let mut resources = ResourceUpdates::new();
+        resources.add_image(
+            self.external_image_key.unwrap(),
+            ImageDescriptor::new(100, 100, ImageFormat::BGRA8, true),
+            ImageData::External(ExternalImageData {
+                id: ExternalImageId(0),
+                channel_index: 0,
+                image_type: ExternalImageType::Texture2DHandle
+            }),
+            None,
+        );
 
-            let iframe_pipeline_id = PipelineId(0, 1);
-            let layout_size = LayoutSize::new(100.0, 100.0);
-            let mut builder = DisplayListBuilder::new(iframe_pipeline_id, layout_size);
-            let resources = ResourceUpdates::new();
+        let pipeline_id = PipelineId(1, 0);
+        let layer = 1;
+        let color = ColorF::new(1., 1., 0., 1.);
+        let bounds = DeviceUintRect::new(DeviceUintPoint::zero(), framebuffer_size);
+        let document_id = api.add_document(framebuffer_size, layer);
 
-            let bounds = (0, 0).to(50, 50);
-            let info = LayoutPrimitiveInfo::new(bounds);
-            builder.push_stacking_context(
-                &info,
-                ScrollPolicy::Scrollable,
-                None,
-                TransformStyle::Flat,
-                None,
-                MixBlendMode::Normal,
-                Vec::new(),
-            );
+        api.set_root_pipeline(document_id, pipeline_id);
 
-            builder.push_rect(&info, ColorF::new(1.0, 1.0, 0.0, 1.0));
-            builder.pop_stacking_context();
+        let document = Document {
+            id: document_id,
+            pipeline_id,
+            content_rect: bounds.to_f32() / ScaleFactor::new(device_pixel_ratio),
+            color,
+        };
 
-            api.set_display_list(
-                document_id,
-                epoch,
-                Some(root_background_color),
-                layout_size,
-                builder.finalize(),
-                true,
-                resources,
-            );
+        let info = LayoutPrimitiveInfo::new(document.content_rect);
+        let mut builder = DisplayListBuilder::new(
+            document.pipeline_id,
+            document.content_rect.size,
+        );
 
-            self.iframe_pipeline_id = Some(iframe_pipeline_id);
-            api.enable_frame_output(document_id, iframe_pipeline_id, true);
-        }
-
-        let bounds = (100, 100).to(200, 200);
-        let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
             ScrollPolicy::Scrollable,
@@ -111,45 +113,68 @@ impl Example for App {
             Vec::new(),
         );
 
-        builder.push_iframe(&info, self.iframe_pipeline_id.unwrap());
+        builder.push_rect(&info, ColorF::new(1.0, 1.0, 0.0, 1.0));
+        builder.pop_stacking_context();
+
+        api.enable_frame_output(document.id, document.pipeline_id, true);
+        api.set_display_list(
+            document.id,
+            Epoch(0),
+            Some(document.color),
+            document.content_rect.size,
+            builder.finalize(),
+            true,
+            resources,
+        );
+        
+        api.generate_frame(document.id, None);
+        self.output_document = Some(document);
+    }
+}
+
+impl Example for App {
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        _resources: &mut ResourceUpdates,
+        framebuffer_size: DeviceUintSize,
+        _pipeline_id: PipelineId,
+        _document_id: DocumentId,
+    ) {
+        if self.output_document.is_none(){
+            let device_pixel_ratio = framebuffer_size.width as f32 /
+                builder.content_size().width;
+            self.init_output_document(api, DeviceUintSize::new(200, 200), device_pixel_ratio);
+        }
+
+        let info = LayoutPrimitiveInfo::new((100, 100).to(200, 200));
+        builder.push_stacking_context(
+            &info,
+            ScrollPolicy::Scrollable,
+            None,
+            TransformStyle::Flat,
+            None,
+            MixBlendMode::Normal,
+            Vec::new(),
+        );
+
+        builder.push_image(
+            &info,
+            info.rect.size,
+            LayoutSize::zero(),
+            ImageRendering::Auto,
+            self.external_image_key.unwrap()
+        );
 
         builder.pop_stacking_context();
     }
 
-    fn draw_custom(&self, gl: &gl::Gl) {
-        let vbo = gl.gen_buffers(1)[0];
-        let vao = gl.gen_vertex_arrays(1)[0];
-
-        let pid = create_program(gl);
-
-        let vertices: [f32; 12] = [0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0];
-
-        gl.active_texture(gl::TEXTURE0);
-        gl.bind_texture(gl::TEXTURE_2D, self.texture_id);
-
-        gl.use_program(pid);
-        let sampler = gl.get_uniform_location(pid, "s");
-        debug_assert!(sampler != -1);
-        gl.uniform_1i(sampler, 0);
-
-        gl.bind_buffer(gl::ARRAY_BUFFER, vbo);
-        gl::buffer_data(gl, gl::ARRAY_BUFFER, &vertices, gl::STATIC_DRAW);
-
-        gl.bind_vertex_array(vao);
-        gl.enable_vertex_attrib_array(0);
-        gl.vertex_attrib_pointer(0, 2, gl::FLOAT, false, 8, 0);
-
-        gl.draw_arrays(gl::TRIANGLES, 0, 6);
-
-        gl.delete_vertex_arrays(&[vao]);
-        gl.delete_buffers(&[vbo]);
-        gl.delete_program(pid);
-    }
-
-    fn get_output_image_handler(
+    fn get_image_handlers(
         &mut self,
         gl: &gl::Gl,
-    ) -> Option<Box<webrender::OutputImageHandler>> {
+    ) -> (Option<Box<webrender::ExternalImageHandler>>, 
+          Option<Box<webrender::OutputImageHandler>>) {
         let texture_id = gl.gen_textures(1)[0];
 
         gl.bind_texture(gl::TEXTURE_2D, texture_id);
@@ -186,50 +211,18 @@ impl Example for App {
         );
         gl.bind_texture(gl::TEXTURE_2D, 0);
 
-        self.texture_id = texture_id;
-        Some(Box::new(OutputHandler::new(texture_id)))
+        (   
+            Some(Box::new(ExternalHandler { texture_id })), 
+            Some(Box::new(OutputHandler { texture_id }))
+        )
     }
 }
 
 fn main() {
     let mut app = App {
-        iframe_pipeline_id: None,
-        texture_id: 0,
+        external_image_key: None,
+        output_document: None
     };
+
     boilerplate::main_wrapper(&mut app, None);
-}
-
-pub fn compile_shader(gl: &gl::Gl, shader_type: gl::GLenum, source: &str) -> gl::GLuint {
-    let id = gl.create_shader(shader_type);
-    gl.shader_source(id, &[source.as_bytes()]);
-    gl.compile_shader(id);
-    let log = gl.get_shader_info_log(id);
-    if gl.get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
-        panic!("{:?} {}", source, log);
-    }
-    id
-}
-
-pub fn create_program(gl: &gl::Gl) -> gl::GLuint {
-    let vs_id = compile_shader(gl, gl::VERTEX_SHADER, VS);
-    let fs_id = compile_shader(gl, gl::FRAGMENT_SHADER, FS);
-
-    let pid = gl.create_program();
-    gl.attach_shader(pid, vs_id);
-    gl.attach_shader(pid, fs_id);
-
-    gl.bind_attrib_location(pid, 0, "aPos");
-    gl.link_program(pid);
-
-    gl.detach_shader(pid, vs_id);
-    gl.detach_shader(pid, fs_id);
-    gl.delete_shader(vs_id);
-    gl.delete_shader(fs_id);
-
-    if gl.get_program_iv(pid, gl::LINK_STATUS) == (0 as gl::GLint) {
-        let error_log = gl.get_program_info_log(pid);
-        panic!("{}", error_log);
-    }
-
-    pid
 }

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -10,6 +10,7 @@ extern crate webrender;
 mod boilerplate;
 
 use boilerplate::{Example, HandyDandyRectBuilder};
+use gleam::gl;
 use std::mem;
 use webrender::api::*;
 
@@ -283,8 +284,12 @@ impl Example for App {
         false
     }
 
-    fn get_external_image_handler(&self) -> Option<Box<webrender::ExternalImageHandler>> {
-        Some(Box::new(ImageGenerator::new()))
+    fn get_image_handlers(
+        &mut self,
+        _gl: &gl::Gl,
+    ) -> (Option<Box<webrender::ExternalImageHandler>>, 
+          Option<Box<webrender::OutputImageHandler>>) {
+        (Some(Box::new(ImageGenerator::new())), None)
     }
 }
 


### PR DESCRIPTION
Takes care of #1695 by replacing the iframe with an external image which gets the output of a sub document piped to it.

I had to change the ordering out the `set_output_image_handler` and `set_external_image_handler` so that I'd have a generated texture ID to pass to the `ExternalImageHandler` struct.

This removes all GL calls besides generating the texture id. 

r? @glennw @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2073)
<!-- Reviewable:end -->
