### PR TITLE
Main FB clear fix for subtraction overflow

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2892,10 +2892,12 @@ impl Renderer {
                 // Note: for non-intersecting document rectangles,
                 // we can omit clearing the depth here, and instead
                 // just clear it for the whole framebuffer at start of the frame.
+                let mut clear_rect = framebuffer_target_rect.to_i32();
                 // Note: `framebuffer_target_rect` needs a Y-flip before going to GL
-                let mut clear_rect = framebuffer_target_rect;
-                clear_rect.origin.y = target_size.height - clear_rect.origin.y - clear_rect.size.height;
-                self.device.clear_target_rect(clear_color, Some(1.0), clear_rect.to_i32());
+                // Note: at this point, the target rectangle is not guaranteed to be within the main framebuffer bounds
+                // but `clear_target_rect` is totally fine with negative origin, as long as width & height are positive
+                clear_rect.origin.y = target_size.height as i32 - clear_rect.origin.y - clear_rect.size.height;
+                self.device.clear_target_rect(clear_color, Some(1.0), clear_rect);
             }
 
             self.device.disable_depth_write();


### PR DESCRIPTION
An attempt to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1418315#c9

The clear rect may end up negative because the document rectangle is provided by the user and we don't guarantee it being inside the main framebuffer anywhere. Adjusting it for the clear should be safe.

cc @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2075)
<!-- Reviewable:end -->
