### PR TITLE
Strongly typed main framebuffer pass

### DIFF
--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -190,19 +190,7 @@ impl PassList {
 
 #[derive(Serialize)]
 pub struct Pass {
-    targets: Vec<Target>,
-}
-
-impl Pass {
-    pub fn new() -> Pass {
-        Pass {
-            targets: Vec::new(),
-        }
-    }
-
-    pub fn add(&mut self, target: Target) {
-        self.targets.push(target);
-    }
+    pub targets: Vec<Target>,
 }
 
 #[derive(Serialize)]

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -665,14 +665,4 @@ impl RenderTask {
             }
         }
     }
-
-    pub fn set_alias(&mut self, id: RenderTaskId) {
-        debug_assert!(self.cache_key.is_some());
-        // TODO(gw): We can easily handle invalidation of tasks that
-        //           contain children in the future. Since we don't
-        //           have any cases of that yet, just assert to simplify
-        //           the current implementation.
-        debug_assert!(self.children.is_empty());
-        self.kind = RenderTaskKind::Alias(id);
-    }
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2892,10 +2892,12 @@ impl Renderer {
                 // Note: for non-intersecting document rectangles,
                 // we can omit clearing the depth here, and instead
                 // just clear it for the whole framebuffer at start of the frame.
+                let mut clear_rect = framebuffer_target_rect.to_i32();
                 // Note: `framebuffer_target_rect` needs a Y-flip before going to GL
-                let mut clear_rect = framebuffer_target_rect;
-                clear_rect.origin.y = target_size.height - clear_rect.origin.y - clear_rect.size.height;
-                self.device.clear_target_rect(clear_color, Some(1.0), clear_rect.to_i32());
+                // Note: at this point, the target rectangle is not guaranteed to be within the main framebuffer bounds
+                // but `clear_target_rect` is totally fine with negative origin, as long as width & height are positive
+                clear_rect.origin.y = target_size.height as i32 - clear_rect.origin.y - clear_rect.size.height;
+                self.device.clear_target_rect(clear_color, Some(1.0), clear_rect);
             }
 
             self.device.disable_depth_write();


### PR DESCRIPTION
While investigating #2075, I noticed that our render pass internals have quite a few run-time invariants related to whether the pass is associated with the main framebuffer or not. For example, the renderer would be highly confused by an alpha task in the framebuffer pass. This PR is an attempt to lift those invariants to the type level.

Overall, I'm quite satisfied with the way it looks. The ugliest part is `RenderPass:build()` function, despite my efforts to clean it up. Hopefully, we can revisit it later. Any feedback is welcome!

Gecko try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=d256bcf8719477b54208e00a295e3c61c1c1bdac

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2077)
<!-- Reviewable:end -->
