### PR TITLE
Fix clip corner optimization.

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -195,7 +195,7 @@ impl ClipWorkItem {
         for &(ref clip, _) in clips {
             match *clip {
                 ClipSource::Rectangle(..) => {
-                    if self.has_compatible_coordinate_system(prim_coordinate_system_id) {
+                    if !self.has_compatible_coordinate_system(prim_coordinate_system_id) {
                         return MaskGeometryKind::Default;
                     }
                 },


### PR DESCRIPTION
We should only be drawing a full clip mask if we encounter a clip
rect that is *not* in a compatible coordinate system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2079)
<!-- Reviewable:end -->
