### PR TITLE
RenderTargetMode with optional depth renderbuffer

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -128,6 +128,7 @@ pub fn main_wrapper<E: Example>(
     let device_pixel_ratio = window.hidpi_factor();
     println!("Device pixel ratio: {}", device_pixel_ratio);
 
+    println!("Loading shaders...");
     let opts = webrender::RendererOptions {
         resource_override_path: res_path,
         debug: true,
@@ -182,6 +183,7 @@ pub fn main_wrapper<E: Example>(
     api.set_root_pipeline(document_id, pipeline_id);
     api.generate_frame(document_id, None);
 
+    println!("Entering event loop");
     'outer: for event in window.wait_events() {
         let mut events = Vec::new();
         events.push(event);

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -8,7 +8,6 @@ use device::{Device, Program, Texture, TextureSlot, VertexDescriptor, VAO};
 use device::{TextureFilter, TextureTarget, VertexAttribute, VertexAttributeKind, VertexUsageHint};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
-use internal_types::RenderTargetMode;
 use std::f32;
 
 #[derive(Debug, Copy, Clone)]
@@ -124,7 +123,7 @@ impl DebugRenderer {
             debug_font_data::BMP_HEIGHT,
             ImageFormat::A8,
             TextureFilter::Linear,
-            RenderTargetMode::None,
+            None,
             1,
             Some(&debug_font_data::FONT_BITMAP),
         );

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -82,9 +82,8 @@ impl BatchTextures {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum RenderTargetMode {
-    None,
-    RenderTarget,
+pub struct RenderTargetInfo {
+    pub has_depth: bool,
 }
 
 #[derive(Debug)]
@@ -103,7 +102,7 @@ pub enum TextureUpdateOp {
         height: u32,
         format: ImageFormat,
         filter: TextureFilter,
-        mode: RenderTargetMode,
+        render_target: Option<RenderTargetInfo>,
         layer_count: i32,
     },
     Update {

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -9,7 +9,7 @@ use device::TextureFilter;
 use frame::FrameId;
 use freelist::{FreeList, FreeListHandle, UpsertResult, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle};
-use internal_types::{CacheTextureId, RenderTargetMode, TextureUpdateList, TextureUpdateSource};
+use internal_types::{CacheTextureId, TextureUpdateList, TextureUpdateSource};
 use internal_types::{SourceTexture, TextureUpdate, TextureUpdateOp};
 use profiler::{ResourceProfileCounter, TextureCacheProfileCounters};
 use resource_cache::CacheItem;
@@ -106,7 +106,7 @@ impl CacheEntry {
         filter: TextureFilter,
         user_data: [f32; 3],
         last_access: FrameId,
-    ) -> CacheEntry {
+    ) -> Self {
         CacheEntry {
             size,
             user_data,
@@ -206,7 +206,7 @@ pub struct TextureCache {
 }
 
 impl TextureCache {
-    pub fn new(max_texture_size: u32) -> TextureCache {
+    pub fn new(max_texture_size: u32) -> Self {
         TextureCache {
             max_texture_size,
             array_a8_linear: TextureArray::new(
@@ -581,8 +581,8 @@ impl TextureCache {
                     height: TEXTURE_LAYER_DIMENSIONS,
                     format: descriptor.format,
                     filter: texture_array.filter,
+                    render_target: None,
                     layer_count: texture_array.layer_count as i32,
-                    mode: RenderTargetMode::RenderTarget, // todo: !!!! remove me!?
                 },
             };
             self.pending_updates.push(update_op);
@@ -670,7 +670,7 @@ impl TextureCache {
                     height: descriptor.height,
                     format: descriptor.format,
                     filter,
-                    mode: RenderTargetMode::RenderTarget,
+                    render_target: None,
                     layer_count: 1,
                 },
             };


### PR DESCRIPTION
This PR figures out automatically if a depth buffer is needed for each target. This is needed in order to provide the following use case for Gecko: having a document covering full screen, with only (transparent, non-intersecting) rounded corners in it. The old code would force the depth clearing, which is expensive.

A nice side effect is that we are no longer allocating the depth buffer for alpha targets and potentially other things, which is saving us VRAM.

Gecko try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=a9d2832688547665dd928f9a513abfb9c76d50bd

cc @mstange 
r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2081)
<!-- Reviewable:end -->
