### PR TITLE
Improve the shader precache code.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -924,7 +924,18 @@ impl LazilyCompiledShader {
         };
 
         if precache {
-            try!{ shader.get(device) };
+            let t0 = precise_time_ns();
+            let program = try!{ shader.get(device) };
+            let t1 = precise_time_ns();
+            device.bind_program(program);
+            device.draw_triangles_u16(0, 3);
+            let t2 = precise_time_ns();
+            println!("[C: {:.1} ms D: {:.1} ms] Precache {} {:?}",
+                (t1 - t0) as f64 / 1000000.0,
+                (t2 - t1) as f64 / 1000000.0,
+                name,
+                features
+            );
         }
 
         Ok(shader)

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -4,6 +4,10 @@ author: Vladimir Vukicevic <vladimir@pobox.com>
 about: WebRender testing and debugging utility
 
 args:
+  - precache:
+      short: c
+      long: precache
+      help: Precache shaders
   - verbose:
       short: v
       long: verbose

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -374,6 +374,7 @@ fn main() {
         args.is_present("verbose"),
         args.is_present("no_scissor"),
         args.is_present("no_batch"),
+        args.is_present("precache"),
         notifier,
     );
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -153,6 +153,7 @@ impl Wrench {
         verbose: bool,
         no_scissor: bool,
         no_batch: bool,
+        precache_shaders: bool,
         notifier: Option<Box<RenderNotifier>>,
     ) -> Self {
         println!("Shader override path: {:?}", shader_override_path);
@@ -182,6 +183,7 @@ impl Wrench {
             debug_flags,
             enable_clear_scissor: !no_scissor,
             max_recorded_profiles: 16,
+            precache_shaders,
             blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new())),
             ..Default::default()
         };


### PR DESCRIPTION
* In precache mode, also issue a draw call after compiling the shader.
  On some drivers, much of the work is deferred until the first
  draw call is issued.
* Record the time for each precaching compilation and log it.
* Add support for shader precache option to wrench.

These options help with benchmarking, to ensure there are no
stalls during benchmarks caused by shader compilation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2090)
<!-- Reviewable:end -->
