### PR TITLE
Support hit testing for ImageMasks

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -103,15 +103,17 @@ impl From<ClipRegion> for ClipSources {
 
 impl ClipSource {
     pub fn contains(&self, point: &LayerPoint) -> bool {
-        // We currently do not handle all types of clip sources, because they
-        // aren't used for ClipScrollNodes and this method is only used during hit testing.
+        // We currently do not handle all BorderCorners, because they aren't used for
+        // ClipScrollNodes and this method is only used during hit testing.
         match self {
             &ClipSource::Rectangle(ref rectangle) => rectangle.contains(point),
             &ClipSource::RoundedRectangle(rect, radii, ClipMode::Clip) =>
                 rounded_rectangle_contains_point(point, &rect, &radii),
             &ClipSource::RoundedRectangle(rect, radii, ClipMode::ClipOut) =>
                 !rounded_rectangle_contains_point(point, &rect, &radii),
-            _ => unreachable!("Tried to call contains on an unsupported ClipSource."),
+            &ClipSource::Image(mask) => mask.rect.contains(point),
+            &ClipSource::BorderCorner(_) =>
+                unreachable!("Tried to call contains on a BorderCornerr."),
         }
     }
 


### PR DESCRIPTION
Now that Gecko is using WebRender hit testing we need to support this
type of ClipSource. For now we just check whether the point is inside
the masked region.

Fixes #2065.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2092)
<!-- Reviewable:end -->
