### PR TITLE
ensure that we request glyphs without a transform for text shadows

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -25,7 +25,7 @@ use internal_types::{FastHashMap, FastHashSet};
 use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, RasterizationSpace};
 use prim_store::{TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
-use prim_store::{PrimitiveContainer, PrimitiveIndex};
+use prim_store::{PrimitiveContainer, PrimitiveIndex, SpecificPrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{RectangleContent, RectanglePrimitive, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
@@ -1582,6 +1582,7 @@ impl FrameBuilder {
             profile_counters,
             None,
             scene_properties,
+            SpecificPrimitiveIndex(0),
         );
 
         let pic = &mut self.prim_store.cpu_pictures[0];

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -20,7 +20,7 @@ use gpu_types::{CompositePrimitiveInstance, PrimitiveInstance, SimplePrimitiveIn
 use gpu_types::{ClipScrollNodeIndex, ClipScrollNodeData};
 use internal_types::{FastHashMap, SourceTexture};
 use internal_types::BatchTextures;
-use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
+use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, RasterizationSpace};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
 use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, PrimitiveRun, RectangleContent};
@@ -547,6 +547,7 @@ fn add_to_batch(
             let font = text_cpu.get_font(
                 ctx.device_pixel_ratio,
                 &scroll_node.transform,
+                RasterizationSpace::Screen,
             );
 
             ctx.resource_cache.fetch_glyphs(
@@ -1483,6 +1484,7 @@ impl RenderTarget for ColorRenderTarget {
                                                 let font = text.get_font(
                                                     ctx.device_pixel_ratio,
                                                     &LayerToWorldTransform::identity(),
+                                                    RasterizationSpace::Local,
                                                 );
 
                                                 ctx.resource_cache.fetch_glyphs(

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -39,3 +39,4 @@ fuzzy(1,44) platform(linux) == text-masking.yaml text-masking-subpx.png
 platform(linux) == subpixel-rotate.yaml subpixel-rotate.png
 platform(linux) == subpixel-scale.yaml subpixel-scale.png
 platform(linux) == subpixel-skew.yaml subpixel-skew.png
+!= shadow-rotate.yaml blank.yaml

--- a/wrench/reftests/text/shadow-rotate.yaml
+++ b/wrench/reftests/text/shadow-rotate.yaml
@@ -1,4 +1,4 @@
---- checks that transformed text shadows can locate glyphs in the glyph cache
+--- #checks that transformed text shadows can locate glyphs in the glyph cache
 root:
   items:
     - type: stacking-context

--- a/wrench/reftests/text/shadow-rotate.yaml
+++ b/wrench/reftests/text/shadow-rotate.yaml
@@ -1,0 +1,18 @@
+--- checks that transformed text shadows can locate glyphs in the glyph cache
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 430, 330]
+      transform: rotate(30)
+      items:
+      - type: "shadow"
+        bounds: [0, 0, 430, 330]
+        blur-radius: 1
+        offset: [0, 1]
+        color: blue
+      - text: "a Bcd Efgh Ijklm Nopqrs Tuvwxyz"
+        origin: 50 200
+        size: 20
+        font: "FreeSans.ttf"
+      - type: "pop-all-shadows"
+


### PR DESCRIPTION
This passes down the rasterization space information into TextRunPrimitiveCpu::prepare_for_render, so that we can ensure glyph requests are kicked off with no transform for text shadows (as discussed with gw). Text shadows do not supply a any transform when calling fetch_glyphs, so if we don't make sure to request the glyphs without a transform, this will cause the crash in issue #2093. Crashtest supplied courtesy of mstange.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2094)
<!-- Reviewable:end -->
