### PR TITLE
Fix mix-blend mode early return bug.

### DIFF
--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -207,10 +207,6 @@ void main(void) {
     vec4 Cb = texture(sCacheRGBA8, vUv0);
     vec4 Cs = texture(sCacheRGBA8, vUv1);
 
-    // The mix-blend-mode functions assume no premultiplied alpha
-    Cb.rgb /= Cb.a;
-    Cs.rgb /= Cs.a;
-
     if (Cb.a == 0.0) {
         oFragColor = Cs;
         return;
@@ -219,6 +215,10 @@ void main(void) {
         oFragColor = vec4(0.0, 0.0, 0.0, 0.0);
         return;
     }
+
+    // The mix-blend-mode functions assume no premultiplied alpha
+    Cb.rgb /= Cb.a;
+    Cs.rgb /= Cs.a;
 
     // Return yellow if none of the branches match (shouldn't happen).
     vec4 result = vec4(1.0, 1.0, 0.0, 1.0);

--- a/wrench/reftests/blend/isolated-premultiplied-2-ref.yaml
+++ b/wrench/reftests/blend/isolated-premultiplied-2-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+        - type: rect
+          bounds: [0, 0, 100, 100]
+          color: [229, 239, 229]

--- a/wrench/reftests/blend/isolated-premultiplied-2.yaml
+++ b/wrench/reftests/blend/isolated-premultiplied-2.yaml
@@ -1,0 +1,13 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 100, 100]
+      items:
+        - type: stacking-context
+          bounds: [0, 0, 100, 100]
+          mix-blend-mode: lighten
+          items:
+          - type: rect
+            bounds: [0, 0, 100, 100]
+            color: [0, 100, 0, 0.1]

--- a/wrench/reftests/blend/reftest.list
+++ b/wrench/reftests/blend/reftest.list
@@ -12,6 +12,7 @@ fuzzy(1,10000) == difference-transparent.yaml difference-transparent-ref.yaml
 == isolated-2.yaml isolated-2-ref.yaml
 == isolated-with-filter.yaml isolated-ref.yaml
 == isolated-premultiplied.yaml blank.yaml
+== isolated-premultiplied-2.yaml isolated-premultiplied-2-ref.yaml
 
 == large.yaml large-ref.yaml
 


### PR DESCRIPTION
We un-premultiplied alpha before the early return but we don't multiply the alpha in the early return. So I just put the action of un-premultiplied alpha later. A related gecko bug is [bug 1414575](https://bugzilla.mozilla.org/show_bug.cgi?id=1414575).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2096)
<!-- Reviewable:end -->
