### PR TITLE
Better ClipChain optimization

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, ComplexClipRegion, DeviceIntRect, ImageMask, ImageRendering, LayerPoint};
-use api::{ClipMode, LayerRect, LayerSize};
+use api::{ClipMode, LayerRect};
 use api::{LayerToWorldTransform, LayoutPoint, LayoutVector2D, LocalClip};
 use border::BorderCornerClipSource;
 use ellipse::Ellipse;
@@ -11,9 +11,7 @@ use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use prim_store::{ClipData, ImageMaskData};
 use resource_cache::ResourceCache;
-use util::{extract_inner_rect_safe, TransformedRect};
-
-pub const MAX_CLIP: f32 = 1000000.0;
+use util::{extract_inner_rect_safe, MaxRect, TransformedRect};
 
 pub type ClipStore = FreeList<ClipSources>;
 pub type ClipSourcesHandle = FreeListHandle<ClipSources>;
@@ -122,11 +120,14 @@ impl ClipSource {
 #[derive(Debug)]
 pub struct ClipSources {
     pub clips: Vec<(ClipSource, GpuCacheHandle)>,
-    pub bounds: MaskBounds,
+    pub local_inner_rect: LayerRect,
+    pub local_outer_rect: Option<LayerRect>
 }
 
 impl ClipSources {
     pub fn new(clips: Vec<ClipSource>) -> ClipSources {
+        let (local_inner_rect, local_outer_rect) = Self::calculate_inner_and_outer_rects(&clips);
+
         let clips = clips
             .into_iter()
             .map(|clip| (clip, GpuCacheHandle::new()))
@@ -134,10 +135,8 @@ impl ClipSources {
 
         ClipSources {
             clips,
-            bounds: MaskBounds {
-                inner: None,
-                outer: None,
-            },
+            local_inner_rect,
+            local_outer_rect,
         }
     }
 
@@ -145,84 +144,82 @@ impl ClipSources {
         &self.clips
     }
 
-    pub fn update(
-        &mut self,
-        layer_transform: &LayerToWorldTransform,
-        gpu_cache: &mut GpuCache,
-        resource_cache: &mut ResourceCache,
-        device_pixel_ratio: f32,
-    ) {
-        if self.clips.is_empty() {
-            return;
+    fn calculate_inner_and_outer_rects(clips: &Vec<ClipSource>) -> (LayerRect, Option<LayerRect>) {
+        if clips.is_empty() {
+            return (LayerRect::zero(), None);
         }
 
-        // compute the local bounds
-        if self.bounds.inner.is_none() {
-            let mut local_rect = Some(LayerRect::new(
-                LayerPoint::new(-MAX_CLIP, -MAX_CLIP),
-                LayerSize::new(2.0 * MAX_CLIP, 2.0 * MAX_CLIP),
-            ));
-            let mut local_inner = local_rect;
-            let mut has_clip_out = false;
-            let mut has_border_clip = false;
+        // Depending on the complexity of the clip, we may either know the outer and/or inner
+        // rect, or neither or these.  In the case of a clip-out, we currently set the mask bounds
+        // to be unknown. This is conservative, but ensures correctness. In the future we can make
+        // this a lot more clever with some proper region handling.
+        let mut local_outer = Some(LayerRect::max_rect());
+        let mut local_inner = local_outer;
+        let mut can_calculate_inner_rect = true;
+        let mut can_calculate_outer_rect = true;
+        for source in clips {
+            match *source {
+                ClipSource::Image(ref mask) => {
+                    if !mask.repeat {
+                        local_outer = local_outer.and_then(|r| r.intersection(&mask.rect));
+                        can_calculate_inner_rect = false;
+                    } else {
+                        can_calculate_inner_rect = false;
+                        can_calculate_outer_rect = false;
+                        break;
+                    }
+                    local_inner = None;
+                }
+                ClipSource::Rectangle(rect) => {
+                    local_outer = local_outer.and_then(|r| r.intersection(&rect));
+                    local_inner = local_inner.and_then(|r| r.intersection(&rect));
+                }
+                ClipSource::RoundedRectangle(ref rect, ref radius, mode) => {
+                    // Once we encounter a clip-out, we just assume the worst
+                    // case clip mask size, for now.
+                    if mode == ClipMode::ClipOut {
+                        can_calculate_inner_rect = false;
+                        can_calculate_outer_rect = false;
+                        break;
+                    }
 
-            for &(ref source, _) in &self.clips {
-                match *source {
-                    ClipSource::Image(ref mask) => {
-                        if !mask.repeat {
-                            local_rect = local_rect.and_then(|r| r.intersection(&mask.rect));
-                        }
-                        local_inner = None;
-                    }
-                    ClipSource::Rectangle(rect) => {
-                        local_rect = local_rect.and_then(|r| r.intersection(&rect));
-                        local_inner = local_inner.and_then(|r| r.intersection(&rect));
-                    }
-                    ClipSource::RoundedRectangle(ref rect, ref radius, mode) => {
-                        // Once we encounter a clip-out, we just assume the worst
-                        // case clip mask size, for now.
-                        if mode == ClipMode::ClipOut {
-                            has_clip_out = true;
-                        }
+                    local_outer = local_outer.and_then(|r| r.intersection(rect));
 
-                        local_rect = local_rect.and_then(|r| r.intersection(rect));
-
-                        let inner_rect = extract_inner_rect_safe(rect, radius);
-                        local_inner = local_inner
-                            .and_then(|r| inner_rect.and_then(|ref inner| r.intersection(inner)));
-                    }
-                    ClipSource::BorderCorner { .. } => {
-                        has_border_clip = true;
-                    }
+                    let inner_rect = extract_inner_rect_safe(rect, radius);
+                    local_inner = local_inner
+                        .and_then(|r| inner_rect.and_then(|ref inner| r.intersection(inner)));
+                }
+                ClipSource::BorderCorner { .. } => {
+                    can_calculate_inner_rect = false;
+                    can_calculate_outer_rect = false;
+                    break;
                 }
             }
-
-            // Work out the type of mask geometry we have, based on the
-            // list of clip sources above.
-            self.bounds = if has_clip_out || has_border_clip {
-                // For clip-out, the mask rect is not known.
-                MaskBounds {
-                    outer: None,
-                    inner: Some(LayerRect::zero().into()),
-                }
-            } else {
-                MaskBounds {
-                    outer: Some(local_rect.unwrap_or(LayerRect::zero()).into()),
-                    inner: Some(local_inner.unwrap_or(LayerRect::zero()).into()),
-                }
-            };
         }
 
-        // update the screen bounds
-        self.bounds.update(layer_transform, device_pixel_ratio);
+        let outer = match can_calculate_outer_rect {
+            true => local_outer,
+            false => None,
+        };
 
+        let inner = match can_calculate_inner_rect {
+            true => local_inner.unwrap_or(LayerRect::zero()),
+            false => LayerRect::zero(),
+        };
+
+        (inner, outer)
+    }
+
+    pub fn update(
+        &mut self,
+        gpu_cache: &mut GpuCache,
+        resource_cache: &mut ResourceCache,
+    ) {
         for &mut (ref mut source, ref mut handle) in &mut self.clips {
             if let Some(mut request) = gpu_cache.request(handle) {
                 match *source {
                     ClipSource::Image(ref mask) => {
-                        let data = ImageMaskData {
-                            local_rect: mask.rect,
-                        };
+                        let data = ImageMaskData { local_rect: mask.rect };
                         data.write_gpu_blocks(request);
                     }
                     ClipSource::Rectangle(rect) => {
@@ -238,10 +235,8 @@ impl ClipSources {
                     }
                 }
             }
-        }
 
-        for &(ref clip, _) in &self.clips {
-            if let ClipSource::Image(ref mask) = *clip {
+            if let ClipSource::Image(ref mask) = *source {
                 resource_cache.request_image(mask.image, ImageRendering::Auto, None, gpu_cache);
             }
         }
@@ -250,6 +245,20 @@ impl ClipSources {
     /// Whether or not this ClipSources has any clips (does any clipping).
     pub fn has_clips(&self) -> bool {
         !self.clips.is_empty()
+    }
+
+    pub fn get_screen_bounds(
+        &self,
+        transform: &LayerToWorldTransform,
+        device_pixel_ratio: f32,
+    ) -> (DeviceIntRect, Option<DeviceIntRect>) {
+        let screen_inner_rect =
+            TransformedRect::new(&self.local_inner_rect, transform, device_pixel_ratio);
+        let screen_outer_rect = self.local_outer_rect.map(|outer_rect|
+            TransformedRect::new(&outer_rect, transform, device_pixel_ratio).bounding_rect
+        );
+
+        (screen_inner_rect.bounding_rect, screen_outer_rect)
     }
 }
 
@@ -266,33 +275,6 @@ impl From<LayerRect> for Geometry {
         Geometry {
             local_rect,
             device_rect: DeviceIntRect::zero(),
-        }
-    }
-}
-
-/// Depending on the complexity of the clip, we may either
-/// know the outer and/or inner rect, or neither or these.
-/// In the case of a clip-out, we currently set the mask
-/// bounds to be unknown. This is conservative, but ensures
-/// correctness. In the future we can make this a lot
-/// more clever with some proper region handling.
-#[derive(Clone, Debug, PartialEq)]
-pub struct MaskBounds {
-    pub outer: Option<Geometry>,
-    pub inner: Option<Geometry>,
-}
-
-impl MaskBounds {
-    pub fn update(&mut self, transform: &LayerToWorldTransform, device_pixel_ratio: f32) {
-        if let Some(ref mut outer) = self.outer {
-            let transformed =
-                TransformedRect::new(&outer.local_rect, transform, device_pixel_ratio);
-            outer.device_rect = transformed.bounding_rect;
-        }
-        if let Some(ref mut inner) = self.inner {
-            let transformed =
-                TransformedRect::new(&inner.local_rect, transform, device_pixel_ratio);
-            inner.device_rect = transformed.inner_rect;
         }
     }
 }

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -25,8 +25,6 @@ const CAN_OVERSCROLL: bool = true;
 #[cfg(not(target_os = "macos"))]
 const CAN_OVERSCROLL: bool = false;
 
-const MAX_LOCAL_VIEWPORT: f32 = 1000000.0;
-
 #[derive(Debug)]
 pub struct StickyFrameInfo {
     pub margins: SideOffsets2D<Option<f32>>,
@@ -294,10 +292,7 @@ impl ClipScrollNode {
         );
 
         let local_clip_rect = if self.world_content_transform.has_perspective_component() {
-            LayerRect::new(
-                LayerPoint::new(-MAX_LOCAL_VIEWPORT, -MAX_LOCAL_VIEWPORT),
-                LayerSize::new(2.0 * MAX_LOCAL_VIEWPORT, 2.0 * MAX_LOCAL_VIEWPORT)
-            )
+            LayerRect::max_rect()
         } else {
             self.combined_local_viewport_rect
         };
@@ -332,7 +327,7 @@ impl ClipScrollNode {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
     ) {
-        let current_clip_chain = state.parent_clip_chain.clone();
+        let mut current_clip_chain = state.parent_clip_chain.clone();
         let clip_sources_handle = match self.node_type {
             NodeType::Clip(ref handle) => handle,
             _ => {
@@ -343,32 +338,53 @@ impl ClipScrollNode {
         };
 
         let clip_sources = clip_store.get_mut(clip_sources_handle);
-        clip_sources.update(
-            &self.world_viewport_transform,
-            gpu_cache,
-            resource_cache,
-            device_pixel_ratio,
-        );
+        clip_sources.update(gpu_cache, resource_cache);
+        let (screen_inner_rect, screen_outer_rect) =
+            clip_sources.get_screen_bounds(&self.world_viewport_transform, device_pixel_ratio);
 
-        let outer_bounds = clip_sources.bounds.outer.as_ref().map_or_else(
-            DeviceIntRect::zero,
-            |rect| rect.device_rect
-        );
+        // If this clip's inner rectangle completely surrounds the existing clip
+        // chain's outer rectangle, we can discard this clip entirely since it isn't
+        // going to affect anything.
+        if screen_inner_rect.contains_rect(&state.combined_outer_clip_bounds) {
+            self.clip_chain_node = current_clip_chain;
+            self.combined_clip_outer_bounds = state.combined_outer_clip_bounds;
+            return;
+        }
 
-        self.combined_clip_outer_bounds = outer_bounds.intersection(
-            &state.combined_outer_clip_bounds).unwrap_or_else(DeviceIntRect::zero);
+        let combined_outer_screen_rect = match screen_outer_rect {
+            Some(outer_rect) => {
+                // If this clips outer rectangle is completely enclosed by the clip
+                // chain's inner rectangle, then the only clip that matters from this point
+                // on is this clip. We can disconnect this clip from the parent clip chain.
+                if state.combined_inner_clip_bounds.contains_rect(&outer_rect) {
+                    current_clip_chain = None;
+                }
+                outer_rect.intersection(&state.combined_outer_clip_bounds)
+                    .unwrap_or_else(DeviceIntRect::zero)
+            }
+            None => state.combined_outer_clip_bounds,
+        };
 
-        // TODO: Combine rectangles in the same axis-aligned clip space here?
+        let combined_inner_screen_rect =
+            state.combined_inner_clip_bounds.intersection(&screen_inner_rect)
+            .unwrap_or_else(DeviceIntRect::zero);
+
+        state.combined_outer_clip_bounds = combined_outer_screen_rect;
+        state.combined_inner_clip_bounds = combined_inner_screen_rect;
+        self.combined_clip_outer_bounds = combined_outer_screen_rect;
+
         self.clip_chain_node = Some(Rc::new(ClipChainNode {
             work_item: ClipWorkItem {
                 scroll_node_data_index: self.node_data_index,
                 clip_sources: clip_sources_handle.weak(),
                 coordinate_system_id: state.current_coordinate_system_id,
             },
+            screen_inner_rect,
+            combined_outer_screen_rect,
+            combined_inner_screen_rect,
             prev: current_clip_chain,
         }));
 
-        state.combined_outer_clip_bounds = self.combined_clip_outer_bounds;
         state.parent_clip_chain = self.clip_chain_node.clone();
     }
 

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -14,6 +14,7 @@ use print_tree::{PrintTree, PrintTreePrinter};
 use render_task::ClipChain;
 use resource_cache::ResourceCache;
 use scene::SceneProperties;
+use util::MaxRect;
 
 pub type ScrollStates = FastHashMap<ClipId, ScrollingState>;
 
@@ -66,6 +67,7 @@ pub struct TransformUpdateState {
     pub nearest_scrolling_ancestor_viewport: LayerRect,
     pub parent_clip_chain: ClipChain,
     pub combined_outer_clip_bounds: DeviceIntRect,
+    pub combined_inner_clip_bounds: DeviceIntRect,
 
     /// An id for keeping track of the axis-aligned space of this node. This is used in
     /// order to to track what kinds of clip optimizations can be done for a particular
@@ -355,6 +357,7 @@ impl ClipScrollTree {
             nearest_scrolling_ancestor_viewport: LayerRect::zero(),
             parent_clip_chain: None,
             combined_outer_clip_bounds: *screen_rect,
+            combined_inner_clip_bounds: DeviceIntRect::max_rect(),
             current_coordinate_system_id: CoordinateSystemId(0),
             next_coordinate_system_id: CoordinateSystemId(0).next(),
         };

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -18,8 +18,8 @@ use gpu_cache::{GpuBlockData, GpuCache, GpuCacheAddress, GpuCacheHandle, GpuData
                 ToGpuBlocks};
 use picture::{PictureKind, PicturePrimitive, RasterizationSpace};
 use profiler::FrameProfileCounters;
-use render_task::{ClipWorkItem, ClipChainNode};
-use render_task::{RenderTask, RenderTaskId, RenderTaskTree};
+use render_task::{ClipChainNode, ClipChainNodeIter, ClipWorkItem, RenderTask, RenderTaskId};
+use render_task::RenderTaskTree;
 use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 use resource_cache::{ImageProperties, ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
@@ -1233,7 +1233,8 @@ impl PrimitiveStore {
         &mut self,
         prim_index: PrimitiveIndex,
         prim_context: &PrimitiveContext,
-        prim_screen_rect: DeviceIntRect,
+        prim_screen_rect: &DeviceIntRect,
+        screen_rect: &DeviceIntRect,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
@@ -1242,64 +1243,111 @@ impl PrimitiveStore {
     ) -> bool {
         let metadata = &mut self.cpu_metadata[prim_index.0];
         metadata.clip_task_id = None;
+
+        let prim_screen_rect = match prim_screen_rect.intersection(screen_rect) {
+            Some(rect) => rect,
+            None => {
+                metadata.screen_rect = None;
+                return false;
+            }
+        };
+
+        let clip_chain = prim_context.clip_node.clip_chain_node.clone();
+        let mut combined_outer_rect = match clip_chain {
+            Some(ref node) => prim_screen_rect.intersection(&node.combined_outer_screen_rect),
+            None => Some(prim_screen_rect),
+        };
+
+        let prim_coordinate_system_id = prim_context.scroll_node.coordinate_system_id;
         let transform = &prim_context.scroll_node.world_content_transform;
+        let extra_clip =  {
+            let prim_clips = clip_store.get_mut(&metadata.clip_sources);
+            if prim_clips.has_clips() {
+                prim_clips.update(gpu_cache, resource_cache);
+                let (screen_inner_rect, screen_outer_rect) =
+                    prim_clips.get_screen_bounds(transform, prim_context.device_pixel_ratio);
 
-        clip_store.get_mut(&metadata.clip_sources).update(
-            transform,
-            gpu_cache,
-            resource_cache,
-            prim_context.device_pixel_ratio,
-        );
+                if let Some(outer) = screen_outer_rect {
+                    combined_outer_rect = combined_outer_rect.and_then(|r| r.intersection(&outer));
+                }
 
-        // Try to create a mask if we may need to.
-        let prim_clips = clip_store.get(&metadata.clip_sources);
-        let is_axis_aligned = transform.transform_kind() == TransformedRectKind::AxisAligned;
-
-        let has_clips = prim_context.clip_node.clip_chain_node.is_some() || prim_clips.has_clips();
-        let clip_task = if has_clips {
-            // Take into account the actual clip info of the primitive, and
-            // mutate the current bounds accordingly.
-            let mask_rect = match prim_clips.bounds.outer {
-                Some(ref outer) => match prim_screen_rect.intersection(&outer.device_rect) {
-                    Some(rect) => rect,
-                    None => {
-                        metadata.screen_rect = None;
-                        return false;
-                    }
-                },
-                _ => prim_screen_rect,
-            };
-
-            let extra_clip = if prim_clips.has_clips() {
                 Some(Rc::new(ClipChainNode {
                     work_item: ClipWorkItem {
                         scroll_node_data_index: prim_context.scroll_node.node_data_index,
                         clip_sources: metadata.clip_sources.weak(),
-                        coordinate_system_id: prim_context.scroll_node.coordinate_system_id,
+                        coordinate_system_id: prim_coordinate_system_id,
                     },
+                    screen_inner_rect,
+                    combined_outer_screen_rect:
+                        combined_outer_rect.unwrap_or_else(DeviceIntRect::zero),
+                    combined_inner_screen_rect: DeviceIntRect::zero(),
                     prev: None,
                 }))
             } else {
                 None
-            };
-
-            RenderTask::new_mask(
-                None,
-                mask_rect,
-                prim_context.clip_node.clip_chain_node.clone(),
-                extra_clip,
-                prim_screen_rect,
-                clip_store,
-                is_axis_aligned,
-                prim_context.scroll_node.coordinate_system_id,
-            )
-        } else {
-            None
+            }
         };
+
+        // If everything is clipped out, then we don't need to render this primitive.
+        let combined_outer_rect = match combined_outer_rect {
+            Some(rect) if !rect.is_empty() => rect,
+            _ => {
+                metadata.screen_rect = None;
+                return false;
+            }
+        };
+
+        // Filter out all the clip instances that don't contribute to the result.
+        let mut combined_inner_rect = *screen_rect;
+        let clips: Vec<_> = ClipChainNodeIter { current: extra_clip }
+            .chain(ClipChainNodeIter { current: clip_chain })
+            .take_while(|node| {
+                !node.combined_inner_screen_rect.contains_rect(&combined_outer_rect)
+            })
+            .filter_map(|node| {
+                combined_inner_rect = if !node.screen_inner_rect.is_empty() {
+                    // If this clip's inner area contains the area of the primitive clipped
+                    // by previous clips, then it's not going to affect rendering in any way.
+                    if node.screen_inner_rect.contains_rect(&combined_outer_rect) {
+                        return None;
+                    }
+                    combined_inner_rect.intersection(&node.screen_inner_rect)
+                        .unwrap_or_else(DeviceIntRect::zero)
+                } else {
+                    DeviceIntRect::zero()
+                };
+
+                Some(node.work_item.clone())
+            })
+            .collect();
+
+        if clips.is_empty() {
+            // If we have filtered all clips and the screen rect isn't any smaller, we can just
+            // skip masking entirely.
+            if combined_outer_rect == prim_screen_rect {
+                return true;
+            }
+            // Otherwise we create an empty mask, but with an empty inner rect to avoid further
+            // optimization of the empty mask.
+            combined_inner_rect = DeviceIntRect::zero();
+        }
+
+        if combined_inner_rect.contains_rect(&prim_screen_rect) {
+           return true;
+        }
+
+        let clip_task = RenderTask::new_mask(
+            None,
+            combined_outer_rect,
+            combined_inner_rect,
+            clips,
+            clip_store,
+            transform.transform_kind() == TransformedRectKind::AxisAligned,
+            prim_coordinate_system_id,
+        );
 
         if let Some(clip_task) = clip_task {
             let clip_task_id = render_tasks.add(clip_task);
-
             metadata.clip_task_id = Some(clip_task_id);
             tasks.push(clip_task_id);
         }
@@ -1322,6 +1370,7 @@ impl PrimitiveStore {
         scene_properties: &SceneProperties,
         profile_counters: &mut FrameProfileCounters,
         pic_index: SpecificPrimitiveIndex,
+        screen_rect: &DeviceIntRect,
     ) -> Option<LayerRect> {
         // Reset the visibility of this primitive.
         // Do some basic checks first, that can early out
@@ -1381,6 +1430,7 @@ impl PrimitiveStore {
                 rfid,
                 scene_properties,
                 cpu_prim_index,
+                screen_rect,
             );
 
             let metadata = &mut self.cpu_metadata[prim_index.0];
@@ -1395,7 +1445,7 @@ impl PrimitiveStore {
             );
         }
 
-        let (local_rect, device_rect) = {
+        let (local_rect, unclipped_device_rect) = {
             let metadata = &mut self.cpu_metadata[prim_index.0];
             if metadata.local_rect.size.width <= 0.0 ||
                metadata.local_rect.size.height <= 0.0 {
@@ -1403,10 +1453,7 @@ impl PrimitiveStore {
                 return None;
             }
 
-            let local_rect = metadata
-                .local_rect
-                .intersection(&metadata.local_clip_rect);
-
+            let local_rect = metadata.local_rect.intersection(&metadata.local_clip_rect);
             let local_rect = match local_rect {
                 Some(local_rect) => local_rect,
                 None if perform_culling => return None,
@@ -1420,27 +1467,20 @@ impl PrimitiveStore {
             );
 
             let clip_bounds = &prim_context.clip_node.combined_clip_outer_bounds;
-            metadata.screen_rect = xf_rect.bounding_rect
-                                          .intersection(clip_bounds);
+            metadata.screen_rect = xf_rect.bounding_rect.intersection(clip_bounds);
 
-            let device_rect = match metadata.screen_rect {
-                Some(device_rect) => device_rect,
-                None => {
-                    if perform_culling {
-                        return None
-                    } else {
-                        DeviceIntRect::zero()
-                    }
-                }
-            };
+            if metadata.screen_rect.is_none() && perform_culling {
+                return None;
+            }
 
-            (local_rect, device_rect)
+            (local_rect, xf_rect.bounding_rect)
         };
 
         if !self.update_clip_task(
             prim_index,
             prim_context,
-            device_rect,
+            &unclipped_device_rect,
+            screen_rect,
             resource_cache,
             gpu_cache,
             render_tasks,
@@ -1489,6 +1529,7 @@ impl PrimitiveStore {
         original_reference_frame_id: Option<ClipId>,
         scene_properties: &SceneProperties,
         pic_index: SpecificPrimitiveIndex,
+        screen_rect: &DeviceIntRect,
     ) -> PrimitiveRunLocalRect {
         let mut result = PrimitiveRunLocalRect {
             local_rect_in_actual_parent_space: LayerRect::zero(),
@@ -1555,6 +1596,7 @@ impl PrimitiveStore {
                     scene_properties,
                     profile_counters,
                     pic_index,
+                    screen_rect,
                 ) {
                     profile_counters.visible_primitives.inc();
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -36,11 +36,14 @@ pub type ClipChain = Option<Rc<ClipChainNode>>;
 #[derive(Debug)]
 pub struct ClipChainNode {
     pub work_item: ClipWorkItem,
+    pub screen_inner_rect: DeviceIntRect,
+    pub combined_outer_screen_rect: DeviceIntRect,
+    pub combined_inner_screen_rect: DeviceIntRect,
     pub prev: ClipChain,
 }
 
-struct ClipChainNodeIter {
-    current: ClipChain,
+pub struct ClipChainNodeIter {
+    pub current: ClipChain,
 }
 
 impl Iterator for ClipChainNodeIter {
@@ -326,79 +329,33 @@ impl RenderTask {
 
     pub fn new_mask(
         key: Option<ClipId>,
-        task_rect: DeviceIntRect,
-        raw_clips: ClipChain,
-        extra_clip: ClipChain,
-        prim_rect: DeviceIntRect,
+        outer_rect: DeviceIntRect,
+        inner_rect: DeviceIntRect,
+        clips: Vec<ClipWorkItem>,
         clip_store: &ClipStore,
         is_axis_aligned: bool,
         prim_coordinate_system_id: CoordinateSystemId,
-    ) -> Option<Self> {
-        // Filter out all the clip instances that don't contribute to the result
-        let mut current_coordinate_system_id = prim_coordinate_system_id;
-        let mut inner_rect = Some(task_rect);
-        let clips: Vec<_> = ClipChainNodeIter { current: raw_clips }
-            .chain(ClipChainNodeIter { current: extra_clip })
-            .filter_map(|node| {
-                let work_item = node.work_item.clone();
-
-                // FIXME(1828): This is a workaround until we can fix the inconsistency between
-                // the shader and the CPU code around how inner_rects are handled.
-                if !node.work_item.has_compatible_coordinate_system(current_coordinate_system_id) {
-                    current_coordinate_system_id = node.work_item.coordinate_system_id;
-                    inner_rect = None;
-                    return Some(work_item)
-                }
-
-                let clip_info = clip_store
-                    .get_opt(&node.work_item.clip_sources)
-                    .expect("bug: clip item should exist");
-                debug_assert!(clip_info.has_clips());
-
-                match clip_info.bounds.inner {
-                    Some(ref inner) if !inner.device_rect.is_empty() => {
-                        inner_rect = inner_rect.and_then(|r| r.intersection(&inner.device_rect));
-                        if inner.device_rect.contains_rect(&task_rect) {
-                            return None;
-                        }
-                    }
-                    _ => inner_rect = None,
-                }
-
-                Some(work_item)
-            })
-            .collect();
-
-        // Nothing to do, all clips are irrelevant for this case
-        if clips.is_empty() {
-            return None;
-        }
-
-
+    ) -> Option<RenderTask> {
         // TODO(gw): This optimization is very conservative for now.
         //           For now, only draw optimized geometry if it is
         //           a single aligned rect mask with rounded corners.
         //           In the future, we'll expand this to handle the
         //           more complex types of clip mask geometry.
-        let mut geometry_kind = MaskGeometryKind::Default;
-        if let Some(inner_rect) = inner_rect {
-            // If the inner rect completely contains the primitive
-            // rect, then this mask can't affect the primitive.
-            if inner_rect.contains_rect(&prim_rect) {
-                return None;
-            }
-            if is_axis_aligned && clips.len() == 1 {
-                geometry_kind = clips[0].get_geometry_kind(clip_store, prim_coordinate_system_id);
-            }
-        }
+        let geometry_kind = if is_axis_aligned &&
+            clips.len() == 1 &&
+            inner_rect.size != DeviceIntSize::zero() {
+            clips[0].get_geometry_kind(clip_store, prim_coordinate_system_id)
+        } else {
+            MaskGeometryKind::Default
+        };
 
         Some(RenderTask {
             cache_key: key.map(RenderTaskKey::CacheMask),
             children: Vec::new(),
-            location: RenderTaskLocation::Dynamic(None, task_rect.size),
+            location: RenderTaskLocation::Dynamic(None, outer_rect.size),
             kind: RenderTaskKind::CacheMask(CacheMaskTask {
-                actual_rect: task_rect,
-                inner_rect: inner_rect.unwrap_or(DeviceIntRect::zero()),
+                actual_rect: outer_rect,
+                inner_rect: inner_rect,
                 clips,
                 geometry_kind,
                 coordinate_system_id: prim_coordinate_system_id,

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, ComplexClipRegion, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use api::{DevicePoint, DeviceRect, DeviceSize, LayerRect, LayerToWorldTransform};
-use api::{LayoutPoint, LayoutRect, LayoutSize};
-use api::WorldPoint3D;
+use api::{DevicePoint, DeviceRect, DeviceSize, LayerPoint, LayerRect, LayerSize};
+use api::{LayerToWorldTransform, LayoutPoint, LayoutRect, LayoutSize, WorldPoint3D};
 use euclid::{Point2D, Rect, Size2D, TypedPoint2D, TypedRect, TypedSize2D, TypedTransform2D};
 use euclid::TypedTransform3D;
 use num_traits::Zero;
 use std::f32::consts::FRAC_1_SQRT_2;
 use std::i32;
+use std::f32;
 
 // Matches the definition of SK_ScalarNearlyZero in Skia.
 const NEARLY_ZERO: f32 = 1.0 / 4096.0;
@@ -438,6 +438,15 @@ pub mod test {
 
 pub trait MaxRect {
     fn max_rect() -> Self;
+}
+
+impl MaxRect for LayerRect {
+    fn max_rect() -> Self {
+        LayerRect::new(
+            LayerPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),
+            LayerSize::new(f32::MAX, f32::MAX),
+        )
+    }
 }
 
 impl MaxRect for DeviceIntRect {


### PR DESCRIPTION
Better ClipChain optimization

There are a lot of situations where we can omit redundant clips or
combine a series of clips into a single empty mask (which has the
effect of clipping the primitive in screen space). Briefly, some of the
optimizations this change includes:

1. When the inner rect of a clip completely encloses the outer rect
   of a parent, we can ignore it.
2. When the outer rectangle of a clip is completely enclosed by the
   inner rectangle of a parent, we can start a new ClipChan and
   ignore the parents.
3. If the combined inner rectangle of a ClipChain completely
   encloses the intersection of a primitive and the current clips,
   we can stop applying clips from that chain.
4. If a clip's inner rect completely encloses the intersection
   of a primitive and the current clips, we can ignore it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2104)
<!-- Reviewable:end -->
