### PR TITLE
Add support for basic performance annotations to reftests.

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -154,6 +154,6 @@ pub use device::{build_shader_strings, ProgramCache};
 pub use renderer::{CpuProfile, DebugFlags, GpuProfile, OutputImageHandler, RendererKind};
 pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, ReadPixelsFormat, Renderer, RendererOptions};
-pub use renderer::{ThreadListener};
+pub use renderer::{RendererStats, ThreadListener};
 pub use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 pub use webrender_api as api;

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -1,5 +1,5 @@
 == filter-grayscale.yaml filter-grayscale-ref.yaml
-== filter-blur.yaml filter-blur.png
+== draw_calls(4) color_targets(6) alpha_targets(0) filter-blur.yaml filter-blur.png
 == isolated.yaml isolated-ref.yaml
 == invisible.yaml invisible-ref.yaml
 == opacity.yaml opacity-ref.yaml
@@ -13,7 +13,7 @@
 == filter-invert.yaml filter-invert-ref.yaml
 == filter-invert-2.yaml filter-invert-2-ref.yaml
 == filter-large-blur-radius.yaml filter-large-blur-radius.png
-== filter-small-blur-radius.yaml filter-small-blur-radius.png
+== draw_calls(4) color_targets(4) alpha_targets(0) filter-small-blur-radius.yaml filter-small-blur-radius.png
 == filter-saturate-red-1.yaml filter-saturate-red-1-ref.yaml
 == filter-saturate-red-2.yaml filter-saturate-red-2-ref.yaml
 == filter-saturate-red-3.yaml filter-saturate-red-3-ref.yaml

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -18,8 +18,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use time;
 use webrender;
-use webrender::DebugFlags;
 use webrender::api::*;
+use webrender::{DebugFlags, RendererStats};
 use yaml_frame_writer::YamlFrameWriterReceiver;
 use {WindowWrapper, BLACK_COLOR, WHITE_COLOR};
 
@@ -476,9 +476,11 @@ impl Wrench {
         self.renderer.get_frame_profiles()
     }
 
-    pub fn render(&mut self) {
+    pub fn render(&mut self) -> RendererStats {
         self.renderer.update();
-        self.renderer.render(self.window_size).unwrap();
+        self.renderer
+            .render(self.window_size)
+            .expect("errors encountered during render!")
     }
 
     pub fn refresh(&mut self) {


### PR DESCRIPTION
This basic implementation allows a reftest to optionally specifiy
the expected number of draw calls, alpha targets and color targets
that the test should use.

This can be used for things such as:
 * Ensuring primitives are batching together as expected.
 * Ensuring that tests use the expected number of render targets.
 * Ensuring that invisible filters are removed.
 * Ensuring that certain operations (e.g. opacity) get collapsed
   into a more efficient rendering strategy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2105)
<!-- Reviewable:end -->
