### PR TITLE
support synthetic bold on Windows using DWrite font simulations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1029,7 +1029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webrender"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "angle 0.5.0 (git+https://github.com/servo/angle?branch=servo)",
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1039,7 +1039,7 @@ dependencies = [
  "core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1057,13 +1057,13 @@ dependencies = [
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.54.0",
+ "webrender_api 0.55.0",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1071,7 +1071,7 @@ dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1090,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wrench"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,7 +1098,7 @@ dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-loader 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1112,7 +1112,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.54.0",
+ "webrender 0.55.0",
  "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
 ]
 
@@ -1204,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum deflate 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "24c5f3de3a8e183ab9a169654b652407e5e80bed40986bcca92c2b088b9bfa80"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c4c7cc7b396419bc0a4d90371d0cee16cb5053b53647d287c0b728000c41fe"
-"checksum dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36e3b27cd0b8a68e00f07e8d8e1e4f4d8a6b8b873290a734f63bd56d792d23e1"
+"checksum dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a207eb7b40e25d1d28dc679f451d321fb6954b73ceaa47986702575865469461"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
@@ -43,7 +43,7 @@ servo-glutin = "0.13"     # for the example apps
 freetype = { version = "0.3", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-dwrote = "0.4"
+dwrote = "0.4.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.4"

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1286,9 +1286,9 @@ impl FrameBuilder {
             font.bg_color,
             render_mode,
             font.subpx_dir,
+            font.flags,
             font.platform_options,
             font.variations.clone(),
-            font.synthetic_italics,
         );
         let prim = TextRunPrimitiveCpu {
             font: prim_font,

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -5,8 +5,9 @@
 #[cfg(test)]
 use api::{IdNamespace, LayoutPoint};
 use api::{ColorF, ColorU, DevicePoint, DeviceUintSize};
-use api::{FontInstancePlatformOptions, FontRenderMode, FontVariation};
-use api::{FontKey, FontTemplate, GlyphDimensions, GlyphKey, SubpixelDirection};
+use api::{FontInstanceFlags, FontInstancePlatformOptions};
+use api::{FontKey, FontRenderMode, FontTemplate, FontVariation};
+use api::{GlyphDimensions, GlyphKey, SubpixelDirection};
 use api::{ImageData, ImageDescriptor, ImageFormat, LayerToWorldTransform};
 use app_units::Au;
 use device::TextureFilter;
@@ -139,9 +140,9 @@ pub struct FontInstance {
     pub bg_color: ColorU,
     pub render_mode: FontRenderMode,
     pub subpx_dir: SubpixelDirection,
+    pub flags: FontInstanceFlags,
     pub platform_options: Option<FontInstancePlatformOptions>,
     pub variations: Vec<FontVariation>,
-    pub synthetic_italics: bool,
     pub transform: FontTransform,
 }
 
@@ -153,9 +154,9 @@ impl FontInstance {
         bg_color: ColorU,
         render_mode: FontRenderMode,
         subpx_dir: SubpixelDirection,
+        flags: FontInstanceFlags,
         platform_options: Option<FontInstancePlatformOptions>,
         variations: Vec<FontVariation>,
-        synthetic_italics: bool,
     ) -> Self {
         FontInstance {
             font_key,
@@ -164,9 +165,9 @@ impl FontInstance {
             bg_color,
             render_mode,
             subpx_dir,
+            flags,
             platform_options,
             variations,
-            synthetic_italics,
             transform: FontTransform::identity(),
         }
     }
@@ -611,9 +612,9 @@ fn raterize_200_glyphs() {
         ColorU::new(0, 0, 0, 0),
         FontRenderMode::Subpixel,
         SubpixelDirection::Horizontal,
+        Default::default(),
         None,
         Vec::new(),
-        false,
     );
 
     let mut glyph_keys = Vec::with_capacity(200);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -350,7 +350,7 @@ impl ResourceCache {
         let FontInstanceOptions {
             render_mode,
             subpx_dir,
-            synthetic_italics,
+            flags,
             bg_color,
             ..
         } = options.unwrap_or_default();
@@ -362,9 +362,9 @@ impl ResourceCache {
             bg_color,
             render_mode,
             subpx_dir,
+            flags,
             platform_options,
             variations,
-            synthetic_italics,
         );
         if self.glyph_rasterizer.is_bitmap_font(&instance) {
             instance.render_mode = instance.render_mode.limit_by(FontRenderMode::Bitmap);

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
@@ -24,4 +24,4 @@ core-foundation = "0.4"
 core-graphics = "0.12.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-dwrote = "0.4"
+dwrote = "0.4.1"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrench"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 build = "build.rs"
 license = "MPL-2.0"
@@ -32,7 +32,7 @@ headless = [ "osmesa-sys", "osmesa-src" ]
 logging = [ "env_logger" ]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-dwrote = "0.4"
+dwrote = "0.4.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 font-loader = "0.5"

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -249,7 +249,12 @@ impl Wrench {
             .collect();
 
         // Retrieve the metrics for each glyph.
-        let instance_key = self.add_font_instance(font_key, size, false, Some(FontRenderMode::Alpha));
+        let instance_key = self.add_font_instance(
+            font_key,
+            size,
+            FontInstanceFlags::empty(),
+            Some(FontRenderMode::Alpha),
+        );
         let mut keys = Vec::new();
         for glyph_index in &indices {
             keys.push(GlyphKey::new(
@@ -407,16 +412,16 @@ impl Wrench {
     pub fn add_font_instance(&mut self,
         font_key: FontKey,
         size: Au,
-        synthetic_italics: bool,
+        flags: FontInstanceFlags,
         render_mode: Option<FontRenderMode>,
     ) -> FontInstanceKey {
         let key = self.api.generate_font_instance_key();
         let mut update = ResourceUpdates::new();
-        let options = FontInstanceOptions {
-            render_mode: render_mode.unwrap_or(FontRenderMode::Subpixel),
-            synthetic_italics,
-            ..Default::default()
-        };
+        let mut options: FontInstanceOptions = Default::default();
+        options.flags |= flags;
+        if let Some(render_mode) = render_mode {
+            options.render_mode = render_mode;
+        }
         update.add_font_instance(key, font_key, size, Some(options), None, Vec::new());
         self.api.update_resources(update);
         key

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -442,7 +442,7 @@ impl YamlFrameReader {
         &mut self,
         font_key: FontKey,
         size: Au,
-        synthetic_italics: bool,
+        flags: FontInstanceFlags,
         wrench: &mut Wrench,
     ) -> FontInstanceKey {
         let font_render_mode = self.font_render_mode;
@@ -453,7 +453,7 @@ impl YamlFrameReader {
                 wrench.add_font_instance(
                     font_key,
                     size,
-                    synthetic_italics,
+                    flags,
                     font_render_mode,
                 )
             })
@@ -989,7 +989,16 @@ impl YamlFrameReader {
     ) {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
-        let synthetic_italics = item["synthetic-italics"].as_bool().unwrap_or(false);
+        let mut flags = FontInstanceFlags::empty();
+        if item["synthetic-italics"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::SYNTHETIC_ITALICS;
+        }
+        if item["synthetic-bold"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::SYNTHETIC_BOLD;
+        }
+        if item["embedded-bitmaps"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::EMBEDDED_BITMAPS;
+        }
 
         assert!(
             item["blur-radius"].is_badvalue(),
@@ -1000,7 +1009,7 @@ impl YamlFrameReader {
         let font_key = self.get_or_create_font(desc, wrench);
         let font_instance_key = self.get_or_create_font_instance(font_key,
                                                                  size,
-                                                                 synthetic_italics,
+                                                                 flags,
                                                                  wrench);
 
         assert!(


### PR DESCRIPTION
This is necessary to fix downstream Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1418564

In the process, I cleaned up a lot how certain settings (synthetic bold, embedded bitmaps) were communicated to the font backends. Since these were common to all backends, I made them a cleaner set of platform-independent flags, rather than having a bunch of different bools littered about randomly in FontInstancePlatformOptions.

I also modified dwrote (as evidenced in dwrote 0.4.1) to support a necessary function to clone a font face with the desired simulations for this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2120)
<!-- Reviewable:end -->
