### PR TITLE
use deserialize_from for faster deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -68,7 +68,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -234,8 +234,8 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -268,7 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -427,7 +427,7 @@ dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -712,7 +712,7 @@ name = "ron"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -727,25 +727,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.8"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.8"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.15.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,7 +760,7 @@ dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1019,8 +1019,8 @@ dependencies = [
  "plane-split 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1043,7 +1043,8 @@ dependencies = [
  "dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1079,7 +1080,7 @@ dependencies = [
  "osmesa-src 17.2.0-devel (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1236,9 +1237,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c355cb9fd143cf53c37843614eea66405c8ef0961e9d80690a1453e5b3e48c4"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
-"checksum serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f530d36fb84ec48fb7146936881f026cdbf4892028835fd9398475f82c1bb4"
-"checksum serde_derive 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "10552fad5500771f3902d0c5ba187c5881942b811b7ba0d8fbbfbf84d80806d3"
-"checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
+"checksum serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7c37d7f192f00041e8a613e936717923a71bc0c9051fc4425a49b104140f05"
+"checksum serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "0672de7300b02bac3f3689f8faea813c4a1ea9fe0cb49e80f714231d267518a2"
+"checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
 "checksum servo-fontconfig-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6be80777ee6edecbbbf8774c76e19dddfe336256c57a4ded06d6ad3df7be358e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,25 +728,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "serde"
 version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gankro/serde?branch=deserialize_from_enums3#fc6117367ef974fb2d3b2017c21c375d34823415"
 dependencies = [
- "serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.23 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "serde 1.0.23 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.23"
+source = "git+https://github.com/gankro/serde?branch=deserialize_from_enums3#fc6117367ef974fb2d3b2017c21c375d34823415"
+dependencies = [
+ "quote 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.17.0 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+replace = "serde_derive 1.0.23 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)"
 
 [[package]]
 name = "serde_derive_internals"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gankro/serde?branch=deserialize_from_enums3#fc6117367ef974fb2d3b2017c21c375d34823415"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1237,9 +1249,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c355cb9fd143cf53c37843614eea66405c8ef0961e9d80690a1453e5b3e48c4"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
+"checksum serde 1.0.23 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)" = "<none>"
 "checksum serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7c37d7f192f00041e8a613e936717923a71bc0c9051fc4425a49b104140f05"
+"checksum serde_derive 1.0.23 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)" = "<none>"
 "checksum serde_derive 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "0672de7300b02bac3f3689f8faea813c4a1ea9fe0cb49e80f714231d267518a2"
-"checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
+"checksum serde_derive_internals 0.17.0 (git+https://github.com/gankro/serde?branch=deserialize_from_enums3)" = "<none>"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a088f8d775a5c5314aae09bd77340bc9c67d72b9a45258be34c83548b4814cd9"
 "checksum servo-fontconfig-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6be80777ee6edecbbbf8774c76e19dddfe336256c57a4ded06d6ad3df7be358e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ members = [
 [profile.release]
 debug = true
 panic = "abort"
+
+[replace]
+"serde:1.0.23" = { git = "https://github.com/gankro/serde", branch = "deserialize_from_enums3" }
+"serde_derive:1.0.23" = { git = "https://github.com/gankro/serde", branch = "deserialize_from_enums3", feature="deserialize_from" }

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.2.1"
 euclid = "0.16"
 ipc-channel = {version = "0.9", optional = true}
 serde = { version = "1.0.23", features = ["rc", "derive"] }
-serde_derive = { version = "1.0.23" }
+serde_derive = { version = "1.0.23", features = ["deserialize_from"] }
 time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -16,7 +16,8 @@ bincode = "0.9"
 byteorder = "1.2.1"
 euclid = "0.16"
 ipc-channel = {version = "0.9", optional = true}
-serde = { version = "1.0", features = ["rc", "derive"] }
+serde = { version = "1.0.23", features = ["rc", "derive"] }
+serde_derive = { version = "1.0.23" }
 time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -88,6 +88,7 @@ impl LayerPrimitiveInfo {
 pub type LayoutPrimitiveInfo = PrimitiveInfo<LayoutPixel>;
 pub type LayerPrimitiveInfo = PrimitiveInfo<LayerPixel>;
 
+#[repr(u8)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -225,8 +225,12 @@ impl<'a> BuiltDisplayListIter<'a> {
                 return None;
             }
 
-            self.cur_item = bincode::deserialize_from(&mut UnsafeReader::new(&mut self.data), bincode::Infinite)
-                .expect("MEH: malicious process?");
+            {
+                let reader = bincode::read_types::IoReader::new(UnsafeReader::new(&mut self.data));
+                let mut deserializer = bincode::Deserializer::new(reader, bincode::Infinite);
+                self.cur_item.deserialize_from(&mut deserializer)
+                    .expect("MEH: malicious process?");
+            }
 
             match self.cur_item.item {
                 SetGradientStops => {


### PR DESCRIPTION
It seems to at least be correct!

Heading out for the day, but @glennw or @jrmuizel might be interested in profiling this, so here it is.

What's going on here is an incredibly deep yak shave that I don't have the spirit to enumerate, but in essence this changes our deserialize pattern from: `deserialize() -> Result<T, E>` to `deserialize(dest: &mut T) -> Result<(), E>` (which is recursively invoked on fields).

This seems to significantly improve the codegen, as Rust is Very Bad at optimizing away all the copies from using Results. Currently this relies on my own fork of serde/serde_derive for the new trait method, and all the derivation work. I hope to upstream most of this.

The Hard Part of this entire thing, which I doubt will be upstreamable, will be handling enums. There is no way in Rust to build an enum up "in place". This is a pretty serious problem, because SpecificDisplayItem, the thing we're trying to deserialize, is an enum! 

To handle this, I rely on the [deterministic layout](https://github.com/rust-lang/rfcs/pull/2195) of a `repr(u8)` enum to transmute into its repr and manipulate the tag and payload seperately. Specifically I can produce a more optimized enum deserialization iff:

* The enum has a repr(int) annotation
* The enum has a nonelike (payloadless) variant
* The enum has a somelike (payloadfull) variant
* The enum is Copy

We then generate roughly this code:

```rust
fn deserialize_enum(&mut self) {
  let repr = transmute<&mut Self, &mut Repr>(self);
  
  // First mark the enum as empty
  repr.somelike.tag = Tag::nonelike;

  match deserialize_tag() {
     Tag::A => {
       try!(repr.A.field1.deserialize_from());
       try!(repr.A.field2.deserialize_from());
       try!(repr.A.field3.deserialize_from());

       // NOW mark the enum as having data!
       repr.somelike.tag = Tag::A;
       Ok(())
     }
     Tag::B => { ... }
  }
}
```

The point of this is that it prevents any memory-unsafety from observing a "partially" deserialized enum. The problem with it is that it would cause a leak if one of the cases contained a type with a destructor. However this is doubly fine for us: SpecificDisplayItem is completely POD, and we hard abort the whole process if we find an error while deserializing. Also note that currently unions forbid non-Copy types, so destructors aren't *actually* a concern, but also we have literally no way to check for trait impls so this just leads to a cryptic error pointing to the `#[derive(Deserialize)]` annotation.

So either this design leaks, or it leads to cryptic errors. Either way, this will probably block the enum derive code from ever being properly upstreamed.

Missing optimizations from this PR that are also possible:

* Bincode still branches+masks on every f32 read due to some safety scare. This should be fixed upstream Soon™️. Without this, deserializing f32's is bloated enough that it actually produces a loop, instead of straight-line code. With this, we get straight-line code, but there's still a branch for length checking on each f32 read, instead of a single check and a memcpy. It's hard for us to fix this at our abstraction level; ideally rustc/llvm would fix it.

* AuxIter still uses the old deserialization method because it needs to return an `Option<T>` anyway. It could be changed to be a "fake" iterator like BuiltDisplayListIter too if it's desirable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2128)
<!-- Reviewable:end -->
