### PR TITLE
Add border edges to the opaque pass where possible.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -327,6 +327,8 @@ impl ToGpuBlocks for YuvImagePrimitiveCpu {
 pub struct BorderPrimitiveCpu {
     pub corner_instances: [BorderCornerInstance; 4],
     pub gpu_blocks: [GpuBlockData; 8],
+    pub opacity: PrimitiveOpacity,
+    pub all_edges_simple: bool,
 }
 
 impl ToGpuBlocks for BorderPrimitiveCpu {
@@ -1037,7 +1039,7 @@ impl PrimitiveStore {
             }
             PrimitiveContainer::Border(border_cpu) => {
                 let metadata = PrimitiveMetadata {
-                    opacity: PrimitiveOpacity::translucent(),
+                    opacity: border_cpu.opacity,
                     prim_kind: PrimitiveKind::Border,
                     cpu_prim_index: SpecificPrimitiveIndex(self.cpu_borders.len()),
                     ..base_metadata


### PR DESCRIPTION
This covers the common use cases of border edges (solid with opaque color).

This helps reduce draw calls significantly on some pages, and also
makes the batching code simpler (since opaque batching is much
faster than alpha batching, due to not needing to check overlap).

It also provides a GPU time win, since we're moving more pixels to
the opaque pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2130)
<!-- Reviewable:end -->
