### PR TITLE
Render task tree view in debug server

### DIFF
--- a/debugger/js/app.js
+++ b/debugger/js/app.js
@@ -2,8 +2,9 @@ var state = {
     connected: false,
     page: "options",
     passes: [],
+    render_tasks: [],
     documents: [],
-    clipscrolltree: [],
+    clip_scroll_tree: [],
     screenshot: []
 }
 
@@ -24,10 +25,12 @@ class Connection {
             var json = JSON.parse(evt.data);
             if (json['kind'] == "passes") {
                 state.passes = json['passes'];
+            } else if (json['kind'] == "render_tasks") {
+                state.render_tasks = json['root'];
             } else if (json['kind'] == "documents") {
                 state.documents = json['root'];
-            } else if (json['kind'] == "clipscrolltree") {
-                state.clipscrolltree = json['root'];
+            } else if (json['kind'] == "clip_scroll_tree") {
+                state.clip_scroll_tree = json['root'];
             } else if (json['kind'] == "screenshot") {
                 state.screenshot =  json['data'];
             } else {
@@ -74,8 +77,9 @@ Vue.component('app', {
                         <div class="column">
                             <options v-if="state.page == 'options'"></options>
                             <passview v-if="state.page == 'passes'" :passes=state.passes></passview>
+                            <rendertaskview v-if="state.page == 'render_tasks'" :render_tasks=state.render_tasks></rendertaskview>
                             <documentview v-if="state.page == 'documents'" :documents=state.documents></documentview>
-                            <clipscrolltreeview v-if="state.page == 'clipscrolltree'" :clipscrolltree=state.clipscrolltree></clipscrolltreeview>
+                            <clipscrolltreeview v-if="state.page == 'clip_scroll_tree'" :clip_scroll_tree=state.clip_scroll_tree></documentview>
                             <screenshotview v-if="state.page == 'screenshot'" :screenshot=state.screenshot></screenshotview>
                         </div>
                     </div>
@@ -269,6 +273,28 @@ Vue.component('treeview', {
     `
 })
 
+Vue.component('rendertaskview', {
+    props: [
+        'render_tasks'
+    ],
+    methods: {
+        fetch: function() {
+            connection.send("fetch_render_tasks");
+        }
+    },
+    template: `
+        <div class="box">
+            <h1 class="title">Render Tasks <a v-on:click="fetch" class="button is-info">Refresh</a></h1>
+            <hr/>
+            <div>
+                <ul>
+                    <treeview :model=render_tasks></treeview>
+                </ul>
+            </div>
+        </div>
+    `
+})
+
 Vue.component('documentview', {
     props: [
         'documents'
@@ -293,20 +319,20 @@ Vue.component('documentview', {
 
 Vue.component('clipscrolltreeview', {
     props: [
-        'clipscrolltree'
+        'clip_scroll_tree'
     ],
     methods: {
         fetch: function() {
-            connection.send("fetch_clipscrolltree");
+            connection.send("fetch_clip_scroll_tree");
         }
     },
     template: `
         <div class="box">
-            <h1 class="title">Clip-scroll Tree <a v-on:click="fetch" class="button is-info">Refresh</a></h1>
+            <h1 class="title">Clip-Scroll Tree <a v-on:click="fetch" class="button is-info">Refresh</a></h1>
             <hr/>
             <div>
                 <ul>
-                    <treeview :model=clipscrolltree></treeview>
+                    <treeview :model=clip_scroll_tree></treeview>
                 </ul>
             </div>
         </div>
@@ -352,9 +378,8 @@ Vue.component('mainmenu', {
             <ul class="menu-list">
                 <li><a v-on:click="setPage('options')" v-bind:class="{ 'is-active': page == 'options' }">Debug Options</a></li>
                 <li><a v-on:click="setPage('passes')" v-bind:class="{ 'is-active': page == 'passes' }">Passes</a></li>
+                <li><a v-on:click="setPage('render_tasks')" v-bind:class="{ 'is-active': page == 'render_tasks' }">Render Tasks</a></li>
                 <li><a v-on:click="setPage('documents')" v-bind:class="{ 'is-active': page == 'documents' }">Documents</a></li>
-                <li><a v-on:click="setPage('clipscrolltree')" v-bind:class="{ 'is-active': page == 'clipscrolltree' }">Clip-scroll Tree</a></li>
-                <li><a v-on:click="setPage('screenshot')" v-bind:class="{ 'is-active': page == 'screenshot' }">Screenshot</a></li>
             </ul>
         </aside>
     `

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -82,7 +82,7 @@ pub struct TransformUpdateState {
 }
 
 impl ClipScrollTree {
-    pub fn new() -> ClipScrollTree {
+    pub fn new() -> Self {
         let dummy_pipeline = PipelineId::dummy();
         ClipScrollTree {
             nodes: FastHashMap::default(),

--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -62,7 +62,8 @@ impl ws::Handler for Server {
                     "fetch_passes" => DebugCommand::FetchPasses,
                     "fetch_screenshot" => DebugCommand::FetchScreenshot,
                     "fetch_documents" => DebugCommand::FetchDocuments,
-                    "fetch_clipscrolltree" => DebugCommand::FetchClipScrollTree,
+                    "fetch_clip_scroll_tree" => DebugCommand::FetchClipScrollTree,
+                    "fetch_render_tasks" => DebugCommand::FetchRenderTasks,
                     msg => {
                         println!("unknown msg {}", msg);
                         return Ok(());
@@ -258,7 +259,7 @@ pub struct DocumentList {
 }
 
 impl DocumentList {
-    pub fn new() -> DocumentList {
+    pub fn new() -> Self {
         DocumentList {
             kind: "documents",
             root: TreeNode::new("root"),
@@ -302,9 +303,28 @@ pub struct ClipScrollTreeList {
 }
 
 impl ClipScrollTreeList {
-    pub fn new() -> ClipScrollTreeList {
+    pub fn new() -> Self {
         ClipScrollTreeList {
-            kind: "clipscrolltree",
+            kind: "clip_scroll_tree",
+            root: TreeNode::new("root"),
+        }
+    }
+
+    pub fn add(&mut self, item: TreeNode) {
+        self.root.add_child(item);
+    }
+}
+
+#[derive(Serialize)]
+pub struct RenderTaskList {
+    kind: &'static str,
+    root: TreeNode,
+}
+
+impl RenderTaskList {
+    pub fn new() -> Self {
+        RenderTaskList {
+            kind: "render_tasks",
             root: TreeNode::new("root"),
         }
     }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -648,7 +648,7 @@ impl RenderBackend {
             let mut debug_doc = debug_server::TreeNode::new("document");
 
             for (_, pipeline) in &doc.scene.pipelines {
-                let mut debug_dl = debug_server::TreeNode::new("display_list");
+                let mut debug_dl = debug_server::TreeNode::new("display-list");
                 self.traverse_items(&mut pipeline.display_list.iter(), &mut debug_dl);
                 debug_doc.add_child(debug_dl);
             }
@@ -669,7 +669,7 @@ impl RenderBackend {
         let mut debug_root = debug_server::ClipScrollTreeList::new();
 
         for (_, doc) in &self.documents {
-            let debug_node = debug_server::TreeNode::new("document clip_scroll tree");
+            let debug_node = debug_server::TreeNode::new("document clip-scroll tree");
             let mut builder = debug_server::TreeNodeBuilder::new(debug_node);
 
             // TODO(gw): Restructure the storage of clip-scroll tree, clip store

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -263,8 +263,10 @@ pub enum DebugCommand {
     FetchPasses,
     /// Fetch clip-scroll tree.
     FetchClipScrollTree,
+    /// Fetch render tasks.
+    FetchRenderTasks,
     /// Fetch screenshot.
-    FetchScreenshot
+    FetchScreenshot,
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
MOARE debugging!

It would be great to somewhat automate the implementation of Json messages being passed for our structs, but for now the manual code is sufficient.

r? @glennw 

![wr-render-tasks](https://user-images.githubusercontent.com/107301/33398115-d6e95358-d51b-11e7-8858-99325dee349b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2136)
<!-- Reviewable:end -->
