### PR TITLE
Tidy up a few parts of the frame builder code.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -3,13 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderSide, BorderStyle, BorderWidths, ClipAndScrollInfo, ColorF};
-use api::{EdgeAaSegmentMask, LayerPoint, LayerRect};
+use api::{LayerPoint, LayerRect};
 use api::{LayerPrimitiveInfo, LayerSize, NormalBorder, RepeatMode};
 use clip::ClipSource;
 use ellipse::Ellipse;
 use frame_builder::FrameBuilder;
 use gpu_cache::GpuDataRequest;
-use prim_store::{BorderPrimitiveCpu, RectangleContent, PrimitiveContainer, TexelRect};
+use internal_types::EdgeAaSegmentMask;
+use prim_store::{BorderPrimitiveCpu, PrimitiveContainer, TexelRect};
 use util::{lerp, pack_as_float};
 
 #[repr(u8)]
@@ -382,12 +383,11 @@ impl FrameBuilder {
             // Add a solid rectangle for each visible edge/corner combination.
             if top_edge == BorderEdgeKind::Solid {
                 info.rect = LayerRect::new(p0, LayerSize::new(rect_width, top_len));
-                info.edge_aa_segment_mask = EdgeAaSegmentMask::BOTTOM;
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    RectangleContent::Fill(border.top.color),
-                    None,
+                    border.top.color,
+                    EdgeAaSegmentMask::BOTTOM,
                 );
             }
             if left_edge == BorderEdgeKind::Solid {
@@ -395,12 +395,11 @@ impl FrameBuilder {
                     LayerPoint::new(p0.x, p0.y + top_len),
                     LayerSize::new(left_len, rect_height - top_len - bottom_len),
                 );
-                info.edge_aa_segment_mask = EdgeAaSegmentMask::RIGHT;
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    RectangleContent::Fill(border.left.color),
-                    None,
+                    border.left.color,
+                    EdgeAaSegmentMask::RIGHT,
                 );
             }
             if right_edge == BorderEdgeKind::Solid {
@@ -408,12 +407,11 @@ impl FrameBuilder {
                     LayerPoint::new(p1.x - right_len, p0.y + top_len),
                     LayerSize::new(right_len, rect_height - top_len - bottom_len),
                 );
-                info.edge_aa_segment_mask = EdgeAaSegmentMask::LEFT;
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    RectangleContent::Fill(border.right.color),
-                    None,
+                    border.right.color,
+                    EdgeAaSegmentMask::LEFT,
                 );
             }
             if bottom_edge == BorderEdgeKind::Solid {
@@ -421,12 +419,11 @@ impl FrameBuilder {
                     LayerPoint::new(p0.x, p1.y - bottom_len),
                     LayerSize::new(rect_width, bottom_len),
                 );
-                info.edge_aa_segment_mask = EdgeAaSegmentMask::TOP;
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
-                    RectangleContent::Fill(border.bottom.color),
-                    None,
+                    border.bottom.color,
+                    EdgeAaSegmentMask::TOP,
                 );
             }
         } else {

--- a/webrender/src/box_shadow.rs
+++ b/webrender/src/box_shadow.rs
@@ -4,10 +4,11 @@
 
 use api::{BorderRadiusKind, ColorF, LayerPoint, LayerRect, LayerSize, LayerVector2D};
 use api::{BorderRadius, BoxShadowClipMode, LayoutSize, LayerPrimitiveInfo};
-use api::{ClipMode, ClipAndScrollInfo, ComplexClipRegion, EdgeAaSegmentMask, LocalClip};
+use api::{ClipMode, ClipAndScrollInfo, ComplexClipRegion, LocalClip};
 use api::{PipelineId};
 use clip::ClipSource;
 use frame_builder::FrameBuilder;
+use internal_types::EdgeAaSegmentMask;
 use prim_store::{PrimitiveContainer, RectangleContent, RectanglePrimitive};
 use prim_store::{BrushMaskKind, BrushKind, BrushPrimitive};
 use picture::PicturePrimitive;

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -21,7 +21,7 @@ use euclid::{SideOffsets2D, vec2};
 use frame::FrameId;
 use glyph_rasterizer::FontInstance;
 use gpu_cache::GpuCache;
-use internal_types::{FastHashMap, FastHashSet};
+use internal_types::{EdgeAaSegmentMask, FastHashMap, FastHashSet};
 use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, RasterizationSpace};
 use prim_store::{TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
@@ -755,20 +755,61 @@ impl FrameBuilder {
         &mut self,
         clip_and_scroll: ClipAndScrollInfo,
         info: &LayerPrimitiveInfo,
-        content: RectangleContent,
-        scrollbar_info: Option<ScrollbarInfo>,
+        color: ColorF,
+        edge_aa_segment_mask: EdgeAaSegmentMask,
     ) {
-        if let RectangleContent::Fill(ColorF{a, ..}) = content {
-            if a == 0.0 {
-                // Don't add transparent rectangles to the draw list, but do consider them for hit
-                // testing. This allows specifying invisible hit testing areas.
-                self.add_primitive_to_hit_testing_list(info, clip_and_scroll);
-                return;
-            }
+        if color.a == 0.0 {
+            // Don't add transparent rectangles to the draw list, but do consider them for hit
+            // testing. This allows specifying invisible hit testing areas.
+            self.add_primitive_to_hit_testing_list(info, clip_and_scroll);
+            return;
         }
+
         let prim = RectanglePrimitive {
-            content,
-            edge_aa_segment_mask: info.edge_aa_segment_mask,
+            content: RectangleContent::Fill(color),
+            edge_aa_segment_mask,
+        };
+
+        self.add_primitive(
+            clip_and_scroll,
+            info,
+            Vec::new(),
+            PrimitiveContainer::Rectangle(prim),
+        );
+    }
+
+    pub fn add_clear_rectangle(
+        &mut self,
+        clip_and_scroll: ClipAndScrollInfo,
+        info: &LayerPrimitiveInfo,
+    ) {
+        let prim = RectanglePrimitive {
+            content: RectangleContent::Clear,
+            edge_aa_segment_mask: EdgeAaSegmentMask::empty(),
+        };
+
+        self.add_primitive(
+            clip_and_scroll,
+            info,
+            Vec::new(),
+            PrimitiveContainer::Rectangle(prim),
+        );
+    }
+
+    pub fn add_scroll_bar(
+        &mut self,
+        clip_and_scroll: ClipAndScrollInfo,
+        info: &LayerPrimitiveInfo,
+        color: ColorF,
+        scrollbar_info: ScrollbarInfo,
+    ) {
+        if color.a == 0.0 {
+            return;
+        }
+
+        let prim = RectanglePrimitive {
+            content: RectangleContent::Fill(color),
+            edge_aa_segment_mask: EdgeAaSegmentMask::empty(),
         };
 
         let prim_index = self.add_primitive(
@@ -778,13 +819,11 @@ impl FrameBuilder {
             PrimitiveContainer::Rectangle(prim),
         );
 
-        if let Some(ScrollbarInfo(clip_id, frame_rect)) = scrollbar_info {
-            self.scrollbar_prims.push(ScrollbarPrimitive {
-                prim_index,
-                clip_id,
-                frame_rect,
-            });
-        }
+        self.scrollbar_prims.push(ScrollbarPrimitive {
+            prim_index,
+            clip_id: scrollbar_info.0,
+            frame_rect: scrollbar_info.1,
+        });
     }
 
     pub fn add_line(

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -190,3 +190,18 @@ pub struct UvRect {
     pub uv0: DevicePoint,
     pub uv1: DevicePoint,
 }
+
+bitflags! {
+    /// Each bit of the edge AA mask is:
+    /// 0, when the edge of the primitive needs to be considered for AA
+    /// 1, when the edge of the segment needs to be considered for AA
+    ///
+    /// *Note*: the bit values have to match the shader logic in
+    /// `write_transform_vertex()` function.
+    pub struct EdgeAaSegmentMask: u8 {
+        const LEFT = 0x1;
+        const TOP = 0x2;
+        const RIGHT = 0x4;
+        const BOTTOM = 0x8;
+    }
+}

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,14 +6,14 @@ use api::{BorderRadius, BuiltDisplayList, ColorF, ComplexClipRegion, DeviceIntRe
 use api::{DevicePoint, ExtendMode, FontRenderMode, GlyphInstance, GlyphKey};
 use api::{GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag, LayerPoint, LayerRect};
 use api::{ClipMode, LayerSize, LayerVector2D, LayerToWorldTransform, LineOrientation, LineStyle};
-use api::{ClipAndScrollInfo, EdgeAaSegmentMask, PremultipliedColorF, TileOffset};
+use api::{ClipAndScrollInfo, PremultipliedColorF, TileOffset};
 use api::{ClipId, LayerTransform, PipelineId, YuvColorSpace, YuvFormat};
 use border::BorderCornerInstance;
 use clip_scroll_tree::{CoordinateSystemId, ClipScrollTree};
 use clip::{ClipSourcesHandle, ClipStore};
 use frame_builder::PrimitiveContext;
 use glyph_rasterizer::{FontInstance, FontTransform};
-use internal_types::FastHashMap;
+use internal_types::{EdgeAaSegmentMask, FastHashMap};
 use gpu_cache::{GpuBlockData, GpuCache, GpuCacheAddress, GpuCacheHandle, GpuDataRequest,
                 ToGpuBlocks};
 use picture::{PictureKind, PicturePrimitive, RasterizationSpace};

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -39,22 +39,6 @@ impl ClipAndScrollInfo {
     }
 }
 
-bitflags! {
-    /// Each bit of the edge AA mask is:
-    /// 0, when the edge of the primitive needs to be considered for AA
-    /// 1, when the edge of the segment needs to be considered for AA
-    ///
-    /// *Note*: the bit values have to match the shader logic in
-    /// `write_transform_vertex()` function.
-    #[derive(Deserialize, Serialize)]
-    pub struct EdgeAaSegmentMask: u8 {
-        const LEFT = 0x1;
-        const TOP = 0x2;
-        const RIGHT = 0x4;
-        const BOTTOM = 0x8;
-    }
-}
-
 /// A tag that can be used to identify items during hit testing. If the tag
 /// is missing then the item doesn't take part in hit testing at all. This
 /// is composed of two numbers. In Servo, the first is an identifier while the
@@ -75,7 +59,6 @@ pub struct DisplayItem {
 pub struct PrimitiveInfo<T> {
     pub rect: TypedRect<f32, T>,
     pub local_clip: LocalClip,
-    pub edge_aa_segment_mask: EdgeAaSegmentMask,
     pub is_backface_visible: bool,
     pub tag: Option<ItemTag>,
 }
@@ -96,7 +79,6 @@ impl LayerPrimitiveInfo {
         PrimitiveInfo {
             rect: rect,
             local_clip: clip,
-            edge_aa_segment_mask: EdgeAaSegmentMask::empty(),
             is_backface_visible: true,
             tag: None,
         }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -315,7 +315,6 @@ impl<'a, 'b> DisplayItemRef<'a, 'b> {
         LayerPrimitiveInfo {
             rect: info.rect.translate(&offset),
             local_clip: info.local_clip.create_with_offset(offset),
-            edge_aa_segment_mask: info.edge_aa_segment_mask,
             is_backface_visible: info.is_backface_visible,
             tag: info.tag,
         }


### PR DESCRIPTION
This is just prep work for the upcoming change to switch
rectangle primitives over to be brush shaders. It shouldn't
have any functional effect, but is a bit easier to review
isolated from the rest of the changes.

* Remove EdgeAaSegmentMask from the public API crate, make internal.
* Remove EdgeAaSegmentMask from the display list types.
* Pass EdgeAaSegmentMask explicitly to add_solid_rectangle.
* Add add_clear_rectangle and add_scroll_bar. Make RectangleContent more of an internal detail.
* Remove the serialize attributes from EdgeAaSegmentMask.
* Don't add scrollbars and clear rects to the hit testing list.
* Don't try to split clear rectangles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2137)
<!-- Reviewable:end -->
