### PR TITLE
Inline serialize_fast

### DIFF
--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -538,6 +538,7 @@ impl<'a> Write for SizeCounter {
 /// If this assumption is incorrect, the result will be Undefined Behaviour. This
 /// assumption should hold for all derived Serialize impls, which is all we currently
 /// use.
+#[inline(always)]
 fn serialize_fast<T: Serialize>(vec: &mut Vec<u8>, e: &T) {
     // manually counting the size is faster than vec.reserve(bincode::serialized_size(&e) as usize) for some reason
     let mut size = SizeCounter(0);


### PR DESCRIPTION
Currently we get an implementation of serialize_fast specialized for
DisplayItem. If we inline serialize_fast we'll hopefully be able to
specialize for each individual display item. This should also save
some copying of DisplayItem around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2151)
<!-- Reviewable:end -->
