### PR TITLE
don't override Mac operating system AA settings

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -63,7 +63,6 @@ fn supports_subpixel_aa() -> bool {
     let ct_font = core_text::font::new_from_name("Helvetica", 16.).unwrap();
     cg_context.set_should_smooth_fonts(true);
     cg_context.set_should_antialias(true);
-    cg_context.set_allows_font_smoothing(true);
     cg_context.set_rgb_fill_color(1.0, 1.0, 1.0, 1.0);
     let point = CGPoint { x: -1., y: 0. };
     let glyph = '|' as CGGlyph;
@@ -558,9 +557,7 @@ impl FontContext {
         cg_context.set_allows_font_subpixel_quantization(false);
         cg_context.set_should_subpixel_quantize_fonts(false);
 
-        cg_context.set_allows_font_smoothing(smooth);
         cg_context.set_should_smooth_fonts(smooth);
-        cg_context.set_allows_antialiasing(antialias);
         cg_context.set_should_antialias(antialias);
 
         // Fill the background. This could be opaque white, opaque black, or


### PR DESCRIPTION
It is possible to disable LCD font smoothing in the operating system settings. By calling CGContext.set_allows_foo() on these we are overriding that, whereas Gecko normally honors them. Just remove these particular AA overrides so that we match Gecko on this. This addresses Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1421041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2152)
<!-- Reviewable:end -->
