### PR TITLE
Check the aa_range before calculating the ellipse distance.

### DIFF
--- a/webrender/res/brush_mask_corner.glsl
+++ b/webrender/res/brush_mask_corner.glsl
@@ -51,7 +51,8 @@ vec4 brush_fs() {
     if (vLocalPos.x < vClipCenter_Radius.x && vLocalPos.y < vClipCenter_Radius.y) {
         // Apply ellipse clip on corner.
         d = distance_to_ellipse(vLocalPos - vClipCenter_Radius.xy,
-                                vClipCenter_Radius.zw);
+                                vClipCenter_Radius.zw,
+                                aa_range);
         d = distance_aa(aa_range, d);
     }
 

--- a/webrender/res/ps_border_corner.glsl
+++ b/webrender/res/ps_border_corner.glsl
@@ -351,10 +351,10 @@ void main(void) {
         // direction of the center of the ellipse (a different offset for each corner).
 
         // Get signed distance from the inner/outer clips.
-        float d0 = distance_to_ellipse(p, vRadii0.xy);
-        float d1 = distance_to_ellipse(p, vRadii0.zw);
-        float d2 = distance_to_ellipse(p, vRadii1.xy);
-        float d3 = distance_to_ellipse(p, vRadii1.zw);
+        float d0 = distance_to_ellipse(p, vRadii0.xy, aa_range);
+        float d1 = distance_to_ellipse(p, vRadii0.zw, aa_range);
+        float d2 = distance_to_ellipse(p, vRadii1.xy, aa_range);
+        float d3 = distance_to_ellipse(p, vRadii1.zw, aa_range);
 
         // SDF subtract main radii
         float d_main = max(d0, -d1);

--- a/wrench/benchmarks/benchmarks.list
+++ b/wrench/benchmarks/benchmarks.list
@@ -2,6 +2,7 @@ aligned-gradient.yaml
 unaligned-gradient.yaml
 simple-batching.yaml
 large-boxshadow-ellipse.yaml
+large-boxshadow-ellipse-2.yaml
 large-clip-rect.yaml
 transforms-simple.yaml
 text-rendering.yaml

--- a/wrench/benchmarks/large-boxshadow-ellipse-2.yaml
+++ b/wrench/benchmarks/large-boxshadow-ellipse-2.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+  - type: box-shadow
+    bounds: [ 0, 0, 1024, 1024 ]
+    color: green
+    clip-mode: inset
+    blur-radius: 10000
+    border-radius: {
+        top-left: [500, 700],
+        top-right: [500, 700],
+        bottom-left: [600, 400],
+        bottom-right: [600, 400],
+    }
+


### PR DESCRIPTION
We always put the ellipse distance to distance_aa. We can avoid some unnecessary calculations if we precheck the distance with aa_range. It also helps gecko [bug 1414575](https://bugzilla.mozilla.org/show_bug.cgi?id=1414575)  2ms on my device. For the large-boxshadow-ellipse-2.yaml, without the patch, I got:

    {
      "name": "benchmarks/large-boxshadow-ellipse-2.yaml",
      "backend_time_ns": 67797,
      "composite_time_ns": 7240335,
      "paint_time_ns": 5583450,
      "draw_calls": 5
    },

with the patch:

    {
      "name": "benchmarks/large-boxshadow-ellipse-2.yaml",
      "backend_time_ns": 63598,
      "composite_time_ns": 4920898,
      "paint_time_ns": 4163536,
      "draw_calls": 5
    },

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2158)
<!-- Reviewable:end -->
