### PR TITLE
Scattered GPU cache updates

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -136,6 +136,7 @@ pub fn main_wrapper<E: Example>(
         precache_shaders: E::PRECACHE_SHADERS,
         device_pixel_ratio,
         clear_color: Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
+        //scatter_gpu_cache_updates: false,
         ..options.unwrap_or(webrender::RendererOptions::default())
     };
 

--- a/webrender/res/gpu_cache_update.glsl
+++ b/webrender/res/gpu_cache_update.glsl
@@ -2,21 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include base
+
 varying vec4 vData;
 
 #ifdef WR_VERTEX_SHADER
-attribute vec4 aValue;
-attribute vec2 aPosition;
+in vec4 aValue;
+in vec2 aPosition;
 
 void main() {
 	vData = aValue;
 	gl_Position = vec4(aPosition * 2.0 - 1.0, 0.0, 1.0);
+	gl_PointSize = 1.0;
 }
 
 #endif //WR_VERTEX_SHADER
 
 #ifdef WR_FRAGMENT_SHADER
+out vec4 oValue;
+
 void main() {
-	gl_FragColor = vData;
+	oValue = vData;
 }
 #endif //WR_FRAGMENT_SHADER

--- a/webrender/res/gpu_cache_update.glsl
+++ b/webrender/res/gpu_cache_update.glsl
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+varying vec4 vData;
+
+#ifdef WR_VERTEX_SHADER
+attribute vec4 aValue;
+attribute vec2 aPosition;
+
+void main() {
+	vData = aValue;
+	gl_Position = vec4(aPosition, 0.0, 1.0);
+}
+
+#endif //WR_VERTEX_SHADER
+
+#ifdef WR_FRAGMENT_SHADER
+void main() {
+	gl_FragColor = vData;
+}
+#endif //WR_FRAGMENT_SHADER

--- a/webrender/res/gpu_cache_update.glsl
+++ b/webrender/res/gpu_cache_update.glsl
@@ -11,9 +11,9 @@ in vec4 aValue;
 in vec2 aPosition;
 
 void main() {
-	vData = aValue;
-	gl_Position = vec4(aPosition * 2.0 - 1.0, 0.0, 1.0);
-	gl_PointSize = 1.0;
+    vData = aValue;
+    gl_Position = vec4(aPosition * 2.0 - 1.0, 0.0, 1.0);
+    gl_PointSize = 1.0;
 }
 
 #endif //WR_VERTEX_SHADER
@@ -22,6 +22,6 @@ void main() {
 out vec4 oValue;
 
 void main() {
-	oValue = vData;
+    oValue = vData;
 }
 #endif //WR_FRAGMENT_SHADER

--- a/webrender/res/gpu_cache_update.glsl
+++ b/webrender/res/gpu_cache_update.glsl
@@ -10,7 +10,7 @@ attribute vec2 aPosition;
 
 void main() {
 	vData = aValue;
-	gl_Position = vec4(aPosition, 0.0, 1.0);
+	gl_Position = vec4(aPosition * 2.0 - 1.0, 0.0, 1.0);
 }
 
 #endif //WR_VERTEX_SHADER

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -411,7 +411,7 @@ impl<V> VBO<V> {
     pub fn streaw_with<'a>(&self, attributes: &'a [VertexAttribute]) -> Stream<'a> {
         debug_assert_eq!(
             mem::size_of::<V>(),
-            attributes.iter().map(|a| a.size_in_bytes() as usize).sum()
+            attributes.iter().map(|a| a.size_in_bytes() as usize).sum::<usize>()
         );
         Stream {
             attributes,

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -408,7 +408,7 @@ impl<V> VBO<V> {
         self.allocated_count
     }
 
-    pub fn streaw_with<'a>(&self, attributes: &'a [VertexAttribute]) -> Stream<'a> {
+    pub fn stream_with<'a>(&self, attributes: &'a [VertexAttribute]) -> Stream<'a> {
         debug_assert_eq!(
             mem::size_of::<V>(),
             attributes.iter().map(|a| a.size_in_bytes() as usize).sum::<usize>()

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -71,6 +71,9 @@ use time::precise_time_ns;
 use util::TransformedRectKind;
 
 pub const MAX_VERTEX_TEXTURE_WIDTH: usize = 1024;
+/// Enabling this toggle would force the GPU cache scattered texture to
+/// be resized every frame, which enables GPU debuggers to see if this
+/// is performed correctly.
 const GPU_CACHE_RESIZE_TEST: bool = false;
 
 const GPU_TAG_BRUSH_SOLID: GpuProfileTag = GpuProfileTag {
@@ -823,8 +826,8 @@ impl CacheTexture {
             //Note: the vertex attributes have to be supplied in the same order
             // as for program creation, but each assigned to a different stream.
             let vao = device.create_custom_vao(&[
-                buf_position.streaw_with(&DESC_GPU_CACHE_UPDATE.vertex_attributes[0..1]),
-                buf_value   .streaw_with(&DESC_GPU_CACHE_UPDATE.vertex_attributes[1..2]),
+                buf_position.stream_with(&DESC_GPU_CACHE_UPDATE.vertex_attributes[0..1]),
+                buf_value   .stream_with(&DESC_GPU_CACHE_UPDATE.vertex_attributes[1..2]),
             ]);
             CacheBus::Scatter {
                 program,
@@ -4553,7 +4556,10 @@ impl Default for RendererOptions {
             clear_color: Some(ColorF::new(1.0, 1.0, 1.0, 1.0)),
             enable_clear_scissor: true,
             max_texture_size: None,
-            scatter_gpu_cache_updates: true,
+            // Scattered GPU cache updates haven't met a test that would show their superiority yet.
+            scatter_gpu_cache_updates: false,
+            // This is best as `Immediate` on Angle, or `Pixelbuffer(Dynamic)` on GL,
+            // but we are unable to make this decision here, so picking the reasonable medium.
             upload_method: UploadMethod::PixelBuffer(VertexUsageHint::Stream),
             workers: None,
             blob_image_renderer: None,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -812,13 +812,12 @@ struct CacheTexture {
 }
 
 impl CacheTexture {
-    fn new(device: &mut Device, use_scatter: bool) -> Self {
+    fn new(device: &mut Device, use_scatter: bool) -> Result<Self, RendererError> {
         let texture = device.create_texture(TextureTarget::Default);
 
         let bus = if use_scatter {
             let program = device
-                .create_program("gpu_cache_update", "", &DESC_GPU_CACHE_UPDATE)
-                .unwrap();
+                .create_program("gpu_cache_update", "", &DESC_GPU_CACHE_UPDATE)?;
             let buf_position = device.create_vbo();
             let buf_value = device.create_vbo();
             //Note: the vertex attributes have to be supplied in the same order
@@ -843,10 +842,10 @@ impl CacheTexture {
             }
         };
 
-        CacheTexture {
+        Ok(CacheTexture {
             texture,
             bus,
-        }
+        })
     }
 
     fn deinit(self, device: &mut Device) {
@@ -2134,7 +2133,7 @@ impl Renderer {
         let gpu_cache_texture = CacheTexture::new(
             &mut device,
             options.scatter_gpu_cache_updates,
-        );
+        )?;
 
         device.end_frame();
 

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -65,6 +65,11 @@ subcommands:
     - png:
         about: render frame described by YAML and save it to a png file
         args:
+          - surface:
+              short: s
+              long: surface
+              help: 'What rendered surface to save as PNG, one of: screen, gpu-cache'
+              takes_value: true
           - INPUT:
               help: The input YAML file
               required: true

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -346,7 +346,7 @@ fn main() {
             DeviceUintSize::new(3840, 2160)
         } else {
             let x = s.find('x').expect(
-                "Size must be specified exactly as 720p, 1080p, 4k, or widthxheight",
+                "Size must be specified exactly as 720p, 1080p, 4k, or width x height",
             );
             let w = s[0 .. x].parse::<u32>().expect("Invalid size width");
             let h = s[x + 1 ..].parse::<u32>().expect("Invalid size height");
@@ -391,8 +391,13 @@ fn main() {
     } else if let Some(subargs) = args.subcommand_matches("replay") {
         Box::new(BinaryFrameReader::new_from_args(subargs)) as Box<WrenchThing>
     } else if let Some(subargs) = args.subcommand_matches("png") {
+        let surface = match subargs.value_of("surface") {
+            Some("screen") | None => png::ReadSurface::Screen,
+            Some("gpu-cache") => png::ReadSurface::GpuCache,
+            _ => panic!("Unknown surface argument value")
+        };
         let reader = YamlFrameReader::new_from_args(subargs);
-        png::png(&mut wrench, &mut window, reader, rx.unwrap());
+        png::png(&mut wrench, surface, &mut window, reader, rx.unwrap());
         wrench.renderer.deinit();
         return;
     } else if let Some(subargs) = args.subcommand_matches("reftest") {

--- a/wrench/src/png.rs
+++ b/wrench/src/png.rs
@@ -12,10 +12,21 @@ use webrender::api::*;
 use wrench::{Wrench, WrenchThing};
 use yaml_frame_reader::YamlFrameReader;
 
-pub fn save_flipped<P: Clone + AsRef<Path>>(
+pub enum ReadSurface {
+    Screen,
+    GpuCache,
+}
+
+pub struct SaveSettings {
+    pub flip_vertical: bool,
+    pub try_crop: bool,
+}
+
+pub fn save<P: Clone + AsRef<Path>>(
     path: P,
     orig_pixels: Vec<u8>,
-    mut size: DeviceUintSize
+    mut size: DeviceUintSize,
+    settings: SaveSettings
 ) {
     let mut buffer = image::RgbaImage::from_raw(
         size.width,
@@ -23,44 +34,83 @@ pub fn save_flipped<P: Clone + AsRef<Path>>(
         orig_pixels,
     ).expect("bug: unable to construct image buffer");
 
-    // flip image vertically (texture is upside down)
-    buffer = image::imageops::flip_vertical(&buffer);
+    if settings.flip_vertical {
+        // flip image vertically (texture is upside down)
+        buffer = image::imageops::flip_vertical(&buffer);
+    }
 
-    if let Ok(existing_image) = image::open(path.clone()) {
-        let old_dims = existing_image.dimensions();
-        println!("Crop from {:?} to {:?}", size, old_dims);
-        size.width = old_dims.0;
-        size.height = old_dims.1;
-        buffer = image::imageops::crop(
-            &mut buffer,
-            0,
-            0,
-            size.width,
-            size.height
-        ).to_image();
+    if settings.try_crop {
+        if let Ok(existing_image) = image::open(path.clone()) {
+            let old_dims = existing_image.dimensions();
+            println!("Crop from {:?} to {:?}", size, old_dims);
+            size.width = old_dims.0;
+            size.height = old_dims.1;
+            buffer = image::imageops::crop(
+                &mut buffer,
+                0,
+                0,
+                size.width,
+                size.height
+            ).to_image();
+        }
     }
 
     let encoder = PNGEncoder::new(File::create(path).unwrap());
     encoder
-        .encode(&buffer.into_vec(), size.width, size.height, ColorType::RGBA(8))
+        .encode(&buffer, size.width, size.height, ColorType::RGBA(8))
         .expect("Unable to encode PNG!");
 }
 
-pub fn png(wrench: &mut Wrench, window: &mut WindowWrapper, mut reader: YamlFrameReader, rx: Receiver<()>) {
+pub fn save_flipped<P: Clone + AsRef<Path>>(
+    path: P,
+    orig_pixels: Vec<u8>,
+    size: DeviceUintSize,
+) {
+    save(path, orig_pixels, size, SaveSettings {
+        flip_vertical: true,
+        try_crop: true,
+    })
+}
+
+pub fn png(
+    wrench: &mut Wrench,
+    surface: ReadSurface,
+    window: &mut WindowWrapper,
+    mut reader: YamlFrameReader,
+    rx: Receiver<()>,
+) {
     reader.do_frame(wrench);
 
     // wait for the frame
     rx.recv().unwrap();
     wrench.render();
 
-    let size = window.get_inner_size_pixels();
-    let device_size = DeviceUintSize::new(size.0, size.1);
-    let data = wrench
-        .renderer
-        .read_pixels_rgba8(DeviceUintRect::new(DeviceUintPoint::zero(), device_size));
+    let (device_size, data, settings) = match surface {
+        ReadSurface::Screen => {
+            let size = window.get_inner_size_pixels();
+            let rect = DeviceUintRect::new(
+                DeviceUintPoint::zero(),
+                DeviceUintSize::new(size.0, size.1),
+            );
+            let data = wrench.renderer
+                .read_pixels_rgba8(rect);
+            (rect.size, data, SaveSettings {
+                flip_vertical: true,
+                try_crop: true,
+            })
+        }
+        ReadSurface::GpuCache => {
+            let (size, data) = wrench.renderer
+                .read_gpu_cache();
+            (size, data, SaveSettings {
+                flip_vertical: false,
+                try_crop: false,
+            })
+        }
+    };
 
     let mut out_path = reader.yaml_path().clone();
     out_path.set_extension("png");
 
-    save_flipped(out_path, data, device_size);
+    save(out_path, data, device_size, settings);
 }


### PR DESCRIPTION
Fixes #2110

This PR introduces the GPU cache uploading via shader writes. It minimizes the amount of data we need to transfer to the GPU in order to reduce the stalls and make us scale better with content (see https://github.com/servo/webrender/issues/2132#issuecomment-348735499).

Note: in terms of efficiency, rasterizing lines would be much better than points. Leaving this for the follow up. Doing so would require us to upload the source data into a texture as opposed to a buffer, and slightly (but non-critically) complicate things.

WIP, because:
  - benchmarking is TODO
  - to be squashed eventually

Try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=f583b2deae1c7312437638bdda6ddc65693d53ed

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2162)
<!-- Reviewable:end -->
