### PR TITLE
fix handling of embedded bitmaps in FreeType font backend

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -175,7 +175,7 @@ impl FontContext {
         if font.flags.contains(FontInstanceFlags::NO_AUTOHINT) {
             load_flags |= FT_LOAD_NO_AUTOHINT;
         }
-        if font.flags.contains(FontInstanceFlags::EMBEDDED_BITMAPS) {
+        if !font.flags.contains(FontInstanceFlags::EMBEDDED_BITMAPS) {
             load_flags |= FT_LOAD_NO_BITMAP;
         }
         if font.flags.contains(FontInstanceFlags::VERTICAL_LAYOUT) {


### PR DESCRIPTION
This fixes a small regression I accidentally made with #2120. The prior "(flags & FONT_EMBEDDED_BITMAP) == 0" statement needed to be !contains() rather than just contains().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2164)
<!-- Reviewable:end -->
