### PR TITLE
Reduce HashMap access in path_for_image

### DIFF
--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -539,16 +539,14 @@ impl YamlFrameWriter {
 
 
     fn path_for_image(&mut self, key: ImageKey) -> Option<PathBuf> {
-        if let Some(ref mut data) = self.images.get_mut(&key) {
-            if data.path.is_some() {
-                return data.path.clone();
-            }
-        } else {
-            return None;
+        let data = match self.images.get_mut(&key) {
+            Some(data) => data,
+            None => return None,
         };
 
-        // Remove the data to munge it
-        let mut data = self.images.remove(&key).unwrap();
+        if data.path.is_some() {
+            return data.path.clone();
+        }
         let mut bytes = data.bytes.take().unwrap();
         let (path_file, path) = self.rsrc_gen.next_rsrc_paths(
             "img",
@@ -594,8 +592,6 @@ impl YamlFrameWriter {
         }
 
         data.path = Some(path.clone());
-        // put it back
-        self.images.insert(key, data);
         Some(path)
     }
 


### PR DESCRIPTION
The old code removed an item from the hashmap, manipulated it, and stored it as a new value.

This patch modifies it in-place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2184)
<!-- Reviewable:end -->
