### PR TITLE
Avoid creating duplicate copies of image files

### DIFF
--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -405,6 +405,12 @@ impl YamlFrameWriter {
         for update in &updates.updates {
             match *update {
                 ResourceUpdate::AddImage(ref img) => {
+                    if let Some(ref data) = self.images.get(&img.key) {
+                          if data.path.is_some() {
+                              return;
+                          }
+                    }
+
                     let stride = img.descriptor.stride.unwrap_or(
                         img.descriptor.width * img.descriptor.format.bytes_per_pixel(),
                     );


### PR DESCRIPTION
When replaying a recording, and moving back and forth over a frame that introduces a new image, the image was saved repeatedly, each time with a new filename.

This adds a check to `AddImage` in case we remember there's already a filename for that image.

I haven't tested how this interacts with `UpdateImage` and `DeleteImage`, but both commands either delete the path, or remove the image entry altogether, bypassing this check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2185)
<!-- Reviewable:end -->
