### PR TITLE
Add a compact profiler mode.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -35,7 +35,7 @@ use resource_cache::ResourceCache;
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
 use tiling::{CompositeOps, Frame};
-use tiling::{RenderPass, RenderPassKind, RenderTargetKind};
+use tiling::{RenderPass, RenderTargetKind};
 use tiling::{RenderTargetContext, ScrollbarPrimitive};
 use util::{self, MaxRect, pack_as_float, RectHelpers, recycle_vec};
 
@@ -1777,22 +1777,6 @@ impl FrameBuilder {
                 &mut deferred_resolves,
                 &self.clip_store,
             );
-
-            profile_counters.passes.inc();
-
-            match pass.kind {
-                RenderPassKind::MainFramebuffer(_) => {
-                    profile_counters.color_targets.add(1);
-                }
-                RenderPassKind::OffScreen { ref color, ref alpha } => {
-                    profile_counters
-                        .color_targets
-                        .add(color.targets.len());
-                    profile_counters
-                        .alpha_targets
-                        .add(alpha.targets.len());
-                }
-            }
         }
 
         let gpu_cache_updates = gpu_cache.end_frame(gpu_cache_profile);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -256,6 +256,7 @@ bitflags! {
         const GPU_SAMPLE_QUERIES= 1 << 5;
         const DISABLE_BATCHING  = 1 << 6;
         const EPOCHS            = 1 << 7;
+        const COMPACT_PROFILER  = 1 << 8;
     }
 }
 
@@ -2549,6 +2550,7 @@ impl Renderer {
                 &profile_samplers,
                 screen_fraction,
                 &mut self.debug,
+                self.debug_flags.contains(DebugFlags::COMPACT_PROFILER),
             );
         }
 
@@ -2987,6 +2989,7 @@ impl Renderer {
         frame_id: FrameId,
         stats: &mut RendererStats,
     ) {
+        self.profile_counters.color_targets.inc();
         let _gm = self.gpu_profile.start_marker("color target");
 
         // sanity check for the depth buffer
@@ -3408,6 +3411,7 @@ impl Renderer {
         render_tasks: &RenderTaskTree,
         stats: &mut RendererStats,
     ) {
+        self.profile_counters.alpha_targets.inc();
         let _gm = self.gpu_profile.start_marker("alpha target");
         let alpha_sampler = self.gpu_profile.start_sampler(GPU_SAMPLER_TAG_ALPHA);
 

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -600,6 +600,9 @@ fn main() {
                 VirtualKeyCode::B => {
                     wrench.renderer.toggle_debug_flags(DebugFlags::ALPHA_PRIM_DBG);
                 }
+                VirtualKeyCode::C => {
+                    wrench.renderer.toggle_debug_flags(DebugFlags::COMPACT_PROFILER);
+                }
                 VirtualKeyCode::Q => {
                     wrench.renderer.toggle_debug_flags(
                         DebugFlags::GPU_TIME_QUERIES | DebugFlags::GPU_SAMPLE_QUERIES


### PR DESCRIPTION
This allows viewing a minimal amount of the most critical data from
the profiler, as shown in the screenshot below.

This is useful for a couple of reasons, namely:
 * Makes it easier to interact with the underlying page.
 * Reduces the amount of GPU time spent drawing the profiler itself.

The profiler code in general is a bit messy - this includes a few
hacks to work around the borrow checker. We should restructure this
a bit in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2186)
<!-- Reviewable:end -->
