### PR TITLE
Force corefoundation 0.4.6 or higher since we use CFNumber::from whic…

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -49,6 +49,6 @@ freetype = { version = "0.3", default-features = false }
 dwrote = "0.4.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.4"
+core-foundation = "0.4.6"
 core-graphics = "0.12.3"
 core-text = { version = "8.0", default-features = false }

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.4"
+core-foundation = "0.4.6"
 core-graphics = "0.12.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
…h didn't exist in 0.4.4

The use of CFNumber::from was added in #2122 and caused downstream gecko bustage since gecko is still using 0.4.4 in its Cargo.lock file. This change will force gecko to update to 0.4.6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2190)
<!-- Reviewable:end -->
