### PR TITLE
Don't run travis-CI except on the merge commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@ matrix:
 os:
   - linux
   - osx
+
+# Travis is slow and often backlogged so we only run it on the "auto" branch
+# which is what bors uses to test the merge commit when merging a PR. Individual
+# PRs can catch errors by checking the taskcluster result instead.
+branches:
+  only:
+    - auto
 notifications:
   webhooks: http://build.servo.org:54856/travis
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
The merge commit is the one that bors actually cares about, and running
travis on the individual PR changes just steals resources away from
testing the merge commits. And anyway, we have taskcluster running on
the PRs so people can check the test results there too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2191)
<!-- Reviewable:end -->
