### PR TITLE
Stop the warning spam about invalid prim rects.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1754,7 +1754,9 @@ impl PrimitiveStore {
             let metadata = &mut self.cpu_metadata[prim_index.0];
             if metadata.local_rect.size.width <= 0.0 ||
                metadata.local_rect.size.height <= 0.0 {
-                warn!("invalid primitive rect {:?}", metadata.local_rect);
+                if metadata.prim_kind != PrimitiveKind::Picture {
+                    warn!("invalid primitive rect {:?}", metadata.local_rect);
+                }
                 return None;
             }
 

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -771,6 +771,9 @@ impl DisplayListBuilder {
     }
 
     fn push_item(&mut self, item: SpecificDisplayItem, info: &LayoutPrimitiveInfo) {
+        if info.rect.is_empty() {
+            return;
+        }
         serialize_fast(
             &mut self.data,
             &DisplayItem {
@@ -1185,7 +1188,14 @@ impl DisplayListBuilder {
             },
         });
 
-        self.push_item(item, info);
+        serialize_fast(
+            &mut self.data,
+            &DisplayItem {
+                item,
+                clip_and_scroll: *self.clip_stack.last().unwrap(),
+                info: *info,
+            },
+        );
         self.push_iter(&filters);
     }
 


### PR DESCRIPTION
The first commit makes it so we don't warn in prim_store.rs if the local_rect of a picture primitive is empty. This is because picture primitves are created with an empty rect that is computed later.  It's not entirely clear to me whether we should still early return from `prepare_prim_for_render` in that case so I kept the current behavior.

The second commit filters out empty rects during display list construction(except for stacking contexts). Turns out gecko creates some of those. This is the simplest place to work around it, but if you prefer I can handle this on the gecko side as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2203)
<!-- Reviewable:end -->
