### PR TITLE
Make sure we mulitply by byte_per_pixel when computing byte offsets.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -1057,7 +1057,7 @@ impl TextureUpdate {
         let update_op = match dirty_rect {
             Some(dirty) => {
                 let stride = descriptor.compute_stride();
-                let offset = descriptor.offset + dirty.origin.y * stride + dirty.origin.x;
+                let offset = descriptor.offset + dirty.origin.y * stride + dirty.origin.x * descriptor.format.bytes_per_pixel();
                 let origin =
                     DeviceUintPoint::new(origin.x + dirty.origin.x, origin.y + dirty.origin.y);
                 TextureUpdateOp::Update {


### PR DESCRIPTION
This fixes us getting confused by dirty rects when doing image updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2204)
<!-- Reviewable:end -->
