### PR TITLE
Use a more conservative approach for inner rect calculation

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -10,7 +10,7 @@ use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use prim_store::{ClipData, ImageMaskData};
 use resource_cache::ResourceCache;
-use util::{MaxRect, calculate_screen_inner_rect, calculate_screen_bounding_rect, extract_inner_rect_safe};
+use util::{MaxRect, MatrixHelpers, calculate_screen_bounding_rect, extract_inner_rect_safe};
 
 pub type ClipStore = FreeList<ClipSources>;
 pub type ClipSourcesHandle = FreeListHandle<ClipSources>;
@@ -251,8 +251,20 @@ impl ClipSources {
         transform: &LayerToWorldTransform,
         device_pixel_ratio: f32,
     ) -> (DeviceIntRect, Option<DeviceIntRect>) {
-        let screen_inner_rect =
-            calculate_screen_inner_rect(transform, &self.local_inner_rect, device_pixel_ratio);
+        // If this translation isn't axis aligned or has a perspective component, don't try to
+        // calculate the inner rectangle. The rectangle that we produce would include potentially
+        // clipped screen area.
+        // TODO(mrobinson): We should eventually try to calculate an inner region or some inner
+        // rectangle so that we can do screen inner rectangle optimizations for these kind of
+        // cilps.
+        let can_calculate_inner_rect =
+            transform.preserves_2d_axis_alignment() && !transform.has_perspective_component();
+        let screen_inner_rect = if can_calculate_inner_rect {
+            calculate_screen_bounding_rect(transform, &self.local_inner_rect, device_pixel_ratio)
+        } else {
+            DeviceIntRect::zero()
+        };
+
         let screen_outer_rect = self.local_outer_rect.map(|outer_rect|
             calculate_screen_bounding_rect(transform, &outer_rect, device_pixel_ratio)
         );

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -8,7 +8,6 @@ use euclid::{Point2D, Rect, TypedScale, Size2D, TypedPoint2D, TypedRect, TypedSi
 use euclid::{TypedTransform2D, TypedTransform3D};
 use num_traits::Zero;
 use std::{i32, f32};
-use std::cmp::Ordering;
 
 // Matches the definition of SK_ScalarNearlyZero in Skia.
 const NEARLY_ZERO: f32 = 1.0 / 4096.0;
@@ -158,36 +157,6 @@ pub fn calculate_screen_bounding_rect(
         .round_out()
         .intersection(&max_rect)
         .unwrap_or(max_rect)
-        .to_i32()
-}
-
-pub fn calculate_screen_inner_rect(
-    transform: &LayerToWorldTransform,
-    rect: &LayerRect,
-    device_pixel_ratio: f32
-) -> DeviceIntRect {
-    let points = [
-        transform.transform_point2d(&rect.origin),
-        transform.transform_point2d(&rect.top_right()),
-        transform.transform_point2d(&rect.bottom_left()),
-        transform.transform_point2d(&rect.bottom_right()),
-    ];
-    let mut xs = [points[0].x, points[1].x, points[2].x, points[3].x];
-    let mut ys = [points[0].y, points[1].y, points[2].y, points[3].y];
-
-    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-    ys.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-
-    let rect = DeviceRect::new(
-        DevicePoint::new(xs[1], ys[1]),
-        DeviceSize::new(xs[2] - xs[1], ys[2] - ys[1]),
-    ) * device_pixel_ratio;
-
-    let max_rect = DeviceRect::max_rect();
-    rect
-        .intersection(&max_rect)
-        .unwrap_or(max_rect)
-        .round_in()
         .to_i32()
 }
 


### PR DESCRIPTION
This is a temporary workaround for a Gecko issue with the conservative
inner rect calculation for clips. In this case we just don't calculate
an inner rect when faced with a non-axis-aligned transformation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2205)
<!-- Reviewable:end -->
