### PR TITLE
pass subpixel dir to shader via glyph instances instead of text run

### DIFF
--- a/webrender/res/cs_text_run.glsl
+++ b/webrender/res/cs_text_run.glsl
@@ -18,10 +18,11 @@ void main(void) {
 
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data1;
+    int subpx_dir = prim.user_data2;
 
     Glyph glyph = fetch_glyph(prim.specific_prim_address,
                               glyph_index,
-                              text.subpx_dir);
+                              subpx_dir);
 
     GlyphResource res = fetch_glyph_resource(resource_address);
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -733,12 +733,11 @@ struct TextRun {
     vec4 color;
     vec4 bg_color;
     vec2 offset;
-    int subpx_dir;
 };
 
 TextRun fetch_text_run(int address) {
     vec4 data[3] = fetch_from_resource_cache_3(address);
-    return TextRun(data[0], data[1], data[2].xy, int(data[2].z));
+    return TextRun(data[0], data[1], data[2].xy);
 }
 
 struct Image {

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -59,17 +59,7 @@ void main(void) {
 
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data1;
-
-    int subpx_dir;
-    switch (uMode) {
-        case MODE_BITMAP:
-        case MODE_COLOR_BITMAP:
-            subpx_dir = SUBPX_DIR_NONE;
-            break;
-        default:
-            subpx_dir = text.subpx_dir;
-            break;
-    }
+    int subpx_dir = prim.user_data2;
 
     Glyph glyph = fetch_glyph(prim.specific_prim_address,
                               glyph_index,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -820,7 +820,7 @@ impl TextRunPrimitiveCpu {
         request.push([
             self.offset.x,
             self.offset.y,
-            self.font.subpx_dir.limit_by(self.font.render_mode) as u32 as f32,
+            0.0,
             0.0,
         ]);
         request.extend_from_slice(&self.glyph_gpu_blocks);


### PR DESCRIPTION
This is a follow-up to #2198. I overlooked cs_text_run, which will also need to know about subpx_dir. Since we don't break up batches for these text shadow glyphs, and since subpixel direction now depends on the glyph format which is size/transform dependent, it just made a lot more sense to pass it in via the (now) unused user_data2 in the glyph instance. This also moves some decision logic out of the shader. Since all these parameters get routed out of prim.user_dataN almost straight to fetch_glyph, it makes some sense to put subpx_dir there anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2207)
<!-- Reviewable:end -->
