### PR TITLE
Ignore DeleteDocument during playback of last frame to avoid crashing

### DIFF
--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -133,6 +133,7 @@ impl WrenchThing for BinaryFrameReader {
                     let mut buffer = vec![0; len as usize];
                     self.file.read_exact(&mut buffer).unwrap();
                     let msg = deserialize(&buffer).unwrap();
+                    let mut store_message = true;
                     // In order to detect the first valid frame, we
                     // need to find:
                     // (a) SetRootPipeline
@@ -150,9 +151,15 @@ impl WrenchThing for BinaryFrameReader {
                             found_frame_marker = false;
                             found_pipeline = true;
                         }
+                        // Wrench depends on the document always existing
+                        ApiMsg::DeleteDocument(_) => {
+                            store_message = false;
+                        }
                         _ => {}
                     }
-                    self.frame_data.push(Item::Message(msg));
+                    if store_message {
+                        self.frame_data.push(Item::Message(msg));
+                    }
                     // Frames are marked by the GenerateFrame message.
                     // On the first frame, we additionally need to find at least
                     // a SetDisplayList and a SetRootPipeline.


### PR DESCRIPTION
This fixes the crash during "replay" when reaching the last frame.
The render backend gets sent a `DeleteDocument`, so it delete its document, and then wrench asks it to `UpdateDocument`.

If we do let it accept the `DeleteDocument`, and have wrench detect it and do no more updates, then we won't be able to rewind. Ignoring it is the simplest option.

Does this break anything? Can there be recordings with multiple documents that are added and deleted as it goes? From what I've seen, wrench adds its own document when it starts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2209)
<!-- Reviewable:end -->
