### PR TITLE
Allocate 2 GPU blocks for a deferred image

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2112,7 +2112,7 @@ fn resolve_image(
                     // This is an external texture - we will add it to
                     // the deferred resolves list to be patched by
                     // the render thread...
-                    let cache_handle = gpu_cache.push_deferred_per_frame_blocks(1);
+                    let cache_handle = gpu_cache.push_deferred_per_frame_blocks(2);
                     deferred_resolves.push(DeferredResolve {
                         image_properties,
                         address: gpu_cache.get_address(&cache_handle),


### PR DESCRIPTION
Fixes #2208 and supposedly https://github.com/servo/servo/pull/19531#issuecomment-350429510

The breakage is caused by this line: https://github.com/servo/webrender/pull/2162/files#diff-f5062b694b9fe53fc1757ed483d577d9R3923
The block count in the update used to be 1, which surprised me as a mistake. TL;DR: it was always wrong (! since `fetch_image_resource` requires exactly 2 blocks), but my fix was missing a crucial bit to work, which is this PR.

cc @glennw @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2211)
<!-- Reviewable:end -->
