### PR TITLE
Define and enforce BLOCKS_PER_UV_RECT

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -720,6 +720,7 @@ struct ImageResource {
 };
 
 ImageResource fetch_image_resource(int address) {
+    //Note: number of blocks has to match `renderer::BLOCKS_PER_UV_RECT`
     vec4 data[2] = fetch_from_resource_cache_2(address);
     return ImageResource(data[0], data[1].x);
 }

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -32,6 +32,7 @@ use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 use std::{mem, u16, u32};
 use std::ops::Add;
 
+
 pub const GPU_CACHE_INITIAL_HEIGHT: u32 = 512;
 const FRAMES_BEFORE_EVICTION: usize = 10;
 const NEW_ROWS_PER_RESIZE: u32 = 512;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -21,13 +21,14 @@ use picture::{PictureKind, PicturePrimitive, RasterizationSpace};
 use profiler::FrameProfileCounters;
 use render_task::{ClipChain, ClipChainNode, ClipChainNodeIter, ClipWorkItem, RenderTask};
 use render_task::{RenderTaskId, RenderTaskTree};
-use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+use renderer::{BLOCKS_PER_UV_RECT, MAX_VERTEX_TEXTURE_WIDTH};
 use resource_cache::{ImageProperties, ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, u16, usize};
 use std::rc::Rc;
 use util::{MatrixHelpers, calculate_screen_bounding_rect, extract_inner_rect_safe, pack_as_float};
 use util::recycle_vec;
+
 
 const MIN_BRUSH_SPLIT_AREA: f32 = 128.0 * 128.0;
 
@@ -448,7 +449,7 @@ pub struct ImagePrimitiveCpu {
     pub tile_offset: Option<TileOffset>,
     pub tile_spacing: LayerSize,
     // TODO(gw): Build on demand
-    pub gpu_blocks: [GpuBlockData; 2],
+    pub gpu_blocks: [GpuBlockData; BLOCKS_PER_UV_RECT],
 }
 
 impl ToGpuBlocks for ImagePrimitiveCpu {

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -76,6 +76,9 @@ pub const MAX_VERTEX_TEXTURE_WIDTH: usize = 1024;
 /// is performed correctly.
 const GPU_CACHE_RESIZE_TEST: bool = false;
 
+/// Number of GPU blocks per UV rectangle provided for an image.
+pub const BLOCKS_PER_UV_RECT: usize = 2;
+
 const GPU_TAG_BRUSH_SOLID: GpuProfileTag = GpuProfileTag {
     label: "B_Solid",
     color: debug_colors::RED,
@@ -3923,7 +3926,7 @@ impl Renderer {
 
             list.updates.push(GpuCacheUpdate::Copy {
                 block_index: list.blocks.len(),
-                block_count: 2,
+                block_count: BLOCKS_PER_UV_RECT,
                 address: deferred_resolve.address,
             });
             list.blocks.push([image.u0, image.v0, image.u1, image.v1].into());

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -29,8 +29,8 @@ use profiler::FrameProfileCounters;
 use render_task::{ClipWorkItem};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKey, RenderTaskKind};
 use render_task::{BlurTask, ClearMode, RenderTaskLocation, RenderTaskTree};
-use renderer::BlendMode;
-use renderer::ImageBufferKind;
+use renderer::{BlendMode, ImageBufferKind};
+use renderer::BLOCKS_PER_UV_RECT;
 use resource_cache::{GlyphFetchResult, ResourceCache};
 use std::{cmp, usize, f32, i32};
 use std::collections::hash_map::Entry;
@@ -2112,7 +2112,7 @@ fn resolve_image(
                     // This is an external texture - we will add it to
                     // the deferred resolves list to be patched by
                     // the render thread...
-                    let cache_handle = gpu_cache.push_deferred_per_frame_blocks(2);
+                    let cache_handle = gpu_cache.push_deferred_per_frame_blocks(BLOCKS_PER_UV_RECT);
                     deferred_resolves.push(DeferredResolve {
                         image_properties,
                         address: gpu_cache.get_address(&cache_handle),


### PR DESCRIPTION
A stronger version of the fix for #2208
Replaces #2211

TODO: try push

Note: I tried going all the way to type-level enforcement of the GPU block count for everything but faced a few run-time driven GPU layouts (clip sources, borders). Perhaps, next time...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2212)
<!-- Reviewable:end -->
