### PR TITLE
fix glyph clipping when scale is used

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -8,6 +8,10 @@ flat varying vec4 vColor;
 varying vec3 vUv;
 flat varying vec4 vUvBorder;
 
+#ifdef WR_FEATURE_GLYPH_TRANSFORM
+varying vec4 vUvClip;
+#endif
+
 #ifdef WR_VERTEX_SHADER
 
 #define MODE_ALPHA              0
@@ -114,6 +118,7 @@ void main(void) {
 
 #ifdef WR_FEATURE_GLYPH_TRANSFORM
     vec2 f = (transform * vi.local_pos - glyph_rect.p0) / glyph_rect.size;
+    vUvClip = vec4(f, 1.0 - f);
 #else
     vec2 f = (vi.local_pos - glyph_rect.p0) / glyph_rect.size;
 #endif
@@ -147,16 +152,19 @@ void main(void) {
     vec2 st1 = res.uv_rect.zw / texture_size;
 
     vUv = vec3(mix(st0, st1, f), res.layer);
-    vUvBorder = (res.uv_rect + vec4(0.499, 0.499, -0.499, -0.499)) / texture_size.xyxy;
+    vUvBorder = (res.uv_rect + vec4(0.5, 0.5, -0.5, -0.5)) / texture_size.xyxy;
 }
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
 void main(void) {
-    vec4 mask = texture(sColor0, vUv);
+    vec3 tc = vec3(clamp(vUv.xy, vUvBorder.xy, vUvBorder.zw), vUv.z);
+    vec4 mask = texture(sColor0, tc);
 
-    float alpha = float(all(lessThanEqual(vec4(vUvBorder.xy, vUv.xy), vec4(vUv.xy, vUvBorder.zw))));
-    alpha *= do_clip();
+    float alpha = do_clip();
+#ifdef WR_FEATURE_GLYPH_TRANSFORM
+    alpha *= float(all(greaterThanEqual(vUvClip, vec4(0.0))));
+#endif
 
 #ifdef WR_FEATURE_SUBPX_BG_PASS1
     mask.rgb = vec3(mask.a) - mask.rgb;


### PR DESCRIPTION
This is to fix downstream Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1424562

It turns out that we're not going to be able to live within the 0.5 to N-0.5 bounds when sampling the texture if there is scaling or some aberrant snapping in play. Imagine a 2 pixel wide bitmap being stretched over 3 device space pixels, the sample taps on the ends will unfortunately be outside these bounds.

We still need to clip, but we need to use a more permissive clip that allows for this sampling to happen anywhere in the 0..N range. To prevent texels bleeding in from outside the glyph, unfortunately we need to restore the original clamping behavior as well. I also ifdef'd the clipping to avoid it costing us in those non-transform cases where we don't actually need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2213)
<!-- Reviewable:end -->
