### PR TITLE
Lock serde to 1.0.23 exactly so gankro's replace works even when a ne…

### DIFF
--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -16,8 +16,8 @@ bincode = "0.9"
 byteorder = "1.2.1"
 euclid = "0.16"
 ipc-channel = {version = "0.9", optional = true}
-serde = { version = "1.0.23", features = ["rc", "derive"] }
-serde_derive = { version = "1.0.23", features = ["deserialize_from"] }
+serde = { version = "=1.0.23", features = ["rc", "derive"] }
+serde_derive = { version = "=1.0.23", features = ["deserialize_from"] }
 time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
…wer caret-compatible release is available on crates.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2214)
<!-- Reviewable:end -->
