### PR TITLE
Fix inverted translation for reference frames between sticky frames a…

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -659,9 +659,10 @@ impl ClipScrollNode {
                 state.parent_reference_frame_transform = self.world_viewport_transform;
                 state.parent_combined_viewport_rect = combined_local_viewport_rect;
                 state.parent_accumulated_scroll_offset = LayerVector2D::zero();
+                let translation = -info.origin_in_parent_reference_frame;
                 state.nearest_scrolling_ancestor_viewport =
                     state.nearest_scrolling_ancestor_viewport
-                       .translate(&info.origin_in_parent_reference_frame);
+                       .translate(&translation);
             }
             NodeType::Clip(..) => {
                 state.parent_combined_viewport_rect = combined_local_viewport_rect;

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -12,4 +12,5 @@
 == sticky.yaml sticky-ref.yaml
 == sticky-nested.yaml sticky-ref.yaml
 == sticky-applied.yaml sticky-applied-ref.yaml
+== sticky-transformed.yaml sticky-transformed-ref.yaml
 == sibling-hidden-clip.yaml sibling-hidden-clip-ref.yaml

--- a/wrench/reftests/scrolling/sticky-transformed-ref.yaml
+++ b/wrench/reftests/scrolling/sticky-transformed-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - type: rect
+      bounds: [10, 30, 10, 10]
+      color: green

--- a/wrench/reftests/scrolling/sticky-transformed.yaml
+++ b/wrench/reftests/scrolling/sticky-transformed.yaml
@@ -1,0 +1,21 @@
+root:
+  items:
+    # There is a new reference frame introduced between the scrollframe and
+    # the sticky item. This tests that the sticky item is still positioned
+    # correctly.
+    - type: scroll-frame
+      bounds: [10, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+      - type: stacking-context
+        bounds: [10, 20, 10, 10]
+        transform: translate(0, 10)
+        items:
+        - type: sticky-frame
+          bounds: [0, 0, 10, 10]
+          margin-top: 10
+          vertical-offset-bounds: [0, 200]
+          items:
+          - type: rect
+            bounds: [0, 0, 10, 10]
+            color: green


### PR DESCRIPTION
…nd their scrolling ancestor

r? @mrobinson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2221)
<!-- Reviewable:end -->
