### PR TITLE
Make image mask path optional in YAML reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "gleam 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -17,6 +17,7 @@ app_units = "0.6"
 image = "0.17"
 clap = { version = "2", features = ["yaml"] }
 lazy_static = "1"
+log = "0.3"
 yaml-rust = { git = "https://github.com/vvuk/yaml-rust", features = ["preserve_order"] }
 serde_json = "1.0"
 ron = "0.1.3"

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -25,6 +25,8 @@ extern crate glutin;
 extern crate image;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate log;
 #[cfg(feature = "headless")]
 extern crate osmesa_sys;
 extern crate ron;

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -464,7 +464,18 @@ impl YamlFrameReader {
             return None;
         }
 
-        let file = rsrc_path(&item["image"], &self.aux_dir);
+        let file = match item["image"].as_str() {
+            Some(filename) => {
+                let mut file = self.aux_dir.clone();
+                file.push(filename);
+                file
+            }
+            None => {
+                warn!("No image provided for the image-mask!");
+                return None;
+            }
+        };
+
         let (image_key, image_dims) =
             self.add_or_get_image(&file, None, wrench);
         let image_rect = item["rect"]


### PR DESCRIPTION
Otherwise we crash during "show" command on some frames.
Appears to be broken as of #1412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2225)
<!-- Reviewable:end -->
