### PR TITLE
Fix path typo to font file in basic example

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -259,7 +259,7 @@ impl Example for App {
         if false {
             // draw text?
             let font_key = api.generate_font_key();
-            let font_bytes = load_file("../wrench/reftest/text/FreeSans.ttf");
+            let font_bytes = load_file("../wrench/reftests/text/FreeSans.ttf");
             resources.add_raw_font(font_key, font_bytes, 0);
 
             let font_instance_key = api.generate_font_instance_key();


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2230)
<!-- Reviewable:end -->
