### PR TITLE
add reftest for color emoji fast shadows

### DIFF
--- a/wrench/reftests/text/color-bitmap-shadow-ref.yaml
+++ b/wrench/reftests/text/color-bitmap-shadow-ref.yaml
@@ -1,0 +1,30 @@
+---
+root:
+  items:
+        -
+          text: "\u263A"
+          origin: [8, 56]
+          size: 36
+          color: white
+          family: "Apple Color Emoji"
+          embedded-bitmaps: true
+        -
+          type: rect
+          bounds: [56, 56, 48, 48]
+          color: yellow
+        -
+          type: rect
+          bounds: [56, 56, 48, 12]
+          color: black
+        -
+          type: rect
+          bounds: [56, 92, 48, 12]
+          color: black
+        -
+          type: rect
+          bounds: [56, 56, 12, 48]
+          color: black
+        -
+          type: rect
+          bounds: [92, 56, 12, 48]
+          color: black

--- a/wrench/reftests/text/color-bitmap-shadow.yaml
+++ b/wrench/reftests/text/color-bitmap-shadow.yaml
@@ -1,0 +1,34 @@
+--- # checks that color emoji fast shadows use the shadow color
+root:
+  items:
+        -
+          type: "shadow"
+          bounds: [0, 0, 115, 115]
+          offset: [48, 48]
+          blur-radius: 0
+          color: yellow
+        -
+          text: "\u263A"
+          origin: [8, 56]
+          size: 36
+          color: blue
+          family: "Apple Color Emoji"
+          embedded-bitmaps: true
+        -
+          type: "pop-all-shadows"
+        -
+          type: rect
+          bounds: [56, 56, 48, 12]
+          color: black
+        -
+          type: rect
+          bounds: [56, 92, 48, 12]
+          color: black
+        -
+          type: rect
+          bounds: [56, 56, 12, 48]
+          color: black
+        -
+          type: rect
+          bounds: [92, 56, 12, 48]
+          color: black

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -43,3 +43,4 @@ platform(linux) == subpixel-skew.yaml subpixel-skew.png
 != shadow-rotate.yaml blank.yaml
 platform(linux) == embedded-bitmaps.yaml embedded-bitmaps.png
 platform(linux) == clipped-transform.yaml clipped-transform.png
+platform(mac) == color-bitmap-shadow.yaml color-bitmap-shadow-ref.yaml


### PR DESCRIPTION
This is a follow-up to #2223. It ensures that the color bitmap's color does not improperly leak into the shadow. It is Mac only for now due to the relative impossibility of making cross-platform color bitmap fonts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2233)
<!-- Reviewable:end -->
