### PR TITLE
Ensure that we update the epoch of images so that we don't redraw them. 

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -532,8 +532,10 @@ impl ResourceCache {
         // valid to use as-is.
         let (entry, needs_update) = match self.cached_images.entry(request) {
             Occupied(entry) => {
-                let needs_update = entry.get().as_ref().unwrap().epoch != template.epoch;
-                (entry.into_mut(), needs_update)
+                let info = entry.into_mut();
+                let needs_update = info.as_mut().unwrap().epoch != template.epoch;
+                info.as_mut().unwrap().epoch = template.epoch;
+                (info, needs_update)
             }
             Vacant(entry) => (
                 entry.insert(Ok(

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -246,21 +246,24 @@ impl<'a> RawtestHarness<'a> {
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
         let info = LayoutPrimitiveInfo::new(rect(0.0, 60.0, 200.0, 200.0));
         let info2 = LayoutPrimitiveInfo::new(rect(200.0, 60.0, 200.0, 200.0));
+        let push_images = |builder: &mut DisplayListBuilder| {
+            builder.push_image(
+                &info,
+                size(200.0, 200.0),
+                size(0.0, 0.0),
+                ImageRendering::Auto,
+                blob_img,
+            );
+            builder.push_image(
+                &info2,
+                size(200.0, 200.0),
+                size(0.0, 0.0),
+                ImageRendering::Auto,
+                blob_img2,
+            );
+        };
 
-        builder.push_image(
-            &info,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img,
-        );
-        builder.push_image(
-            &info2,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img2,
-        );
+        push_images(&mut builder);
 
         let mut epoch = Epoch(0);
 
@@ -284,21 +287,7 @@ impl<'a> RawtestHarness<'a> {
         );
 
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
-        builder.push_image(
-            &info,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img,
-        );
-        builder.push_image(
-            &info2,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img2,
-        );
-
+        push_images(&mut builder);
         self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
         let _pixels_second = self.render_and_get_pixels(window_rect);
 
@@ -313,21 +302,7 @@ impl<'a> RawtestHarness<'a> {
         );
 
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
-        builder.push_image(
-            &info,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img,
-        );
-        builder.push_image(
-            &info2,
-            size(200.0, 200.0),
-            size(0.0, 0.0),
-            ImageRendering::Auto,
-            blob_img2,
-        );
-
+        push_images(&mut builder);
         self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
         let _pixels_third = self.render_and_get_pixels(window_rect);
 

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -50,6 +50,27 @@ impl<'a> RawtestHarness<'a> {
         self.wrench.renderer.read_pixels_rgba8(window_rect)
     }
 
+    fn submit_dl(
+        &mut self,
+        epoch: &mut Epoch,
+        layout_size: LayoutSize,
+        builder: DisplayListBuilder,
+        resources: Option<ResourceUpdates>
+    ) {
+        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
+        self.wrench.api.set_display_list(
+            self.wrench.document_id,
+            *epoch,
+            root_background_color,
+            layout_size,
+            builder.finalize(),
+            false,
+            resources.unwrap_or(ResourceUpdates::new()),
+        );
+        epoch.0 += 1;
+
+        self.wrench.api.generate_frame(self.wrench.document_id, None);
+    }
 
     fn test_tile_decomposition(&mut self) {
         // This exposes a crash in tile decomposition
@@ -64,8 +85,6 @@ impl<'a> RawtestHarness<'a> {
             Some(128),
         );
 
-        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
-
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
 
         let info = LayoutPrimitiveInfo::new(rect(448.899994, 74.0, 151.000031, 56.));
@@ -79,18 +98,9 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            self.wrench.document_id,
-            Epoch(0),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            resources,
-        );
-        self.wrench
-            .api
-            .generate_frame(self.wrench.document_id, None);
+        let mut epoch = Epoch(0);
+
+        self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
 
         self.rx.recv().unwrap();
         self.wrench.render();
@@ -108,7 +118,6 @@ impl<'a> RawtestHarness<'a> {
         let window_size = DeviceUintSize::new(window_size.0, window_size.1);
 
         let test_size = DeviceUintSize::new(400, 400);
-        let document_id = self.wrench.document_id;
 
         let window_rect = DeviceUintRect::new(
             DeviceUintPoint::new(0, window_size.height - test_size.height),
@@ -127,7 +136,6 @@ impl<'a> RawtestHarness<'a> {
                 None,
             );
         }
-        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
 
         // draw the blob the first time
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
@@ -141,17 +149,9 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            document_id,
-            Epoch(0),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            resources,
-        );
-        self.wrench.api.generate_frame(document_id, None);
+        let mut epoch = Epoch(0);
 
+        self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
 
         // draw the blob image a second time at a different location
 
@@ -166,17 +166,7 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            document_id,
-            Epoch(1),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            ResourceUpdates::new(),
-        );
-
-        self.wrench.api.generate_frame(document_id, None);
+        self.submit_dl(&mut epoch, layout_size, builder, None);
 
         let pixels_first = self.render_and_get_pixels(window_rect);
         let pixels_second = self.render_and_get_pixels(window_rect);
@@ -193,7 +183,6 @@ impl<'a> RawtestHarness<'a> {
         let window_size = DeviceUintSize::new(window_size.0, window_size.1);
 
         let test_size = DeviceUintSize::new(400, 400);
-        let document_id = self.wrench.document_id;
 
         let window_rect = DeviceUintRect::new(
             point(0, window_size.height - test_size.height),
@@ -212,7 +201,6 @@ impl<'a> RawtestHarness<'a> {
             );
             img
         };
-        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
 
         // draw the blob the first time
         let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
@@ -226,16 +214,9 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            document_id,
-            Epoch(0),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            resources,
-        );
-        self.wrench.api.generate_frame(document_id, None);
+        let mut epoch = Epoch(0);
+
+        self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
         let pixels_first = self.render_and_get_pixels(window_rect);
 
         // draw the blob image a second time after updating it with the same color
@@ -258,17 +239,7 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            document_id,
-            Epoch(1),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            resources,
-        );
-
-        self.wrench.api.generate_frame(document_id, None);
+        self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
         let pixels_second = self.render_and_get_pixels(window_rect);
 
         // draw the blob image a third time after updating it with a different color
@@ -291,18 +262,7 @@ impl<'a> RawtestHarness<'a> {
             blob_img,
         );
 
-        self.wrench.api.set_display_list(
-            document_id,
-            Epoch(2),
-            root_background_color,
-            layout_size,
-            builder.finalize(),
-            false,
-            resources,
-        );
-
-        self.wrench.api.generate_frame(document_id, None);
-
+        self.submit_dl(&mut epoch, layout_size, builder, Some(resources));
         let pixels_third = self.render_and_get_pixels(window_rect);
 
         assert!(pixels_first == pixels_second);
@@ -321,8 +281,6 @@ impl<'a> RawtestHarness<'a> {
             test_size,
         );
         let layout_size = LayoutSize::new(400., 400.);
-        let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
-
 
         let mut do_test = |should_try_and_fail| {
             let mut builder = DisplayListBuilder::new(self.wrench.root_pipeline_id, layout_size);
@@ -366,18 +324,7 @@ impl<'a> RawtestHarness<'a> {
 
             builder.pop_clip_id();
 
-            self.wrench.api.set_display_list(
-                self.wrench.document_id,
-                Epoch(0),
-                root_background_color,
-                layout_size,
-                builder.finalize(),
-                false,
-                ResourceUpdates::new(),
-            );
-            self.wrench
-                .api
-                .generate_frame(self.wrench.document_id, None);
+            self.submit_dl(&mut Epoch(0), layout_size, builder, None);
 
             self.render_and_get_pixels(window_rect)
         };

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -138,6 +138,8 @@ pub struct Wrench {
     pub verbose: bool,
 
     pub frame_start_sender: chase_lev::Worker<time::SteadyTime>,
+
+    pub callbacks: Arc<Mutex<blob::BlobCallbacks>>,
 }
 
 impl Wrench {
@@ -174,6 +176,7 @@ impl Wrench {
 
         let mut debug_flags = DebugFlags::default();
         debug_flags.set(DebugFlags::DISABLE_BATCHING, no_batch);
+        let callbacks = Arc::new(Mutex::new(blob::BlobCallbacks::new()));
 
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dp_ratio,
@@ -185,7 +188,7 @@ impl Wrench {
             enable_clear_scissor: !no_scissor,
             max_recorded_profiles: 16,
             precache_shaders,
-            blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new())),
+            blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new(callbacks.clone()))),
             disable_dual_source_blending,
             ..Default::default()
         };
@@ -225,6 +228,8 @@ impl Wrench {
 
             graphics_api,
             frame_start_sender: timing_sender,
+
+            callbacks,
         };
 
         wrench.set_title("start");


### PR DESCRIPTION
This cleans up the rawtests a little, adds the ability to track blob image requests, adds a test to make sure that we don't request unnecessarily and fixes the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2240)
<!-- Reviewable:end -->
