### PR TITLE
Extend segment building to handle clip in/out, multiple clip regions.

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#define VECS_PER_SPECIFIC_BRUSH 0
+
 #include shared,prim_shared,brush
 
 #ifdef WR_FEATURE_ALPHA_PASS

--- a/webrender/res/brush_mask_corner.glsl
+++ b/webrender/res/brush_mask_corner.glsl
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#define VECS_PER_SPECIFIC_BRUSH 1
+
 #include shared,prim_shared,ellipse,brush
 
 flat varying float vClipMode;

--- a/webrender/res/brush_mask_rounded_rect.glsl
+++ b/webrender/res/brush_mask_rounded_rect.glsl
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#define VECS_PER_SPECIFIC_BRUSH 4
+
 #include shared,prim_shared,ellipse,brush
 
 flat varying float vClipMode;

--- a/webrender/res/brush_solid.glsl
+++ b/webrender/res/brush_solid.glsl
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#define VECS_PER_SPECIFIC_BRUSH 1
+
 #include shared,prim_shared,brush
 
 flat varying vec4 vColor;

--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -433,28 +433,20 @@ impl FrameBuilder {
             );
             let p3 = info.rect.bottom_right();
 
+            let segment = |x0, y0, x1, y1, mask| BrushSegment::new(
+                LayerPoint::new(x0, y0),
+                LayerSize::new(x1-x0, y1-y0),
+                false,
+                mask
+            );
+
             // Add a solid rectangle for each visible edge/corner combination.
             if top_edge == BorderEdgeKind::Solid {
                 let descriptor = BrushSegmentDescriptor {
                     segments: vec![
-                        BrushSegment::new(
-                            LayerPoint::new(p0.x, p0.y),
-                            LayerSize::new(p1.x - p0.x, p1.y - p0.y),
-                            false,
-                            EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::LEFT,
-                        ),
-                        BrushSegment::new(
-                            LayerPoint::new(p2.x, p0.y),
-                            LayerSize::new(p3.x - p2.x, p1.y - p0.y),
-                            false,
-                            EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT,
-                        ),
-                        BrushSegment::new(
-                            LayerPoint::new(p1.x, p0.y),
-                            LayerSize::new(p2.x - p1.x, p1.y - p0.y),
-                            false,
-                            EdgeAaSegmentMask::TOP,
-                        ),
+                        segment(p0.x, p0.y, p1.x, p1.y, EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::LEFT),
+                        segment(p2.x, p0.y, p3.x, p1.y, EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT),
+                        segment(p1.x, p0.y, p2.x, p1.y, EdgeAaSegmentMask::TOP),
                     ],
                     clip_mask_kind: BrushClipMaskKind::Unknown,
                 };
@@ -463,19 +455,14 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     border.top.color,
-                    Some(Box::new(descriptor)),
+                    Some(descriptor),
                 );
             }
 
             if left_edge == BorderEdgeKind::Solid {
                 let descriptor = BrushSegmentDescriptor {
                     segments: vec![
-                        BrushSegment::new(
-                            LayerPoint::new(p0.x, p1.y),
-                            LayerSize::new(p1.x - p0.x, p2.y - p1.y),
-                            false,
-                            EdgeAaSegmentMask::LEFT,
-                        ),
+                        segment(p0.x, p1.y, p1.x, p2.y, EdgeAaSegmentMask::LEFT),
                     ],
                     clip_mask_kind: BrushClipMaskKind::Unknown,
                 };
@@ -484,19 +471,14 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     border.left.color,
-                    Some(Box::new(descriptor)),
+                    Some(descriptor),
                 );
             }
 
             if right_edge == BorderEdgeKind::Solid {
                 let descriptor = BrushSegmentDescriptor {
                     segments: vec![
-                        BrushSegment::new(
-                            LayerPoint::new(p2.x, p1.y),
-                            LayerSize::new(p3.x - p2.x, p2.y - p1.y),
-                            false,
-                            EdgeAaSegmentMask::RIGHT,
-                        ),
+                        segment(p2.x, p1.y, p3.x, p2.y, EdgeAaSegmentMask::RIGHT),
                     ],
                     clip_mask_kind: BrushClipMaskKind::Unknown,
                 };
@@ -505,31 +487,16 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     border.right.color,
-                    Some(Box::new(descriptor)),
+                    Some(descriptor),
                 );
             }
 
             if bottom_edge == BorderEdgeKind::Solid {
                 let descriptor = BrushSegmentDescriptor {
                     segments: vec![
-                        BrushSegment::new(
-                            LayerPoint::new(p1.x, p2.y),
-                            LayerSize::new(p2.x - p1.x, p3.y - p2.y),
-                            false,
-                            EdgeAaSegmentMask::BOTTOM,
-                        ),
-                        BrushSegment::new(
-                            LayerPoint::new(p2.x, p2.y),
-                            LayerSize::new(p3.x - p2.x, p3.y - p2.y),
-                            false,
-                            EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::RIGHT,
-                        ),
-                        BrushSegment::new(
-                            LayerPoint::new(p0.x, p2.y),
-                            LayerSize::new(p1.x - p0.x, p3.y - p2.y),
-                            false,
-                            EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::LEFT,
-                        ),
+                        segment(p1.x, p2.y, p2.x, p3.y, EdgeAaSegmentMask::BOTTOM),
+                        segment(p2.x, p2.y, p3.x, p3.y, EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::RIGHT),
+                        segment(p0.x, p2.y, p1.x, p3.y, EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::LEFT),
                     ],
                     clip_mask_kind: BrushClipMaskKind::Unknown,
                 };
@@ -538,7 +505,7 @@ impl FrameBuilder {
                     clip_and_scroll,
                     &info,
                     border.bottom.color,
-                    Some(Box::new(descriptor)),
+                    Some(descriptor),
                 );
             }
         } else {

--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -9,8 +9,8 @@ use clip::ClipSource;
 use ellipse::Ellipse;
 use frame_builder::FrameBuilder;
 use gpu_cache::GpuDataRequest;
-use prim_store::{BrushAntiAliasMode, BrushSegmentDescriptor, BrushSegmentKind};
-use prim_store::{BorderPrimitiveCpu, PrimitiveContainer, TexelRect};
+use prim_store::{BorderPrimitiveCpu, BrushSegment, BrushSegmentDescriptor};
+use prim_store::{BrushClipMaskKind, EdgeAaSegmentMask, PrimitiveContainer, TexelRect};
 use util::{lerp, pack_as_float};
 
 #[repr(u8)]
@@ -422,84 +422,123 @@ impl FrameBuilder {
         let has_no_curve = radius.is_zero();
 
         if has_no_curve && all_corners_simple && all_edges_simple {
-            let inner_rect = LayerRect::new(
-                LayerPoint::new(
-                    info.rect.origin.x + left_len,
-                    info.rect.origin.y + top_len,
-                ),
-                LayerSize::new(
-                    info.rect.size.width - left_len - right_len,
-                    info.rect.size.height - top_len - bottom_len,
-                ),
+            let p0 = info.rect.origin;
+            let p1 = LayerPoint::new(
+                info.rect.origin.x + left_len,
+                info.rect.origin.y + top_len,
             );
+            let p2 = LayerPoint::new(
+                info.rect.origin.x + info.rect.size.width - right_len,
+                info.rect.origin.y + info.rect.size.height - bottom_len,
+            );
+            let p3 = info.rect.bottom_right();
 
             // Add a solid rectangle for each visible edge/corner combination.
             if top_edge == BorderEdgeKind::Solid {
-                let descriptor = BrushSegmentDescriptor::new(
-                    &info.rect,
-                    &inner_rect,
-                    Some(&[
-                        BrushSegmentKind::TopLeft,
-                        BrushSegmentKind::TopMid,
-                        BrushSegmentKind::TopRight
-                    ]),
-                );
+                let descriptor = BrushSegmentDescriptor {
+                    segments: vec![
+                        BrushSegment::new(
+                            LayerPoint::new(p0.x, p0.y),
+                            LayerSize::new(p1.x - p0.x, p1.y - p0.y),
+                            false,
+                            EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::LEFT,
+                        ),
+                        BrushSegment::new(
+                            LayerPoint::new(p2.x, p0.y),
+                            LayerSize::new(p3.x - p2.x, p1.y - p0.y),
+                            false,
+                            EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT,
+                        ),
+                        BrushSegment::new(
+                            LayerPoint::new(p1.x, p0.y),
+                            LayerSize::new(p2.x - p1.x, p1.y - p0.y),
+                            false,
+                            EdgeAaSegmentMask::TOP,
+                        ),
+                    ],
+                    clip_mask_kind: BrushClipMaskKind::Unknown,
+                };
+
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
                     border.top.color,
                     Some(Box::new(descriptor)),
-                    BrushAntiAliasMode::Segment,
                 );
             }
+
             if left_edge == BorderEdgeKind::Solid {
-                let descriptor = BrushSegmentDescriptor::new(
-                    &info.rect,
-                    &inner_rect,
-                    Some(&[
-                        BrushSegmentKind::MidLeft,
-                    ]),
-                );
+                let descriptor = BrushSegmentDescriptor {
+                    segments: vec![
+                        BrushSegment::new(
+                            LayerPoint::new(p0.x, p1.y),
+                            LayerSize::new(p1.x - p0.x, p2.y - p1.y),
+                            false,
+                            EdgeAaSegmentMask::LEFT,
+                        ),
+                    ],
+                    clip_mask_kind: BrushClipMaskKind::Unknown,
+                };
+
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
                     border.left.color,
                     Some(Box::new(descriptor)),
-                    BrushAntiAliasMode::Segment,
                 );
             }
+
             if right_edge == BorderEdgeKind::Solid {
-                let descriptor = BrushSegmentDescriptor::new(
-                    &info.rect,
-                    &inner_rect,
-                    Some(&[
-                        BrushSegmentKind::MidRight,
-                    ]),
-                );
+                let descriptor = BrushSegmentDescriptor {
+                    segments: vec![
+                        BrushSegment::new(
+                            LayerPoint::new(p2.x, p1.y),
+                            LayerSize::new(p3.x - p2.x, p2.y - p1.y),
+                            false,
+                            EdgeAaSegmentMask::RIGHT,
+                        ),
+                    ],
+                    clip_mask_kind: BrushClipMaskKind::Unknown,
+                };
+
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
                     border.right.color,
                     Some(Box::new(descriptor)),
-                    BrushAntiAliasMode::Segment,
                 );
             }
+
             if bottom_edge == BorderEdgeKind::Solid {
-                let descriptor = BrushSegmentDescriptor::new(
-                    &info.rect,
-                    &inner_rect,
-                    Some(&[
-                        BrushSegmentKind::BottomLeft,
-                        BrushSegmentKind::BottomMid,
-                        BrushSegmentKind::BottomRight
-                    ]),
-                );
+                let descriptor = BrushSegmentDescriptor {
+                    segments: vec![
+                        BrushSegment::new(
+                            LayerPoint::new(p1.x, p2.y),
+                            LayerSize::new(p2.x - p1.x, p3.y - p2.y),
+                            false,
+                            EdgeAaSegmentMask::BOTTOM,
+                        ),
+                        BrushSegment::new(
+                            LayerPoint::new(p2.x, p2.y),
+                            LayerSize::new(p3.x - p2.x, p3.y - p2.y),
+                            false,
+                            EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::RIGHT,
+                        ),
+                        BrushSegment::new(
+                            LayerPoint::new(p0.x, p2.y),
+                            LayerSize::new(p1.x - p0.x, p3.y - p2.y),
+                            false,
+                            EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::LEFT,
+                        ),
+                    ],
+                    clip_mask_kind: BrushClipMaskKind::Unknown,
+                };
+
                 self.add_solid_rectangle(
                     clip_and_scroll,
                     &info,
                     border.bottom.color,
                     Some(Box::new(descriptor)),
-                    BrushAntiAliasMode::Segment,
                 );
             }
         } else {

--- a/webrender/src/box_shadow.rs
+++ b/webrender/src/box_shadow.rs
@@ -10,7 +10,7 @@ use app_units::Au;
 use clip::ClipSource;
 use frame_builder::FrameBuilder;
 use gpu_types::BrushImageKind;
-use prim_store::{BrushAntiAliasMode, PrimitiveContainer};
+use prim_store::{PrimitiveContainer};
 use prim_store::{BrushMaskKind, BrushKind, BrushPrimitive};
 use picture::PicturePrimitive;
 use util::RectHelpers;
@@ -136,7 +136,6 @@ impl FrameBuilder {
                             color: *color,
                         },
                         None,
-                        BrushAntiAliasMode::Primitive,
                     )
                 ),
             );
@@ -188,7 +187,6 @@ impl FrameBuilder {
                                 kind: BrushMaskKind::Corner(corner_size),
                             },
                             None,
-                            BrushAntiAliasMode::Primitive,
                         );
                     } else {
                         // Create a minimal size primitive mask to blur. In this
@@ -226,7 +224,6 @@ impl FrameBuilder {
                                 kind: BrushMaskKind::RoundedRect(clip_rect, shadow_radius),
                             },
                             None,
-                            BrushAntiAliasMode::Primitive,
                         );
                     };
 
@@ -311,7 +308,6 @@ impl FrameBuilder {
                             kind: BrushMaskKind::RoundedRect(clip_rect, shadow_radius),
                         },
                         None,
-                        BrushAntiAliasMode::Primitive,
                     );
                     let brush_info = LayerPrimitiveInfo::new(brush_rect);
                     let brush_prim_index = self.create_primitive(

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -17,7 +17,6 @@ use euclid::rect;
 use frame_builder::{FrameBuilder, FrameBuilderConfig, ScrollbarInfo};
 use gpu_cache::GpuCache;
 use internal_types::{FastHashMap, FastHashSet, RenderedDocument};
-use prim_store::{BrushAntiAliasMode};
 use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
@@ -106,7 +105,6 @@ impl<'a> FlattenContext<'a> {
                         &info,
                         bg_color,
                         None,
-                        BrushAntiAliasMode::Primitive,
                     );
                 }
             }
@@ -448,7 +446,6 @@ impl<'a> FlattenContext<'a> {
                     &prim_info,
                     info.color,
                     None,
-                    BrushAntiAliasMode::Primitive,
                 );
             }
             SpecificDisplayItem::ClearRectangle => {

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -24,7 +24,7 @@ use gpu_cache::GpuCache;
 use gpu_types::ClipScrollNodeData;
 use internal_types::{FastHashMap, FastHashSet, RenderPassIndex};
 use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, RasterizationSpace};
-use prim_store::{BrushAntiAliasMode, BrushKind, BrushPrimitive, TexelRect, YuvImagePrimitiveCpu};
+use prim_store::{BrushKind, BrushPrimitive, TexelRect, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, LinePrimitive, PrimitiveKind};
 use prim_store::{PrimitiveContainer, PrimitiveIndex, SpecificPrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
@@ -760,7 +760,6 @@ impl FrameBuilder {
         info: &LayerPrimitiveInfo,
         color: ColorF,
         segments: Option<Box<BrushSegmentDescriptor>>,
-        aa_mode: BrushAntiAliasMode,
     ) {
         if color.a == 0.0 {
             // Don't add transparent rectangles to the draw list, but do consider them for hit
@@ -774,7 +773,6 @@ impl FrameBuilder {
                 color,
             },
             segments,
-            aa_mode,
         );
 
         self.add_primitive(
@@ -793,7 +791,6 @@ impl FrameBuilder {
         let prim = BrushPrimitive::new(
             BrushKind::Clear,
             None,
-            BrushAntiAliasMode::Primitive,
         );
 
         self.add_primitive(
@@ -820,7 +817,6 @@ impl FrameBuilder {
                 color,
             },
             None,
-            BrushAntiAliasMode::Primitive,
         );
 
         let prim_index = self.add_primitive(

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -759,7 +759,7 @@ impl FrameBuilder {
         clip_and_scroll: ClipAndScrollInfo,
         info: &LayerPrimitiveInfo,
         color: ColorF,
-        segments: Option<Box<BrushSegmentDescriptor>>,
+        segments: Option<BrushSegmentDescriptor>,
     ) {
         if color.a == 0.0 {
             // Don't add transparent rectangles to the draw list, but do consider them for hit

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -154,7 +154,7 @@ pub struct BrushInstance {
     pub scroll_id: ClipScrollNodeIndex,
     pub clip_task_address: RenderTaskAddress,
     pub z: i32,
-    pub segment_kind: i32,
+    pub segment_index: i32,
     pub user_data0: i32,
     pub user_data1: i32,
 }
@@ -168,7 +168,7 @@ impl From<BrushInstance> for PrimitiveInstance {
                 ((instance.clip_id.0 as i32) << 16) | instance.scroll_id.0 as i32,
                 instance.clip_task_address.0 as i32,
                 instance.z,
-                instance.segment_kind,
+                instance.segment_index,
                 instance.user_data0,
                 instance.user_data1,
             ]

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -86,6 +86,7 @@ mod render_task;
 mod renderer;
 mod resource_cache;
 mod scene;
+mod segment;
 mod spring;
 mod texture_allocator;
 mod texture_cache;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1330,15 +1330,24 @@ impl PrimitiveStore {
 
         let metadata = &self.cpu_metadata[prim_index.0];
         let brush = &mut self.cpu_brushes[metadata.cpu_prim_index.0];
-        if !brush.kind.is_solid() {
-            return;
-        }
-        if metadata.local_rect.size.area() <= MIN_BRUSH_SPLIT_AREA {
-            return;
-        }
-        if let Some(ref segment_desc) = brush.segment_desc {
-            if segment_desc.clip_mask_kind != BrushClipMaskKind::Unknown {
-                return;
+
+        match brush.segment_desc {
+            Some(ref segment_desc) => {
+                // If we already have a segment descriptor, only run through the
+                // clips list if we haven't already determined the mask kind.
+                if segment_desc.clip_mask_kind != BrushClipMaskKind::Unknown {
+                    return;
+                }
+            }
+            None => {
+                // If no segment descriptor built yet, see if it is a brush
+                // type that wants to be segmented.
+                if !brush.kind.is_solid() {
+                    return;
+                }
+                if metadata.local_rect.size.area() <= MIN_BRUSH_SPLIT_AREA {
+                    return;
+                }
             }
         }
 

--- a/webrender/src/segment.rs
+++ b/webrender/src/segment.rs
@@ -1,0 +1,771 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api::{BorderRadius, ClipMode, LayerPoint, LayerPointAu, LayerRect, LayerSize};
+use app_units::Au;
+use prim_store::EdgeAaSegmentMask;
+use std::cmp;
+use util::extract_inner_rect_safe;
+
+// The segment builder outputs a list of these segments.
+#[derive(Debug, PartialEq)]
+pub struct Segment {
+    pub rect: LayerRect,
+    pub has_mask: bool,
+    pub edge_flags: EdgeAaSegmentMask,
+}
+
+// The segment builder creates a list of x/y axis events
+// that are used to build a segment list. Right now, we
+// don't bother providing a list of *which* clip regions
+// are active for a given segment. Instead, if there is
+// any clip mask present in a segment, we will just end
+// up drawing each of the masks to that segment clip.
+// This is a fairly rare case, but we can detect this
+// in the future and only apply clip masks that are
+// relevant to each segment region.
+// TODO(gw): Provide clip region info with each segment.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+enum EventKind {
+    Begin,
+    End,
+}
+
+// Events must be ordered such that when the coordinates
+// of two events are the same, the end events are processed
+// before the begin events. This ensures that we're able
+// to detect which regions are active for a given segment.
+impl Ord for EventKind {
+    fn cmp(&self, other: &EventKind) -> cmp::Ordering {
+        match (*self, *other) {
+            (EventKind::Begin, EventKind::Begin) |
+            (EventKind::End, EventKind::End) => {
+                cmp::Ordering::Equal
+            }
+            (EventKind::Begin, EventKind::End) => {
+                cmp::Ordering::Greater
+            }
+            (EventKind::End, EventKind::Begin) => {
+                cmp::Ordering::Less
+            }
+        }
+    }
+}
+
+// A x/y event where we will create a vertex in the
+// segment builder.
+#[derive(Debug, Eq, PartialEq, PartialOrd)]
+struct Event {
+    value: Au,
+    item_index: ItemIndex,
+    kind: EventKind,
+}
+
+impl Ord for Event {
+    fn cmp(&self, other: &Event) -> cmp::Ordering {
+        match self.value.cmp(&other.value) {
+            cmp::Ordering::Equal => {
+                self.kind.cmp(&other.kind)
+            }
+            order => {
+                order
+            }
+        }
+    }
+}
+
+impl Event {
+    fn begin(value: f32, index: usize) -> Event {
+        Event {
+            value: Au::from_f32_px(value),
+            item_index: ItemIndex(index),
+            kind: EventKind::Begin,
+        }
+    }
+
+    fn end(value: f32, index: usize) -> Event {
+        Event {
+            value: Au::from_f32_px(value),
+            item_index: ItemIndex(index),
+            kind: EventKind::End,
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        match self.kind {
+            EventKind::Begin => true,
+            EventKind::End => false,
+        }
+    }
+}
+
+// An item that provides some kind of clip region (either
+// a clip in/out rect, or a mask region).
+#[derive(Debug)]
+struct Item {
+    rect: LayerRect,
+    mode: ClipMode,
+    has_mask: bool,
+    active_x: bool,
+    active_y: bool,
+}
+
+impl Item {
+    fn new(
+        rect: LayerRect,
+        mode: ClipMode,
+        has_mask: bool,
+    ) -> Item {
+        Item {
+            rect,
+            mode,
+            has_mask,
+            active_x: false,
+            active_y: false,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd)]
+struct ItemIndex(usize);
+
+// The main public interface to the segment module.
+pub struct SegmentBuilder {
+    items: Vec<Item>,
+    bounding_rect: Option<LayerRect>,
+}
+
+impl SegmentBuilder {
+    // Create a new segment builder, supplying the primitive
+    // local rect and associated local clip rect.
+    pub fn new(
+        local_rect: LayerRect,
+        local_clip_rect: LayerRect,
+    ) -> SegmentBuilder {
+        let mut builder = SegmentBuilder {
+            items: Vec::new(),
+            bounding_rect: Some(local_rect),
+        };
+
+        builder.push_rect(local_rect, None, ClipMode::Clip);
+        builder.push_rect(local_clip_rect, None, ClipMode::Clip);
+
+        builder
+    }
+
+    // Push some kind of clipping region into the segment builder.
+    // If radius is None, it's a simple rect.
+    pub fn push_rect(
+        &mut self,
+        rect: LayerRect,
+        radius: Option<BorderRadius>,
+        mode: ClipMode,
+    ) {
+        // Keep track of a minimal bounding rect for the set of
+        // segments that will be generated.
+        if mode == ClipMode::Clip {
+            self.bounding_rect = self.bounding_rect.and_then(|bounding_rect| {
+                bounding_rect.intersection(&rect)
+            });
+        }
+
+        match radius {
+            Some(radius) => {
+                // For a rounded rect, try to create a nine-patch where there
+                // is a clip item for each corner, inner and edge region.
+                match extract_inner_rect_safe(&rect, &radius) {
+                    Some(inner) => {
+                        let p0 = rect.origin;
+                        let p1 = inner.origin;
+                        let p2 = inner.bottom_right();
+                        let p3 = rect.bottom_right();
+
+                        let corner_segments = &[
+                            LayerRect::new(
+                                LayerPoint::new(p0.x, p0.y),
+                                LayerSize::new(p1.x - p0.x, p1.y - p0.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p2.x, p0.y),
+                                LayerSize::new(p3.x - p2.x, p1.y - p0.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p2.x, p2.y),
+                                LayerSize::new(p3.x - p2.x, p3.y - p2.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p0.x, p2.y),
+                                LayerSize::new(p1.x - p0.x, p3.y - p2.y),
+                            ),
+                        ];
+
+                        for segment in corner_segments {
+                            self.items.push(Item::new(
+                                *segment,
+                                mode,
+                                true
+                            ));
+                        }
+
+                        let other_segments = &[
+                            LayerRect::new(
+                                LayerPoint::new(p1.x, p0.y),
+                                LayerSize::new(p2.x - p1.x, p1.y - p0.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p2.x, p1.y),
+                                LayerSize::new(p3.x - p2.x, p2.y - p1.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p1.x, p2.y),
+                                LayerSize::new(p2.x - p1.x, p3.y - p2.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p0.x, p1.y),
+                                LayerSize::new(p1.x - p0.x, p2.y - p1.y),
+                            ),
+                            LayerRect::new(
+                                LayerPoint::new(p1.x, p1.y),
+                                LayerSize::new(p2.x - p1.x, p2.y - p1.y),
+                            ),
+                        ];
+
+                        for segment in other_segments {
+                            self.items.push(Item::new(
+                                *segment,
+                                mode,
+                                false,
+                            ));
+                        }
+                    }
+                    None => {
+                        // If we get here, we could not extract an inner rectangle
+                        // for this clip region. This can occur in cases such as
+                        // a rounded rect where the top-left and bottom-left radii
+                        // result in overlapping rects. In that case, just create
+                        // a single clip region for the entire rounded rect.
+                        self.items.push(Item::new(
+                            rect,
+                            mode,
+                            true,
+                        ))
+                    }
+                }
+            }
+            None => {
+                // For a simple rect, just create one clipping item.
+                self.items.push(Item::new(
+                    rect,
+                    mode,
+                    false,
+                ))
+            }
+        }
+    }
+
+    // Consume this segment builder and produce a list of segments.
+    pub fn build<F>(self, mut f: F) where F: FnMut(Segment) {
+        if let Some(bounding_rect) = self.bounding_rect {
+            // First, filter out any items that don't intersect
+            // with the visible bounding rect.
+            let mut items: Vec<Item> = self.items
+                .into_iter()
+                .filter(|item| item.rect.intersects(&bounding_rect))
+                .collect();
+
+            // Create events for each item
+            let mut x_events = Vec::new();
+            let mut y_events = Vec::new();
+
+            for (item_index, item) in items.iter().enumerate() {
+                let p0 = item.rect.origin;
+                let p1 = item.rect.bottom_right();
+
+                x_events.push(Event::begin(p0.x, item_index));
+                x_events.push(Event::end(p1.x, item_index));
+                y_events.push(Event::begin(p0.y, item_index));
+                y_events.push(Event::end(p1.y, item_index));
+            }
+
+            // Get the minimal bounding rect in app units. We will
+            // work in fixed point in order to avoid float precision
+            // error while handling events.
+            let p0 = LayerPointAu::new(
+                Au::from_f32_px(bounding_rect.origin.x),
+                Au::from_f32_px(bounding_rect.origin.y),
+            );
+
+            let p1 = LayerPointAu::new(
+                Au::from_f32_px(bounding_rect.origin.x + bounding_rect.size.width),
+                Au::from_f32_px(bounding_rect.origin.y + bounding_rect.size.height),
+            );
+
+            // Sort the events in ascending order.
+            x_events.sort();
+            y_events.sort();
+
+            // Generate segments from the event lists, by sweeping the y-axis
+            // and then the x-axis for each event. This can generate a significant
+            // number of segments, but most importantly, it ensures that there are
+            // no t-junctions in the generated segments. It's probably possible
+            // to come up with more efficient segmentation algorithms, at least
+            // for simple / common cases.
+
+            // Each coordinate is clamped to the bounds of the minimal
+            // bounding rect. This ensures that we don't generate segments
+            // outside that bounding rect, but does allow correctly handling
+            // clips where the clip region starts outside the minimal
+            // rect but still intersects with it.
+
+            let mut prev_y = clamp(p0.y, y_events[0].value, p1.y);
+
+            for ey in &y_events {
+                let cur_y = clamp(p0.y, ey.value, p1.y);
+
+                if cur_y != prev_y {
+                    let mut prev_x = clamp(p0.x, x_events[0].value, p1.x);
+
+                    for ex in &x_events {
+                        let cur_x = clamp(p0.x, ex.value, p1.x);
+
+                        if cur_x != prev_x {
+                            emit_segment_if_needed(
+                                &mut f,
+                                prev_x,
+                                prev_y,
+                                cur_x,
+                                cur_y,
+                                &items,
+                                &p0,
+                                &p1,
+                            );
+
+                            prev_x = cur_x;
+                        }
+
+                        items[ex.item_index.0].active_x = ex.is_active();
+                    }
+
+                    prev_y = cur_y;
+                }
+
+                items[ey.item_index.0].active_y = ey.is_active();
+            }
+        }
+    }
+}
+
+fn clamp(low: Au, value: Au, high: Au) -> Au {
+    value.max(low).min(high)
+}
+
+fn emit_segment_if_needed<F>(
+    f: &mut F,
+    x0: Au,
+    y0: Au,
+    x1: Au,
+    y1: Au,
+    items: &[Item],
+    bounds_p0: &LayerPointAu,
+    bounds_p1: &LayerPointAu,
+) where F: FnMut(Segment) {
+    debug_assert!(x1 > x0);
+    debug_assert!(y1 > y0);
+
+    // TODO(gw): Don't scan the whole list of items for
+    //           each segment rect. Store active list
+    //           in a hash set or similar if this ever
+    //           shows up in a profile.
+    let mut has_clip_mask = false;
+
+    for item in items {
+        if item.active_x && item.active_y {
+            has_clip_mask |= item.has_mask;
+
+            if item.mode == ClipMode::ClipOut && !item.has_mask {
+                return;
+            }
+        }
+    }
+
+    let segment_rect = LayerRect::new(
+        LayerPoint::new(
+            x0.to_f32_px(),
+            y0.to_f32_px(),
+        ),
+        LayerSize::new(
+            (x1 - x0).to_f32_px(),
+            (y1 - y0).to_f32_px(),
+        ),
+    );
+
+    // Determine which edges touch the bounding rect. This allows
+    // the shaders to apply AA correctly along those edges. It also
+    // allows the batching code to determine which are inner segments
+    // without edges, and push those through the opaque pass.
+    let mut edge_flags = EdgeAaSegmentMask::empty();
+    if x0 == bounds_p0.x {
+        edge_flags |= EdgeAaSegmentMask::LEFT;
+    }
+    if x1 == bounds_p1.x {
+        edge_flags |= EdgeAaSegmentMask::RIGHT;
+    }
+    if y0 == bounds_p0.y {
+        edge_flags |= EdgeAaSegmentMask::TOP;
+    }
+    if y1 == bounds_p1.y {
+        edge_flags |= EdgeAaSegmentMask::BOTTOM;
+    }
+
+    f(Segment {
+        rect: segment_rect,
+        has_mask: has_clip_mask,
+        edge_flags,
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use api::{BorderRadius, ClipMode, LayerPoint, LayerRect, LayerSize};
+    use prim_store::EdgeAaSegmentMask;
+    use super::{Segment, SegmentBuilder};
+    use std::cmp;
+
+    fn rect(x0: f32, y0: f32, x1: f32, y1: f32) -> LayerRect {
+        LayerRect::new(
+            LayerPoint::new(x0, y0),
+            LayerSize::new(x1-x0, y1-y0),
+        )
+    }
+
+    fn seg(x0: f32, y0: f32, x1: f32, y1: f32, has_mask: bool) -> Segment {
+        Segment {
+            rect: LayerRect::new(
+                LayerPoint::new(x0, y0),
+                LayerSize::new(x1-x0, y1-y0),
+            ),
+            has_mask,
+            edge_flags: EdgeAaSegmentMask::empty(),
+        }
+    }
+
+    fn segment_sorter(s0: &Segment, s1: &Segment) -> cmp::Ordering {
+        let r0 = &s0.rect;
+        let r1 = &s1.rect;
+
+        if r0.origin.x != r1.origin.x {
+            r0.origin.x.partial_cmp(&r1.origin.x).unwrap()
+        } else if r0.origin.y != r1.origin.y {
+            r0.origin.y.partial_cmp(&r1.origin.y).unwrap()
+        } else if r0.size.width != r1.size.width {
+            r0.size.width.partial_cmp(&r1.size.width).unwrap()
+        } else {
+            r0.size.height.partial_cmp(&r1.size.height).unwrap()
+        }
+    }
+
+    fn seg_test(
+        local_rect: LayerRect,
+        local_clip_rect: LayerRect,
+        clips: &[(LayerRect, Option<BorderRadius>, ClipMode)],
+        expected_segments: &mut [Segment]
+    ) {
+        let mut sb = SegmentBuilder::new(
+            local_rect,
+            local_clip_rect,
+        );
+        let mut segments = Vec::new();
+        for &(rect, radius, mode) in clips {
+            sb.push_rect(rect, radius, mode);
+        }
+        sb.build(|rect| {
+            segments.push(rect);
+        });
+        segments.sort_by(segment_sorter);
+        expected_segments.sort_by(segment_sorter);
+        assert_eq!(
+            segments.len(),
+            expected_segments.len(),
+            "segments\n{:?}\nexpected\n{:?}\n",
+            segments,
+            expected_segments
+        );
+        for (segment, expected) in segments.iter().zip(expected_segments.iter()) {
+            assert_eq!(segment, expected);
+        }
+    }
+
+    #[test]
+    fn segment_empty() {
+        seg_test(
+            rect(0.0, 0.0, 0.0, 0.0),
+            rect(0.0, 0.0, 0.0, 0.0),
+            &[],
+            &mut [],
+        );
+    }
+
+    #[test]
+    fn segment_single() {
+        seg_test(
+            rect(10.0, 20.0, 30.0, 40.0),
+            rect(10.0, 20.0, 30.0, 40.0),
+            &[],
+            &mut [
+                seg(10.0, 20.0, 30.0, 40.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_single_clip() {
+        seg_test(
+            rect(10.0, 20.0, 30.0, 40.0),
+            rect(10.0, 20.0, 25.0, 35.0),
+            &[],
+            &mut [
+                seg(10.0, 20.0, 25.0, 35.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_inner_clip() {
+        seg_test(
+            rect(10.0, 20.0, 30.0, 40.0),
+            rect(15.0, 25.0, 25.0, 35.0),
+            &[],
+            &mut [
+                seg(15.0, 25.0, 25.0, 35.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_outer_clip() {
+        seg_test(
+            rect(15.0, 25.0, 25.0, 35.0),
+            rect(10.0, 20.0, 30.0, 40.0),
+            &[],
+            &mut [
+                seg(15.0, 25.0, 25.0, 35.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_clip_int() {
+        seg_test(
+            rect(10.0, 20.0, 30.0, 40.0),
+            rect(20.0, 10.0, 40.0, 30.0),
+            &[],
+            &mut [
+                seg(20.0, 20.0, 30.0, 30.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_clip_disjoint() {
+        seg_test(
+            rect(10.0, 20.0, 30.0, 40.0),
+            rect(30.0, 20.0, 50.0, 40.0),
+            &[],
+            &mut [],
+        );
+    }
+
+    #[test]
+    fn segment_clips() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(-1000.0, -1000.0, 1000.0, 1000.0),
+            &[
+                (rect(20.0, 20.0, 40.0, 40.0), None, ClipMode::Clip),
+                (rect(40.0, 20.0, 60.0, 40.0), None, ClipMode::Clip),
+            ],
+            &mut [
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_rounded_clip() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(-1000.0, -1000.0, 1000.0, 1000.0),
+            &[
+                (rect(20.0, 20.0, 60.0, 60.0), Some(BorderRadius::uniform(10.0)), ClipMode::Clip),
+            ],
+            &mut [
+                // corners
+                seg(20.0, 20.0, 30.0, 30.0, true),
+                seg(20.0, 50.0, 30.0, 60.0, true),
+                seg(50.0, 20.0, 60.0, 30.0, true),
+                seg(50.0, 50.0, 60.0, 60.0, true),
+
+                // inner
+                seg(30.0, 30.0, 50.0, 50.0, false),
+
+                // edges
+                seg(30.0, 20.0, 50.0, 30.0, false),
+                seg(30.0, 50.0, 50.0, 60.0, false),
+                seg(20.0, 30.0, 30.0, 50.0, false),
+                seg(50.0, 30.0, 60.0, 50.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_clip_out() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(-1000.0, -1000.0, 2000.0, 2000.0),
+            &[
+                (rect(20.0, 20.0, 60.0, 60.0), None, ClipMode::ClipOut),
+            ],
+            &mut [
+                seg(0.0, 0.0, 20.0, 20.0, false),
+                seg(20.0, 0.0, 60.0, 20.0, false),
+                seg(60.0, 0.0, 100.0, 20.0, false),
+
+                seg(0.0, 20.0, 20.0, 60.0, false),
+                seg(60.0, 20.0, 100.0, 60.0, false),
+
+                seg(0.0, 60.0, 20.0, 100.0, false),
+                seg(20.0, 60.0, 60.0, 100.0, false),
+                seg(60.0, 60.0, 100.0, 100.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_rounded_clip_out() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(-1000.0, -1000.0, 2000.0, 2000.0),
+            &[
+                (rect(20.0, 20.0, 60.0, 60.0), Some(BorderRadius::uniform(10.0)), ClipMode::ClipOut),
+            ],
+            &mut [
+                // top row
+                seg(0.0, 0.0, 20.0, 20.0, false),
+                seg(20.0, 0.0, 30.0, 20.0, false),
+                seg(30.0, 0.0, 50.0, 20.0, false),
+                seg(50.0, 0.0, 60.0, 20.0, false),
+                seg(60.0, 0.0, 100.0, 20.0, false),
+
+                // left
+                seg(0.0, 20.0, 20.0, 30.0, false),
+                seg(0.0, 30.0, 20.0, 50.0, false),
+                seg(0.0, 50.0, 20.0, 60.0, false),
+
+                // right
+                seg(60.0, 20.0, 100.0, 30.0, false),
+                seg(60.0, 30.0, 100.0, 50.0, false),
+                seg(60.0, 50.0, 100.0, 60.0, false),
+
+                // bottom row
+                seg(0.0, 60.0, 20.0, 100.0, false),
+                seg(20.0, 60.0, 30.0, 100.0, false),
+                seg(30.0, 60.0, 50.0, 100.0, false),
+                seg(50.0, 60.0, 60.0, 100.0, false),
+                seg(60.0, 60.0, 100.0, 100.0, false),
+
+                // inner corners
+                seg(20.0, 20.0, 30.0, 30.0, true),
+                seg(20.0, 50.0, 30.0, 60.0, true),
+                seg(50.0, 20.0, 60.0, 30.0, true),
+                seg(50.0, 50.0, 60.0, 60.0, true),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_clip_in_clip_out() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(-1000.0, -1000.0, 2000.0, 2000.0),
+            &[
+                (rect(20.0, 20.0, 60.0, 60.0), None, ClipMode::Clip),
+                (rect(50.0, 50.0, 80.0, 80.0), None, ClipMode::ClipOut),
+            ],
+            &mut [
+                seg(20.0, 20.0, 50.0, 50.0, false),
+                seg(50.0, 20.0, 60.0, 50.0, false),
+                seg(20.0, 50.0, 50.0, 60.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_rounded_clip_overlap() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(0.0, 0.0, 100.0, 100.0),
+            &[
+                (rect(0.0, 0.0, 10.0, 10.0), None, ClipMode::ClipOut),
+                (rect(0.0, 0.0, 100.0, 100.0), Some(BorderRadius::uniform(10.0)), ClipMode::Clip),
+            ],
+            &mut [
+                // corners
+                seg(0.0, 90.0, 10.0, 100.0, true),
+                seg(90.0, 0.0, 100.0, 10.0, true),
+                seg(90.0, 90.0, 100.0, 100.0, true),
+
+                // inner
+                seg(10.0, 10.0, 90.0, 90.0, false),
+
+                // edges
+                seg(10.0, 0.0, 90.0, 10.0, false),
+                seg(10.0, 90.0, 90.0, 100.0, false),
+                seg(0.0, 10.0, 10.0, 90.0, false),
+                seg(90.0, 10.0, 100.0, 90.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_rounded_clip_overlap_reverse() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(0.0, 0.0, 100.0, 100.0),
+            &[
+                (rect(10.0, 10.0, 90.0, 90.0), None, ClipMode::Clip),
+                (rect(0.0, 0.0, 100.0, 100.0), Some(BorderRadius::uniform(10.0)), ClipMode::Clip),
+            ],
+            &mut [
+                seg(10.0, 10.0, 90.0, 90.0, false),
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_clip_in_clip_out_overlap() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(0.0, 0.0, 100.0, 100.0),
+            &[
+                (rect(10.0, 10.0, 90.0, 90.0), None, ClipMode::Clip),
+                (rect(10.0, 10.0, 90.0, 90.0), None, ClipMode::ClipOut),
+            ],
+            &mut [
+            ],
+        );
+    }
+
+    #[test]
+    fn segment_event_order() {
+        seg_test(
+            rect(0.0, 0.0, 100.0, 100.0),
+            rect(0.0, 0.0, 100.0, 100.0),
+            &[
+                (rect(0.0, 0.0, 100.0, 90.0), None, ClipMode::ClipOut),
+            ],
+            &mut [
+                seg(0.0, 90.0, 100.0, 100.0, false),
+            ],
+        );
+    }
+}

--- a/webrender/src/segment.rs
+++ b/webrender/src/segment.rs
@@ -439,14 +439,21 @@ mod test {
         )
     }
 
-    fn seg(x0: f32, y0: f32, x1: f32, y1: f32, has_mask: bool) -> Segment {
+    fn seg(
+        x0: f32,
+        y0: f32,
+        x1: f32,
+        y1: f32,
+        has_mask: bool,
+        edge_flags: Option<EdgeAaSegmentMask>,
+    ) -> Segment {
         Segment {
             rect: LayerRect::new(
                 LayerPoint::new(x0, y0),
                 LayerSize::new(x1-x0, y1-y0),
             ),
             has_mask,
-            edge_flags: EdgeAaSegmentMask::empty(),
+            edge_flags: edge_flags.unwrap_or(EdgeAaSegmentMask::empty()),
         }
     }
 
@@ -513,7 +520,13 @@ mod test {
             rect(10.0, 20.0, 30.0, 40.0),
             &[],
             &mut [
-                seg(10.0, 20.0, 30.0, 40.0, false),
+                seg(10.0, 20.0, 30.0, 40.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -525,7 +538,13 @@ mod test {
             rect(10.0, 20.0, 25.0, 35.0),
             &[],
             &mut [
-                seg(10.0, 20.0, 25.0, 35.0, false),
+                seg(10.0, 20.0, 25.0, 35.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -537,7 +556,13 @@ mod test {
             rect(15.0, 25.0, 25.0, 35.0),
             &[],
             &mut [
-                seg(15.0, 25.0, 25.0, 35.0, false),
+                seg(15.0, 25.0, 25.0, 35.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -549,7 +574,13 @@ mod test {
             rect(10.0, 20.0, 30.0, 40.0),
             &[],
             &mut [
-                seg(15.0, 25.0, 25.0, 35.0, false),
+                seg(15.0, 25.0, 25.0, 35.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -561,7 +592,13 @@ mod test {
             rect(20.0, 10.0, 40.0, 30.0),
             &[],
             &mut [
-                seg(20.0, 20.0, 30.0, 30.0, false),
+                seg(20.0, 20.0, 30.0, 30.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -600,19 +637,19 @@ mod test {
             ],
             &mut [
                 // corners
-                seg(20.0, 20.0, 30.0, 30.0, true),
-                seg(20.0, 50.0, 30.0, 60.0, true),
-                seg(50.0, 20.0, 60.0, 30.0, true),
-                seg(50.0, 50.0, 60.0, 60.0, true),
+                seg(20.0, 20.0, 30.0, 30.0, true, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::TOP)),
+                seg(20.0, 50.0, 30.0, 60.0, true, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::BOTTOM)),
+                seg(50.0, 20.0, 60.0, 30.0, true, Some(EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::TOP)),
+                seg(50.0, 50.0, 60.0, 60.0, true, Some(EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::BOTTOM)),
 
                 // inner
-                seg(30.0, 30.0, 50.0, 50.0, false),
+                seg(30.0, 30.0, 50.0, 50.0, false, None),
 
                 // edges
-                seg(30.0, 20.0, 50.0, 30.0, false),
-                seg(30.0, 50.0, 50.0, 60.0, false),
-                seg(20.0, 30.0, 30.0, 50.0, false),
-                seg(50.0, 30.0, 60.0, 50.0, false),
+                seg(30.0, 20.0, 50.0, 30.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(30.0, 50.0, 50.0, 60.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(20.0, 30.0, 30.0, 50.0, false, Some(EdgeAaSegmentMask::LEFT)),
+                seg(50.0, 30.0, 60.0, 50.0, false, Some(EdgeAaSegmentMask::RIGHT)),
             ],
         );
     }
@@ -626,16 +663,16 @@ mod test {
                 (rect(20.0, 20.0, 60.0, 60.0), None, ClipMode::ClipOut),
             ],
             &mut [
-                seg(0.0, 0.0, 20.0, 20.0, false),
-                seg(20.0, 0.0, 60.0, 20.0, false),
-                seg(60.0, 0.0, 100.0, 20.0, false),
+                seg(0.0, 0.0, 20.0, 20.0, false, Some(EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::LEFT)),
+                seg(20.0, 0.0, 60.0, 20.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(60.0, 0.0, 100.0, 20.0, false, Some(EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT)),
 
-                seg(0.0, 20.0, 20.0, 60.0, false),
-                seg(60.0, 20.0, 100.0, 60.0, false),
+                seg(0.0, 20.0, 20.0, 60.0, false, Some(EdgeAaSegmentMask::LEFT)),
+                seg(60.0, 20.0, 100.0, 60.0, false, Some(EdgeAaSegmentMask::RIGHT)),
 
-                seg(0.0, 60.0, 20.0, 100.0, false),
-                seg(20.0, 60.0, 60.0, 100.0, false),
-                seg(60.0, 60.0, 100.0, 100.0, false),
+                seg(0.0, 60.0, 20.0, 100.0, false, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::BOTTOM)),
+                seg(20.0, 60.0, 60.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(60.0, 60.0, 100.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM | EdgeAaSegmentMask::RIGHT)),
             ],
         );
     }
@@ -650,34 +687,34 @@ mod test {
             ],
             &mut [
                 // top row
-                seg(0.0, 0.0, 20.0, 20.0, false),
-                seg(20.0, 0.0, 30.0, 20.0, false),
-                seg(30.0, 0.0, 50.0, 20.0, false),
-                seg(50.0, 0.0, 60.0, 20.0, false),
-                seg(60.0, 0.0, 100.0, 20.0, false),
+                seg(0.0, 0.0, 20.0, 20.0, false, Some(EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::LEFT)),
+                seg(20.0, 0.0, 30.0, 20.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(30.0, 0.0, 50.0, 20.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(50.0, 0.0, 60.0, 20.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(60.0, 0.0, 100.0, 20.0, false, Some(EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT)),
 
                 // left
-                seg(0.0, 20.0, 20.0, 30.0, false),
-                seg(0.0, 30.0, 20.0, 50.0, false),
-                seg(0.0, 50.0, 20.0, 60.0, false),
+                seg(0.0, 20.0, 20.0, 30.0, false, Some(EdgeAaSegmentMask::LEFT)),
+                seg(0.0, 30.0, 20.0, 50.0, false, Some(EdgeAaSegmentMask::LEFT)),
+                seg(0.0, 50.0, 20.0, 60.0, false, Some(EdgeAaSegmentMask::LEFT)),
 
                 // right
-                seg(60.0, 20.0, 100.0, 30.0, false),
-                seg(60.0, 30.0, 100.0, 50.0, false),
-                seg(60.0, 50.0, 100.0, 60.0, false),
+                seg(60.0, 20.0, 100.0, 30.0, false, Some(EdgeAaSegmentMask::RIGHT)),
+                seg(60.0, 30.0, 100.0, 50.0, false, Some(EdgeAaSegmentMask::RIGHT)),
+                seg(60.0, 50.0, 100.0, 60.0, false, Some(EdgeAaSegmentMask::RIGHT)),
 
                 // bottom row
-                seg(0.0, 60.0, 20.0, 100.0, false),
-                seg(20.0, 60.0, 30.0, 100.0, false),
-                seg(30.0, 60.0, 50.0, 100.0, false),
-                seg(50.0, 60.0, 60.0, 100.0, false),
-                seg(60.0, 60.0, 100.0, 100.0, false),
+                seg(0.0, 60.0, 20.0, 100.0, false, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::BOTTOM)),
+                seg(20.0, 60.0, 30.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(30.0, 60.0, 50.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(50.0, 60.0, 60.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(60.0, 60.0, 100.0, 100.0, false, Some(EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::BOTTOM)),
 
                 // inner corners
-                seg(20.0, 20.0, 30.0, 30.0, true),
-                seg(20.0, 50.0, 30.0, 60.0, true),
-                seg(50.0, 20.0, 60.0, 30.0, true),
-                seg(50.0, 50.0, 60.0, 60.0, true),
+                seg(20.0, 20.0, 30.0, 30.0, true, None),
+                seg(20.0, 50.0, 30.0, 60.0, true, None),
+                seg(50.0, 20.0, 60.0, 30.0, true, None),
+                seg(50.0, 50.0, 60.0, 60.0, true, None),
             ],
         );
     }
@@ -692,9 +729,9 @@ mod test {
                 (rect(50.0, 50.0, 80.0, 80.0), None, ClipMode::ClipOut),
             ],
             &mut [
-                seg(20.0, 20.0, 50.0, 50.0, false),
-                seg(50.0, 20.0, 60.0, 50.0, false),
-                seg(20.0, 50.0, 50.0, 60.0, false),
+                seg(20.0, 20.0, 50.0, 50.0, false, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::TOP)),
+                seg(50.0, 20.0, 60.0, 50.0, false, Some(EdgeAaSegmentMask::TOP | EdgeAaSegmentMask::RIGHT)),
+                seg(20.0, 50.0, 50.0, 60.0, false, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::BOTTOM)),
             ],
         );
     }
@@ -710,18 +747,18 @@ mod test {
             ],
             &mut [
                 // corners
-                seg(0.0, 90.0, 10.0, 100.0, true),
-                seg(90.0, 0.0, 100.0, 10.0, true),
-                seg(90.0, 90.0, 100.0, 100.0, true),
+                seg(0.0, 90.0, 10.0, 100.0, true, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::BOTTOM)),
+                seg(90.0, 0.0, 100.0, 10.0, true, Some(EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::TOP)),
+                seg(90.0, 90.0, 100.0, 100.0, true, Some(EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::BOTTOM)),
 
                 // inner
-                seg(10.0, 10.0, 90.0, 90.0, false),
+                seg(10.0, 10.0, 90.0, 90.0, false, None),
 
                 // edges
-                seg(10.0, 0.0, 90.0, 10.0, false),
-                seg(10.0, 90.0, 90.0, 100.0, false),
-                seg(0.0, 10.0, 10.0, 90.0, false),
-                seg(90.0, 10.0, 100.0, 90.0, false),
+                seg(10.0, 0.0, 90.0, 10.0, false, Some(EdgeAaSegmentMask::TOP)),
+                seg(10.0, 90.0, 90.0, 100.0, false, Some(EdgeAaSegmentMask::BOTTOM)),
+                seg(0.0, 10.0, 10.0, 90.0, false, Some(EdgeAaSegmentMask::LEFT)),
+                seg(90.0, 10.0, 100.0, 90.0, false, Some(EdgeAaSegmentMask::RIGHT)),
             ],
         );
     }
@@ -736,7 +773,13 @@ mod test {
                 (rect(0.0, 0.0, 100.0, 100.0), Some(BorderRadius::uniform(10.0)), ClipMode::Clip),
             ],
             &mut [
-                seg(10.0, 10.0, 90.0, 90.0, false),
+                seg(10.0, 10.0, 90.0, 90.0, false,
+                    Some(EdgeAaSegmentMask::LEFT |
+                         EdgeAaSegmentMask::TOP |
+                         EdgeAaSegmentMask::RIGHT |
+                         EdgeAaSegmentMask::BOTTOM
+                    )
+                ),
             ],
         );
     }
@@ -764,7 +807,7 @@ mod test {
                 (rect(0.0, 0.0, 100.0, 90.0), None, ClipMode::ClipOut),
             ],
             &mut [
-                seg(0.0, 90.0, 100.0, 100.0, false),
+                seg(0.0, 90.0, 100.0, 100.0, false, Some(EdgeAaSegmentMask::LEFT | EdgeAaSegmentMask::RIGHT | EdgeAaSegmentMask::BOTTOM)),
             ],
         );
     }

--- a/webrender_api/src/units.rs
+++ b/webrender_api/src/units.rs
@@ -12,6 +12,7 @@
 //! The terms "layer" and "stacking context" can be used interchangeably
 //! in the context of coordinate systems.
 
+use app_units::Au;
 use euclid::{Length, TypedRect, TypedSize2D, TypedTransform3D};
 use euclid::{TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D};
 
@@ -95,6 +96,10 @@ pub type LayerToWorldTransform = TypedTransform3D<f32, LayerPixel, WorldPixel>;
 pub type WorldToLayerTransform = TypedTransform3D<f32, WorldPixel, LayerPixel>;
 pub type ScrollToWorldTransform = TypedTransform3D<f32, ScrollLayerPixel, WorldPixel>;
 
+// Fixed position coordinates, to avoid float precision errors.
+pub type LayerPointAu = TypedPoint2D<Au, LayerPixel>;
+pub type LayerRectAu = TypedRect<Au, LayerPixel>;
+pub type LayerSizeAu = TypedSize2D<Au, LayerPixel>;
 
 pub fn device_length(value: f32, device_pixel_ratio: f32) -> DeviceIntLength {
     DeviceIntLength::new((value * device_pixel_ratio).round() as i32)


### PR DESCRIPTION
Introduce segment builder, which is able to handle a much larger
range of clip scenarios than the initial segment implementation.

Instead of only handling the simple case of a single nine-patch
clip, we can now handle any number of local clip regions, and most
importantly, both clip and clip out modes. The support for clip-out
means we can often eliminate large areas of internal pixels for
items such as box-shadows. Note: the box-shadow code is not currently
hooked up to take advantage of this yet.

In the future, the segment builder can quite easily be extended to
handle the remaining clip sources that aren't handled - the image
mask and border corner clip sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2242)
<!-- Reviewable:end -->
