### PR TITLE
Add dual-source blending path for subpixel text when supported.

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -22,8 +22,9 @@ varying vec4 vUvClip;
 #define MODE_SUBPX_BG_PASS0     4
 #define MODE_SUBPX_BG_PASS1     5
 #define MODE_SUBPX_BG_PASS2     6
-#define MODE_BITMAP             7
-#define MODE_COLOR_BITMAP       8
+#define MODE_SUBPX_DUAL_SOURCE  7
+#define MODE_BITMAP             8
+#define MODE_COLOR_BITMAP       9
 
 VertexInfo write_text_vertex(vec2 clamped_local_pos,
                              RectWithSize local_clip_rect,
@@ -134,6 +135,7 @@ void main(void) {
             break;
         case MODE_SUBPX_PASS1:
         case MODE_SUBPX_BG_PASS2:
+        case MODE_SUBPX_DUAL_SOURCE:
             vMaskSwizzle = vec2(1.0, 0.0);
             vColor = text.color;
             break;
@@ -170,6 +172,12 @@ void main(void) {
     alpha *= float(all(greaterThanEqual(vUvClip, vec4(0.0))));
 #endif
 
+#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+    vec4 alpha_mask = mask * alpha;
+    oFragColor = vColor * alpha_mask;
+    oFragBlend = alpha_mask * vColor.a;
+#else
     oFragColor = vColor * mask * alpha;
+#endif
 }
 #endif

--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -8,6 +8,10 @@
 #extension GL_OES_EGL_image_external_essl3 : require
 #endif
 
+#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+#extension GL_ARB_explicit_attrib_location : require
+#endif
+
 #include base
 
 // The textureLod() doesn't support samplerExternalOES for WR_FEATURE_TEXTURE_EXTERNAL.
@@ -46,7 +50,12 @@
     // Uniform inputs
 
     // Fragment shader outputs
-    out vec4 oFragColor;
+    #ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+        layout(location = 0, index = 0) out vec4 oFragColor;
+        layout(location = 0, index = 1) out vec4 oFragBlend;
+    #else
+        out vec4 oFragColor;
+    #endif
 #endif
 
 //======================================================================================

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1925,6 +1925,9 @@ impl Device {
             .blend_func(gl::CONSTANT_COLOR, gl::ONE_MINUS_SRC_COLOR);
         self.gl.blend_equation(gl::FUNC_ADD);
     }
+    pub fn set_blend_mode_subpixel_dual_source(&self) {
+        self.gl.blend_func(gl::ONE, gl::ONE_MINUS_SRC1_COLOR);
+    }
 
     pub fn supports_extension(&self, extension: &str) -> bool {
         self.extensions.iter().any(|s| s == extension)

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -930,7 +930,7 @@ pub struct FrameContext {
     clip_scroll_tree: ClipScrollTree,
     pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
     id: FrameId,
-    frame_builder_config: FrameBuilderConfig,
+    pub frame_builder_config: FrameBuilderConfig,
 }
 
 impl FrameContext {

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -74,6 +74,8 @@ pub struct FrameBuilderConfig {
     pub enable_scrollbars: bool,
     pub default_font_render_mode: FontRenderMode,
     pub debug: bool,
+    pub dual_source_blending_is_supported: bool,
+    pub dual_source_blending_is_enabled: bool,
 }
 
 #[derive(Debug)]
@@ -166,6 +168,8 @@ impl FrameBuilder {
                 enable_scrollbars: false,
                 default_font_render_mode: FontRenderMode::Mono,
                 debug: false,
+                dual_source_blending_is_enabled: true,
+                dual_source_blending_is_supported: false,
             },
         }
     }
@@ -1763,6 +1767,8 @@ impl FrameBuilder {
         }
 
         let mut deferred_resolves = vec![];
+        let use_dual_source_blending = self.config.dual_source_blending_is_enabled &&
+                                       self.config.dual_source_blending_is_supported;
 
         for (pass_index, pass) in passes.iter_mut().enumerate() {
             let ctx = RenderTargetContext {
@@ -1771,6 +1777,7 @@ impl FrameBuilder {
                 resource_cache,
                 node_data: &node_data,
                 clip_scroll_tree,
+                use_dual_source_blending,
             };
 
             pass.build(

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -588,6 +588,22 @@ impl RenderBackend {
                             self.load_capture(&root, &mut profile_counters);
                             ResultMsg::DebugOutput(DebugOutput::LoadCapture)
                         },
+                        DebugCommand::EnableDualSourceBlending(enable) => {
+                            // Set in the config used for any future documents
+                            // that are created.
+                            self.frame_config
+                                .dual_source_blending_is_enabled = enable;
+
+                            // Set for any existing documents.
+                            for (_, doc) in &mut self.documents {
+                                doc.frame_ctx
+                                   .frame_builder_config
+                                   .dual_source_blending_is_enabled = enable;
+                            }
+
+                            // We don't want to forward this message to the renderer.
+                            continue;
+                        }
                         _ => ResultMsg::DebugCommand(option),
                     };
                     self.result_tx.send(msg).unwrap();

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -314,7 +314,8 @@ impl BatchList {
             BlendMode::PremultipliedDestOut |
             BlendMode::SubpixelConstantTextColor(..) |
             BlendMode::SubpixelVariableTextColor |
-            BlendMode::SubpixelWithBgColor => {
+            BlendMode::SubpixelWithBgColor |
+            BlendMode::SubpixelDualSource => {
                 self.alpha_batch_list
                     .get_suitable_batch(key, item_bounding_rect)
             }
@@ -596,6 +597,8 @@ fn add_to_batch(
                         GlyphFormat::TransformedSubpixel => {
                             if text_cpu.font.bg_color.a != 0 {
                                 BlendMode::SubpixelWithBgColor
+                            } else if ctx.use_dual_source_blending {
+                                BlendMode::SubpixelDualSource
                             } else {
                                 BlendMode::SubpixelConstantTextColor(text_cpu.font.color.into())
                             }
@@ -1246,6 +1249,7 @@ pub struct RenderTargetContext<'a> {
     pub resource_cache: &'a ResourceCache,
     pub node_data: &'a [ClipScrollNodeData],
     pub clip_scroll_tree: &'a ClipScrollTree,
+    pub use_dual_source_blending: bool,
 }
 
 struct TextureAllocator {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -272,6 +272,8 @@ pub enum DebugCommand {
     SaveCapture(PathBuf),
     /// Load a capture of all the documents state.
     LoadCapture(PathBuf),
+    /// Configure if dual-source blending is used, if available.
+    EnableDualSourceBlending(bool),
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -774,6 +776,11 @@ impl RenderApi {
     /// Load a capture of the current frame state for debugging.
     pub fn load_capture(&self, path: PathBuf) {
         let msg = ApiMsg::DebugCommand(DebugCommand::LoadCapture(path));
+        self.send_message(msg);
+    }
+
+    pub fn send_debug_cmd(&self, cmd: DebugCommand) {
+        let msg = ApiMsg::DebugCommand(cmd);
         self.send_message(msg);
     }
 }

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -29,7 +29,10 @@ options(disable-aa) == ahem.yaml ahem-ref.yaml
 platform(linux) == isolated-text.yaml isolated-text.png
 platform(mac) == white-opacity.yaml white-opacity.png
 fuzzy(1,4) platform(linux) options(disable-subpixel) == colors.yaml colors-alpha.png
-fuzzy(1,6) platform(linux) == colors.yaml colors-subpx.png
+# Run without dual-source blending path, batches are broken when text colors change.
+fuzzy(1,6) platform(linux) options(disable-dual-source-blending) draw_calls(5) == colors.yaml colors-subpx.png
+# Run with both dual-source blending, ensuring batching is improved.
+fuzzy(1,6) platform(linux) draw_calls(2) == colors.yaml colors-subpx.png
 platform(linux) options(disable-subpixel) == border-radius.yaml border-radius-alpha.png
 platform(linux) == border-radius.yaml border-radius-subpx.png
 options(disable-aa) == transparent-no-aa.yaml transparent-no-aa-ref.yaml

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -32,6 +32,9 @@ args:
       short: a
       long: no-subpixel-aa
       help: Disable subpixel aa
+  - slow_subpixel:
+      long: slow-subpixel
+      help: Disable dual source blending
   - headless:
       short: h
       long: headless

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -383,6 +383,7 @@ fn main() {
         args.is_present("no_scissor"),
         args.is_present("no_batch"),
         args.is_present("precache"),
+        args.is_present("slow_subpixel"),
         notifier,
     );
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -154,6 +154,7 @@ impl Wrench {
         no_scissor: bool,
         no_batch: bool,
         precache_shaders: bool,
+        disable_dual_source_blending: bool,
         notifier: Option<Box<RenderNotifier>>,
     ) -> Self {
         println!("Shader override path: {:?}", shader_override_path);
@@ -185,6 +186,7 @@ impl Wrench {
             max_recorded_profiles: 16,
             precache_shaders,
             blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new())),
+            disable_dual_source_blending,
             ..Default::default()
         };
 


### PR DESCRIPTION
This makes it possible to share batches when the text color is
different between runs. This can result in significantly better
draw call batching.

Add option to wrench to disable dual source blending path.

Add reftest option to control if dual-source blending is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2244)
<!-- Reviewable:end -->
