### PR TITLE
implement synthetic italics with a skew transform on all platforms

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -102,25 +102,17 @@ impl FontTransform {
         )
     }
 
-    #[allow(dead_code)]
-    pub fn inverse(&self) -> Option<Self> {
-        let det = self.determinant();
-        if det != 0.0 {
-            let inv_det = det.recip() as f32;
-            Some(FontTransform::new(
-                self.scale_y * inv_det,
-                -self.skew_x * inv_det,
-                -self.skew_y * inv_det,
-                self.scale_x * inv_det
-            ))
-        } else {
-            None
-        }
+    pub fn invert_scale(&self, x_scale: f64, y_scale: f64) -> Self {
+        self.pre_scale(x_scale.recip() as f32, y_scale.recip() as f32)
     }
 
-    #[allow(dead_code)]
-    pub fn apply(&self, x: f32, y: f32) -> (f32, f32) {
-        (self.scale_x * x + self.skew_x * y, self.skew_y * x + self.scale_y * y)
+    pub fn synthesize_italics(&self, skew_factor: f32) -> Self {
+        FontTransform::new(
+            self.scale_x,
+            self.skew_x - self.scale_x * skew_factor,
+            self.skew_y,
+            self.scale_y - self.skew_y * skew_factor,
+        )
     }
 }
 

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -22,7 +22,7 @@ use core_text;
 use core_text::font::{CTFont, CTFontRef};
 use core_text::font_descriptor::{kCTFontDefaultOrientation, kCTFontColorGlyphsTrait};
 use gamma_lut::{ColorLut, GammaLut};
-use glyph_rasterizer::{FontInstance, GlyphFormat, RasterizedGlyph};
+use glyph_rasterizer::{FontInstance, FontTransform, GlyphFormat, RasterizedGlyph};
 use internal_types::FastHashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
@@ -264,6 +264,9 @@ fn is_bitmap_font(ct_font: &CTFont) -> bool {
     (traits & kCTFontColorGlyphsTrait) != 0
 }
 
+// Skew factor matching Gecko/CG.
+const OBLIQUE_SKEW_FACTOR: f32 = 0.25;
+
 impl FontContext {
     pub fn new() -> FontContext {
         debug!("Test for subpixel AA support: {}", supports_subpixel_aa());
@@ -358,7 +361,28 @@ impl FontContext {
                 let glyph = key.index as CGGlyph;
                 let bitmap = is_bitmap_font(ct_font);
                 let (x_offset, y_offset) = if bitmap { (0.0, 0.0) } else { font.get_subpx_offset(key) };
-                let metrics = get_glyph_metrics(ct_font, None, glyph, x_offset, y_offset, 0.0);
+                let transform = if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+                    let shape = FontTransform::identity().synthesize_italics(OBLIQUE_SKEW_FACTOR);
+                    Some(CGAffineTransform {
+                        a: shape.scale_x as f64,
+                        b: -shape.skew_y as f64,
+                        c: -shape.skew_x as f64,
+                        d: shape.scale_y as f64,
+                        tx: 0.0,
+                        ty: 0.0,
+                    })
+                } else {
+                    None
+                };
+                let extra_strikes = font.get_extra_strikes(1.0);
+                let metrics = get_glyph_metrics(
+                    ct_font,
+                    transform.as_ref(),
+                    glyph,
+                    x_offset,
+                    y_offset,
+                    extra_strikes as f64,
+                );
                 if metrics.rasterized_width == 0 || metrics.rasterized_height == 0 {
                     None
                 } else {
@@ -454,22 +478,28 @@ impl FontContext {
         };
 
         let bitmap = is_bitmap_font(&ct_font);
-        let shape = font.transform.pre_scale(y_scale.recip() as f32, y_scale.recip() as f32);
-        let transform = if bitmap || shape.is_identity() {
-            None
+        let (mut shape, (x_offset, y_offset)) = if bitmap {
+            (FontTransform::identity(), (0.0, 0.0))
         } else {
+            (font.transform.invert_scale(y_scale, y_scale), font.get_subpx_offset(key))
+        };
+        if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+            shape = shape.synthesize_italics(OBLIQUE_SKEW_FACTOR);
+        }
+        let transform = if !shape.is_identity() {
             Some(CGAffineTransform {
                 a: shape.scale_x as f64,
                 b: -shape.skew_y as f64,
                 c: -shape.skew_x as f64,
                 d: shape.scale_y as f64,
                 tx: 0.0,
-                ty: 0.0
+                ty: 0.0,
             })
+        } else {
+            None
         };
 
         let glyph = key.index as CGGlyph;
-        let (x_offset, y_offset) = if bitmap { (0.0, 0.0) } else { font.get_subpx_offset(key) };
         let (strike_scale, pixel_step) = if bitmap { (y_scale, 1.0) } else { (x_scale, y_scale / x_scale) };
         let extra_strikes = font.get_extra_strikes(strike_scale);
         let metrics = get_glyph_metrics(

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -53,7 +53,56 @@ unsafe impl Send for FontContext {}
 
 extern "C" {
     fn FT_GlyphSlot_Embolden(slot: FT_GlyphSlot);
-    fn FT_GlyphSlot_Oblique(slot: FT_GlyphSlot);
+}
+
+// Skew factor matching Gecko/FreeType.
+const OBLIQUE_SKEW_FACTOR: f32 = 0.2;
+
+fn get_skew_bounds(bottom: i32, top: i32) -> (f32, f32) {
+    let skew_min = ((bottom as f32 + 0.5) * OBLIQUE_SKEW_FACTOR).floor();
+    let skew_max = ((top as f32 - 0.5) * OBLIQUE_SKEW_FACTOR).ceil();
+    (skew_min, skew_max)
+}
+
+fn skew_bitmap(bitmap: &[u8], width: usize, height: usize, left: i32, top: i32) -> (Vec<u8>, usize, i32) {
+    let stride = width * 4;
+    // Calculate the skewed horizontal offsets of the bottom and top of the glyph.
+    let (skew_min, skew_max) = get_skew_bounds(top - height as i32, top);
+    // Allocate enough extra width for the min/max skew offsets.
+    let skew_width = width + (skew_max - skew_min) as usize;
+    let mut skew_buffer = vec![0u8; skew_width * height * 4];
+    for y in 0 .. height {
+        // Calculate a skew offset at the vertical center of the current row.
+        let offset = (top as f32 - y as f32 - 0.5) * OBLIQUE_SKEW_FACTOR - skew_min;
+        // Get a blend factor in 0..256 constant across all pixels in the row.
+        let blend = (offset.fract() * 256.0) as u32;
+        let src_row = y * stride;
+        let dest_row = (y * skew_width + offset.floor() as usize) * 4;
+        let mut prev_px = [0u32; 4];
+        for (src, dest) in
+            bitmap[src_row .. src_row + stride].chunks(4).zip(
+                skew_buffer[dest_row .. dest_row + stride].chunks_mut(4)
+            ) {
+            let px = [src[0] as u32, src[1] as u32, src[2] as u32, src[3] as u32];
+            // Blend current pixel with previous pixel based on blend factor.
+            let next_px = [px[0] * blend, px[1] * blend, px[2] * blend, px[3] * blend];
+            dest[0] = ((((px[0] << 8) - next_px[0]) + prev_px[0] + 128) >> 8) as u8;
+            dest[1] = ((((px[1] << 8) - next_px[1]) + prev_px[1] + 128) >> 8) as u8;
+            dest[2] = ((((px[2] << 8) - next_px[2]) + prev_px[2] + 128) >> 8) as u8;
+            dest[3] = ((((px[3] << 8) - next_px[3]) + prev_px[3] + 128) >> 8) as u8;
+            // Save the remainder for blending onto the next pixel.
+            prev_px = next_px;
+        }
+        // If the skew misaligns the final pixel, write out the remainder.
+        if blend > 0 {
+            let dest = &mut skew_buffer[dest_row + stride .. dest_row + stride + 4];
+            dest[0] = ((prev_px[0] + 128) >> 8) as u8;
+            dest[1] = ((prev_px[1] + 128) >> 8) as u8;
+            dest[2] = ((prev_px[2] + 128) >> 8) as u8;
+            dest[3] = ((prev_px[3] + 128) >> 8) as u8;
+        }
+    }
+    (skew_buffer, skew_width, left + skew_min as i32)
 }
 
 impl FontContext {
@@ -194,7 +243,10 @@ impl FontContext {
             unsafe { FT_Set_Transform(face.face, ptr::null_mut(), ptr::null_mut()) };
             self.choose_bitmap_size(face.face, req_size * y_scale)
         } else {
-            let shape = font.transform.pre_scale(x_scale.recip() as f32, y_scale.recip() as f32);
+            let mut shape = font.transform.invert_scale(x_scale, y_scale);
+            if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+                shape = shape.synthesize_italics(OBLIQUE_SKEW_FACTOR);
+            };
             let mut ft_shape = FT_Matrix {
                 xx: (shape.scale_x * 65536.0) as FT_Fixed,
                 xy: (shape.skew_x * -65536.0) as FT_Fixed,
@@ -305,40 +357,42 @@ impl FontContext {
         slot: FT_GlyphSlot,
         font: &FontInstance,
         glyph: &GlyphKey,
-        scale_bitmaps: bool,
+        transform_bitmaps: bool,
     ) -> Option<GlyphDimensions> {
         let metrics = unsafe { &(*slot).metrics };
 
-        let advance = metrics.horiAdvance as f32 / 64.0;
+        let mut advance = metrics.horiAdvance as f32 / 64.0;
         match unsafe { (*slot).format } {
             FT_Glyph_Format::FT_GLYPH_FORMAT_BITMAP => {
-                let left = unsafe { (*slot).bitmap_left };
-                let top = unsafe { (*slot).bitmap_top };
-                let width = unsafe { (*slot).bitmap.width };
-                let height = unsafe { (*slot).bitmap.rows };
-                if scale_bitmaps {
+                let mut left = unsafe { (*slot).bitmap_left };
+                let mut top = unsafe { (*slot).bitmap_top };
+                let mut width = unsafe { (*slot).bitmap.width };
+                let mut height = unsafe { (*slot).bitmap.rows };
+                if transform_bitmaps {
                     let y_size = unsafe { (*(*(*slot).face).size).metrics.y_ppem };
                     let scale = font.size.to_f32_px() / y_size as f32;
                     let x0 = left as f32 * scale;
                     let x1 = width as f32 * scale + x0;
                     let y1 = top as f32 * scale;
                     let y0 = y1 - height as f32 * scale;
-                    Some(GlyphDimensions {
-                        left: x0.round() as i32,
-                        top: y1.round() as i32,
-                        width: (x1.ceil() - x0.floor()) as u32,
-                        height: (y1.ceil() - y0.floor()) as u32,
-                        advance: advance * scale,
-                    })
-                } else {
-                    Some(GlyphDimensions {
-                        left,
-                        top,
-                        width,
-                        height,
-                        advance,
-                    })
+                    left = x0.round() as i32;
+                    top = y1.round() as i32;
+                    width = (x1.ceil() - x0.floor()) as u32;
+                    height = (y1.ceil() - y0.floor()) as u32;
+                    advance *= scale;
+                    if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+                        let (skew_min, skew_max) = get_skew_bounds(top - height as i32, top);
+                        left += skew_min as i32;
+                        width += (skew_max - skew_min) as u32;
+                    }
                 }
+                Some(GlyphDimensions {
+                    left,
+                    top,
+                    width,
+                    height,
+                    advance,
+                })
             }
             FT_Glyph_Format::FT_GLYPH_FORMAT_OUTLINE => {
                 let cbox = self.get_bounding_box(slot, font, glyph);
@@ -429,10 +483,6 @@ impl FontContext {
                 dx - ((cbox.xMin + dx) & !63),
                 dy - ((cbox.yMin + dy) & !63),
             );
-
-            if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
-                FT_GlyphSlot_Oblique(slot);
-            }
         }
 
         if font.render_mode == FontRenderMode::Subpixel {
@@ -514,23 +564,23 @@ impl FontContext {
 
         let bitmap = unsafe { &(*slot).bitmap };
         let pixel_mode = unsafe { mem::transmute(bitmap.pixel_mode as u32) };
-        let (actual_width, actual_height) = match pixel_mode {
+        let (mut actual_width, actual_height) = match pixel_mode {
             FT_Pixel_Mode::FT_PIXEL_MODE_LCD => {
                 assert!(bitmap.width % 3 == 0);
-                ((bitmap.width / 3) as i32, bitmap.rows as i32)
+                ((bitmap.width / 3) as usize, bitmap.rows as usize)
             }
             FT_Pixel_Mode::FT_PIXEL_MODE_LCD_V => {
                 assert!(bitmap.rows % 3 == 0);
-                (bitmap.width as i32, (bitmap.rows / 3) as i32)
+                (bitmap.width as usize, (bitmap.rows / 3) as usize)
             }
             FT_Pixel_Mode::FT_PIXEL_MODE_MONO |
             FT_Pixel_Mode::FT_PIXEL_MODE_GRAY |
             FT_Pixel_Mode::FT_PIXEL_MODE_BGRA => {
-                (bitmap.width as i32, bitmap.rows as i32)
+                (bitmap.width as usize, bitmap.rows as usize)
             }
             _ => panic!("Unsupported {:?}", pixel_mode),
         };
-        let mut final_buffer = vec![0; (actual_width * actual_height * 4) as usize];
+        let mut final_buffer = vec![0u8; actual_width * actual_height * 4];
 
         // Extract the final glyph from FT format into BGRA8 format, which is
         // what WR expects.
@@ -539,7 +589,7 @@ impl FontContext {
         let mut dest: usize = 0;
         while dest < final_buffer.len() {
             let mut src = src_row;
-            let row_end = dest + actual_width as usize * 4;
+            let row_end = dest + actual_width * 4;
             match pixel_mode {
                 FT_Pixel_Mode::FT_PIXEL_MODE_MONO => {
                     while dest < row_end {
@@ -613,10 +663,19 @@ impl FontContext {
         }
 
         match format {
+            FT_Glyph_Format::FT_GLYPH_FORMAT_BITMAP => {
+                if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+                    let (skew_buffer, skew_width, skew_left) =
+                        skew_bitmap(&final_buffer, actual_width, actual_height, left, top);
+                    final_buffer = skew_buffer;
+                    actual_width = skew_width;
+                    left = skew_left;
+                }
+            }
             FT_Glyph_Format::FT_GLYPH_FORMAT_OUTLINE => {
                 unsafe {
                     left += (*slot).bitmap_left;
-                    top += (*slot).bitmap_top - actual_height;
+                    top += (*slot).bitmap_top - actual_height as i32;
                 }
             }
             _ => {}

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -6,7 +6,7 @@ use api::{FontInstanceFlags, FontKey, FontRenderMode};
 use api::{ColorU, GlyphDimensions, GlyphKey, SubpixelDirection};
 use dwrote;
 use gamma_lut::{ColorLut, GammaLut};
-use glyph_rasterizer::{FontInstance, GlyphFormat, RasterizedGlyph};
+use glyph_rasterizer::{FontInstance, FontTransform, GlyphFormat, RasterizedGlyph};
 use internal_types::FastHashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
@@ -86,6 +86,9 @@ fn is_bitmap_font(font: &FontInstance) -> bool {
         font.flags.contains(FontInstanceFlags::EMBEDDED_BITMAPS)
 }
 
+// Skew factor matching Gecko/DWrite.
+const OBLIQUE_SKEW_FACTOR: f32 = 0.3;
+
 impl FontContext {
     pub fn new() -> FontContext {
         // These are the default values we use in Gecko.
@@ -160,16 +163,10 @@ impl FontContext {
         &mut self,
         font: &FontInstance,
     ) -> &dwrote::FontFace {
-        if !font.flags.intersects(FontInstanceFlags::SYNTHETIC_BOLD | FontInstanceFlags::SYNTHETIC_ITALICS) {
+        if !font.flags.contains(FontInstanceFlags::SYNTHETIC_BOLD) {
             return self.fonts.get(&font.font_key).unwrap();
         }
-        let mut sims = dwrote::DWRITE_FONT_SIMULATIONS_NONE;
-        if font.flags.contains(FontInstanceFlags::SYNTHETIC_BOLD) {
-            sims = sims | dwrote::DWRITE_FONT_SIMULATIONS_BOLD;
-        }
-        if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
-            sims = sims | dwrote::DWRITE_FONT_SIMULATIONS_OBLIQUE;
-        }
+        let sims = dwrote::DWRITE_FONT_SIMULATIONS_BOLD;
         match self.simulations.entry((font.font_key, sims)) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
@@ -239,7 +236,20 @@ impl FontContext {
     ) -> Option<GlyphDimensions> {
         let size = font.size.to_f32_px();
         let bitmaps = is_bitmap_font(font);
-        let analysis = self.create_glyph_analysis(font, key, size, None, bitmaps);
+        let transform = if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+            let shape = FontTransform::identity().synthesize_italics(OBLIQUE_SKEW_FACTOR);
+            Some(dwrote::DWRITE_MATRIX {
+                m11: shape.scale_x,
+                m12: shape.skew_y,
+                m21: shape.skew_x,
+                m22: shape.scale_y,
+                dx: 0.0,
+                dy: 0.0,
+            })
+        } else {
+            None
+        };
+        let analysis = self.create_glyph_analysis(font, key, size, transform, bitmaps);
 
         let texture_type = dwrite_texture_type(font.render_mode);
 
@@ -344,11 +354,15 @@ impl FontContext {
         let (.., y_scale) = font.transform.compute_scale().unwrap_or((1.0, 1.0));
         let size = (font.size.to_f64_px() * y_scale) as f32;
         let bitmaps = is_bitmap_font(font);
-        let transform = if bitmaps {
-            None
+        let (mut shape, (x_offset, y_offset)) = if bitmaps {
+            (FontTransform::identity(), (0.0, 0.0))
         } else {
-            let (x_offset, y_offset) = font.get_subpx_offset(key);
-            let shape = font.transform.pre_scale(y_scale.recip() as f32, y_scale.recip() as f32);
+            (font.transform.invert_scale(y_scale, y_scale), font.get_subpx_offset(key))
+        };
+        if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+            shape = shape.synthesize_italics(OBLIQUE_SKEW_FACTOR);
+        }
+        let transform = if !shape.is_identity() || (x_offset, y_offset) != (0.0, 0.0) {
             Some(dwrote::DWRITE_MATRIX {
                 m11: shape.scale_x,
                 m12: shape.skew_y,
@@ -357,6 +371,8 @@ impl FontContext {
                 dx: x_offset as f32,
                 dy: y_offset as f32,
             })
+        } else {
+            None
         };
 
         let analysis = self.create_glyph_analysis(font, key, size, transform, bitmaps);

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -23,8 +23,7 @@ fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 options(disable-aa) == shadow-atomic.yaml shadow-atomic-ref.yaml
 options(disable-aa) == shadow-ordering.yaml shadow-ordering-ref.yaml
-# enable when synthetic-italics implemented on mac
-platform(linux) != synthetic-italics.yaml synthetic-italics-ref.yaml
+!= synthetic-italics.yaml synthetic-italics-ref.yaml
 options(disable-aa) == ahem.yaml ahem-ref.yaml
 platform(linux) == isolated-text.yaml isolated-text.png
 platform(mac) == white-opacity.yaml white-opacity.png


### PR DESCRIPTION
This tries to implement synthetic italics in a way that is compatible with how Gecko does it. That means we no longer use the myriad backend APIs for this, but instead supply skew transforms for the outline that match the transform Gecko is using for metrics.

FreeType requires a bit of extra care in that transforms only apply to outlines and not to bitmaps. So bitmap data must unfortunately be manually transformed to accomplish this.  However, FreeType's own synthetic italics mechanism did not work for bitmaps at all either, so this rewrite was a necessity there anyway. The Windows/Mac backends take care of the bitmap data transforms themselves, so we at least avoid the complexity in those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2245)
<!-- Reviewable:end -->
