### PR TITLE
Recurse to children of empty ClipScrollNodes

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -417,17 +417,18 @@ impl ClipScrollTree {
 
             node.push_gpu_node_data(gpu_node_data);
 
-            if node.children.is_empty() || node.combined_clip_outer_bounds.is_empty() {
-                return
+            if node.children.is_empty() {
+                return;
             }
+
 
             node.prepare_state_for_children(&mut state);
             node.children.clone()
         };
 
-        for child_layer_id in node_children {
+        for child_node_id in node_children {
             self.update_node(
-                child_layer_id,
+                child_node_id,
                 &mut state,
                 next_coordinate_system_id,
                 device_pixel_scale,


### PR DESCRIPTION
This is important in order to clean up stale data during scrolling and
fixes a crash in Gecko. There is no test for this, because wrench does
not have the ability to easily test scrolling animation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2249)
<!-- Reviewable:end -->
