### PR TITLE
Remove RG8 and RGB8 support from texture cache.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -458,7 +458,6 @@ impl Texture {
     pub fn get_bpp(&self) -> u32 {
         match self.format {
             ImageFormat::A8 => 1,
-            ImageFormat::RGB8 => 3,
             ImageFormat::BGRA8 => 4,
             ImageFormat::RG8 => 2,
             ImageFormat::RGBAF32 => 16,
@@ -1930,7 +1929,6 @@ fn gl_texture_formats_for_image_format(
         } else {
             (GL_FORMAT_A as gl::GLint, GL_FORMAT_A)
         },
-        ImageFormat::RGB8 => (gl::RGB as gl::GLint, gl::RGB),
         ImageFormat::BGRA8 => match gl.get_type() {
             gl::GlType::Gl => (gl::RGBA as gl::GLint, get_gl_format_bgra(gl)),
             gl::GlType::Gles => (get_gl_format_bgra(gl) as gl::GLint, get_gl_format_bgra(gl)),
@@ -2056,7 +2054,6 @@ impl<'a> UploadTarget<'a> {
     fn update_impl(&mut self, chunk: UploadChunk) {
         let (gl_format, bpp, data_type) = match self.texture.format {
             ImageFormat::A8 => (GL_FORMAT_A, 1, gl::UNSIGNED_BYTE),
-            ImageFormat::RGB8 => (gl::RGB, 3, gl::UNSIGNED_BYTE),
             ImageFormat::BGRA8 => (get_gl_format_bgra(self.gl), 4, gl::UNSIGNED_BYTE),
             ImageFormat::RG8 => (gl::RG, 2, gl::UNSIGNED_BYTE),
             ImageFormat::RGBAF32 => (gl::RGBA, 16, gl::FLOAT),

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -314,20 +314,16 @@ impl FrameProfileCounters {
 #[derive(Clone)]
 pub struct TextureCacheProfileCounters {
     pub pages_a8_linear: ResourceProfileCounter,
-    pub pages_rgb8_linear: ResourceProfileCounter,
     pub pages_rgba8_linear: ResourceProfileCounter,
     pub pages_rgba8_nearest: ResourceProfileCounter,
-    pub pages_rg8_linear: ResourceProfileCounter,
 }
 
 impl TextureCacheProfileCounters {
     pub fn new() -> Self {
         TextureCacheProfileCounters {
             pages_a8_linear: ResourceProfileCounter::new("Texture A8 cached pages"),
-            pages_rgb8_linear: ResourceProfileCounter::new("Texture RGB8 cached pages"),
             pages_rgba8_linear: ResourceProfileCounter::new("Texture RGBA8 cached pages (L)"),
             pages_rgba8_nearest: ResourceProfileCounter::new("Texture RGBA8 cached pages (N)"),
-            pages_rg8_linear: ResourceProfileCounter::new("Texture RG8 cached pages"),
         }
     }
 }
@@ -998,10 +994,8 @@ impl Profiler {
         Profiler::draw_counters(
             &[
                 &backend_profile.resources.texture_cache.pages_a8_linear,
-                &backend_profile.resources.texture_cache.pages_rgb8_linear,
                 &backend_profile.resources.texture_cache.pages_rgba8_linear,
                 &backend_profile.resources.texture_cache.pages_rgba8_nearest,
-                &backend_profile.resources.texture_cache.pages_rg8_linear,
                 &backend_profile.ipc.display_lists,
             ],
             debug_renderer,

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -166,13 +166,9 @@ impl TextureCacheHandle {
 pub struct TextureCache {
     // A lazily allocated, fixed size, texture array for
     // each format the texture cache supports.
-    // TODO(gw): Do we actually need RG8 and RGB8 or
-    // are they only used by external textures?
     array_rgba8_nearest: TextureArray,
     array_a8_linear: TextureArray,
     array_rgba8_linear: TextureArray,
-    array_rg8_linear: TextureArray,
-    array_rgb8_linear: TextureArray,
 
     // Maximum texture size supported by hardware.
     max_texture_size: u32,
@@ -219,16 +215,6 @@ impl TextureCache {
                 TextureFilter::Linear,
                 TEXTURE_ARRAY_LAYERS_LINEAR,
             ),
-            array_rg8_linear: TextureArray::new(
-                ImageFormat::RG8,
-                TextureFilter::Linear,
-                TEXTURE_ARRAY_LAYERS_LINEAR,
-            ),
-            array_rgb8_linear: TextureArray::new(
-                ImageFormat::RGB8,
-                TextureFilter::Linear,
-                TEXTURE_ARRAY_LAYERS_LINEAR,
-            ),
             array_rgba8_nearest: TextureArray::new(
                 ImageFormat::BGRA8,
                 TextureFilter::Nearest,
@@ -252,10 +238,6 @@ impl TextureCache {
 
         self.array_a8_linear
             .update_profile(&mut texture_cache_profile.pages_a8_linear);
-        self.array_rg8_linear
-            .update_profile(&mut texture_cache_profile.pages_rg8_linear);
-        self.array_rgb8_linear
-            .update_profile(&mut texture_cache_profile.pages_rgb8_linear);
         self.array_rgba8_linear
             .update_profile(&mut texture_cache_profile.pages_rgba8_linear);
         self.array_rgba8_nearest
@@ -386,13 +368,10 @@ impl TextureCache {
             (ImageFormat::A8, TextureFilter::Linear) => &mut self.array_a8_linear,
             (ImageFormat::BGRA8, TextureFilter::Linear) => &mut self.array_rgba8_linear,
             (ImageFormat::BGRA8, TextureFilter::Nearest) => &mut self.array_rgba8_nearest,
-            (ImageFormat::RGB8, TextureFilter::Linear) => &mut self.array_rgb8_linear,
-            (ImageFormat::RG8, TextureFilter::Linear) => &mut self.array_rg8_linear,
             (ImageFormat::Invalid, _) |
             (ImageFormat::RGBAF32, _) |
-            (ImageFormat::A8, TextureFilter::Nearest) |
-            (ImageFormat::RG8, TextureFilter::Nearest) |
-            (ImageFormat::RGB8, TextureFilter::Nearest) => unreachable!(),
+            (ImageFormat::RG8, _) |
+            (ImageFormat::A8, TextureFilter::Nearest) => unreachable!(),
         };
 
         &mut texture_array.regions[region_index as usize]
@@ -561,13 +540,10 @@ impl TextureCache {
             (ImageFormat::A8, TextureFilter::Linear) => &mut self.array_a8_linear,
             (ImageFormat::BGRA8, TextureFilter::Linear) => &mut self.array_rgba8_linear,
             (ImageFormat::BGRA8, TextureFilter::Nearest) => &mut self.array_rgba8_nearest,
-            (ImageFormat::RGB8, TextureFilter::Linear) => &mut self.array_rgb8_linear,
-            (ImageFormat::RG8, TextureFilter::Linear) => &mut self.array_rg8_linear,
             (ImageFormat::Invalid, _) |
             (ImageFormat::RGBAF32, _) |
             (ImageFormat::A8, TextureFilter::Nearest) |
-            (ImageFormat::RG8, TextureFilter::Nearest) |
-            (ImageFormat::RGB8, TextureFilter::Nearest) => unreachable!(),
+            (ImageFormat::RG8, _) => unreachable!(),
         };
 
         // Lazy initialize this texture array if required.

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -52,7 +52,6 @@ pub struct ExternalImageData {
 pub enum ImageFormat {
     Invalid = 0,
     A8 = 1,
-    RGB8 = 2,
     BGRA8 = 3,
     RGBAF32 = 4,
     RG8 = 5,
@@ -62,7 +61,6 @@ impl ImageFormat {
     pub fn bytes_per_pixel(self) -> u32 {
         match self {
             ImageFormat::A8 => 1,
-            ImageFormat::RGB8 => 3,
             ImageFormat::BGRA8 => 4,
             ImageFormat::RGBAF32 => 16,
             ImageFormat::RG8 => 2,

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -221,18 +221,6 @@ impl JsonFrameWriter {
         );
 
         let ok = match data.format {
-            ImageFormat::RGB8 => if data.stride == data.width * 3 {
-                save_buffer(
-                    &path_file,
-                    &bytes,
-                    data.width,
-                    data.height,
-                    ColorType::RGB(8),
-                ).unwrap();
-                true
-            } else {
-                false
-            },
             ImageFormat::BGRA8 => if data.stride == data.width * 4 {
                 unpremultiply(bytes.as_mut_slice());
                 save_buffer(

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -554,7 +554,6 @@ impl YamlFrameWriter {
 
         assert!(data.stride > 0);
         let (color_type, bpp) = match data.format {
-            ImageFormat::RGB8 => (ColorType::RGB(8), 3),
             ImageFormat::BGRA8 => (ColorType::RGBA(8), 4),
             ImageFormat::A8 => (ColorType::Gray(8), 1),
             _ => {


### PR DESCRIPTION
RGB8 support is removed completely from WR. It's not supported
by many modern GPUs as a native format. Instead, expect the client
code to convert it to RGBx first.

RG8 support is removed from the texture cache, but remains as a
supported image format. It's used by some variants of YUV formats.
This allows RG8 images to be used as external images, but not
placed into the texture cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2260)
<!-- Reviewable:end -->
