### PR TITLE
Fix FreeType synthetic italics hinting

### DIFF
--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -200,7 +200,13 @@ impl FontContext {
         let face = self.faces.get(&font.font_key).unwrap();
 
         let mut load_flags = FT_LOAD_DEFAULT;
-        let FontInstancePlatformOptions { hinting, .. } = font.platform_options.unwrap_or_default();
+        let FontInstancePlatformOptions { mut hinting, .. } = font.platform_options.unwrap_or_default();
+        // Disable hinting if there is a non-axis-aligned transform.
+        if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) ||
+           ((font.transform.scale_x != 0.0 || font.transform.scale_y != 0.0) &&
+            (font.transform.skew_x != 0.0 || font.transform.skew_y != 0.0)) {
+            hinting = FontHinting::None;
+        }
         match (hinting, font.render_mode) {
             (FontHinting::None, _) => load_flags |= FT_LOAD_NO_HINTING,
             (FontHinting::Mono, _) => load_flags = FT_LOAD_TARGET_MONO,

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -681,7 +681,7 @@ impl FontContext {
             FT_Glyph_Format::FT_GLYPH_FORMAT_OUTLINE => {
                 unsafe {
                     left += (*slot).bitmap_left;
-                    top += (*slot).bitmap_top - actual_height as i32;
+                    top += (*slot).bitmap_top - height as i32;
                 }
             }
             _ => {}


### PR DESCRIPTION
This is a follow-up to #2245. In certain cases with skew matrices and/or disable anti-aliasing, the apparent weight and offsetting of the font will significantly differ from Gecko, causing some reftests to fail. These changes ensure that we match Gecko which has the beneficial side-effect that not only do the synthetic italics reftests pass, but a few other WebRender related failures are fixed as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2262)
<!-- Reviewable:end -->
