### PR TITLE
add reftests for synthetic bold

### DIFF
--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -23,6 +23,9 @@ fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 options(disable-aa) == shadow-atomic.yaml shadow-atomic-ref.yaml
 options(disable-aa) == shadow-ordering.yaml shadow-ordering-ref.yaml
+!= synthetic-bold.yaml synthetic-bold-not-ref.yaml
+fuzzy(1,229) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml
+!= synthetic-bold-transparent.yaml synthetic-bold.yaml
 != synthetic-italics.yaml synthetic-italics-ref.yaml
 options(disable-aa) == ahem.yaml ahem-ref.yaml
 platform(linux) == isolated-text.yaml isolated-text.png

--- a/wrench/reftests/text/synthetic-bold-not-ref.yaml
+++ b/wrench/reftests/text/synthetic-bold-not-ref.yaml
@@ -1,0 +1,5 @@
+root:
+  items:
+    - text: "Fake bold is great"
+      origin: 20 40
+      size: 20

--- a/wrench/reftests/text/synthetic-bold-transparent-ref.yaml
+++ b/wrench/reftests/text/synthetic-bold-transparent-ref.yaml
@@ -1,0 +1,10 @@
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 660, 210]
+      filters: opacity(0.5)
+      items:
+      - text: "Fake bold is great"
+        origin: 20 40
+        size: 20
+        synthetic-bold: true

--- a/wrench/reftests/text/synthetic-bold-transparent.yaml
+++ b/wrench/reftests/text/synthetic-bold-transparent.yaml
@@ -1,0 +1,7 @@
+root:
+  items:
+    - text: "Fake bold is great"
+      origin: 20 40
+      size: 20
+      color: [0, 0, 0, 0.5]
+      synthetic-bold: true

--- a/wrench/reftests/text/synthetic-bold.yaml
+++ b/wrench/reftests/text/synthetic-bold.yaml
@@ -1,0 +1,6 @@
+root:
+  items:
+    - text: "Fake bold is great"
+      origin: 20 40
+      size: 20
+      synthetic-bold: true


### PR DESCRIPTION
* synthetic bold does a thing
* transparent text is smeared properly (needs to be a tiny bit fuzzy)
* transparent synthetic bold is actually transparent (sanity check)

All pass locally, might need to tweak fuzzyness based on CI results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2270)
<!-- Reviewable:end -->

  