### PR TITLE
Adjust the clip region for shadow elements.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -852,6 +852,8 @@ impl FrameBuilder {
             );
             let mut info = info.clone();
             info.rect = info.rect.translate(&shadow_offset);
+            info.local_clip =
+              LocalClip::from(info.local_clip.clip_rect().translate(&shadow_offset));
             let prim_index = self.create_primitive(
                 &info,
                 Vec::new(),
@@ -1362,6 +1364,8 @@ impl FrameBuilder {
             let rect = info.rect;
             let mut info = info.clone();
             info.rect = rect.translate(&text_prim.offset);
+            info.local_clip =
+              LocalClip::from(info.local_clip.clip_rect().translate(&text_prim.offset));
             let prim_index = self.create_primitive(
                 &info,
                 Vec::new(),

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -21,6 +21,7 @@ fuzzy(1,735) == shadow-grey.yaml shadow-grey-ref.yaml
 fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 options(disable-aa) == shadow-atomic.yaml shadow-atomic-ref.yaml
+options(disable-aa) == shadow-clip-rect.yaml shadow-atomic-ref.yaml
 options(disable-aa) == shadow-ordering.yaml shadow-ordering-ref.yaml
 != synthetic-bold.yaml synthetic-bold-not-ref.yaml
 fuzzy(1,229) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml

--- a/wrench/reftests/text/shadow-clip-rect.yaml
+++ b/wrench/reftests/text/shadow-clip-rect.yaml
@@ -1,0 +1,45 @@
+--- # checks that decorations on "real" content and "shadow" content are on seperate, atomic, layers
+root:
+  items:
+        -
+          type: "shadow"
+          bounds: [14, 18, 205, 35]
+          blur-radius: 0
+          offset: [20, 16]
+          color: green
+        -
+          type: "shadow"
+          bounds: [14, 18, 205, 35]
+          blur-radius: 0
+          offset: [10, 8]
+          color: black
+        -
+          type: line
+          clip-rect: [14, 18, 205, 35]
+          baseline: 45
+          start: 14
+          end: 210
+          width: 3
+          orientation: horizontal
+          color: red
+          style: solid
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [14, 18, 205, 35]
+          glyphs: [55, 75, 76, 86, 3, 76, 86, 3, 87, 75, 72, 3, 69, 72, 86, 87]
+          offsets: [16, 43, 35.533333, 43, 51.533333, 43, 60.4, 43, 72.833336, 43, 80.833336, 43, 89.7, 43, 102.13333, 43, 110.13333, 43, 119, 43, 135, 43, 149.2, 43, 157.2, 43, 173.2, 43, 187.4, 43, 196.26666, 43]
+          size: 18
+          color: red
+          font: "VeraBd.ttf"
+        -
+          type: line
+          clip-rect: [14, 18, 205, 35]
+          baseline: 32
+          start: 14
+          end: 210
+          width: 3
+          orientation: horizontal
+          color: red
+          style: solid
+        -
+          type: "pop-all-shadows"


### PR DESCRIPTION
This patch is intend to fix #1928.

In webrender, shadow elements inherit the same clip with the original elements which leads the shadow to apply the wrong clip region when doing fast-shadow.
To fix this, when adding a shadow line primitive, I adjust PrimitiveInfo's local_clip_rect to fit the correct clip region and apply the clip outside of the shadow to the shadow line primitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2278)
<!-- Reviewable:end -->
