### PR TITLE
Clip via ClipChains instead of ClipScrollNodes

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, DeviceIntRect, DevicePixelScale, LayerPoint, LayerRect};
-use api::{LayerToWorldTransform, LayerVector2D, PipelineId, ScrollClamping, ScrollEventPhase};
-use api::{PropertyBinding, LayoutTransform, ScrollLayerState, ScrollLocation, WorldPoint};
+use api::{ClipId, DeviceIntRect, DevicePixelScale, LayerPoint, LayerRect, LayerToWorldTransform};
+use api::{LayerVector2D, LayoutTransform, PipelineId, PropertyBinding, ScrollClamping};
+use api::{ScrollEventPhase, ScrollLayerState, ScrollLocation, WorldPoint};
 use clip::ClipStore;
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollingState, StickyFrameInfo};
 use gpu_cache::GpuCache;
@@ -359,7 +359,7 @@ impl ClipScrollTree {
             parent_accumulated_scroll_offset: LayerVector2D::zero(),
             nearest_scrolling_ancestor_offset: LayerVector2D::zero(),
             nearest_scrolling_ancestor_viewport: LayerRect::zero(),
-            parent_clip_chain: None,
+            parent_clip_chain: ClipChain::empty(screen_rect),
             current_coordinate_system_id: CoordinateSystemId::root(),
             coordinate_system_relative_transform: TransformOrOffset::zero(),
             invertible: true,
@@ -369,7 +369,6 @@ impl ClipScrollTree {
             root_reference_frame_id,
             &mut state,
             &mut next_coordinate_system_id,
-            screen_rect,
             device_pixel_scale,
             clip_store,
             resource_cache,
@@ -384,7 +383,6 @@ impl ClipScrollTree {
         layer_id: ClipId,
         state: &mut TransformUpdateState,
         next_coordinate_system_id: &mut CoordinateSystemId,
-        screen_rect: &DeviceIntRect,
         device_pixel_scale: DevicePixelScale,
         clip_store: &mut ClipStore,
         resource_cache: &mut ResourceCache,
@@ -407,7 +405,6 @@ impl ClipScrollTree {
             node.update(
                 &mut state,
                 next_coordinate_system_id,
-                screen_rect,
                 device_pixel_scale,
                 clip_store,
                 resource_cache,
@@ -421,7 +418,6 @@ impl ClipScrollTree {
                 return;
             }
 
-
             node.prepare_state_for_children(&mut state);
             node.children.clone()
         };
@@ -431,7 +427,6 @@ impl ClipScrollTree {
                 child_node_id,
                 &mut state,
                 next_coordinate_system_id,
-                screen_rect,
                 device_pixel_scale,
                 clip_store,
                 resource_cache,
@@ -612,4 +607,8 @@ impl ClipScrollTree {
                    .unwrap_or_else(|| WorldPoint::new(point.x, point.y))
 
     }
+
+    pub fn get_clip_chain(&self, id: &ClipId) -> Option<&ClipChain> {
+        self.nodes[id].clip_chain.as_ref()
+     }
 }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -29,7 +29,7 @@ use prim_store::{PrimitiveContainer, PrimitiveIndex, SpecificPrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{BrushSegmentDescriptor, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_task::{ClearMode, RenderTask, RenderTaskId, RenderTaskTree};
+use render_task::{ClearMode, ClipChain, RenderTask, RenderTaskId, RenderTaskTree};
 use resource_cache::ResourceCache;
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
@@ -129,7 +129,7 @@ pub struct FrameBuilder {
 pub struct PrimitiveContext<'a> {
     pub device_pixel_scale: DevicePixelScale,
     pub display_list: &'a BuiltDisplayList,
-    pub clip_node: &'a ClipScrollNode,
+    pub clip_chain: Option<&'a ClipChain>,
     pub scroll_node: &'a ClipScrollNode,
 }
 
@@ -137,13 +137,13 @@ impl<'a> PrimitiveContext<'a> {
     pub fn new(
         device_pixel_scale: DevicePixelScale,
         display_list: &'a BuiltDisplayList,
-        clip_node: &'a ClipScrollNode,
+        clip_chain: Option<&'a ClipChain>,
         scroll_node: &'a ClipScrollNode,
     ) -> Self {
         PrimitiveContext {
             device_pixel_scale,
             display_list,
-            clip_node,
+            clip_chain,
             scroll_node,
         }
     }
@@ -1582,7 +1582,7 @@ impl FrameBuilder {
         let root_prim_context = PrimitiveContext::new(
             device_pixel_scale,
             display_list,
-            root_clip_scroll_node,
+            root_clip_scroll_node.clip_chain.as_ref(),
             root_clip_scroll_node,
         );
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -21,8 +21,8 @@ use gpu_cache::{GpuBlockData, GpuCache, GpuCacheAddress, GpuCacheHandle, GpuData
 use gpu_types::{ClipChainRectIndex, ClipScrollNodeData};
 use picture::{PictureKind, PicturePrimitive};
 use profiler::FrameProfileCounters;
-use render_task::{ClipChain, ClipChainNode, ClipChainNodeIter, ClipWorkItem, RenderTask};
-use render_task::{RenderTaskId, RenderTaskTree};
+use render_task::{ClipChain, ClipChainNode, ClipChainNodeIter, ClipChainNodeRef, ClipWorkItem};
+use render_task::{RenderTask, RenderTaskId, RenderTaskTree};
 use renderer::{BLOCKS_PER_UV_RECT, MAX_VERTEX_TEXTURE_WIDTH};
 use resource_cache::{ImageProperties, ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
@@ -1554,11 +1554,12 @@ impl PrimitiveStore {
             }
         };
 
-        let clip_chain = prim_context.clip_node.clip_chain_node.clone();
-        let mut combined_outer_rect = match clip_chain {
-            Some(ref node) => prim_screen_rect.intersection(&node.combined_outer_screen_rect),
+        let mut combined_outer_rect = match prim_context.clip_chain {
+            Some(ref chain) => prim_screen_rect.intersection(&chain.combined_outer_screen_rect),
             None => Some(prim_screen_rect),
         };
+
+        let clip_chain = prim_context.clip_chain.map_or(None, |x| x.nodes.clone());
 
         let prim_coordinate_system_id = prim_context.scroll_node.coordinate_system_id;
         let transform = &prim_context.scroll_node.world_content_transform;
@@ -1587,9 +1588,6 @@ impl PrimitiveStore {
                     local_clip_rect: LayerRect::zero(),
                     screen_inner_rect,
                     screen_outer_rect: screen_outer_rect.unwrap_or(prim_screen_rect),
-                    combined_outer_screen_rect:
-                        combined_outer_rect.unwrap_or_else(DeviceIntRect::zero),
-                    combined_inner_screen_rect: DeviceIntRect::zero(),
                     prev: None,
                 }))
             } else {
@@ -1787,7 +1785,7 @@ impl PrimitiveStore {
                 prim_context.device_pixel_scale,
             );
 
-            let clip_bounds = match prim_context.clip_node.clip_chain_node {
+            let clip_bounds = match prim_context.clip_chain {
                 Some(ref node) => node.combined_outer_screen_rect,
                 None => *screen_rect,
             };
@@ -1870,12 +1868,23 @@ impl PrimitiveStore {
             //           a new primitive context for every run (if the hash
             //           lookups ever show up in a profile).
             let scroll_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.scroll_node_id];
-            let clip_node = &clip_scroll_tree.nodes[&run.clip_and_scroll.clip_node_id()];
+            let clip_chain = clip_scroll_tree.get_clip_chain(&run.clip_and_scroll.clip_node_id());
 
-            if perform_culling && !clip_node.is_visible() {
-                debug!("{:?} of clipped out {:?}", run.base_prim_index, pipeline_id);
-                continue;
+            if perform_culling {
+                if !scroll_node.invertible {
+                    debug!("{:?} {:?}: position not invertible", run.base_prim_index, pipeline_id);
+                    continue;
+                }
+
+                match clip_chain {
+                     Some(ref chain) if chain.combined_outer_screen_rect.is_empty() => {
+                        debug!("{:?} {:?}: clipped out", run.base_prim_index, pipeline_id);
+                        continue;
+                    }
+                    _ => {},
+                }
             }
+
 
             let parent_relative_transform = parent_prim_context
                 .scroll_node
@@ -1904,13 +1913,13 @@ impl PrimitiveStore {
             let child_prim_context = PrimitiveContext::new(
                 parent_prim_context.device_pixel_scale,
                 display_list,
-                clip_node,
+                clip_chain,
                 scroll_node,
             );
 
 
             let clip_chain_rect = match perform_culling {
-                true => get_local_clip_rect_for_nodes(scroll_node, clip_node),
+                true => get_local_clip_rect_for_nodes(scroll_node, clip_chain),
                 false => None,
             };
 
@@ -1993,17 +2002,14 @@ impl InsideTest<ComplexClipRegion> for ComplexClipRegion {
 }
 
 fn convert_clip_chain_to_clip_vector(
-    clip_chain: ClipChain,
-    extra_clip: ClipChain,
+    clip_chain_nodes: ClipChainNodeRef,
+    extra_clip: ClipChainNodeRef,
     combined_outer_rect: &DeviceIntRect,
     combined_inner_rect: &mut DeviceIntRect,
 ) -> Vec<ClipWorkItem> {
     // Filter out all the clip instances that don't contribute to the result.
     ClipChainNodeIter { current: extra_clip }
-        .chain(ClipChainNodeIter { current: clip_chain })
-        .take_while(|node| {
-            !node.combined_inner_screen_rect.contains_rect(&combined_outer_rect)
-        })
+        .chain(ClipChainNodeIter { current: clip_chain_nodes })
         .filter_map(|node| {
             *combined_inner_rect = if !node.screen_inner_rect.is_empty() {
                 // If this clip's inner area contains the area of the primitive clipped
@@ -2024,9 +2030,14 @@ fn convert_clip_chain_to_clip_vector(
 
 fn get_local_clip_rect_for_nodes(
     scroll_node: &ClipScrollNode,
-    clip_node: &ClipScrollNode,
+    clip_chain: Option<&ClipChain>,
 ) -> Option<LayerRect> {
-    let local_rect = ClipChainNodeIter { current: clip_node.clip_chain_node.clone() }.fold(
+    let clip_chain_nodes = match clip_chain {
+        Some(ref clip_chain) => clip_chain.nodes.clone(),
+        None => return None,
+    };
+
+    let local_rect = ClipChainNodeIter { current: clip_chain_nodes }.fold(
         None,
         |combined_local_clip_rect: Option<LayerRect>, node| {
             if node.work_item.coordinate_system_id != scroll_node.coordinate_system_id {


### PR DESCRIPTION
Further develop the idea of ClipChains. In PrimitiveContext, keep track of
ClipChains instead of a particular clipping ClipScrollNode. This will
allow using an API-defined ClipChain for clipping in a later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2279)
<!-- Reviewable:end -->
