### PR TITLE
Red flicker fix/workaround

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4082,6 +4082,7 @@ impl Renderer {
             }
         } else {
             if list.texture.is_some() {
+                list.check_ready();
                 return
             }
             match self.texture_resolver.render_target_pool.pop() {
@@ -4103,6 +4104,7 @@ impl Renderer {
             None,
         );
         list.texture = Some(texture);
+        list.check_ready();
     }
 
     fn prepare_tile_frame(&mut self, frame: &mut Frame) {
@@ -4217,8 +4219,8 @@ impl Renderer {
                     (None, None)
                 }
                 RenderPassKind::OffScreen { ref mut alpha, ref mut color } => {
-                    assert!(alpha.targets.is_empty() || alpha.texture.is_some());
-                    assert!(color.targets.is_empty() || color.texture.is_some());
+                    alpha.check_ready();
+                    color.check_ready();
 
                     for (target_index, target) in alpha.targets.iter().enumerate() {
                         stats.alpha_target_count += 1;

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -201,6 +201,22 @@ impl<T: RenderTarget> RenderTargetList<T> {
     pub fn needs_depth(&self) -> bool {
         self.targets.iter().any(|target| target.needs_depth())
     }
+
+    pub fn check_ready(&self) {
+        match self.texture {
+            Some(ref t) => {
+                assert_eq!(t.get_dimensions(), self.max_size);
+                assert_eq!(t.get_format(), self.format);
+                assert_eq!(t.get_render_target_layer_count(), self.targets.len());
+                assert_eq!(t.get_layer_count() as usize, self.targets.len());
+                assert_eq!(t.has_depth(), t.get_rt_info().unwrap().has_depth);
+                assert_eq!(t.has_depth(), self.needs_depth());
+            }
+            None => {
+                assert!(self.targets.is_empty())
+            }
+        }
+    }
 }
 
 /// Frame output information for a given pipeline ID.


### PR DESCRIPTION
Addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1421696
~~TODO:~~ gecko try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=27240e664f521285aa3d3ae76fce18886eba46c1&selectedJob=155374418

PR contains 3 things:
  1. extensive validation of the render target list state with assertions. Note: none of those were triggered by the bug, but it's good to have them anyway for the future.
  2. fixed reset to the previous FBO in `update_texture_storage` (this may fix some other issues, technically)
  3. `WORK_AROUND_TEX_IMAGE ` fix, which resets a render target before trying to re-initialize it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2280)
<!-- Reviewable:end -->
