### PR TITLE
show subpixel AA on fast text shadows

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -806,7 +806,7 @@ impl AlphaBatcher {
                                     } else if ctx.use_dual_source_blending {
                                         BlendMode::SubpixelDualSource
                                     } else {
-                                        BlendMode::SubpixelConstantTextColor(text_cpu.font.color.into())
+                                        BlendMode::SubpixelConstantTextColor(text_cpu.get_color())
                                     }
                                 }
                                 GlyphFormat::Alpha |

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -220,8 +220,6 @@ pub enum GlyphFormat {
 impl GlyphFormat {
     pub fn ignore_color(self) -> Self {
         match self {
-            GlyphFormat::Subpixel => GlyphFormat::Alpha,
-            GlyphFormat::TransformedSubpixel => GlyphFormat::TransformedAlpha,
             GlyphFormat::ColorBitmap => GlyphFormat::Bitmap,
             _ => self,
         }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -679,6 +679,14 @@ impl TextRunPrimitiveCpu {
         self.shadow_color.a != 0
     }
 
+    pub fn get_color(&self) -> ColorF {
+        ColorF::from(if self.is_shadow() {
+            self.shadow_color
+        } else {
+            self.font.color
+        })
+    }
+
     fn prepare_for_render(
         &mut self,
         resource_cache: &mut ResourceCache,
@@ -728,14 +736,9 @@ impl TextRunPrimitiveCpu {
     }
 
     fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
-        let bg_color = ColorF::from(self.font.bg_color);
-        let color = ColorF::from(if self.is_shadow() {
-            self.shadow_color
-        } else {
-            self.font.color
-        });
-        request.push(color.premultiplied());
+        request.push(self.get_color().premultiplied());
         // this is the only case where we need to provide plain color to GPU
+        let bg_color = ColorF::from(self.font.bg_color);
         request.extend_from_slice(&[
             GpuBlockData { data: [bg_color.r, bg_color.g, bg_color.b, 1.0] }
         ]);

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -6,8 +6,7 @@
 != shadow-cover-1.yaml blank.yaml
 != shadow-cover-2.yaml blank.yaml
 
-# needs issue #1483
-# == shadow.yaml shadow-ref.yaml
+== shadow.yaml shadow-ref.yaml
 != shadow-cover-1.yaml shadow-cover-2.yaml
 != shadow-many.yaml shadow.yaml
 != shadow-complex.yaml shadow-many.yaml

--- a/wrench/reftests/text/shadow.yaml
+++ b/wrench/reftests/text/shadow.yaml
@@ -18,7 +18,7 @@ root:
           type: "pop-all-shadows"
         -
           type: "shadow"
-          bounds: [14, 318, 205, 35]
+          bounds: [12, 314, 205, 35]
           blur-radius: 5
           offset: [-2, -4]
           color: red


### PR DESCRIPTION
This lets fast text shadows reuse the subpixel AA masks from the original text. On those platforms that use gamma-lut, this might cause a slight but barely noticeable perceptual difference between if the text was directly rendered in that color vs making a shadow with that shadow color. However, this allows us to keep avoiding double rasterization of the glyphs, allowing fast text shadows to still be fast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2281)
<!-- Reviewable:end -->
