### PR TITLE
RON update to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ron"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1019,7 +1019,7 @@ dependencies = [
  "plane-split 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1080,7 +1080,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1236,7 +1236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum ron 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c355cb9fd143cf53c37843614eea66405c8ef0961e9d80690a1453e5b3e48c4"
+"checksum ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65d83b510b781c24b86db69aa8d1a1befffae7b64944ea1fea7243cd3bb72cfb"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { optional = true, version = "1.0" }
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 image = { optional = true, version = "0.17" }
 base64 = { optional = true, version = "0.3.0" }
-ron = { optional = true, version = "0.1.3" }
+ron = { optional = true, version = "0.1.5" }
 
 [dev-dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -816,16 +816,17 @@ impl ToDebugString for SpecificDisplayItem {
 impl RenderBackend {
     // Note: the mutable `self` is only needed here for resolving blob images
     fn save_capture(&mut self, root: &PathBuf) -> Vec<ExternalCaptureImage> {
-        use ron::ser::pretty;
+        use ron::ser::{to_string_pretty, PrettyConfig};
         use std::fs;
         use std::io::Write;
 
         info!("capture: saving {}", root.to_string_lossy());
+        let ron_config = PrettyConfig::default();
         let (resources, deferred) = self.resource_cache.save_capture(root);
 
         for (&id, doc) in &self.documents {
             info!("\tdocument {:?}", id);
-            let ron = pretty::to_string(&doc.scene).unwrap();
+            let ron = to_string_pretty(&doc.scene, ron_config.clone()).unwrap();
             let file_name = format!("scene-{}-{}.ron", (id.0).0, id.1);
             let ron_path = root.clone().join(file_name);
             let mut file = fs::File::create(ron_path).unwrap();
@@ -844,7 +845,7 @@ impl RenderBackend {
             resources,
         };
 
-        let ron = pretty::to_string(&serial).unwrap();
+        let ron = to_string_pretty(&serial, ron_config).unwrap();
         let ron_path = root.clone().join("backend.ron");
         let mut file = fs::File::create(ron_path).unwrap();
         write!(file, "{}\n", ron).unwrap();

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1"
 log = "0.3"
 yaml-rust = { git = "https://github.com/vvuk/yaml-rust", features = ["preserve_order"] }
 serde_json = "1.0"
-ron = "0.1.3"
+ron = "0.1.5"
 time = "0.1"
 crossbeam = "0.2"
 osmesa-sys = { version = "0.1.2", optional = true }

--- a/wrench/src/ron_frame_writer.rs
+++ b/wrench/src/ron_frame_writer.rs
@@ -82,7 +82,7 @@ impl RonFrameWriter {
 
         let mut file = fs::File::create(&frame_file_name).unwrap();
 
-        let s = ron::ser::pretty::to_string(&dl).unwrap();
+        let s = ron::ser::to_string_pretty(&dl, Default::default()).unwrap();
         file.write_all(&s.into_bytes()).unwrap();
         file.write_all(b"\n").unwrap();
     }


### PR DESCRIPTION
Avoids a warning about deprecated `pretty::to_string` when using the latest version.
(Really minor and harmless! /famous last words)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2282)
<!-- Reviewable:end -->
