### PR TITLE
support glyph transforms for writing modes

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -1283,8 +1283,10 @@ impl FrameBuilder {
         let mut render_mode = self.config
             .default_font_render_mode
             .limit_by(font.render_mode);
+        let mut flags = font.flags;
         if let Some(options) = glyph_options {
             render_mode = render_mode.limit_by(options.render_mode);
+            flags |= options.flags;
         }
 
         // There are some conditions under which we can't use
@@ -1309,7 +1311,7 @@ impl FrameBuilder {
             font.bg_color,
             render_mode,
             font.subpx_dir,
-            font.flags,
+            flags,
             font.platform_options,
             font.variations.clone(),
         );

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -114,6 +114,18 @@ impl FontTransform {
             self.scale_y - self.skew_y * skew_factor,
         )
     }
+
+    pub fn swap_xy(&self) -> Self {
+        FontTransform::new(self.skew_x, self.scale_x, self.scale_y, self.skew_y)
+    }
+
+    pub fn flip_x(&self) -> Self {
+        FontTransform::new(-self.scale_x, self.skew_x, -self.skew_y, self.scale_y)
+    }
+
+    pub fn flip_y(&self) -> Self {
+        FontTransform::new(self.scale_x, -self.skew_y, self.skew_y, -self.scale_y)
+    }
 }
 
 impl<'a> From<&'a LayerToWorldTransform> for FontTransform {

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -361,8 +361,23 @@ impl FontContext {
                 let glyph = key.index as CGGlyph;
                 let bitmap = is_bitmap_font(ct_font);
                 let (x_offset, y_offset) = if bitmap { (0.0, 0.0) } else { font.get_subpx_offset(key) };
-                let transform = if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
-                    let shape = FontTransform::identity().synthesize_italics(OBLIQUE_SKEW_FACTOR);
+                let transform = if font.flags.intersects(FontInstanceFlags::SYNTHETIC_ITALICS |
+                                                         FontInstanceFlags::TRANSPOSE |
+                                                         FontInstanceFlags::FLIP_X |
+                                                         FontInstanceFlags::FLIP_Y) {
+                    let mut shape = FontTransform::identity();
+                    if font.flags.contains(FontInstanceFlags::FLIP_X) {
+                        shape = shape.flip_x();
+                    }
+                    if font.flags.contains(FontInstanceFlags::FLIP_Y) {
+                        shape = shape.flip_y();
+                    }
+                    if font.flags.contains(FontInstanceFlags::TRANSPOSE) {
+                        shape = shape.swap_xy();
+                    }
+                    if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
+                        shape = shape.synthesize_italics(OBLIQUE_SKEW_FACTOR);
+                    }
                     Some(CGAffineTransform {
                         a: shape.scale_x as f64,
                         b: -shape.skew_y as f64,
@@ -483,6 +498,15 @@ impl FontContext {
         } else {
             (font.transform.invert_scale(y_scale, y_scale), font.get_subpx_offset(key))
         };
+        if font.flags.contains(FontInstanceFlags::FLIP_X) {
+            shape = shape.flip_x();
+        }
+        if font.flags.contains(FontInstanceFlags::FLIP_Y) {
+            shape = shape.flip_y();
+        }
+        if font.flags.contains(FontInstanceFlags::TRANSPOSE) {
+            shape = shape.swap_xy();
+        }
         if font.flags.contains(FontInstanceFlags::SYNTHETIC_ITALICS) {
             shape = shape.synthesize_italics(OBLIQUE_SKEW_FACTOR);
         }

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -117,7 +117,6 @@ fn get_glyph_metrics(
 
     if let Some(transform) = transform {
         bounds = bounds.apply_transform(transform);
-        advance = advance.apply_transform(transform);
     }
 
     // First round out to pixel boundaries

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -199,6 +199,16 @@ impl Hash for FontVariation {
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct GlyphOptions {
     pub render_mode: FontRenderMode,
+    pub flags: FontInstanceFlags,
+}
+
+impl Default for GlyphOptions {
+    fn default() -> GlyphOptions {
+        GlyphOptions {
+            render_mode: FontRenderMode::Subpixel,
+            flags: FontInstanceFlags::empty(),
+        }
+    }
 }
 
 bitflags! {
@@ -210,6 +220,9 @@ bitflags! {
         const SYNTHETIC_BOLD    = 1 << 1;
         const EMBEDDED_BITMAPS  = 1 << 2;
         const SUBPIXEL_BGR      = 1 << 3;
+        const TRANSPOSE         = 1 << 4;
+        const FLIP_X            = 1 << 5;
+        const FLIP_Y            = 1 << 6;
 
         // Windows flags
         const FORCE_GDI         = 1 << 16;

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -49,3 +49,4 @@ platform(linux) == subpixel-skew.yaml subpixel-skew.png
 platform(linux) == embedded-bitmaps.yaml embedded-bitmaps.png
 platform(linux) == clipped-transform.yaml clipped-transform.png
 platform(mac) == color-bitmap-shadow.yaml color-bitmap-shadow-ref.yaml
+platform(linux) == writing-modes.yaml writing-modes-ref.yaml

--- a/wrench/reftests/text/writing-modes-ref.yaml
+++ b/wrench/reftests/text/writing-modes-ref.yaml
@@ -1,0 +1,19 @@
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 300, 60]
+      transform: rotate(90) translate(-120, 160)
+      items:
+        - text: "This is sideways-left"
+          origin: 0 40
+          size: 20
+          font: "FreeSans.ttf"
+    - type: stacking-context
+      bounds: [0, 0, 300, 60]
+      transform: rotate(-90) translate(-90, 120)
+      items:
+        - text: "This is sideways-right"
+          origin: 0 40
+          size: 20
+          font: "FreeSans.ttf"
+

--- a/wrench/reftests/text/writing-modes.yaml
+++ b/wrench/reftests/text/writing-modes.yaml
@@ -1,0 +1,15 @@
+root:
+  items:
+    - text: "This is sideways-left"
+      origin: 20 40
+      size: 20
+      transpose: true
+      flip-x: true
+      font: "FreeSans.ttf"
+    - text: "This is sideways-right"
+      origin: 70 300
+      size: 20
+      transpose: true
+      flip-y: true
+      font: "FreeSans.ttf"
+

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -195,7 +195,7 @@ pub struct YamlFrameReader {
     image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
     fonts: HashMap<FontDescriptor, FontKey>,
-    font_instances: HashMap<(FontKey, Au), FontInstanceKey>,
+    font_instances: HashMap<(FontKey, Au, FontInstanceFlags), FontInstanceKey>,
     font_render_mode: Option<FontRenderMode>,
 }
 
@@ -461,7 +461,7 @@ impl YamlFrameReader {
         let font_render_mode = self.font_render_mode;
 
         *self.font_instances
-            .entry((font_key, size))
+            .entry((font_key, size, flags))
             .or_insert_with(|| {
                 wrench.add_font_instance(
                     font_key,
@@ -1023,6 +1023,15 @@ impl YamlFrameReader {
         if item["embedded-bitmaps"].as_bool().unwrap_or(false) {
             flags |= FontInstanceFlags::EMBEDDED_BITMAPS;
         }
+        if item["transpose"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::TRANSPOSE;
+        }
+        if item["flip-x"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::FLIP_X;
+        }
+        if item["flip-y"].as_bool().unwrap_or(false) {
+            flags |= FontInstanceFlags::FLIP_Y;
+        }
 
         assert!(
             item["blur-radius"].is_badvalue(),
@@ -1082,6 +1091,7 @@ impl YamlFrameReader {
                 text,
                 size,
                 origin,
+                flags,
             );
 
             let glyphs = glyph_indices


### PR DESCRIPTION
This allows glyphs to have local axis-aligned transforms that can be used to implement such features as CSS writing modes. To this effect, new FontInstanceFlags have been added that allow the expression of any variation of such transforms, and also a way to add on these extra flags to a text run via specifying extra flags in GlyphOptions. This addresses https://github.com/servo/webrender/issues/1690 and https://bugzilla.mozilla.org/show_bug.cgi?id=1400384

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2288)
<!-- Reviewable:end -->
