### PR TITLE
Move edge AA flags from GPU cache data into instance struct.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -23,6 +23,7 @@ struct BrushInstance {
     int clip_address;
     int z;
     int segment_index;
+    int edge_mask;
     ivec2 user_data;
 };
 
@@ -35,7 +36,8 @@ BrushInstance load_brush() {
     bi.scroll_node_id = aData0.z % 65536;
     bi.clip_address = aData0.w;
     bi.z = aData1.x;
-    bi.segment_index = aData1.y;
+    bi.segment_index = aData1.y & 0xffff;
+    bi.edge_mask = aData1.y >> 16;
     bi.user_data = aData1.zw;
 
     return bi;
@@ -125,7 +127,7 @@ void main(void) {
             vLocalBounds = vec4(vec2(-1000000.0), vec2(1000000.0));
 #endif
         } else {
-            bvec4 edge_mask = notEqual(int(segment_data[1].x) & ivec4(1, 2, 4, 8), ivec4(0));
+            bvec4 edge_mask = notEqual(brush.edge_mask & ivec4(1, 2, 4, 8), ivec4(0));
             vi = write_transform_vertex(
                 local_segment_rect,
                 brush_prim.local_rect,

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -19,7 +19,7 @@ use internal_types::{FastHashMap, SourceTexture};
 use picture::{PictureCompositeMode, PictureKind, PicturePrimitive, PictureSurface};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
-use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, PrimitiveRun};
+use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PrimitiveRun};
 use render_task::{ClipWorkItem};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind};
 use render_task::{RenderTaskTree};
@@ -663,6 +663,7 @@ impl AlphaBatcher {
                     scroll_id,
                     clip_task_address,
                     z,
+                    edge_flags: EdgeAaSegmentMask::empty(),
                     segment_index: 0,
                     user_data0: 0,
                     user_data1: 0,
@@ -862,6 +863,7 @@ impl AlphaBatcher {
                                     clip_task_address,
                                     z,
                                     segment_index: 0,
+                                    edge_flags: EdgeAaSegmentMask::empty(),
                                     user_data0: cache_item.uv_rect_handle.as_int(gpu_cache),
                                     user_data1: image_kind as i32,
                                 };
@@ -890,6 +892,7 @@ impl AlphaBatcher {
                                     clip_task_address,
                                     z,
                                     segment_index: 0,
+                                    edge_flags: EdgeAaSegmentMask::empty(),
                                     user_data0: cache_task_address.0 as i32,
                                     user_data1: BrushImageKind::Simple as i32,
                                 };
@@ -971,6 +974,7 @@ impl AlphaBatcher {
                                                     clip_task_address,
                                                     z,
                                                     segment_index: 0,
+                                                    edge_flags: EdgeAaSegmentMask::empty(),
                                                     user_data0: cache_task_address.0 as i32,
                                                     user_data1: BrushImageKind::Simple as i32,
                                                 };
@@ -1261,6 +1265,7 @@ impl AlphaBatcher {
             clip_task_address,
             z,
             segment_index: 0,
+            edge_flags: EdgeAaSegmentMask::empty(),
             user_data0: 0,
             user_data1: 0,
         };
@@ -1292,6 +1297,7 @@ impl AlphaBatcher {
 
                     let instance = PrimitiveInstance::from(BrushInstance {
                         segment_index: i as i32,
+                        edge_flags: segment.edge_flags,
                         clip_task_address,
                         ..base_instance
                     });

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -4,6 +4,7 @@
 
 use api::{LayerToWorldTransform};
 use gpu_cache::GpuCacheAddress;
+use prim_store::EdgeAaSegmentMask;
 use render_task::RenderTaskAddress;
 
 // Contains type that must exactly match the same structures declared in GLSL.
@@ -154,6 +155,7 @@ pub struct BrushInstance {
     pub clip_task_address: RenderTaskAddress,
     pub z: i32,
     pub segment_index: i32,
+    pub edge_flags: EdgeAaSegmentMask,
     pub user_data0: i32,
     pub user_data1: i32,
 }
@@ -167,7 +169,7 @@ impl From<BrushInstance> for PrimitiveInstance {
                 ((instance.clip_chain_rect_index.0 as i32) << 16) | instance.scroll_id.0 as i32,
                 instance.clip_task_address.0 as i32,
                 instance.z,
-                instance.segment_index,
+                instance.segment_index | ((instance.edge_flags.bits() as i32) << 16),
                 instance.user_data0,
                 instance.user_data1,
             ]

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1264,13 +1264,7 @@ impl PrimitiveStore {
                     //           up in the future so it's enforced that these
                     //           types use a shared function to write out the
                     //           GPU blocks...
-                    request.push(metadata.local_rect);
-                    request.push([
-                        EdgeAaSegmentMask::empty().bits() as f32,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]);
+                    request.write_segment(metadata.local_rect);
                 }
                 PrimitiveKind::Border => {
                     let border = &self.cpu_borders[metadata.cpu_prim_index.0];
@@ -1311,13 +1305,7 @@ impl PrimitiveStore {
                     //           up in the future so it's enforced that these
                     //           types use a shared function to write out the
                     //           GPU blocks...
-                    request.push(metadata.local_rect);
-                    request.push([
-                        EdgeAaSegmentMask::empty().bits() as f32,
-                        0.0,
-                        0.0,
-                        0.0
-                    ]);
+                    request.write_segment(metadata.local_rect);
                 }
                 PrimitiveKind::Brush => {
                     let brush = &self.cpu_brushes[metadata.cpu_prim_index.0];
@@ -1326,23 +1314,11 @@ impl PrimitiveStore {
                         Some(ref segment_desc) => {
                             for segment in &segment_desc.segments {
                                 // has to match VECS_PER_SEGMENT
-                                request.push(segment.local_rect);
-                                request.push([
-                                    segment.edge_flags.bits() as f32,
-                                    0.0,
-                                    0.0,
-                                    0.0
-                                ]);
+                                request.write_segment(segment.local_rect);
                             }
                         }
                         None => {
-                            request.push(metadata.local_rect);
-                            request.push([
-                                EdgeAaSegmentMask::empty().bits() as f32,
-                                0.0,
-                                0.0,
-                                0.0
-                            ]);
+                            request.write_segment(metadata.local_rect);
                         }
                     }
                 }
@@ -2060,5 +2036,25 @@ fn get_local_clip_rect_for_nodes(
         Some(local_rect) =>
             Some(scroll_node.coordinate_system_relative_transform.unapply(&local_rect)),
         None => None,
+    }
+}
+
+impl<'a> GpuDataRequest<'a> {
+    // Write the GPU cache data for an individual segment.
+    // TODO(gw): The second block is currently unused. In
+    //           the future, it will be used to store a
+    //           UV rect, allowing segments to reference
+    //           part of an image.
+    fn write_segment(
+        &mut self,
+        local_rect: LayerRect,
+    ) {
+        self.push(local_rect);
+        self.push([
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        ]);
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -17,7 +17,7 @@ use gpu_types::{PrimitiveInstance};
 use internal_types::{FastHashMap, RenderPassIndex, SourceTexture};
 use picture::{PictureKind};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveStore};
-use prim_store::{BrushMaskKind, BrushKind, DeferredResolve};
+use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, EdgeAaSegmentMask};
 use profiler::FrameProfileCounters;
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind};
 use render_task::{BlurTask, ClearMode, RenderTaskLocation, RenderTaskTree};
@@ -468,6 +468,7 @@ impl RenderTarget for AlphaRenderTarget {
                                             clip_task_address: RenderTaskAddress(0),
                                             z: 0,
                                             segment_index: 0,
+                                            edge_flags: EdgeAaSegmentMask::empty(),
                                             user_data0: 0,
                                             user_data1: 0,
                                         };


### PR DESCRIPTION
This means that there is now a complete GPU block of unused data
in the GPU cache data for each segment. This will allow us to
store a UV sub-rect in here in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2290)
<!-- Reviewable:end -->
