### PR TITLE
Add travis_wait to override the 10 minute timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,6 @@ script:
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features profiler,capture); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cargo test --all --verbose); fi
-  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && python script/headless.py reftest); fi
+  - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && travis_wait python script/headless.py reftest); fi
   - if [ $BUILD_KIND = RELEASE ]; then (cd wrench && cargo build --release); fi
   - if [ $TRAVIS_RUST_VERSION == "nightly" ]; then (cd webrender && cargo bench --verbose); fi


### PR DESCRIPTION
We seem to be hitting this on every PR right now. Let's see if
this might fix it.

See documentation:

https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2291)
<!-- Reviewable:end -->
