### PR TITLE
Resurrect non-premultiplied alpha codepath for use in Gecko

### DIFF
--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -265,6 +265,7 @@ impl Example for App {
             api::LayoutSize::new(500.0, 500.0),
             api::LayoutSize::new(0.0, 0.0),
             api::ImageRendering::Auto,
+            api::AlphaType::PremultipliedAlpha,
             blob_img1,
         );
 
@@ -274,6 +275,7 @@ impl Example for App {
             api::LayoutSize::new(200.0, 200.0),
             api::LayoutSize::new(0.0, 0.0),
             api::ImageRendering::Auto,
+            api::AlphaType::PremultipliedAlpha,
             blob_img2,
         );
 

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -164,6 +164,7 @@ impl Example for App {
             info.rect.size,
             LayoutSize::zero(),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             self.external_image_key.unwrap()
         );
 

--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -59,6 +59,7 @@ impl Example for App {
             image_size,
             LayoutSize::zero(),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             self.image_key,
         );
 
@@ -71,6 +72,7 @@ impl Example for App {
             image_size,
             LayoutSize::zero(),
             ImageRendering::Pixelated,
+            AlphaType::PremultipliedAlpha,
             self.image_key,
         );
 

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -147,6 +147,7 @@ impl Example for App {
                 image_size,
                 LayoutSize::zero(),
                 ImageRendering::Auto,
+                AlphaType::PremultipliedAlpha,
                 *key,
             );
         }
@@ -162,6 +163,7 @@ impl Example for App {
                 image_size,
                 LayoutSize::zero(),
                 ImageRendering::Auto,
+                AlphaType::PremultipliedAlpha,
                 image_key,
             );
         }
@@ -177,6 +179,7 @@ impl Example for App {
             image_size,
             LayoutSize::zero(),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             swap_key,
         );
         self.swap_index = 1 - self.swap_index;

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1860,6 +1860,12 @@ impl Device {
         }
     }
 
+    pub fn set_blend_mode_alpha(&self) {
+        self.gl.blend_func_separate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA,
+                                    gl::ONE, gl::ONE);
+        self.gl.blend_equation(gl::FUNC_ADD);
+    }
+
     pub fn set_blend_mode_premultiplied_alpha(&self) {
         self.gl.blend_func(gl::ONE, gl::ONE_MINUS_SRC_ALPHA);
         self.gl.blend_equation(gl::FUNC_ADD);

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -405,6 +405,7 @@ impl<'a> FlattenContext<'a> {
                             None,
                             info.image_key,
                             info.image_rendering,
+                            info.alpha_type,
                             None,
                         );
                     }
@@ -915,6 +916,7 @@ impl<'a> FlattenContext<'a> {
                 None,
                 info.image_key,
                 info.image_rendering,
+                info.alpha_type,
                 Some(tile_offset),
             );
         }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderDetails, BorderDisplayItem, BuiltDisplayList, ClipAndScrollInfo, ClipId, ColorF};
-use api::{ColorU, DeviceIntPoint, DevicePixelScale, DeviceUintPoint, DeviceUintRect};
+use api::{AlphaType, BorderDetails, BorderDisplayItem, BuiltDisplayList, ClipAndScrollInfo, ClipId};
+use api::{ColorF, ColorU, DeviceIntPoint, DevicePixelScale, DeviceUintPoint, DeviceUintRect};
 use api::{DeviceUintSize, DocumentLayer, ExtendMode, FontRenderMode, GlyphInstance, GlyphOptions};
 use api::{GradientStop, HitTestFlags, HitTestItem, HitTestResult, ImageKey, ImageRendering};
 use api::{ItemRange, ItemTag, LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize};
@@ -1087,6 +1087,7 @@ impl FrameBuilder {
                         Some(segment.sub_rect),
                         border.image_key,
                         ImageRendering::Auto,
+                        AlphaType::PremultipliedAlpha,
                         None,
                     );
                 }
@@ -1410,6 +1411,7 @@ impl FrameBuilder {
         sub_rect: Option<TexelRect>,
         image_key: ImageKey,
         image_rendering: ImageRendering,
+        alpha_type: AlphaType,
         tile: Option<TileOffset>,
     ) {
         let sub_rect_block = sub_rect.unwrap_or(TexelRect::invalid()).into();
@@ -1429,6 +1431,7 @@ impl FrameBuilder {
             image_rendering,
             tile_offset: tile,
             tile_spacing,
+            alpha_type,
             gpu_blocks: [
                 [
                     stretch_size.width,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderRadius, BuiltDisplayList, ClipAndScrollInfo, ClipId, ClipMode, ColorF, ColorU};
-use api::{DeviceIntRect, DevicePixelScale, DevicePoint};
+use api::{AlphaType, BorderRadius, BuiltDisplayList, ClipAndScrollInfo, ClipId, ClipMode};
+use api::{ColorF, ColorU, DeviceIntRect, DevicePixelScale, DevicePoint};
 use api::{ComplexClipRegion, ExtendMode, FontRenderMode};
 use api::{GlyphInstance, GlyphKey, GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag};
 use api::{LayerPoint, LayerRect, LayerSize, LayerToWorldTransform, LayerVector2D, LineOrientation};
@@ -362,6 +362,7 @@ pub struct ImagePrimitiveCpu {
     pub image_rendering: ImageRendering,
     pub tile_offset: Option<TileOffset>,
     pub tile_spacing: LayerSize,
+    pub alpha_type: AlphaType,
     // TODO(gw): Build on demand
     pub gpu_blocks: [GpuBlockData; BLOCKS_PER_UV_RECT],
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -764,6 +764,7 @@ impl SourceTextureResolver {
 #[allow(dead_code)] // SubpixelVariableTextColor is not used at the moment.
 pub enum BlendMode {
     None,
+    Alpha,
     PremultipliedAlpha,
     PremultipliedDestOut,
     SubpixelDualSource,
@@ -1294,6 +1295,7 @@ impl BrushShader {
             BlendMode::None => {
                 self.opaque.bind(device, projection, mode, renderer_errors)
             }
+            BlendMode::Alpha |
             BlendMode::PremultipliedAlpha |
             BlendMode::PremultipliedDestOut |
             BlendMode::SubpixelDualSource |
@@ -3521,6 +3523,7 @@ impl Renderer {
                 if self.debug_flags.contains(DebugFlags::ALPHA_PRIM_DBG) {
                     let color = match batch.key.blend_mode {
                         BlendMode::None => debug_colors::BLACK,
+                        BlendMode::Alpha |
                         BlendMode::PremultipliedAlpha => debug_colors::GREY,
                         BlendMode::PremultipliedDestOut => debug_colors::SALMON,
                         BlendMode::SubpixelConstantTextColor(..) => debug_colors::GREEN,
@@ -3547,6 +3550,7 @@ impl Renderer {
                         self.device.set_blend(true);
 
                         match batch.key.blend_mode {
+                            BlendMode::Alpha => panic!("Attempt to composite non-premultiplied text primitives."),
                             BlendMode::PremultipliedAlpha => {
                                 self.device.set_blend_mode_premultiplied_alpha();
 
@@ -3714,6 +3718,10 @@ impl Renderer {
                             match batch.key.blend_mode {
                                 BlendMode::None => {
                                     self.device.set_blend(false);
+                                }
+                                BlendMode::Alpha => {
+                                    self.device.set_blend(true);
+                                    self.device.set_blend_mode_alpha();
                                 }
                                 BlendMode::PremultipliedAlpha => {
                                     self.device.set_blend(true);

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -507,6 +507,7 @@ pub struct ImageDisplayItem {
     pub stretch_size: LayoutSize,
     pub tile_spacing: LayoutSize,
     pub image_rendering: ImageRendering,
+    pub alpha_type: AlphaType,
 }
 
 #[repr(u32)]
@@ -515,6 +516,12 @@ pub enum ImageRendering {
     Auto = 0,
     CrispEdges = 1,
     Pixelated = 2,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum AlphaType {
+    Alpha = 0,
+    PremultipliedAlpha = 1,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use {BorderDetails, BorderDisplayItem, BorderRadius, BorderWidths, BoxShadowClipMode};
+use {AlphaType, BorderDetails, BorderDisplayItem, BorderRadius, BorderWidths, BoxShadowClipMode};
 use {BoxShadowDisplayItem, ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion};
 use {DisplayItem, ExtendMode, FilterOp, FontInstanceKey, GlyphInstance, GlyphOptions, Gradient};
 use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
@@ -964,6 +964,7 @@ impl DisplayListBuilder {
         stretch_size: LayoutSize,
         tile_spacing: LayoutSize,
         image_rendering: ImageRendering,
+        alpha_type: AlphaType,
         key: ImageKey,
     ) {
         let item = SpecificDisplayItem::Image(ImageDisplayItem {
@@ -971,6 +972,7 @@ impl DisplayListBuilder {
             stretch_size,
             tile_spacing,
             image_rendering,
+            alpha_type,
         });
 
         self.push_item(item, info);

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -98,6 +98,7 @@ impl<'a> RawtestHarness<'a> {
             size(151., 56.0),
             size(151.0, 56.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -149,6 +150,7 @@ impl<'a> RawtestHarness<'a> {
             size(200.0, 200.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -166,6 +168,7 @@ impl<'a> RawtestHarness<'a> {
             size(200.0, 200.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -252,6 +255,7 @@ impl<'a> RawtestHarness<'a> {
                 size(200.0, 200.0),
                 size(0.0, 0.0),
                 ImageRendering::Auto,
+                AlphaType::PremultipliedAlpha,
                 blob_img,
             );
             builder.push_image(
@@ -259,6 +263,7 @@ impl<'a> RawtestHarness<'a> {
                 size(200.0, 200.0),
                 size(0.0, 0.0),
                 ImageRendering::Auto,
+                AlphaType::PremultipliedAlpha,
                 blob_img2,
             );
         };
@@ -345,6 +350,7 @@ impl<'a> RawtestHarness<'a> {
             size(200.0, 200.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -370,6 +376,7 @@ impl<'a> RawtestHarness<'a> {
             size(200.0, 200.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -393,6 +400,7 @@ impl<'a> RawtestHarness<'a> {
             size(200.0, 200.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             blob_img,
         );
 
@@ -495,6 +503,7 @@ impl<'a> RawtestHarness<'a> {
             size(150.0, 50.0),
             size(0.0, 0.0),
             ImageRendering::Auto,
+            AlphaType::PremultipliedAlpha,
             image,
         );
 

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -1001,7 +1001,15 @@ impl YamlFrameReader {
                 item
             ),
         };
-        dl.push_image(&info, stretch_size, tile_spacing, rendering, image_key);
+        let alpha_type = match item["alpha-type"].as_str() {
+            Some("premultiplied-alpha") | None => AlphaType::PremultipliedAlpha,
+            Some("alpha") => AlphaType::Alpha,
+            Some(_) => panic!(
+                "AlphaType can be premultiplied-alpha or alpha -- got {:?}",
+                item
+            ),
+        };
+        dl.push_image(&info, stretch_size, tile_spacing, rendering, alpha_type, image_key);
     }
 
     fn handle_text(

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -765,6 +765,10 @@ impl YamlFrameWriter {
                         ImageRendering::CrispEdges => str_node(&mut v, "rendering", "crisp-edges"),
                         ImageRendering::Pixelated => str_node(&mut v, "rendering", "pixelated"),
                     };
+                    match item.alpha_type {
+                        AlphaType::PremultipliedAlpha => str_node(&mut v, "alpha-type", "premultiplied-alpha"),
+                        AlphaType::Alpha => str_node(&mut v, "alpha-type", "alpha"),
+                    };
                 }
                 YuvImage(_) => {
                     str_node(&mut v, "type", "yuv-image");


### PR DESCRIPTION
I think we need this to fix some canvas reftests that have been failing for a long time. See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1429951 for the gecko side patch, which has the list of failing reftests.

Also I don't really know this code well, most of this patch is just copy-paste, so please let me know if I'm way off base here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2295)
<!-- Reviewable:end -->
