### PR TITLE
Add support for API-defined ClipChains

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, DeviceIntRect, DevicePixelScale, LayerPoint, LayerRect, LayerToWorldTransform};
-use api::{LayerVector2D, LayoutTransform, PipelineId, PropertyBinding, ScrollClamping};
-use api::{ScrollEventPhase, ScrollLayerState, ScrollLocation, WorldPoint};
+use api::{ClipId, ClipChainId, DeviceIntRect, DevicePixelScale, LayerPoint, LayerRect};
+use api::{LayerToWorldTransform, LayerVector2D, LayoutTransform, PipelineId, PropertyBinding};
+use api::{ScrollClamping, ScrollEventPhase, ScrollLayerState, ScrollLocation, WorldPoint};
 use clip::ClipStore;
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollingState, StickyFrameInfo};
 use gpu_cache::GpuCache;
@@ -40,8 +40,23 @@ impl CoordinateSystemId {
     }
 }
 
+struct ClipChainDescriptor {
+    id: ClipChainId,
+    parent: Option<ClipChainId>,
+    clips: Vec<ClipId>,
+}
+
 pub struct ClipScrollTree {
     pub nodes: FastHashMap<ClipId, ClipScrollNode>,
+
+    /// A Vec of all descriptors that describe ClipChains in the order in which they are
+    /// encountered during display list flattening. ClipChains are expected to never be
+    /// the children of ClipChains later in the list.
+    clip_chains_descriptors: Vec<ClipChainDescriptor>,
+
+    /// A HashMap of built ClipChains that are described by `clip_chains_descriptors`.
+    pub clip_chains: FastHashMap<ClipChainId, ClipChain>,
+
     pub pending_scroll_offsets: FastHashMap<ClipId, (LayerPoint, ScrollClamping)>,
 
     /// The ClipId of the currently scrolling node. Used to allow the same
@@ -94,6 +109,8 @@ impl ClipScrollTree {
         let dummy_pipeline = PipelineId::dummy();
         ClipScrollTree {
             nodes: FastHashMap::default(),
+            clip_chains_descriptors: Vec::new(),
+            clip_chains: FastHashMap::default(),
             pending_scroll_offsets: FastHashMap::default(),
             currently_scrolling_node_id: None,
             root_reference_frame_id: ClipId::root_reference_frame(dummy_pipeline),
@@ -243,6 +260,8 @@ impl ClipScrollTree {
         }
 
         self.pipelines_to_discard.clear();
+        self.clip_chains.clear();
+        self.clip_chains_descriptors.clear();
         scroll_states
     }
 
@@ -376,6 +395,8 @@ impl ClipScrollTree {
             node_data,
             scene_properties,
         );
+
+        self.build_clip_chains(screen_rect);
     }
 
     fn update_node(
@@ -434,6 +455,25 @@ impl ClipScrollTree {
                 gpu_node_data,
                 scene_properties,
             );
+        }
+    }
+
+    pub fn build_clip_chains(&mut self, screen_rect: &DeviceIntRect) {
+        for descriptor in &self.clip_chains_descriptors {
+            let mut chain = match descriptor.parent {
+                Some(id) => self.clip_chains[&id].clone(),
+                None => ClipChain::empty(screen_rect),
+            };
+
+            for clip_id in &descriptor.clips {
+                if let Some(ref node_chain) = self.nodes[&clip_id].clip_chain {
+                    if let Some(ref nodes) = node_chain.nodes {
+                        chain.add_node((**nodes).clone());
+                    }
+                }
+            }
+
+            self.clip_chains.insert(descriptor.id, chain);
         }
     }
 
@@ -505,6 +545,15 @@ impl ClipScrollTree {
             id.pipeline_id(),
         );
         self.add_node(node, id);
+    }
+
+    pub fn add_clip_chain_descriptor(
+        &mut self,
+        id: ClipChainId,
+        parent: Option<ClipChainId>,
+        clips: Vec<ClipId>
+    ) {
+        self.clip_chains_descriptors.push(ClipChainDescriptor { id, parent, clips });
     }
 
     pub fn add_node(&mut self, node: ClipScrollNode, id: ClipId) {
@@ -609,6 +658,10 @@ impl ClipScrollTree {
     }
 
     pub fn get_clip_chain(&self, id: &ClipId) -> Option<&ClipChain> {
-        self.nodes[id].clip_chain.as_ref()
-     }
+        match id {
+            &ClipId::ClipChain(clip_chain_id) => Some(&self.clip_chains[&clip_chain_id]),
+            _ => self.nodes[id].clip_chain.as_ref(),
+        }
+    }
+
 }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -74,6 +74,24 @@ impl<'a> FlattenContext<'a> {
             .collect()
     }
 
+    fn get_clip_chain_items(
+        &self,
+        pipeline_id: PipelineId,
+        items: ItemRange<ClipId>,
+    ) -> Vec<ClipId> {
+        if items.is_empty() {
+            return vec![];
+        }
+
+        self.scene
+            .pipelines
+            .get(&pipeline_id)
+            .expect("No display list?")
+            .display_list
+            .get(items)
+            .collect()
+    }
+
     fn flatten_root(
         &mut self,
         traversal: &mut BuiltDisplayListIter<'a>,
@@ -559,6 +577,10 @@ impl<'a> FlattenContext<'a> {
                     clip_region,
                 );
             }
+            SpecificDisplayItem::ClipChain(ref info) => {
+                let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items());
+                self.clip_scroll_tree.add_clip_chain_descriptor(info.id, info.parent, items);
+            },
             SpecificDisplayItem::ScrollFrame(ref info) => {
                 let complex_clips = self.get_complex_clips(pipeline_id, item.complex_clip().0);
                 let clip_region = ClipRegion::create_for_clip_node(

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -801,6 +801,7 @@ impl ToDebugString for SpecificDisplayItem {
             SpecificDisplayItem::PushStackingContext(..) => String::from("push_stacking_context"),
             SpecificDisplayItem::Iframe(..) => String::from("iframe"),
             SpecificDisplayItem::Clip(..) => String::from("clip"),
+            SpecificDisplayItem::ClipChain(..) => String::from("clip_chain"),
             SpecificDisplayItem::ScrollFrame(..) => String::from("scroll_frame"),
             SpecificDisplayItem::StickyFrame(..) => String::from("sticky_frame"),
             SpecificDisplayItem::SetGradientStops => String::from("set_gradient_stops"),

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -111,6 +111,7 @@ pub enum SpecificDisplayItem {
     BoxShadow(BoxShadowDisplayItem),
     Gradient(GradientDisplayItem),
     RadialGradient(RadialGradientDisplayItem),
+    ClipChain(ClipChainItem),
     Iframe(IframeDisplayItem),
     PushStackingContext(PushStackingContextDisplayItem),
     PopStackingContext,
@@ -126,6 +127,7 @@ pub enum SpecificDisplayItem {
 #[derive(Deserialize, Serialize)]
 pub enum CompletelySpecificDisplayItem {
     Clip(ClipDisplayItem, Vec<ComplexClipRegion>),
+    ClipChain(ClipChainItem, Vec<ClipId>),
     ScrollFrame(ScrollFrameDisplayItem, Vec<ComplexClipRegion>),
     StickyFrame(StickyFrameDisplayItem),
     Rectangle(RectangleDisplayItem),
@@ -425,6 +427,12 @@ pub struct RadialGradient {
     pub ratio_xy: f32,
     pub extend_mode: ExtendMode,
 } // IMPLICIT stops: Vec<GradientStop>
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ClipChainItem {
+    pub id: ClipChainId,
+    pub parent: Option<ClipChainId>,
+} // IMPLICIT stops: Vec<ClipId>
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RadialGradientDisplayItem {
@@ -734,9 +742,14 @@ impl ComplexClipRegion {
     }
 }
 
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ClipChainId(pub u64, pub PipelineId);
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ClipId {
     Clip(u64, PipelineId),
+    ClipChain(ClipChainId),
     ClipExternalId(u64, PipelineId),
     DynamicallyAddedNode(u64, PipelineId),
 }
@@ -763,6 +776,7 @@ impl ClipId {
     pub fn pipeline_id(&self) -> PipelineId {
         match *self {
             ClipId::Clip(_, pipeline_id) |
+            ClipId::ClipChain(ClipChainId(_, pipeline_id)) |
             ClipId::ClipExternalId(_, pipeline_id) |
             ClipId::DynamicallyAddedNode(_, pipeline_id) => pipeline_id,
         }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -3,16 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use {AlphaType, BorderDetails, BorderDisplayItem, BorderRadius, BorderWidths, BoxShadowClipMode};
-use {BoxShadowDisplayItem, ClipAndScrollInfo, ClipDisplayItem, ClipId, ColorF, ComplexClipRegion};
-use {DisplayItem, ExtendMode, FilterOp, FontInstanceKey, GlyphInstance, GlyphOptions, Gradient};
-use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
-use {ImageRendering, LayerPrimitiveInfo, LayoutPoint, LayoutPrimitiveInfo, LayoutRect, LayoutSize};
-use {LayoutTransform, LayoutVector2D, LineDisplayItem, LineOrientation, LineStyle, LocalClip};
-use {MixBlendMode, PipelineId, PropertyBinding, PushStackingContextDisplayItem, RadialGradient};
-use {RadialGradientDisplayItem, RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy};
-use {ScrollSensitivity, Shadow, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem};
-use {StickyOffsetBounds, TextDisplayItem, TransformStyle, YuvColorSpace, YuvData};
-use YuvImageDisplayItem;
+use {BoxShadowDisplayItem, ClipAndScrollInfo, ClipChainId, ClipChainItem, ClipDisplayItem, ClipId};
+use {ColorF, ComplexClipRegion, DisplayItem, ExtendMode, FilterOp, FontInstanceKey, GlyphInstance};
+use {GlyphOptions, Gradient, GradientDisplayItem, GradientStop, IframeDisplayItem};
+use {ImageDisplayItem, ImageKey, ImageMask, ImageRendering, LayerPrimitiveInfo, LayoutPoint};
+use {LayoutPrimitiveInfo, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
+use {LineDisplayItem, LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId};
+use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
+use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity, Shadow};
+use {SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, StickyOffsetBounds};
+use {TextDisplayItem, TransformStyle, YuvColorSpace, YuvData, YuvImageDisplayItem};
 use bincode;
 use euclid::SideOffsets2D;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,7 @@ pub struct BuiltDisplayListIter<'a> {
     cur_stops: ItemRange<GradientStop>,
     cur_glyphs: ItemRange<GlyphInstance>,
     cur_filters: ItemRange<FilterOp>,
+    cur_clip_chain_items: ItemRange<ClipId>,
     cur_complex_clip: (ItemRange<ComplexClipRegion>, usize),
     peeking: Peek,
 }
@@ -197,6 +198,7 @@ impl<'a> BuiltDisplayListIter<'a> {
             cur_stops: ItemRange::default(),
             cur_glyphs: ItemRange::default(),
             cur_filters: ItemRange::default(),
+            cur_clip_chain_items: ItemRange::default(),
             cur_complex_clip: (ItemRange::default(), 0),
             peeking: Peek::NotPeeking,
         }
@@ -223,6 +225,7 @@ impl<'a> BuiltDisplayListIter<'a> {
         // Don't let these bleed into another item
         self.cur_stops = ItemRange::default();
         self.cur_complex_clip = (ItemRange::default(), 0);
+        self.cur_clip_chain_items = ItemRange::default();
 
         loop {
             if self.data.len() == 0 {
@@ -242,6 +245,9 @@ impl<'a> BuiltDisplayListIter<'a> {
 
                     // This is a dummy item, skip over it
                     continue;
+                }
+                ClipChain(_) => {
+                    self.cur_clip_chain_items = skip_slice::<ClipId>(self.list, &mut self.data).0;
                 }
                 Clip(_) | ScrollFrame(_) => {
                     self.cur_complex_clip = self.skip_slice::<ComplexClipRegion>()
@@ -356,6 +362,10 @@ impl<'a, 'b> DisplayItemRef<'a, 'b> {
         self.iter.cur_filters
     }
 
+    pub fn clip_chain_items(&self) -> ItemRange<ClipId> {
+        self.iter.cur_clip_chain_items
+    }
+
     pub fn display_list(&self) -> &BuiltDisplayList {
         self.iter.display_list()
     }
@@ -418,20 +428,27 @@ impl Serialize for BuiltDisplayList {
         let mut seq = serializer.serialize_seq(None)?;
         let mut traversal = self.iter();
         while let Some(item) = traversal.next() {
-            let di = item.display_item();
+            let display_item = item.display_item();
             let serial_di = GenericDisplayItem {
-                item: match di.item {
-                    SpecificDisplayItem::Clip(v) => Clip(v,
+                item: match display_item.item {
+                    SpecificDisplayItem::Clip(v) => Clip(
+                        v,
                         item.iter.list.get(item.iter.cur_complex_clip.0).collect()
                     ),
-                    SpecificDisplayItem::ScrollFrame(v) => ScrollFrame(v,
+                    SpecificDisplayItem::ClipChain(v) => ClipChain(
+                        v,
+                        item.iter.list.get(item.iter.cur_clip_chain_items).collect(),
+                    ),
+                    SpecificDisplayItem::ScrollFrame(v) => ScrollFrame(
+                        v,
                         item.iter.list.get(item.iter.cur_complex_clip.0).collect()
                     ),
                     SpecificDisplayItem::StickyFrame(v) => StickyFrame(v),
                     SpecificDisplayItem::Rectangle(v) => Rectangle(v),
                     SpecificDisplayItem::ClearRectangle => ClearRectangle,
                     SpecificDisplayItem::Line(v) => Line(v),
-                    SpecificDisplayItem::Text(v) => Text(v,
+                    SpecificDisplayItem::Text(v) => Text(
+                        v,
                         item.iter.list.get(item.iter.cur_glyphs).collect()
                     ),
                     SpecificDisplayItem::Image(v) => Image(v),
@@ -441,7 +458,8 @@ impl Serialize for BuiltDisplayList {
                     SpecificDisplayItem::Gradient(v) => Gradient(v),
                     SpecificDisplayItem::RadialGradient(v) => RadialGradient(v),
                     SpecificDisplayItem::Iframe(v) => Iframe(v),
-                    SpecificDisplayItem::PushStackingContext(v) => PushStackingContext(v,
+                    SpecificDisplayItem::PushStackingContext(v) => PushStackingContext(
+                        v,
                         item.iter.list.get(item.iter.cur_filters).collect()
                     ),
                     SpecificDisplayItem::PopStackingContext => PopStackingContext,
@@ -451,8 +469,8 @@ impl Serialize for BuiltDisplayList {
                     SpecificDisplayItem::PushShadow(v) => PushShadow(v),
                     SpecificDisplayItem::PopAllShadows => PopAllShadows,
                 },
-                clip_and_scroll: di.clip_and_scroll,
-                info: di.info,
+                clip_and_scroll: display_item.clip_and_scroll,
+                info: display_item.info,
             };
             seq.serialize_element(&serial_di)?
         }
@@ -492,39 +510,44 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
         for complete in list {
             let item = DisplayItem {
                 item: match complete.item {
-                    Clip(v, complex_clips) => {
+                    Clip(specific_item, complex_clips) => {
                         push_vec(&mut temp, complex_clips);
-                        SpecificDisplayItem::Clip(v)
+                        SpecificDisplayItem::Clip(specific_item)
                     },
-                    ScrollFrame(v, complex_clips) => {
+                    ClipChain(specific_item, clip_chain_ids) => {
+                        push_vec(&mut temp, clip_chain_ids);
+                        SpecificDisplayItem::ClipChain(specific_item)
+                    }
+                    ScrollFrame(specific_item, complex_clips) => {
                         push_vec(&mut temp, complex_clips);
-                        SpecificDisplayItem::ScrollFrame(v)
+                        SpecificDisplayItem::ScrollFrame(specific_item)
                     },
-                    StickyFrame(v) => SpecificDisplayItem::StickyFrame(v),
-                    Rectangle(v) => SpecificDisplayItem::Rectangle(v),
+                    StickyFrame(specific_item) => SpecificDisplayItem::StickyFrame(specific_item),
+                    Rectangle(specific_item) => SpecificDisplayItem::Rectangle(specific_item),
                     ClearRectangle => SpecificDisplayItem::ClearRectangle,
-                    Line(v) => SpecificDisplayItem::Line(v),
-                    Text(v, glyphs) => {
+                    Line(specific_item) => SpecificDisplayItem::Line(specific_item),
+                    Text(specific_item, glyphs) => {
                         push_vec(&mut temp, glyphs);
-                        SpecificDisplayItem::Text(v)
+                        SpecificDisplayItem::Text(specific_item)
                     },
-                    Image(v) => SpecificDisplayItem::Image(v),
-                    YuvImage(v) => SpecificDisplayItem::YuvImage(v),
-                    Border(v) => SpecificDisplayItem::Border(v),
-                    BoxShadow(v) => SpecificDisplayItem::BoxShadow(v),
-                    Gradient(v) => SpecificDisplayItem::Gradient(v),
-                    RadialGradient(v) => SpecificDisplayItem::RadialGradient(v),
-                    Iframe(v) => SpecificDisplayItem::Iframe(v),
-                    PushStackingContext(v, filters) => {
+                    Image(specific_item) => SpecificDisplayItem::Image(specific_item),
+                    YuvImage(specific_item) => SpecificDisplayItem::YuvImage(specific_item),
+                    Border(specific_item) => SpecificDisplayItem::Border(specific_item),
+                    BoxShadow(specific_item) => SpecificDisplayItem::BoxShadow(specific_item),
+                    Gradient(specific_item) => SpecificDisplayItem::Gradient(specific_item),
+                    RadialGradient(specific_item) =>
+                        SpecificDisplayItem::RadialGradient(specific_item),
+                    Iframe(specific_item) => SpecificDisplayItem::Iframe(specific_item),
+                    PushStackingContext(specific_item, filters) => {
                         push_vec(&mut temp, filters);
-                        SpecificDisplayItem::PushStackingContext(v)
+                        SpecificDisplayItem::PushStackingContext(specific_item)
                     },
                     PopStackingContext => SpecificDisplayItem::PopStackingContext,
                     SetGradientStops(stops) => {
                         push_vec(&mut temp, stops);
                         SpecificDisplayItem::SetGradientStops
                     },
-                    PushShadow(v) => SpecificDisplayItem::PushShadow(v),
+                    PushShadow(specific_item) => SpecificDisplayItem::PushShadow(specific_item),
                     PopAllShadows => SpecificDisplayItem::PopAllShadows,
                 },
                 clip_and_scroll: complete.clip_and_scroll,
@@ -766,6 +789,7 @@ pub struct SaveState {
     dl_len: usize,
     clip_stack_len: usize,
     next_clip_id: u64,
+    next_clip_chain_id: u64,
 }
 
 #[derive(Clone)]
@@ -774,6 +798,7 @@ pub struct DisplayListBuilder {
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ClipAndScrollInfo>,
     next_clip_id: u64,
+    next_clip_chain_id: u64,
     builder_start_time: u64,
 
     /// The size of the content of this display list. This is used to allow scrolling
@@ -804,6 +829,7 @@ impl DisplayListBuilder {
                 ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id)),
             ],
             next_clip_id: FIRST_CLIP_ID,
+            next_clip_chain_id: 0,
             builder_start_time: start_time,
             content_size,
             save_state: None,
@@ -829,6 +855,7 @@ impl DisplayListBuilder {
             clip_stack_len: self.clip_stack.len(),
             dl_len: self.data.len(),
             next_clip_id: self.next_clip_id,
+            next_clip_chain_id: self.next_clip_chain_id,
         });
     }
 
@@ -839,6 +866,7 @@ impl DisplayListBuilder {
         self.clip_stack.truncate(state.clip_stack_len);
         self.data.truncate(state.dl_len);
         self.next_clip_id = state.next_clip_id;
+        self.next_clip_chain_id = state.next_clip_chain_id;
     }
 
     /// Discards the builder's save (indicating the attempted operation was sucessful).
@@ -1317,6 +1345,11 @@ impl DisplayListBuilder {
         })
     }
 
+    fn generate_clip_chain_id(&mut self) -> ClipChainId {
+        self.next_clip_chain_id += 1;
+        ClipChainId(self.next_clip_chain_id - 1, self.pipeline_id)
+    }
+
     pub fn define_scroll_frame<I>(
         &mut self,
         id: Option<ClipId>,
@@ -1357,8 +1390,8 @@ impl DisplayListBuilder {
     {
         let id = self.generate_clip_id(id);
         let item = SpecificDisplayItem::ScrollFrame(ScrollFrameDisplayItem {
-            id: id,
-            image_mask: image_mask,
+            id,
+            image_mask,
             scroll_sensitivity,
         });
         let info = LayoutPrimitiveInfo::with_clip_rect(content_rect, clip_rect);
@@ -1366,6 +1399,21 @@ impl DisplayListBuilder {
         let scrollinfo = ClipAndScrollInfo::simple(parent);
         self.push_item_with_clip_scroll_info(item, &info, scrollinfo);
         self.push_iter(complex_clips);
+        id
+    }
+
+    pub fn define_clip_chain<I>(
+        &mut self,
+        parent: Option<ClipChainId>,
+        clips: I,
+    ) -> ClipChainId
+    where
+        I: IntoIterator<Item = ClipId>,
+        I::IntoIter: ExactSizeIterator + Clone,
+    {
+        let id = self.generate_clip_chain_id();
+        self.push_new_empty_item(SpecificDisplayItem::ClipChain(ClipChainItem { id, parent}));
+        self.push_iter(clips);
         id
     }
 

--- a/wrench/reftests/clip/custom-clip-chains-ref.yaml
+++ b/wrench/reftests/clip/custom-clip-chains-ref.yaml
@@ -1,0 +1,17 @@
+root:
+  items:
+       - type: clip
+         id: 1
+         bounds: [0, 0, 200, 200]
+         complex:
+           - rect: [0, 0, 200, 200]
+             radius: {
+               top-left: 20,
+               top-right: 20,
+               bottom-left: 20,
+               bottom-right: 20,
+             }
+         items:
+         - type: rect
+           bounds: [0, 0, 200, 200]
+           color: green

--- a/wrench/reftests/clip/custom-clip-chains.yaml
+++ b/wrench/reftests/clip/custom-clip-chains.yaml
@@ -1,0 +1,62 @@
+# This tests a clip chain (clipid=6) that is composed of two clips (clipid=3
+# and clipid=4) with a parent clip chain (composed of two more clips (clipid=1
+# and clipid=2). This effectively  tests a "complex" clip chain that includes
+# and is applied to multiple non-hierarchical reference frames as well as
+# having a similarly complicated parent. Each clip is a rounded corner which,
+# when rotated, clips a box with all corners rounded.
+root:
+  items:
+    -
+      bounds: [0, 0, 200, 200]
+      type: stacking-context
+      transform: rotate(180)
+      items:
+       - type: clip
+         id: 1
+         bounds: [0, 0, 200, 200]
+         complex:
+           - rect: [0, 0, 200, 200]
+             radius: {
+               top-left: 20,
+             }
+       - type: clip
+         id: 2
+         bounds: [0, 0, 200, 200]
+         complex:
+           - rect: [0, 0, 200, 200]
+             radius: {
+               top-right: 20,
+             }
+    -
+      bounds: [0, 0, 200, 200]
+      type: stacking-context
+      transform: rotate(90)
+      items:
+       - type: clip
+         id: 3
+         bounds: [0, 0, 200, 200]
+         complex:
+           - rect: [0, 0, 200, 200]
+             radius: {
+               bottom-left: 20,
+             }
+       - type: clip
+         id: 4
+         bounds: [0, 0, 200, 200]
+         complex:
+           - rect: [0, 0, 200, 200]
+             radius: {
+               top-left: 20,
+             }
+
+    - type: clip-chain
+      id: 5
+      clips: [1, 2]
+    - type: clip-chain
+      id: 6
+      parent: 5
+      clips: [3, 4]
+    - type: rect
+      bounds: [0, 0, 200, 200]
+      color: green
+      clip-and-scroll: [0, 6]

--- a/wrench/reftests/clip/reftest.list
+++ b/wrench/reftests/clip/reftest.list
@@ -3,3 +3,4 @@
 == clip-45-degree-rotation.yaml clip-45-degree-rotation-ref.png
 == clip-3d-transform.yaml clip-3d-transform-ref.yaml
 == clip-corner-overlap.yaml clip-corner-overlap-ref.yaml
+== custom-clip-chains.yaml custom-clip-chains-ref.yaml

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -197,6 +197,10 @@ pub struct YamlFrameReader {
     fonts: HashMap<FontDescriptor, FontKey>,
     font_instances: HashMap<(FontKey, Au, FontInstanceFlags), FontInstanceKey>,
     font_render_mode: Option<FontRenderMode>,
+
+    /// A HashMap that allows specifying a numeric id for clip and clip chains in YAML
+    /// and having each of those ids correspond to a unique ClipId.
+    clip_id_map: HashMap<u64, ClipId>,
 }
 
 impl YamlFrameReader {
@@ -215,7 +219,8 @@ impl YamlFrameReader {
             fonts: HashMap::new(),
             font_instances: HashMap::new(),
             font_render_mode: None,
-            image_map: HashMap::new()
+            image_map: HashMap::new(),
+            clip_id_map: HashMap::new(),
         }
     }
 
@@ -268,25 +273,31 @@ impl YamlFrameReader {
         self.reset();
 
         let yaml = yaml_doc.pop().unwrap();
-        if !yaml["pipelines"].is_badvalue() {
-            let pipelines = yaml["pipelines"].as_vec().unwrap();
+        if let Some(pipelines) = yaml["pipelines"].as_vec() {
             for pipeline in pipelines {
-                let pipeline_id = pipeline["id"].as_pipeline_id().unwrap();
-                let content_size = self.get_root_size_from_yaml(wrench, pipeline);
-
-                let mut dl = DisplayListBuilder::new(pipeline_id, content_size);
-                let mut info = LayoutPrimitiveInfo::new(LayoutRect::zero());
-                self.add_stacking_context_from_yaml(&mut dl, wrench, pipeline, true, &mut info);
-                self.display_lists.push(dl.finalize());
+                self.build_pipeline(wrench, pipeline["id"].as_pipeline_id().unwrap(), pipeline);
             }
         }
 
         assert!(!yaml["root"].is_badvalue(), "Missing root stacking context");
-        let content_size = self.get_root_size_from_yaml(wrench, &yaml["root"]);
-        let mut dl = DisplayListBuilder::new(wrench.root_pipeline_id, content_size);
+        let root_pipeline_id = wrench.root_pipeline_id;
+        self.build_pipeline(wrench, root_pipeline_id, &yaml["root"]);
+    }
+
+    pub fn build_pipeline(
+        &mut self,
+        wrench: &mut Wrench,
+        pipeline_id: PipelineId,
+        yaml: &Yaml
+    ) {
+        // Don't allow referencing clips between pipelines for now.
+        self.clip_id_map.clear();
+
+        let content_size = self.get_root_size_from_yaml(wrench, yaml);
+        let mut builder = DisplayListBuilder::new(pipeline_id, content_size);
         let mut info = LayoutPrimitiveInfo::new(LayoutRect::zero());
-        self.add_stacking_context_from_yaml(&mut dl, wrench, &yaml["root"], true, &mut info);
-        self.display_lists.push(dl.finalize());
+        self.add_stacking_context_from_yaml(&mut builder, wrench, yaml, true, &mut info);
+        self.display_lists.push(builder.finalize());
     }
 
     fn to_complex_clip_region(&mut self, item: &Yaml) -> ComplexClipRegion {
@@ -323,6 +334,37 @@ impl YamlFrameReader {
                 array[1].as_f32().unwrap_or(0.0),
             ),
             _ => StickyOffsetBounds::new(0.0, 0.0),
+        }
+    }
+
+    pub fn to_clip_id(&self, id: u64, pipeline_id: PipelineId) -> ClipId {
+        if id == 0 {
+            return ClipId::root_scroll_node(pipeline_id);
+        }
+        self.clip_id_map[&id]
+    }
+
+    fn to_clip_and_scroll_info(
+        &self,
+        item: &Yaml,
+        pipeline_id: PipelineId
+    ) -> Option<ClipAndScrollInfo> {
+        match *item {
+            Yaml::Integer(value) => {
+                Some(ClipAndScrollInfo::simple(self.to_clip_id(value as u64, pipeline_id)))
+            }
+            Yaml::Array(ref array) if array.len() == 2 => {
+                let id_ints = (array[0].as_i64(), array[1].as_i64());
+                if let (Some(scroll_node_numeric_id), Some(clip_node_numeric_id)) = id_ints {
+                    Some(ClipAndScrollInfo::new(
+                        self.to_clip_id(scroll_node_numeric_id as u64, pipeline_id),
+                        self.to_clip_id(clip_node_numeric_id as u64, pipeline_id)
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
         }
     }
 
@@ -1179,7 +1221,10 @@ impl YamlFrameReader {
                 continue;
             }
 
-            let clip_scroll_info = item["clip-and-scroll"].as_clip_and_scroll_info(dl.pipeline_id);
+            let clip_scroll_info = self.to_clip_and_scroll_info(
+                &item["clip-and-scroll"],
+                dl.pipeline_id
+            );
             if let Some(clip_scroll_info) = clip_scroll_info {
                 dl.push_clip_and_scroll_info(clip_scroll_info);
             }
@@ -1195,6 +1240,7 @@ impl YamlFrameReader {
                 "scroll-frame" => self.handle_scroll_frame(dl, wrench, item),
                 "sticky-frame" => self.handle_sticky_frame(dl, wrench, item),
                 "clip" => self.handle_clip(dl, wrench, item),
+                "clip-chain" => self.handle_clip_chain(dl, item),
                 "border" => self.handle_border(dl, wrench, item, &mut info),
                 "gradient" => self.handle_gradient(dl, item, &mut info),
                 "radial-gradient" => self.handle_radial_gradient(dl, item, &mut info),
@@ -1226,31 +1272,31 @@ impl YamlFrameReader {
         let content_size = yaml["content-size"].as_size().unwrap_or(clip_rect.size);
         let content_rect = LayerRect::new(clip_rect.origin, content_size);
 
-        let id = yaml["id"]
-            .as_i64()
-            .map(|id| ClipId::new(id as u64, dl.pipeline_id));
+        let numeric_id = yaml["id"].as_i64().map(|id| id as u64);
         let complex_clips = self.to_complex_clip_regions(&yaml["complex"]);
         let image_mask = self.to_image_mask(&yaml["image-mask"], wrench);
 
-        let id = dl.define_scroll_frame(
-            id,
+        let real_id = dl.define_scroll_frame(
+            None,
             content_rect,
             clip_rect,
             complex_clips,
             image_mask,
             ScrollSensitivity::Script,
         );
+        if let Some(numeric_id) = numeric_id {
+            self.clip_id_map.insert(numeric_id, real_id);
+        }
 
         if let Some(size) = yaml["scroll-offset"].as_point() {
-            self.scroll_offsets
-                .insert(id, LayerPoint::new(size.x, size.y));
+            self.scroll_offsets.insert(real_id, LayerPoint::new(size.x, size.y));
         }
 
-        dl.push_clip_id(id);
         if !yaml["items"].is_badvalue() {
+            dl.push_clip_id(real_id);
             self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);
+            dl.pop_clip_id();
         }
-        dl.pop_clip_id();
     }
 
     pub fn handle_sticky_frame(
@@ -1259,15 +1305,11 @@ impl YamlFrameReader {
         wrench: &mut Wrench,
         yaml: &Yaml,
     ) {
-        let bounds = yaml["bounds"]
-            .as_rect()
-            .expect("sticky frame must have a bounds");
-        let id = yaml["id"]
-            .as_i64()
-            .map(|id| ClipId::new(id as u64, dl.pipeline_id));
+        let bounds = yaml["bounds"].as_rect().expect("sticky frame must have a bounds");
+        let numeric_id = yaml["id"].as_i64().map(|id| id as u64);
 
-        let id = dl.define_sticky_frame(
-            id,
+        let real_id = dl.define_sticky_frame(
+            None,
             bounds,
             SideOffsets2D::new(
                 yaml["margin-top"].as_f32(),
@@ -1280,11 +1322,15 @@ impl YamlFrameReader {
             yaml["previously-applied-offset"].as_vector().unwrap_or(LayoutVector2D::zero()),
         );
 
-        dl.push_clip_id(id);
-        if !yaml["items"].is_badvalue() {
-            self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);
+        if let Some(numeric_id) = numeric_id {
+            self.clip_id_map.insert(numeric_id, real_id);
         }
-        dl.pop_clip_id();
+
+        if !yaml["items"].is_badvalue() {
+            dl.push_clip_id(real_id);
+            self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);
+            dl.pop_clip_id();
+        }
     }
 
     pub fn handle_push_shadow(
@@ -1316,26 +1362,43 @@ impl YamlFrameReader {
         dl.pop_all_shadows();
     }
 
+    pub fn handle_clip_chain(&mut self, builder: &mut DisplayListBuilder, yaml: &Yaml) {
+        let numeric_id = yaml["id"].as_i64().expect("clip chains must have an id");
+        let clip_ids: Vec<ClipId> = yaml["clips"]
+            .as_vec_u64()
+            .unwrap_or_else(Vec::new)
+            .iter().map(|id| self.to_clip_id(*id, builder.pipeline_id))
+            .collect();
+
+        let parent = yaml["parent"].as_i64().map(|id|
+            self.to_clip_id(id as u64, builder.pipeline_id)
+        );
+        let parent = match parent {
+            Some(ClipId::ClipChain(clip_chain_id)) => Some(clip_chain_id),
+            Some(_) => panic!("Tried to create a ClipChain with a non-ClipChain parent"),
+            None => None,
+        };
+
+        let real_id = builder.define_clip_chain(parent, clip_ids);
+        self.clip_id_map.insert(numeric_id as u64, ClipId::ClipChain(real_id));
+    }
+
     pub fn handle_clip(&mut self, dl: &mut DisplayListBuilder, wrench: &mut Wrench, yaml: &Yaml) {
         let clip_rect = yaml["bounds"].as_rect().expect("clip must have a bounds");
-        let id = yaml["id"]
-            .as_i64()
-            .map(|id| ClipId::new(id as u64, dl.pipeline_id));
+        let numeric_id = yaml["id"].as_i64();
         let complex_clips = self.to_complex_clip_regions(&yaml["complex"]);
         let image_mask = self.to_image_mask(&yaml["image-mask"], wrench);
 
-        let id = dl.define_clip(id, clip_rect, complex_clips, image_mask);
-
-        if let Some(size) = yaml["scroll-offset"].as_point() {
-            self.scroll_offsets
-                .insert(id, LayerPoint::new(size.x, size.y));
+        let real_id = dl.define_clip(None, clip_rect, complex_clips, image_mask);
+        if let Some(numeric_id) = numeric_id {
+            self.clip_id_map.insert(numeric_id as u64, real_id);
         }
 
-        dl.push_clip_id(id);
         if !yaml["items"].is_badvalue() {
+            dl.push_clip_id(real_id);
             self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);
+            dl.pop_clip_id();
         }
-        dl.pop_clip_id();
     }
 
     pub fn get_root_size_from_yaml(&mut self, wrench: &mut Wrench, yaml: &Yaml) -> LayoutSize {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1011,6 +1011,22 @@ impl YamlFrameWriter {
                         yaml_node(&mut v, "image-mask", mask_yaml);
                     }
                 }
+                ClipChain(item) => {
+                    str_node(&mut v, "type", "clip-chain");
+
+                    let id = ClipId::ClipChain(item.id);
+                    u32_node(&mut v, "id", clip_id_mapper.map_id(&id) as u32);
+
+                    let clip_ids: Vec<u32> = display_list.get(base.clip_chain_items()).map(|clip_id| {
+                        clip_id_mapper.map_id(&clip_id) as u32
+                    }).collect();
+                    u32_vec_node(&mut v, "clips", &clip_ids);
+
+                    if let Some(parent) = item.parent {
+                        let parent = ClipId::ClipChain(parent);
+                        u32_node(&mut v, "parent", clip_id_mapper.map_id(&parent) as u32);
+                    }
+                }
                 ScrollFrame(item) => {
                     str_node(&mut v, "type", "scroll-frame");
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -15,6 +15,7 @@ pub trait YamlHelper {
     fn as_force_f32(&self) -> Option<f32>;
     fn as_vec_f32(&self) -> Option<Vec<f32>>;
     fn as_vec_u32(&self) -> Option<Vec<u32>>;
+    fn as_vec_u64(&self) -> Option<Vec<u64>>;
     fn as_pipeline_id(&self) -> Option<PipelineId>;
     fn as_rect(&self) -> Option<LayoutRect>;
     fn as_size(&self) -> Option<LayoutSize>;
@@ -28,7 +29,6 @@ pub trait YamlHelper {
     fn as_pt_to_au(&self) -> Option<Au>;
     fn as_vec_string(&self) -> Option<Vec<String>>;
     fn as_border_radius_component(&self) -> LayoutSize;
-    fn as_clip_and_scroll_info(&self, pipeline_id: PipelineId) -> Option<ClipAndScrollInfo>;
     fn as_border_radius(&self) -> Option<BorderRadius>;
     fn as_transform_style(&self) -> Option<TransformStyle>;
     fn as_clip_mode(&self) -> Option<ClipMode>;
@@ -207,6 +207,14 @@ impl YamlHelper for Yaml {
     fn as_vec_u32(&self) -> Option<Vec<u32>> {
         if let Some(v) = self.as_vec() {
             Some(v.iter().map(|v| v.as_i64().unwrap() as u32).collect())
+        } else {
+            None
+        }
+    }
+
+    fn as_vec_u64(&self) -> Option<Vec<u64>> {
+        if let Some(v) = self.as_vec() {
+            Some(v.iter().map(|v| v.as_i64().unwrap() as u64).collect())
         } else {
             None
         }
@@ -453,26 +461,6 @@ impl YamlHelper for Yaml {
             return LayoutSize::new(integer as f32, integer as f32);
         }
         self.as_size().unwrap_or(TypedSize2D::zero())
-    }
-
-    fn as_clip_and_scroll_info(&self, pipeline_id: PipelineId) -> Option<ClipAndScrollInfo> {
-        match *self {
-            Yaml::Integer(value) => Some(ClipAndScrollInfo::simple(
-                ClipId::new(value as u64, pipeline_id),
-            )),
-            Yaml::Array(ref array) if array.len() == 2 => {
-                let id_ints = (array[0].as_i64(), array[1].as_i64());
-                if let (Some(scroll_node_id), Some(clip_node_id)) = id_ints {
-                    Some(ClipAndScrollInfo::new(
-                        ClipId::new(scroll_node_id as u64, pipeline_id),
-                        ClipId::new(clip_node_id as u64, pipeline_id),
-                    ))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
     }
 
     fn as_border_radius(&self) -> Option<BorderRadius> {


### PR DESCRIPTION
API-defined clip chains allow constructing combinations of clips that
select any combination of clips from the ClipScrollTree without regard
to parents of clips. A ClipChain is defined by an optional ClipChain
parent and a vector of clips to use for that chain. A chain's clips are
combined with its parents clips to provide all the clips for display
items that set their clipping ClipId as the clip chain via
ClipId::ClipChain.

Fixes #1964.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2300)
<!-- Reviewable:end -->
