### PR TITLE
Fix for race condition when caching render tasks.

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -261,60 +261,66 @@ impl DebugRenderer {
         self.add_line(p0.x, p1.y, color, p0.x, p0.y, color);
     }
 
-    pub fn render(&mut self, device: &mut Device, viewport_size: &DeviceUintSize) {
-        device.disable_depth();
-        device.set_blend(true);
-        device.set_blend_mode_premultiplied_alpha();
+    pub fn render(
+        &mut self,
+        device: &mut Device,
+        viewport_size: Option<DeviceUintSize>,
+    ) {
+        if let Some(viewport_size) = viewport_size {
+            device.disable_depth();
+            device.set_blend(true);
+            device.set_blend_mode_premultiplied_alpha();
 
-        let projection = Transform3D::ortho(
-            0.0,
-            viewport_size.width as f32,
-            viewport_size.height as f32,
-            0.0,
-            ORTHO_NEAR_PLANE,
-            ORTHO_FAR_PLANE,
-        );
-
-        // Triangles
-        if !self.tri_vertices.is_empty() {
-            device.bind_program(&self.color_program);
-            device.set_uniforms(&self.color_program, &projection, 0);
-            device.bind_vao(&self.tri_vao);
-            device.update_vao_indices(&self.tri_vao, &self.tri_indices, VertexUsageHint::Dynamic);
-            device.update_vao_main_vertices(
-                &self.tri_vao,
-                &self.tri_vertices,
-                VertexUsageHint::Dynamic,
+            let projection = Transform3D::ortho(
+                0.0,
+                viewport_size.width as f32,
+                viewport_size.height as f32,
+                0.0,
+                ORTHO_NEAR_PLANE,
+                ORTHO_FAR_PLANE,
             );
-            device.draw_triangles_u32(0, self.tri_indices.len() as i32);
-        }
 
-        // Lines
-        if !self.line_vertices.is_empty() {
-            device.bind_program(&self.color_program);
-            device.set_uniforms(&self.color_program, &projection, 0);
-            device.bind_vao(&self.line_vao);
-            device.update_vao_main_vertices(
-                &self.line_vao,
-                &self.line_vertices,
-                VertexUsageHint::Dynamic,
-            );
-            device.draw_nonindexed_lines(0, self.line_vertices.len() as i32);
-        }
+            // Triangles
+            if !self.tri_vertices.is_empty() {
+                device.bind_program(&self.color_program);
+                device.set_uniforms(&self.color_program, &projection, 0);
+                device.bind_vao(&self.tri_vao);
+                device.update_vao_indices(&self.tri_vao, &self.tri_indices, VertexUsageHint::Dynamic);
+                device.update_vao_main_vertices(
+                    &self.tri_vao,
+                    &self.tri_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_triangles_u32(0, self.tri_indices.len() as i32);
+            }
 
-        // Glyph
-        if !self.font_indices.is_empty() {
-            device.bind_program(&self.font_program);
-            device.set_uniforms(&self.font_program, &projection, 0);
-            device.bind_texture(DebugSampler::Font, &self.font_texture);
-            device.bind_vao(&self.font_vao);
-            device.update_vao_indices(&self.font_vao, &self.font_indices, VertexUsageHint::Dynamic);
-            device.update_vao_main_vertices(
-                &self.font_vao,
-                &self.font_vertices,
-                VertexUsageHint::Dynamic,
-            );
-            device.draw_triangles_u32(0, self.font_indices.len() as i32);
+            // Lines
+            if !self.line_vertices.is_empty() {
+                device.bind_program(&self.color_program);
+                device.set_uniforms(&self.color_program, &projection, 0);
+                device.bind_vao(&self.line_vao);
+                device.update_vao_main_vertices(
+                    &self.line_vao,
+                    &self.line_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_nonindexed_lines(0, self.line_vertices.len() as i32);
+            }
+
+            // Glyph
+            if !self.font_indices.is_empty() {
+                device.bind_program(&self.font_program);
+                device.set_uniforms(&self.font_program, &projection, 0);
+                device.bind_texture(DebugSampler::Font, &self.font_texture);
+                device.bind_vao(&self.font_vao);
+                device.update_vao_indices(&self.font_vao, &self.font_indices, VertexUsageHint::Dynamic);
+                device.update_vao_main_vertices(
+                    &self.font_vao,
+                    &self.font_vertices,
+                    VertexUsageHint::Dynamic,
+                );
+                device.draw_triangles_u32(0, self.font_indices.len() as i32);
+            }
         }
 
         self.font_indices.clear();

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -34,7 +34,7 @@ use resource_cache::ResourceCache;
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
 use tiling::{CompositeOps, Frame, RenderPass, RenderTargetKind};
-use tiling::{RenderTargetContext, ScrollbarPrimitive};
+use tiling::{RenderPassKind, RenderTargetContext, ScrollbarPrimitive};
 use util::{self, MaxRect, pack_as_float, RectHelpers, recycle_vec};
 
 #[derive(Debug)]
@@ -1757,6 +1757,7 @@ impl FrameBuilder {
         }
 
         let mut deferred_resolves = vec![];
+        let mut has_texture_cache_tasks = false;
         let use_dual_source_blending = self.config.dual_source_blending_is_enabled &&
                                        self.config.dual_source_blending_is_supported;
 
@@ -1778,6 +1779,10 @@ impl FrameBuilder {
                 &self.clip_store,
                 RenderPassIndex(pass_index),
             );
+
+            if let RenderPassKind::OffScreen { ref texture_cache, .. } = pass.kind {
+                has_texture_cache_tasks |= !texture_cache.is_empty();
+            }
         }
 
         let gpu_cache_updates = gpu_cache.end_frame(gpu_cache_profile);
@@ -1799,6 +1804,8 @@ impl FrameBuilder {
             render_tasks,
             deferred_resolves,
             gpu_cache_updates: Some(gpu_cache_updates),
+            has_been_rendered: false,
+            has_texture_cache_tasks,
         }
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -769,6 +769,22 @@ pub struct Frame {
     // patch the data structures.
     #[cfg_attr(feature = "capture", serde(skip))]
     pub deferred_resolves: Vec<DeferredResolve>,
+
+    // True if this frame contains any render tasks
+    // that write to the texture cache.
+    pub has_texture_cache_tasks: bool,
+
+    // True if this frame has been drawn by the
+    // renderer.
+    pub has_been_rendered: bool,
+}
+
+impl Frame {
+    // This frame must be flushed if it writes to the
+    // texture cache, and hasn't been drawn yet.
+    pub fn must_be_drawn(&self) -> bool {
+        self.has_texture_cache_tasks && !self.has_been_rendered
+    }
 }
 
 impl BlurTask {


### PR DESCRIPTION
When the renderer receives multiple Frames from the backend
in a single render loop, it drops the old frames and just
draws the most recent frame.

If that old frame contained a render task to write to the
texture cache, then the texture cache will never be updated.

This patches tracks whether a frame has any texture cache
render tasks, and whether it has been drawn before. If a
frame which meets those conditions is being replaced, then
do a render of that frame first, skipping the main framebuffer
pass.

This is not ideal since we may end up drawing offscreen render
tasks that were batched but which aren't strictly necessary
for the texture cache render target. However, it is very rare
that the render backend is (a) producing frames faster than they
are being consumed by the renderer and (b) also contain texture
cache tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2313)
<!-- Reviewable:end -->
