### PR TITLE
Rename brush_image -> brush_picture.

### DIFF
--- a/webrender/res/brush_picture.glsl
+++ b/webrender/res/brush_picture.glsl
@@ -20,9 +20,9 @@ flat varying vec4 vParams;
 flat varying vec4 vColor;
 #endif
 
-#define BRUSH_IMAGE_SIMPLE      0
-#define BRUSH_IMAGE_NINEPATCH   1
-#define BRUSH_IMAGE_MIRROR      2
+#define BRUSH_PICTURE_SIMPLE      0
+#define BRUSH_PICTURE_NINEPATCH   1
+#define BRUSH_PICTURE_MIRROR      2
 
 #ifdef WR_VERTEX_SHADER
 
@@ -79,20 +79,20 @@ void brush_vs(
     //           to adjust the UVs.
 
     switch (vImageKind) {
-        case BRUSH_IMAGE_SIMPLE: {
+        case BRUSH_PICTURE_SIMPLE: {
             vec2 f = (local_pos - local_rect.p0) / local_rect.size;
             vUv.xy = mix(uv0, uv1, f);
             vUv.xy /= texture_size;
             break;
         }
-        case BRUSH_IMAGE_NINEPATCH: {
+        case BRUSH_PICTURE_NINEPATCH: {
             vec2 local_src_size = src_size / uDevicePixelRatio;
             vUv.xy = (local_pos - local_rect.p0) / local_src_size;
             vParams.xy = vec2(0.5);
             vParams.zw = (local_rect.size / local_src_size - 0.5);
             break;
         }
-        case BRUSH_IMAGE_MIRROR: {
+        case BRUSH_PICTURE_MIRROR: {
             vec2 local_src_size = src_size / uDevicePixelRatio;
             vUv.xy = (local_pos - local_rect.p0) / local_src_size;
             vParams.xy = 0.5 * local_rect.size / local_src_size;
@@ -114,18 +114,18 @@ vec4 brush_fs() {
     vec2 uv;
 
     switch (vImageKind) {
-        case BRUSH_IMAGE_SIMPLE: {
+        case BRUSH_PICTURE_SIMPLE: {
             uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
             break;
         }
-        case BRUSH_IMAGE_NINEPATCH: {
+        case BRUSH_PICTURE_NINEPATCH: {
             uv = clamp(vUv.xy, vec2(0.0), vParams.xy);
             uv += max(vec2(0.0), vUv.xy - vParams.zw);
             uv = mix(vUvBounds_NoClamp.xy, vUvBounds_NoClamp.zw, uv);
             uv = clamp(uv, vUvBounds.xy, vUvBounds.zw);
             break;
         }
-        case BRUSH_IMAGE_MIRROR: {
+        case BRUSH_PICTURE_MIRROR: {
             // Mirror and stretch the box shadow corner over the entire
             // primitives.
             uv = vParams.xy - abs(vUv.xy - vParams.xy);

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -67,7 +67,7 @@ impl BrushImageSourceKind {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub enum BrushBatchKind {
-    Image(BrushImageSourceKind),
+    Picture(BrushImageSourceKind),
     Solid,
     Line,
 }
@@ -838,7 +838,7 @@ impl AlphaBatcher {
                             PictureKind::BoxShadow { image_kind, .. } => {
                                 let textures = BatchTextures::color(cache_item.texture_id);
                                 let kind = BatchKind::Brush(
-                                    BrushBatchKind::Image(
+                                    BrushBatchKind::Picture(
                                         BrushImageSourceKind::from_render_target_kind(picture.target_kind())),
                                 );
                                 let alpha_batch_key = BatchKey::new(
@@ -873,7 +873,7 @@ impl AlphaBatcher {
                         match picture.kind {
                             PictureKind::TextShadow { .. } => {
                                 let kind = BatchKind::Brush(
-                                    BrushBatchKind::Image(
+                                    BrushBatchKind::Picture(
                                         BrushImageSourceKind::from_render_target_kind(picture.target_kind())),
                                 );
                                 let key = BatchKey::new(kind, blend_mode, textures);
@@ -957,7 +957,7 @@ impl AlphaBatcher {
                                             }
                                             FilterOp::DropShadow(offset, _, _) => {
                                                 let kind = BatchKind::Brush(
-                                                    BrushBatchKind::Image(BrushImageSourceKind::ColorAlphaMask),
+                                                    BrushBatchKind::Picture(BrushImageSourceKind::ColorAlphaMask),
                                                 );
                                                 let key = BatchKey::new(kind, blend_mode, textures);
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -582,7 +582,7 @@ impl PicturePrimitive {
                         // TODO(gw): Remove the nastiness with having to pass
                         //           the scale factor through the texture cache
                         //           item user data. This will disappear once
-                        //           the brush_image shader is updated to draw
+                        //           the brush_picture shader is updated to draw
                         //           segments, since the scale factor will not
                         //           be used at all then during drawing.
                         (root_task_id, [scale_factor, 0.0, 0.0])

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -89,8 +89,8 @@ const GPU_TAG_BRUSH_MASK: GpuProfileTag = GpuProfileTag {
     label: "B_Mask",
     color: debug_colors::BLACK,
 };
-const GPU_TAG_BRUSH_IMAGE: GpuProfileTag = GpuProfileTag {
-    label: "B_Image",
+const GPU_TAG_BRUSH_PICTURE: GpuProfileTag = GpuProfileTag {
+    label: "B_Picture",
     color: debug_colors::SILVER,
 };
 const GPU_TAG_BRUSH_LINE: GpuProfileTag = GpuProfileTag {
@@ -223,7 +223,7 @@ impl BatchKind {
             BatchKind::Blend => "Blend",
             BatchKind::Brush(kind) => {
                 match kind {
-                    BrushBatchKind::Image(..) => "Brush (Image)",
+                    BrushBatchKind::Picture(..) => "Brush (Picture)",
                     BrushBatchKind::Solid => "Brush (Solid)",
                     BrushBatchKind::Line => "Brush (Line)",
                 }
@@ -240,7 +240,7 @@ impl BatchKind {
             BatchKind::Blend => GPU_TAG_PRIM_BLEND,
             BatchKind::Brush(kind) => {
                 match kind {
-                    BrushBatchKind::Image(..) => GPU_TAG_BRUSH_IMAGE,
+                    BrushBatchKind::Picture(..) => GPU_TAG_BRUSH_PICTURE,
                     BrushBatchKind::Solid => GPU_TAG_BRUSH_SOLID,
                     BrushBatchKind::Line => GPU_TAG_BRUSH_LINE,
                 }
@@ -1595,9 +1595,9 @@ pub struct Renderer {
     // Brush shaders
     brush_mask_corner: LazilyCompiledShader,
     brush_mask_rounded_rect: LazilyCompiledShader,
-    brush_image_rgba8: BrushShader,
-    brush_image_rgba8_alpha_mask: BrushShader,
-    brush_image_a8: BrushShader,
+    brush_picture_rgba8: BrushShader,
+    brush_picture_rgba8_alpha_mask: BrushShader,
+    brush_picture_a8: BrushShader,
     brush_solid: BrushShader,
     brush_line: BrushShader,
 
@@ -1812,22 +1812,22 @@ impl Renderer {
                              options.precache_shaders)
         };
 
-        let brush_image_a8 = try!{
-            BrushShader::new("brush_image",
+        let brush_picture_a8 = try!{
+            BrushShader::new("brush_picture",
                              &mut device,
                              &["ALPHA_TARGET"],
                              options.precache_shaders)
         };
 
-        let brush_image_rgba8 = try!{
-            BrushShader::new("brush_image",
+        let brush_picture_rgba8 = try!{
+            BrushShader::new("brush_picture",
                              &mut device,
                              &["COLOR_TARGET"],
                              options.precache_shaders)
         };
 
-        let brush_image_rgba8_alpha_mask = try!{
-            BrushShader::new("brush_image",
+        let brush_picture_rgba8_alpha_mask = try!{
+            BrushShader::new("brush_picture",
                              &mut device,
                              &["COLOR_TARGET_ALPHA_MASK"],
                              options.precache_shaders)
@@ -2263,9 +2263,9 @@ impl Renderer {
             cs_blur_rgba8,
             brush_mask_corner,
             brush_mask_rounded_rect,
-            brush_image_rgba8,
-            brush_image_rgba8_alpha_mask,
-            brush_image_a8,
+            brush_picture_rgba8,
+            brush_picture_rgba8_alpha_mask,
+            brush_picture_a8,
             brush_solid,
             brush_line,
             cs_clip_rectangle,
@@ -3153,11 +3153,11 @@ impl Renderer {
                             &mut self.renderer_errors,
                         );
                     }
-                    BrushBatchKind::Image(target_kind) => {
+                    BrushBatchKind::Picture(target_kind) => {
                         let shader = match target_kind {
-                            BrushImageSourceKind::Alpha => &mut self.brush_image_a8,
-                            BrushImageSourceKind::Color => &mut self.brush_image_rgba8,
-                            BrushImageSourceKind::ColorAlphaMask => &mut self.brush_image_rgba8_alpha_mask,
+                            BrushImageSourceKind::Alpha => &mut self.brush_picture_a8,
+                            BrushImageSourceKind::Color => &mut self.brush_picture_rgba8,
+                            BrushImageSourceKind::ColorAlphaMask => &mut self.brush_picture_rgba8_alpha_mask,
                         };
                         shader.bind(
                             &mut self.device,
@@ -4579,9 +4579,9 @@ impl Renderer {
         self.cs_blur_rgba8.deinit(&mut self.device);
         self.brush_mask_rounded_rect.deinit(&mut self.device);
         self.brush_mask_corner.deinit(&mut self.device);
-        self.brush_image_rgba8.deinit(&mut self.device);
-        self.brush_image_rgba8_alpha_mask.deinit(&mut self.device);
-        self.brush_image_a8.deinit(&mut self.device);
+        self.brush_picture_rgba8.deinit(&mut self.device);
+        self.brush_picture_rgba8_alpha_mask.deinit(&mut self.device);
+        self.brush_picture_a8.deinit(&mut self.device);
         self.brush_solid.deinit(&mut self.device);
         self.brush_line.deinit(&mut self.device);
         self.cs_clip_rectangle.deinit(&mut self.device);

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -100,7 +100,7 @@ const SHADERS: &[Shader] = &[
         features: &[],
     },
     Shader {
-        name: "brush_image",
+        name: "brush_picture",
         features: &["COLOR_TARGET", "ALPHA_TARGET"],
     },
     Shader {


### PR DESCRIPTION
In preparation for porting ps_image -> brush_image and starting
to use segments for the image shader.

Eventually, we'll aim to unify brush_image and brush_picture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2319)
<!-- Reviewable:end -->
