### PR TITLE
Handle image sub-rects by pre-rendering to task cache.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -727,12 +727,11 @@ TextRun fetch_text_run(int address) {
 struct Image {
     vec4 stretch_size_and_tile_spacing;  // Size of the actual image and amount of space between
                                          //     tiled instances of this image.
-    vec4 sub_rect;                          // If negative, ignored.
 };
 
 Image fetch_image(int address) {
-    vec4 data[2] = fetch_from_resource_cache_2(address);
-    return Image(data[0], data[1]);
+    vec4 data = fetch_from_resource_cache_1(address);
+    return Image(data);
 }
 
 void write_clip(vec2 global_pos, ClipArea area) {

--- a/webrender/res/ps_image.glsl
+++ b/webrender/res/ps_image.glsl
@@ -50,15 +50,8 @@ void main(void) {
     vec2 texture_size_normalization_factor = vec2(textureSize(sColor0, 0));
 #endif
 
-    vec2 uv0, uv1;
-
-    if (image.sub_rect.x < 0.0) {
-        uv0 = res.uv_rect.p0;
-        uv1 = res.uv_rect.p1;
-    } else {
-        uv0 = res.uv_rect.p0 + image.sub_rect.xy;
-        uv1 = res.uv_rect.p0 + image.sub_rect.zw;
-    }
+    vec2 uv0 = res.uv_rect.p0;
+    vec2 uv1 = res.uv_rect.p1;
 
     // vUv will contain how many times this image has wrapped around the image size.
     vec2 st0 = uv0 / texture_size_normalization_factor;

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -698,9 +698,9 @@ impl AlphaBatcher {
                 let cache_item = match image_cpu.source {
                     ImageSource::Default => {
                         resolve_image(
-                            image_cpu.image_key,
-                            image_cpu.image_rendering,
-                            image_cpu.tile_offset,
+                            image_cpu.key.image_key,
+                            image_cpu.key.image_rendering,
+                            image_cpu.key.tile_offset,
                             ctx.resource_cache,
                             gpu_cache,
                             deferred_resolves,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -6,7 +6,7 @@ use api::{AlphaType, BorderDetails, BorderDisplayItem, BuiltDisplayList, ClipAnd
 use api::{ColorF, ColorU, DeviceIntPoint, DevicePixelScale, DeviceUintPoint, DeviceUintRect};
 use api::{DeviceUintSize, DocumentLayer, ExtendMode, FontRenderMode, GlyphInstance, GlyphOptions};
 use api::{GradientStop, HitTestFlags, HitTestItem, HitTestResult, ImageKey, ImageRendering};
-use api::{ItemRange, ItemTag, LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize};
+use api::{Epoch, ItemRange, ItemTag, LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize};
 use api::{LayerTransform, LayerVector2D, LayoutTransform, LayoutVector2D, LineOrientation};
 use api::{LineStyle, LocalClip, PipelineId, PremultipliedColorF, PropertyBinding, RepeatMode};
 use api::{ScrollSensitivity, Shadow, TexelRect, TileOffset, TransformStyle, WorldPoint};
@@ -24,7 +24,7 @@ use gpu_types::{ClipScrollNodeData, PictureType};
 use internal_types::{FastHashMap, FastHashSet, RenderPassIndex};
 use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive, PictureSurface};
 use prim_store::{BrushKind, BrushPrimitive, YuvImagePrimitiveCpu};
-use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, PrimitiveKind};
+use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, ImageSource, PrimitiveKind};
 use prim_store::{PrimitiveContainer, PrimitiveIndex, SpecificPrimitiveIndex};
 use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{BrushSegmentDescriptor, TextRunPrimitiveCpu};
@@ -1445,7 +1445,9 @@ impl FrameBuilder {
             tile_spacing,
             alpha_type,
             stretch_size,
-            texel_rect: sub_rect.unwrap_or(TexelRect::invalid()),
+            texel_rect: sub_rect,
+            current_epoch: Epoch::invalid(),
+            source: ImageSource::Default,
         };
 
         self.add_primitive(

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -585,7 +585,7 @@ impl PicturePrimitive {
                         //           the brush_picture shader is updated to draw
                         //           segments, since the scale factor will not
                         //           be used at all then during drawing.
-                        (root_task_id, [scale_factor, 0.0, 0.0])
+                        (root_task_id, [scale_factor, 0.0, 0.0], false)
                     }
                 );
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, ImageKey, TexelRect, TileOffset};
-use api::{ImageDescriptor, ImageFormat, ImageRendering, LayerRect, PremultipliedColorF};
+use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
+use api::{ImageDescriptor, ImageFormat, LayerRect, PremultipliedColorF};
 use box_shadow::BoxShadowCacheKey;
 use clip::{ClipSourcesWeakHandle};
 use clip_scroll_tree::CoordinateSystemId;
@@ -268,10 +268,7 @@ impl BlurTask {
 #[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub enum BlitSource {
     Image {
-        image_key: ImageKey,
-        image_rendering: ImageRendering,
-        tile_offset: Option<TileOffset>,
-        sub_rect: Option<TexelRect>,
+        key: ImageCacheKey,
     },
     RenderTask {
         task_id: RenderTaskId,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use api::{ImageDescriptor, ImageFormat, LayerRect, PremultipliedColorF};
+use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, ImageKey, TexelRect, TileOffset};
+use api::{ImageDescriptor, ImageFormat, ImageRendering, LayerRect, PremultipliedColorF};
 use box_shadow::BoxShadowCacheKey;
 use clip::{ClipSourcesWeakHandle};
 use clip_scroll_tree::CoordinateSystemId;
@@ -12,7 +12,7 @@ use gpu_cache::GpuCache;
 use gpu_types::{ClipScrollNodeIndex, PictureType};
 use internal_types::{FastHashMap, RenderPassIndex, SourceTexture};
 use picture::ContentOrigin;
-use prim_store::{PrimitiveIndex};
+use prim_store::{PrimitiveIndex, ImageCacheKey};
 #[cfg(feature = "debugger")]
 use print_tree::{PrintTreePrinter};
 use resource_cache::CacheItem;
@@ -263,6 +263,27 @@ impl BlurTask {
     }
 }
 
+// Where the source data for a blit task can be found.
+#[derive(Debug)]
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
+pub enum BlitSource {
+    Image {
+        image_key: ImageKey,
+        image_rendering: ImageRendering,
+        tile_offset: Option<TileOffset>,
+        sub_rect: Option<TexelRect>,
+    },
+    RenderTask {
+        task_id: RenderTaskId,
+    },
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
+pub struct BlitTask {
+    pub source: BlitSource,
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub struct RenderTaskData {
@@ -278,6 +299,7 @@ pub enum RenderTaskKind {
     HorizontalBlur(BlurTask),
     Readback(DeviceIntRect),
     Scaling(RenderTargetKind),
+    Blit(BlitTask),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -337,6 +359,32 @@ impl RenderTask {
             children: Vec::new(),
             location: RenderTaskLocation::Dynamic(None, screen_rect.size),
             kind: RenderTaskKind::Readback(screen_rect),
+            clear_mode: ClearMode::Transparent,
+            pass_index: None,
+        }
+    }
+
+    pub fn new_blit(
+        size: DeviceIntSize,
+        source: BlitSource,
+    ) -> Self {
+        let mut children = Vec::new();
+
+        // If this blit uses a render task as a source,
+        // ensure it's added as a child task. This will
+        // ensure it gets allocated in the correct pass
+        // and made available as an input when this task
+        // executes.
+        if let BlitSource::RenderTask { task_id } = source {
+            children.push(task_id);
+        }
+
+        RenderTask {
+            children,
+            location: RenderTaskLocation::Dynamic(None, size),
+            kind: RenderTaskKind::Blit(BlitTask {
+                source,
+            }),
             clear_mode: ClearMode::Transparent,
             pass_index: None,
         }
@@ -511,7 +559,8 @@ impl RenderTask {
                 )
             }
             RenderTaskKind::Readback(..) |
-            RenderTaskKind::Scaling(..) => {
+            RenderTaskKind::Scaling(..) |
+            RenderTaskKind::Blit(..) => {
                 (
                     [0.0; 3],
                     [0.0; 4],
@@ -598,6 +647,10 @@ impl RenderTask {
             RenderTaskKind::Picture(ref task_info) => {
                 task_info.target_kind
             }
+
+            RenderTaskKind::Blit(..) => {
+                RenderTargetKind::Color
+            }
         }
     }
 
@@ -613,7 +666,8 @@ impl RenderTask {
             RenderTaskKind::VerticalBlur(..) |
             RenderTaskKind::Readback(..) |
             RenderTaskKind::HorizontalBlur(..) |
-            RenderTaskKind::Scaling(..) => false,
+            RenderTaskKind::Scaling(..) |
+            RenderTaskKind::Blit(..) => false,
 
             RenderTaskKind::CacheMask(..) => true,
         }
@@ -646,6 +700,10 @@ impl RenderTask {
                 pt.new_level("Scaling".to_owned());
                 pt.add_item(format!("kind: {:?}", kind));
             }
+            RenderTaskKind::Blit(ref task) => {
+                pt.new_level("Blit".to_owned());
+                pt.add_item(format!("source: {:?}", task.source));
+            }
         }
 
         pt.add_item(format!("clear to: {:?}", self.clear_mode));
@@ -664,6 +722,7 @@ impl RenderTask {
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum RenderTaskCacheKeyKind {
     BoxShadow(BoxShadowCacheKey),
+    Image(ImageCacheKey),
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -722,7 +781,7 @@ impl RenderTaskCache {
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
         mut f: F,
-    ) -> CacheItem where F: FnMut(&mut RenderTaskTree) -> (RenderTaskId, [f32; 3]) {
+    ) -> CacheItem where F: FnMut(&mut RenderTaskTree) -> (RenderTaskId, [f32; 3], bool) {
         // Get the texture cache handle for this cache key,
         // or create one.
         let cache_entry = self.entries
@@ -735,8 +794,14 @@ impl RenderTaskCache {
         if texture_cache.request(&mut cache_entry.handle, gpu_cache) {
             // Invoke user closure to get render task chain
             // to draw this into the texture cache.
-            let (render_task_id, user_data) = f(render_tasks);
+            let (render_task_id, user_data, is_opaque) = f(render_tasks);
             let render_task = &mut render_tasks[render_task_id];
+
+            // Select the right texture page to allocate from.
+            let image_format = match render_task.target_kind() {
+                RenderTargetKind::Color => ImageFormat::BGRA8,
+                RenderTargetKind::Alpha => ImageFormat::R8,
+            };
 
             // Find out what size to alloc in the texture cache.
             let size = match render_task.location {
@@ -753,8 +818,8 @@ impl RenderTaskCache {
             let descriptor = ImageDescriptor::new(
                 size.width as u32,
                 size.height as u32,
-                ImageFormat::R8,
-                false,
+                image_format,
+                is_opaque,
             );
 
             // Allocate space in the texture cache, but don't supply

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -68,7 +68,7 @@ use std::thread;
 use texture_cache::TextureCache;
 use thread_profiler::{register_thread_with_profiler, write_profile};
 use tiling::{AlphaRenderTarget, ColorRenderTarget};
-use tiling::{RenderPass, RenderPassKind, RenderTargetList};
+use tiling::{BlitJob, BlitJobSource, RenderPass, RenderPassKind, RenderTargetList};
 use tiling::{Frame, RenderTarget, ScalingInfo, TextureCacheRenderTarget};
 use time::precise_time_ns;
 use util::TransformedRectKind;
@@ -165,6 +165,10 @@ const GPU_TAG_PRIM_BORDER_EDGE: GpuProfileTag = GpuProfileTag {
 const GPU_TAG_BLUR: GpuProfileTag = GpuProfileTag {
     label: "Blur",
     color: debug_colors::VIOLET,
+};
+const GPU_TAG_BLIT: GpuProfileTag = GpuProfileTag {
+    label: "Blit",
+    color: debug_colors::LIME,
 };
 
 const GPU_SAMPLER_TAG_ALPHA: GpuProfileTag = GpuProfileTag {
@@ -3327,6 +3331,50 @@ impl Renderer {
         );
     }
 
+    fn handle_blits(
+        &mut self,
+        blits: &[BlitJob],
+        render_tasks: &RenderTaskTree,
+    ) {
+        if blits.is_empty() {
+            return;
+        }
+
+        let _timer = self.gpu_profile.start_timer(GPU_TAG_BLIT);
+
+        // TODO(gw): For now, we don't bother batching these by source texture.
+        //           If if ever shows up as an issue, we can easily batch them.
+        for blit in blits {
+            let source_rect = match blit.source {
+                BlitJobSource::Texture(texture_id, layer, source_rect) => {
+                    // A blit from a texture into this target.
+                    let src_texture = self.texture_resolver
+                        .resolve(&texture_id)
+                        .expect("BUG: invalid source texture");
+                    self.device.bind_read_target(Some((src_texture, layer)));
+                    source_rect
+                }
+                BlitJobSource::RenderTask(task_id) => {
+                    // A blit from the child render task into this target.
+                    // TODO(gw): Support R8 format here once we start
+                    //           creating mips for alpha masks.
+                    let src_texture = self.texture_resolver
+                        .resolve(&SourceTexture::CacheRGBA8)
+                        .expect("BUG: invalid source texture");
+                    let source = &render_tasks[task_id];
+                    let (source_rect, layer) = source.get_target_rect();
+                    self.device.bind_read_target(Some((src_texture, layer.0 as i32)));
+                    source_rect
+                }
+            };
+            debug_assert_eq!(source_rect.size, blit.target_rect.size);
+            self.device.blit_render_target(
+                source_rect,
+                blit.target_rect,
+            );
+        }
+    }
+
     fn handle_scaling(
         &mut self,
         render_tasks: &RenderTaskTree,
@@ -3415,6 +3463,9 @@ impl Renderer {
                 self.device.disable_depth_write();
             }
         }
+
+        // Handle any blits from the texture cache to this target.
+        self.handle_blits(&target.blits, render_tasks);
 
         // Draw any blurs for this target.
         // Blurs are rendered as a standard 2-pass
@@ -3980,6 +4031,7 @@ impl Renderer {
         texture: &SourceTexture,
         layer: i32,
         target: &TextureCacheRenderTarget,
+        render_tasks: &RenderTaskTree,
         stats: &mut RendererStats,
     ) {
         let projection = {
@@ -4003,6 +4055,9 @@ impl Renderer {
                 ORTHO_FAR_PLANE,
             )
         };
+
+        // Handle any blits to this texture from child tasks.
+        self.handle_blits(&target.blits, render_tasks);
 
         // Draw any blurs for this target.
         if !target.horizontal_blurs.is_empty() {
@@ -4289,6 +4344,7 @@ impl Renderer {
                                 &texture_id,
                                 target_index,
                                 target,
+                                &frame.render_tasks,
                                 stats,
                             );
                         }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -405,9 +405,21 @@ impl TextureCache {
                     .get_opt(handle)
                     .expect("BUG: was dropped from cache or not updated!");
                 debug_assert_eq!(entry.last_access, self.frame_id);
+                let (layer_index, origin) = match entry.kind {
+                    EntryKind::Standalone { .. } => {
+                        (0, DeviceUintPoint::zero())
+                    }
+                    EntryKind::Cache {
+                        layer_index,
+                        origin,
+                        ..
+                    } => (layer_index, origin),
+                };
                 CacheItem {
                     uv_rect_handle: entry.uv_rect_handle,
                     texture_id: SourceTexture::TextureCache(entry.texture_id),
+                    uv_rect: DeviceUintRect::new(origin, entry.size),
+                    texture_layer: layer_index as i32,
                 }
             }
             None => panic!("BUG: handle not requested earlier in frame"),

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -6,7 +6,7 @@ use api::{ClipId, ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use api::{DevicePixelScale, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
 use api::{DocumentLayer, FilterOp, ImageFormat};
 use api::{LayerRect, MixBlendMode, PipelineId};
-use batch::{AlphaBatcher, ClipBatcher};
+use batch::{AlphaBatcher, ClipBatcher, resolve_image};
 use clip::{ClipStore};
 use clip_scroll_tree::{ClipScrollTree};
 use device::Texture;
@@ -19,7 +19,7 @@ use picture::{PictureKind};
 use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveStore};
 use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, EdgeAaSegmentMask};
 use profiler::FrameProfileCounters;
-use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind};
+use render_task::{BlitSource, RenderTaskAddress, RenderTaskId, RenderTaskKind};
 use render_task::{BlurTask, ClearMode, RenderTaskLocation, RenderTaskTree};
 use resource_cache::{ResourceCache};
 use std::{cmp, usize, f32, i32};
@@ -104,9 +104,10 @@ pub trait RenderTarget {
         &mut self,
         task_id: RenderTaskId,
         ctx: &RenderTargetContext,
-        gpu_cache: &GpuCache,
+        gpu_cache: &mut GpuCache,
         render_tasks: &RenderTaskTree,
         clip_store: &ClipStore,
+        deferred_resolves: &mut Vec<DeferredResolve>,
     );
     fn used_rect(&self) -> DeviceIntRect;
     fn needs_depth(&self) -> bool;
@@ -159,9 +160,10 @@ impl<T: RenderTarget> RenderTargetList<T> {
         &mut self,
         task_id: RenderTaskId,
         ctx: &RenderTargetContext,
-        gpu_cache: &GpuCache,
+        gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
         clip_store: &ClipStore,
+        deferred_resolves: &mut Vec<DeferredResolve>,
     ) {
         self.targets.last_mut().unwrap().add_task(
             task_id,
@@ -169,6 +171,7 @@ impl<T: RenderTarget> RenderTargetList<T> {
             gpu_cache,
             render_tasks,
             clip_store,
+            deferred_resolves,
         );
     }
 
@@ -233,6 +236,20 @@ pub struct ScalingInfo {
     pub dest_task_id: RenderTaskId,
 }
 
+// Defines where the source data for a blit job can be found.
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
+pub enum BlitJobSource {
+    Texture(SourceTexture, i32, DeviceIntRect),
+    RenderTask(RenderTaskId),
+}
+
+// Information required to do a blit from a source to a target.
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
+pub struct BlitJob {
+    pub source: BlitJobSource,
+    pub target_rect: DeviceIntRect,
+}
+
 /// A render target represents a number of rendering operations on a surface.
 #[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub struct ColorRenderTarget {
@@ -242,6 +259,7 @@ pub struct ColorRenderTarget {
     pub horizontal_blurs: Vec<BlurInstance>,
     pub readbacks: Vec<DeviceIntRect>,
     pub scalings: Vec<ScalingInfo>,
+    pub blits: Vec<BlitJob>,
     // List of frame buffer outputs for this render target.
     pub outputs: Vec<FrameOutput>,
     allocator: Option<TextureAllocator>,
@@ -266,6 +284,7 @@ impl RenderTarget for ColorRenderTarget {
             horizontal_blurs: Vec::new(),
             readbacks: Vec::new(),
             scalings: Vec::new(),
+            blits: Vec::new(),
             allocator: size.map(TextureAllocator::new),
             outputs: Vec::new(),
             alpha_tasks: Vec::new(),
@@ -292,9 +311,10 @@ impl RenderTarget for ColorRenderTarget {
         &mut self,
         task_id: RenderTaskId,
         ctx: &RenderTargetContext,
-        _: &GpuCache,
+        gpu_cache: &mut GpuCache,
         render_tasks: &RenderTaskTree,
         _: &ClipStore,
+        deferred_resolves: &mut Vec<DeferredResolve>,
     ) {
         let task = &render_tasks[task_id];
 
@@ -354,6 +374,54 @@ impl RenderTarget for ColorRenderTarget {
                     dest_task_id: task_id,
                 });
             }
+            RenderTaskKind::Blit(ref task_info) => {
+                match task_info.source {
+                    BlitSource::Image { image_key, image_rendering, tile_offset, sub_rect } => {
+                        // Get the cache item for the source texture.
+                        let cache_item = resolve_image(
+                            image_key,
+                            image_rendering,
+                            tile_offset,
+                            ctx.resource_cache,
+                            gpu_cache,
+                            deferred_resolves,
+                        );
+
+                        // Work out a source rect to copy from the texture, depending on whether
+                        // a sub-rect is present or not.
+                        // TODO(gw): We have much type confusion below - f32, i32 and u32 for
+                        //           various representations of the texel rects. We should make
+                        //           this consistent!
+                        let source_rect = sub_rect.map_or(cache_item.uv_rect.to_i32(), |sub_rect| {
+                            DeviceIntRect::new(
+                                DeviceIntPoint::new(
+                                    cache_item.uv_rect.origin.x as i32 + sub_rect.uv0.x as i32,
+                                    cache_item.uv_rect.origin.y as i32 + sub_rect.uv0.y as i32,
+                                ),
+                                DeviceIntSize::new(
+                                    (sub_rect.uv1.x - sub_rect.uv0.x) as i32,
+                                    (sub_rect.uv1.y - sub_rect.uv0.y) as i32,
+                                ),
+                            )
+                        });
+
+                        // Store the blit job for the renderer to execute, including
+                        // the allocated destination rect within this target.
+                        let (target_rect, _) = task.get_target_rect();
+                        self.blits.push(BlitJob {
+                            source: BlitJobSource::Texture(
+                                cache_item.texture_id,
+                                cache_item.texture_layer,
+                                source_rect,
+                            ),
+                            target_rect,
+                        });
+                    }
+                    BlitSource::RenderTask { .. } => {
+                        panic!("BUG: render task blit jobs to render tasks not supported");
+                    }
+                }
+            }
         }
     }
 
@@ -407,9 +475,10 @@ impl RenderTarget for AlphaRenderTarget {
         &mut self,
         task_id: RenderTaskId,
         ctx: &RenderTargetContext,
-        gpu_cache: &GpuCache,
+        gpu_cache: &mut GpuCache,
         render_tasks: &RenderTaskTree,
         clip_store: &ClipStore,
+        _: &mut Vec<DeferredResolve>,
     ) {
         let task = &render_tasks[task_id];
 
@@ -424,8 +493,9 @@ impl RenderTarget for AlphaRenderTarget {
         }
 
         match task.kind {
-            RenderTaskKind::Readback(..) => {
-                panic!("Should not be added to alpha target!");
+            RenderTaskKind::Readback(..) |
+            RenderTaskKind::Blit(..) => {
+                panic!("BUG: should not be added to alpha target!");
             }
             RenderTaskKind::VerticalBlur(ref info) => {
                 info.add_instances(
@@ -543,6 +613,7 @@ impl RenderTarget for AlphaRenderTarget {
 #[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub struct TextureCacheRenderTarget {
     pub horizontal_blurs: Vec<BlurInstance>,
+    pub blits: Vec<BlitJob>,
 }
 
 impl TextureCacheRenderTarget {
@@ -552,6 +623,7 @@ impl TextureCacheRenderTarget {
     ) -> Self {
         TextureCacheRenderTarget {
             horizontal_blurs: Vec::new(),
+            blits: Vec::new(),
         }
     }
 
@@ -571,6 +643,24 @@ impl TextureCacheRenderTarget {
                     BlurDirection::Horizontal,
                     render_tasks,
                 );
+            }
+            RenderTaskKind::Blit(ref task_info) => {
+                match task_info.source {
+                    BlitSource::Image { .. } => {
+                        // reading/writing from the texture cache at the same time
+                        // is undefined behavior.
+                        panic!("bug: a single blit cannot be to/from texture cache");
+                    }
+                    BlitSource::RenderTask { task_id } => {
+                        // Add a blit job to copy from an existing render
+                        // task to this target.
+                        let (target_rect, _) = task.get_target_rect();
+                        self.blits.push(BlitJob {
+                            source: BlitJobSource::RenderTask(task_id),
+                            target_rect,
+                        });
+                    }
+                }
             }
             RenderTaskKind::VerticalBlur(..) |
             RenderTaskKind::Picture(..) |
@@ -658,7 +748,14 @@ impl RenderPass {
                 for &task_id in &self.tasks {
                     assert_eq!(render_tasks[task_id].target_kind(), RenderTargetKind::Color);
                     render_tasks[task_id].pass_index = Some(pass_index);
-                    target.add_task(task_id, ctx, gpu_cache, render_tasks, clip_store);
+                    target.add_task(
+                        task_id,
+                        ctx,
+                        gpu_cache,
+                        render_tasks,
+                        clip_store,
+                        deferred_resolves,
+                    );
                 }
                 target.build(ctx, gpu_cache, render_tasks, deferred_resolves);
             }
@@ -706,8 +803,22 @@ impl RenderPass {
                         }
                         None => {
                             match target_kind {
-                                RenderTargetKind::Color => color.add_task(task_id, ctx, gpu_cache, render_tasks, clip_store),
-                                RenderTargetKind::Alpha => alpha.add_task(task_id, ctx, gpu_cache, render_tasks, clip_store),
+                                RenderTargetKind::Color => color.add_task(
+                                    task_id,
+                                    ctx,
+                                    gpu_cache,
+                                    render_tasks,
+                                    clip_store,
+                                    deferred_resolves,
+                                ),
+                                RenderTargetKind::Alpha => alpha.add_task(
+                                    task_id,
+                                    ctx,
+                                    gpu_cache,
+                                    render_tasks,
+                                    clip_store,
+                                    deferred_resolves,
+                                ),
                             }
                         }
                     }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -13,6 +13,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::u32;
 
 pub type TileSize = u16;
 /// Documents are rendered in the ascending order of their associated layer values.
@@ -520,6 +521,12 @@ impl fmt::Debug for ApiMsg {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Epoch(pub u32);
+
+impl Epoch {
+    pub fn invalid() -> Epoch {
+        Epoch(u32::MAX)
+    }
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Deserialize, Serialize)]

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -22,7 +22,7 @@ fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 options(disable-aa) == shadow-atomic.yaml shadow-atomic-ref.yaml
 options(disable-aa) == shadow-clip-rect.yaml shadow-atomic-ref.yaml
-options(disable-aa) == shadow-ordering.yaml shadow-ordering-ref.yaml
+options(disable-aa) platform(linux) == shadow-ordering.yaml shadow-ordering-ref.yaml
 != synthetic-bold.yaml synthetic-bold-not-ref.yaml
 fuzzy(1,229) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml
 != synthetic-bold-transparent.yaml synthetic-bold.yaml


### PR DESCRIPTION
This removes any shader related code for handling sub-rects
of images. This is a very small optimization by itself - the
primary goal of this PR is to introduce the infrastructure
that can be used for pre-rendering images.

In the future, we'll aim to make use of this infrastructure
for at least two other cases:

 * Pre-render spacing and repeat sequences of images in
   some situations (when the number of instances generated
   would otherwise be large). This will give a significant
   performance improvement to the image shader, which is
   typically the second most expensive shader on most
   pages. It's also another step to porting the image shader
   to a brush shader, and collapsing it into other shaders
   such as brush_image.

 * Pre-render mip-maps of very large images into a smaller
   surface. This will allow fixing some image quality bugs
   where we sample from a very large texture (typically a
   large alpha mask). It is likely to also help with
   performance, since the primitive will then be sampling
   from a much smaller texture surface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2331)
<!-- Reviewable:end -->
