### PR TITLE
Capture: final strokes (or version 2.718)

### DIFF
--- a/webrender/src/capture.rs
+++ b/webrender/src/capture.rs
@@ -95,6 +95,9 @@ impl CaptureConfig {
     }
 }
 
+/// An image that `ResourceCache` is unable to resolve during a capture.
+/// The image has to be transferred to `Renderer` and locked with the
+/// external image handler to get the actual contents and serialize them.
 #[derive(Deserialize, Serialize)]
 pub struct ExternalCaptureImage {
     pub short_path: String,
@@ -102,6 +105,9 @@ pub struct ExternalCaptureImage {
     pub external: ExternalImageData,
 }
 
+/// A short description of an external image to be saved separately as
+/// "externals/XX.ron", redirecting into a specific texture/blob with
+/// the corresponding UV rectangle.
 #[derive(Deserialize, Serialize)]
 pub struct PlainExternalImage {
     /// Path to the RON file describing the texel data.

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -96,6 +96,7 @@ pub struct PrimitiveRunLocalRect {
 /// that is stored in the frame. This allows the render
 /// thread to iterate this list and update any changed
 /// texture data and update the UV rect.
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub struct DeferredResolve {
     pub address: GpuCacheAddress,
     pub image_properties: ImageProperties,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -62,6 +62,7 @@ pub struct CacheItem {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "capture", derive(Deserialize, Serialize))]
 pub struct ImageProperties {
     pub descriptor: ImageDescriptor,
     pub external_image: Option<ExternalImageData>,
@@ -1022,6 +1023,7 @@ impl ResourceCache {
     pub fn save_capture(
         &mut self, root: &PathBuf
     ) -> (PlainResources, Vec<ExternalCaptureImage>) {
+        #[cfg(feature = "png")]
         use device::ReadPixelsFormat;
         use std::fs;
         use std::io::Write;

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -767,7 +767,6 @@ pub struct Frame {
     // from the backend thread. The render thread
     // will use a callback to resolve these and
     // patch the data structures.
-    #[cfg_attr(feature = "capture", serde(skip))]
     pub deferred_resolves: Vec<DeferredResolve>,
 
     // True if this frame contains any render tasks


### PR DESCRIPTION
Found a few issues while playing with Gecko captures:
  - Cleaner comments/names
  - Fixed CPU side mirroring of GPU cache
  - Fixed native texture map reusal on Load()
  - Fixed resource updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2332)
<!-- Reviewable:end -->
