### PR TITLE
Update RON to enable array indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ron"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1030,7 +1030,7 @@ dependencies = [
  "png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1091,7 +1091,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1248,7 +1248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
-"checksum ron 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65d83b510b781c24b86db69aa8d1a1befffae7b64944ea1fea7243cd3bb72cfb"
+"checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = { optional = true, version = "1.0" }
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 image = { optional = true, version = "0.17" }
 base64 = { optional = true, version = "0.3.0" }
-ron = { optional = true, version = "0.1.5" }
+ron = { optional = true, version = "0.1.7" }
 
 [dev-dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}

--- a/webrender/src/capture.rs
+++ b/webrender/src/capture.rs
@@ -24,7 +24,10 @@ impl CaptureConfig {
         CaptureConfig {
             root,
             bits,
-            pretty: ser::PrettyConfig::default(),
+            pretty: ser::PrettyConfig {
+                enumerate_arrays: true,
+                .. ser::PrettyConfig::default()
+            },
         }
     }
 


### PR DESCRIPTION
This change makes RON to insert comments with indices for serialized arrays, e.g. `// [23]`. It's a small improvement that has great affect on our ability to trace objects linked in different structures. See tracing example below.

---
Supposing we are looking at a GPU capture and noticing an image of size 196. Peeking into `backend.ron` we find this item in the `image_templates` map:
```rust
            ((1), 1): (
                data: "images/1.raw",
                descriptor: (
                    format: BGRA8,
                    width: 196,
                    height: 196,
                    stride: None,
                    offset: 0,
                    is_opaque: true,
                ),
                epoch: (0),
                tiling: None,
            ),
```
This gives us the image key `((1), 1)`. We can see it now in the `scene-1-0.ron` display list:
```rust
                    item: Image((
                        image_key: ((1), 1),
                        stretch_size: (200, 200),
                        tile_spacing: (0, 0),
                        image_rendering: Auto,
                        alpha_type: PremultipliedAlpha,
                    )),
                    clip_and_scroll: (
                        scroll_node_id: Clip(0, (0, 0)),
                        clip_node_id: None,
                    ),
                    info: (
                        rect: ((0, 0), (200, 200)),
                        local_clip: Rect(((0, 0), (1920, 1080))),
                        is_backface_visible: true,
                        tag: None,
                    ),
```

We can also find the cached image of it in `resource_cache.ron`:
```rust
            (
                key: ((1), 1),
                rendering: Auto,
                tile: None,
            ): Ok((
                texture_cache_handle: (
                    entry: Some((
                        index: 75,
                        epoch: (0),
                        _marker: (),
                    )),
                ),
                epoch: (0),
            )),
```
This leads us to the texture cache entry:
```rust
                (
                    next: None,
                    epoch: (0),
                    value: Some((
                        size: (196, 196),
                        kind: Cache(
                            origin: (1792, 1792),
                            layer_index: 3,
                            region_index: 63,
                        ),
                        user_data: (0, 0, 0),
                        last_access: (1),
                        uv_rect_handle: (
                            location: Some((
                                block_index: (895),
                                epoch: (0),
                            )),
                        ),
                        format: BGRA8,
                        filter: Linear,
                        texture_id: (0),
                    )),
                ),// [75]
```
From there we can go even deeper by looking at the region:
```rust
                (
                    layer_index: 3,
                    region_size: 512,
                    slab_size: 256,
                    free_slots: [
                        (0, 0),// [0]
                        (1, 0),// [1]
                        (0, 1),// [2]
                    ],
                    slots_per_axis: 2,
                    total_slot_count: 4,
                    origin: (1536, 1536),
                ),// [63]
```
Eventually leading to the UV rectangle handle in `gpu_cache.ron`:
```rust
            (
                address: (
                    u: 1022,
                    v: 2,
                ),
                next: Some((375)),
                epoch: (0),
                last_access_time: (2),
            ),// [895]
```
We can then compute the GPU block index as 1022 + 2 * 1024 = 3070 and find the associated batch in `frame-1-0.ron`:
```rust
                                    key: (
                                        kind: Transformable(Complex, Image(Texture2DArray)),
                                        blend_mode: PremultipliedAlpha,
                                        textures: (
                                            colors: (TextureCache((0)), Invalid, Invalid),
                                        ),
                                    ),
                                    instances: [
                                        (
                                            data: (1020, 0, 2147483647, 2, 5, 3070, 0, 0),
                                        ),// [0]
                                        (
                                            data: (1016, 0, 2147483647, 3, 7, 3070, 0, 0),
                                        ),// [1]
                                        (
                                            data: (1012, 0, 2147483647, 4, 9, 3070, 0, 0),
                                        ),// [2]
                                        (
                                            data: (1008, 0, 2147483647, 5, 11, 3070, 0, 0),
                                        ),// [3]
                                        (
                                            data: (1004, 0, 2147483647, 6, 13, 3070, 0, 0),
                                        ),// [4]
                                        (
                                            data: (1000, 0, 2147483647, 7, 15, 3070, 0, 0),
                                        ),// [5]
                                    ],
                                    item_rects: [
                                        ((145, 247), (310, 163)),// [0]
                                        ((590, 145), (163, 310)),// [1]
                                        ((932, 140), (265, 275)),// [2]
                                        ((218, 591), (178, 224)),// [3]
                                        ((500, 600), (400, 200)),// [4]
                                        ((961, 553), (278, 294)),// [5]
                                    ],
```
Thus, we traced through all the state and found every piece of the picture related to an item. We can read it, change it, and likely to have a better idea of what went wrong there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2340)
<!-- Reviewable:end -->
