### PR TITLE
Fix a number of small issues with profiler.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -20,7 +20,7 @@ use frame::FrameContext;
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use gpu_cache::GpuCache;
 use internal_types::{DebugOutput, FastHashMap, FastHashSet, RenderedDocument, ResultMsg};
-use profiler::{BackendProfileCounters, ResourceProfileCounters};
+use profiler::{BackendProfileCounters, IpcProfileCounters, ResourceProfileCounters};
 use rayon::ThreadPool;
 use record::ApiRecordingReceiver;
 use resource_cache::ResourceCache;
@@ -260,7 +260,8 @@ impl RenderBackend {
         document_id: DocumentId,
         message: DocumentMsg,
         frame_counter: u32,
-        profile_counters: &mut BackendProfileCounters,
+        ipc_profile_counters: &mut IpcProfileCounters,
+        resource_profile_counters: &mut ResourceProfileCounters,
     ) -> DocumentOps {
         let doc = self.documents.get_mut(&document_id).expect("No document?");
 
@@ -332,7 +333,6 @@ impl RenderBackend {
                 let display_list_received_time = precise_time_ns();
 
                 {
-                    let _timer = profile_counters.total_time.timer();
                     doc.scene.set_display_list(
                         pipeline_id,
                         epoch,
@@ -352,7 +352,7 @@ impl RenderBackend {
                 // really simple and cheap to access, so it's not a big deal.
                 let display_list_consumed_time = precise_time_ns();
 
-                profile_counters.ipc.set(
+                ipc_profile_counters.set(
                     builder_start_time,
                     builder_finish_time,
                     send_start_time,
@@ -368,7 +368,7 @@ impl RenderBackend {
 
                 self.resource_cache.update_resources(
                     updates,
-                    &mut profile_counters.resources
+                    resource_profile_counters
                 );
 
                 DocumentOps::nop()
@@ -396,7 +396,6 @@ impl RenderBackend {
             }
             DocumentMsg::Scroll(delta, cursor, move_phase) => {
                 profile_scope!("Scroll");
-                let _timer = profile_counters.total_time.timer();
 
                 let should_render = doc.frame_ctx.scroll(delta, cursor, move_phase)
                     && doc.render_on_scroll == Some(true);
@@ -409,11 +408,12 @@ impl RenderBackend {
             }
             DocumentMsg::HitTest(pipeline_id, point, flags, tx) => {
                 profile_scope!("HitTest");
+
                 if doc.render_on_hittest {
                     doc.render(
                         &mut self.resource_cache,
                         &mut self.gpu_cache,
-                        &mut profile_counters.resources,
+                        resource_profile_counters,
                     );
                     doc.render_on_hittest = false;
                 }
@@ -428,7 +428,6 @@ impl RenderBackend {
             }
             DocumentMsg::ScrollNodeWithId(origin, id, clamp) => {
                 profile_scope!("ScrollNodeWithScrollId");
-                let _timer = profile_counters.total_time.timer();
 
                 let should_render = doc.frame_ctx.scroll_node(origin, id, clamp)
                     && doc.render_on_scroll == Some(true);
@@ -441,7 +440,6 @@ impl RenderBackend {
             }
             DocumentMsg::TickScrollingBounce => {
                 profile_scope!("TickScrollingBounce");
-                let _timer = profile_counters.total_time.timer();
 
                 doc.frame_ctx.tick_scrolling_bounce_animations();
 
@@ -471,8 +469,6 @@ impl RenderBackend {
                 DocumentOps::build()
             }
             DocumentMsg::GenerateFrame => {
-                let _timer = profile_counters.total_time.timer();
-
                 let mut op = DocumentOps::nop();
 
                 if let Some(ref mut ros) = doc.render_on_scroll {
@@ -656,12 +652,14 @@ impl RenderBackend {
     ) {
         let mut op = DocumentOps::nop();
         for doc_msg in doc_msgs {
+            let _timer = profile_counters.total_time.timer();
             op.combine(
                 self.process_document(
                     document_id,
                     doc_msg,
                     *frame_counter,
-                    profile_counters,
+                    &mut profile_counters.ipc,
+                    &mut profile_counters.resources,
                 )
             );
         }
@@ -669,6 +667,7 @@ impl RenderBackend {
         let doc = self.documents.get_mut(&document_id).unwrap();
 
         if op.build {
+            let _timer = profile_counters.total_time.timer();
             profile_scope!("build scene");
             doc.build_scene(&mut self.resource_cache);
             doc.render_on_hittest = true;
@@ -678,17 +677,26 @@ impl RenderBackend {
             profile_scope!("generate frame");
 
             *frame_counter += 1;
-            let rendered_document = doc.render(
-                &mut self.resource_cache,
-                &mut self.gpu_cache,
-                &mut profile_counters.resources,
-            );
 
-            info!("generated frame for document {:?} with {} passes",
-                document_id, rendered_document.frame.passes.len());
+            // borrow ck hack for profile_counters
+            let (pending_update, rendered_document) = {
+                let _timer = profile_counters.total_time.timer();
 
-            // Publish the frame
-            let pending_update = self.resource_cache.pending_updates();
+                let rendered_document = doc.render(
+                    &mut self.resource_cache,
+                    &mut self.gpu_cache,
+                    &mut profile_counters.resources,
+                );
+
+                info!("generated frame for document {:?} with {} passes",
+                    document_id, rendered_document.frame.passes.len());
+
+                // Publish the frame
+                let pending_update = self.resource_cache.pending_updates();
+
+                (pending_update, rendered_document)
+            };
+
             let msg = ResultMsg::PublishDocument(
                 document_id,
                 rendered_document,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2368,7 +2368,6 @@ impl Renderer {
     /// Should be called before `render()`, as texture cache updates are done here.
     pub fn update(&mut self) {
         profile_scope!("update");
-
         // Pull any pending results and return the most recent.
         while let Ok(msg) = self.result_rx.try_recv() {
             match msg {
@@ -2753,7 +2752,6 @@ impl Renderer {
         framebuffer_size: Option<DeviceUintSize>
     ) -> Result<RendererStats, Vec<RendererError>> {
         profile_scope!("render");
-
         if self.active_documents.is_empty() {
             self.last_time = precise_time_ns();
             return Ok(RendererStats::empty());
@@ -2896,6 +2894,7 @@ impl Renderer {
             }
         }
 
+        self.backend_profile_counters.reset();
         self.profile_counters.reset();
         self.profile_counters.frame_counter.inc();
 

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -464,11 +464,19 @@ fn main() {
         }
 
         let mut do_frame = false;
+        let mut do_render = false;
 
         for event in events {
             match event {
                 glutin::Event::Closed => {
                     break 'outer;
+                }
+
+                glutin::Event::Refresh |
+                glutin::Event::Awakened |
+                glutin::Event::Focused(..) |
+                glutin::Event::MouseMoved(..) => {
+                    do_render = true;
                 }
 
                 glutin::Event::KeyboardInput(ElementState::Pressed, _scan_code, Some(vk)) => match vk {
@@ -477,23 +485,29 @@ fn main() {
                     }
                     VirtualKeyCode::P => {
                         wrench.renderer.toggle_debug_flags(DebugFlags::PROFILER_DBG);
+                        do_render = true;
                     }
                     VirtualKeyCode::O => {
                         wrench.renderer.toggle_debug_flags(DebugFlags::RENDER_TARGET_DBG);
+                        do_render = true;
                     }
                     VirtualKeyCode::I => {
                         wrench.renderer.toggle_debug_flags(DebugFlags::TEXTURE_CACHE_DBG);
+                        do_render = true;
                     }
                     VirtualKeyCode::B => {
                         wrench.renderer.toggle_debug_flags(DebugFlags::ALPHA_PRIM_DBG);
+                        do_render = true;
                     }
                     VirtualKeyCode::S => {
                         wrench.renderer.toggle_debug_flags(DebugFlags::COMPACT_PROFILER);
+                        do_render = true;
                     }
                     VirtualKeyCode::Q => {
                         wrench.renderer.toggle_debug_flags(
                             DebugFlags::GPU_TIME_QUERIES | DebugFlags::GPU_SAMPLE_QUERIES
                         );
+                        do_render = true;
                     }
                     VirtualKeyCode::R => {
                         wrench.set_page_zoom(ZoomFactor::new(1.0));
@@ -501,9 +515,11 @@ fn main() {
                     }
                     VirtualKeyCode::M => {
                         wrench.api.notify_memory_pressure();
+                        do_render = true;
                     }
                     VirtualKeyCode::L => {
                         do_loop = !do_loop;
+                        do_render = true;
                     }
                     VirtualKeyCode::Left => {
                         thing.prev_frame();
@@ -515,6 +531,7 @@ fn main() {
                     }
                     VirtualKeyCode::H => {
                         show_help = !show_help;
+                        do_render = true;
                     }
                     VirtualKeyCode::T => {
                         let file_name = format!("profile-{}.json", cpu_profile_index);
@@ -539,7 +556,7 @@ fn main() {
                         wrench.set_page_zoom(new_zoom_factor);
                         do_frame = true;
                     }
-                    _ => (),
+                    _ => {}
                 }
                 _ => {}
             }
@@ -555,15 +572,17 @@ fn main() {
             }
         }
 
-        if show_help {
-            wrench.show_onscreen_help();
-        }
+        if do_render {
+            if show_help {
+                wrench.show_onscreen_help();
+            }
 
-        wrench.render();
-        window.swap_buffers();
+            wrench.render();
+            window.swap_buffers();
 
-        if do_loop {
-            thing.next_frame();
+            if do_loop {
+                thing.next_frame();
+            }
         }
     }
 


### PR DESCRIPTION
* Backend CPU profile counter wasn't including time spent
  in doc.build_scene() or doc.render() so was almost
  always zero. This probably occurred recently in some of
  the document and/or transaction changes.

* Reset the backend profile counters after rendering a
  frame. This means that if we render a frame twice
  without invoking the render backend, we don't double
  count the render backend time from building that frame.
  This also makes it really clear in the profile view
  when we are rendering the same frame multiple times,
  which lead to:

* Modify wrench so that we only do a frame render when
  it makes sense. That is, if we change a state in the
  renderer itself (e.g. a debug flag), or we've received
  the result of a render backend frame. Previously, we'd
  do a render on every keypress, which meant that we were
  typically rendering two frames for every backend frame.
  It also renders on mousemove, which gives a quick way
  to see how stable the GPU time is when drawing the
  same frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2341)
<!-- Reviewable:end -->
