### PR TITLE
Track removed pipelines and expose them in the renderer.

### DIFF
--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -314,6 +314,8 @@ pub fn main_wrapper<E: Example>(
 
         renderer.update();
         renderer.render(framebuffer_size).unwrap();
+        let _ = renderer.flush_rendered_epochs();
+        let _ = renderer.flush_removed_pipelines();
         example.draw_custom(&*gl);
         window.swap_buffers().ok();
     }

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -314,8 +314,7 @@ pub fn main_wrapper<E: Example>(
 
         renderer.update();
         renderer.render(framebuffer_size).unwrap();
-        let _ = renderer.flush_rendered_epochs();
-        let _ = renderer.flush_removed_pipelines();
+        let _ = renderer.flush_pipeline_info();
         example.draw_custom(&*gl);
         window.swap_buffers().ok();
     }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -22,6 +22,7 @@ use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
 use tiling::{CompositeOps, Frame};
+use renderer::PipelineInfo;
 use std::mem::replace;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Ord)]
@@ -1117,8 +1118,10 @@ impl FrameContext {
     pub fn make_rendered_document(&mut self, frame: Frame) -> RenderedDocument {
         let nodes_bouncing_back = self.clip_scroll_tree.collect_nodes_bouncing_back();
         RenderedDocument::new(
-            self.pipeline_epoch_map.clone(),
-            replace(&mut self.removed_pipelines, Vec::new()),
+            PipelineInfo {
+                epochs: self.pipeline_epoch_map.clone(),
+                removed_pipelines: replace(&mut self.removed_pipelines, Vec::new()),
+            },
             nodes_bouncing_back,
             frame
         )

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -22,6 +22,7 @@ use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
 use tiling::{CompositeOps, Frame};
+use std::mem::replace;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Ord)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -958,6 +959,7 @@ pub struct FrameContext {
     window_size: DeviceUintSize,
     clip_scroll_tree: ClipScrollTree,
     pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+    removed_pipelines: Vec<PipelineId>,
     id: FrameId,
     pub frame_builder_config: FrameBuilderConfig,
 }
@@ -967,6 +969,7 @@ impl FrameContext {
         FrameContext {
             window_size: DeviceUintSize::zero(),
             pipeline_epoch_map: FastHashMap::default(),
+            removed_pipelines: Vec::new(),
             clip_scroll_tree: ClipScrollTree::new(),
             id: FrameId(0),
             frame_builder_config: config,
@@ -1023,7 +1026,7 @@ impl FrameContext {
     pub fn create_frame_builder(
         &mut self,
         old_builder: FrameBuilder,
-        scene: &Scene,
+        scene: &mut Scene,
         resource_cache: &mut ResourceCache,
         window_size: DeviceUintSize,
         inner_rect: DeviceUintRect,
@@ -1101,6 +1104,9 @@ impl FrameContext {
 
         self.clip_scroll_tree
             .finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
+
+        self.removed_pipelines.extend(scene.removed_pipelines.drain(..));
+
         frame_builder
     }
 
@@ -1108,9 +1114,14 @@ impl FrameContext {
         self.pipeline_epoch_map.insert(pipeline_id, epoch);
     }
 
-    pub fn make_rendered_document(&self, frame: Frame) -> RenderedDocument {
+    pub fn make_rendered_document(&mut self, frame: Frame) -> RenderedDocument {
         let nodes_bouncing_back = self.clip_scroll_tree.collect_nodes_bouncing_back();
-        RenderedDocument::new(self.pipeline_epoch_map.clone(), nodes_bouncing_back, frame)
+        RenderedDocument::new(
+            self.pipeline_epoch_map.clone(),
+            replace(&mut self.removed_pipelines, Vec::new()),
+            nodes_bouncing_back,
+            frame
+        )
     }
 
     //TODO: this can probably be simplified if `build()` is called directly by RB.

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, DeviceUintRect, DocumentId, Epoch};
+use api::{ClipId, DeviceUintRect, DocumentId};
 use api::{ExternalImageData, ExternalImageId};
-use api::{ImageFormat, PipelineId};
+use api::ImageFormat;
 use api::DebugCommand;
 use device::TextureFilter;
+use renderer::PipelineInfo;
 use gpu_cache::GpuCacheUpdateList;
 use fxhash::FxHasher;
 use profiler::BackendProfileCounters;
@@ -131,12 +132,12 @@ impl TextureUpdateList {
 
 /// Mostly wraps a tiling::Frame, adding a bit of extra information.
 pub struct RenderedDocument {
-    /// The last rendered epoch for each pipeline present in the frame.
+    /// The pipeline info contains:
+    /// - The last rendered epoch for each pipeline present in the frame.
     /// This information is used to know if a certain transformation on the layout has
     /// been rendered, which is necessary for reftests.
-    pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
-    /// Pipelines that were removed from the scene.
-    pub removed_pipelines: Vec<PipelineId>,
+    /// - Pipelines that were removed from the scene.
+    pub pipeline_info: PipelineInfo,
     /// The layers that are currently affected by the over-scrolling animation.
     pub layers_bouncing_back: FastHashSet<ClipId>,
 
@@ -145,14 +146,12 @@ pub struct RenderedDocument {
 
 impl RenderedDocument {
     pub fn new(
-        pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
-        removed_pipelines: Vec<PipelineId>,
+        pipeline_info: PipelineInfo,
         layers_bouncing_back: FastHashSet<ClipId>,
         frame: tiling::Frame,
     ) -> Self {
         RenderedDocument {
-            pipeline_epoch_map,
-            removed_pipelines,
+            pipeline_info,
             layers_bouncing_back,
             frame,
         }

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -135,6 +135,8 @@ pub struct RenderedDocument {
     /// This information is used to know if a certain transformation on the layout has
     /// been rendered, which is necessary for reftests.
     pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+    /// Pipelines that were removed from the scene.
+    pub removed_pipelines: Vec<PipelineId>,
     /// The layers that are currently affected by the over-scrolling animation.
     pub layers_bouncing_back: FastHashSet<ClipId>,
 
@@ -144,11 +146,13 @@ pub struct RenderedDocument {
 impl RenderedDocument {
     pub fn new(
         pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+        removed_pipelines: Vec<PipelineId>,
         layers_bouncing_back: FastHashSet<ClipId>,
         frame: tiling::Frame,
     ) -> Self {
         RenderedDocument {
             pipeline_epoch_map,
+            removed_pipelines,
             layers_bouncing_back,
             frame,
         }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -126,7 +126,7 @@ impl Document {
         // this code is why we have `Option`, which is never `None`
         let frame_builder = self.frame_ctx.create_frame_builder(
             self.frame_builder.take().unwrap(),
-            &self.scene,
+            &mut self.scene,
             resource_cache,
             self.view.window_size,
             self.view.inner_rect,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -37,9 +37,9 @@ use serde_json;
 use std::path::PathBuf;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use std::sync::mpsc::Sender;
+use std::mem::replace;
 use std::u32;
 use time::precise_time_ns;
-
 
 #[cfg_attr(feature = "capture", derive(Clone, Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -72,6 +72,12 @@ struct Document {
     // A set of pipelines that the caller has requested be
     // made available as output textures.
     output_pipelines: FastHashSet<PipelineId>,
+    // The pipeline removal notifications that will be sent in the next frame.
+    // Because of async scene building, removed pipelines should not land here
+    // as soon as the render backend receives a DocumentMsg::RemovePipeline.
+    // Instead, the notification should be added to this list when the first
+    // scene that does not contain the pipeline becomes current.
+    removed_pipelines: Vec<PipelineId>,
     // A helper switch to prevent any frames rendering triggered by scrolling
     // messages between `SetDisplayList` and `GenerateFrame`.
     // If we allow them, then a reftest that scrolls a few layers before generating
@@ -104,6 +110,7 @@ impl Document {
         };
         Document {
             scene: Scene::new(),
+            removed_pipelines: Vec::new(),
             view: DocumentView {
                 window_size,
                 inner_rect: DeviceUintRect::new(DeviceUintPoint::zero(), window_size),
@@ -126,13 +133,14 @@ impl Document {
         // this code is why we have `Option`, which is never `None`
         let frame_builder = self.frame_ctx.create_frame_builder(
             self.frame_builder.take().unwrap(),
-            &mut self.scene,
+            &self.scene,
             resource_cache,
             self.view.window_size,
             self.view.inner_rect,
             self.view.accumulated_scale_factor(),
             &self.output_pipelines,
         );
+        self.removed_pipelines.extend(self.scene.removed_pipelines.drain(..));
         self.frame_builder = Some(frame_builder);
     }
 
@@ -155,6 +163,7 @@ impl Document {
             &mut resource_profile.texture_cache,
             &mut resource_profile.gpu_cache,
             &self.scene.properties,
+            replace(&mut self.removed_pipelines, Vec::new()),
         );
 
         self.hit_tester = Some(hit_tester);
@@ -976,6 +985,7 @@ impl RenderBackend {
                 output_pipelines: FastHashSet::default(),
                 render_on_scroll: None,
                 render_on_hittest: false,
+                removed_pipelines: Vec::new(),
                 hit_tester: None,
             };
 
@@ -983,7 +993,7 @@ impl RenderBackend {
             let render_doc = match CaptureConfig::deserialize::<Frame, _>(root, frame_name) {
                 Some(frame) => {
                     info!("\tloaded a built frame with {} passes", frame.passes.len());
-                    doc.frame_ctx.make_rendered_document(frame)
+                    doc.frame_ctx.make_rendered_document(frame, Vec::new())
                 }
                 None => {
                     doc.build_scene(&mut self.resource_cache);

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -101,6 +101,7 @@ pub struct ScenePipeline {
 pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipelines: FastHashMap<PipelineId, ScenePipeline>,
+    pub removed_pipelines: Vec<PipelineId>,
     pub properties: SceneProperties,
 }
 
@@ -109,6 +110,7 @@ impl Scene {
         Scene {
             root_pipeline_id: None,
             pipelines: FastHashMap::default(),
+            removed_pipelines: Vec::new(),
             properties: SceneProperties::new(),
         }
     }
@@ -143,6 +145,7 @@ impl Scene {
             self.root_pipeline_id = None;
         }
         self.pipelines.remove(&pipeline_id);
+        self.removed_pipelines.push(pipeline_id);
     }
 
     pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -548,8 +548,7 @@ impl Wrench {
 
     pub fn render(&mut self) -> RendererStats {
         self.renderer.update();
-        let _ = self.renderer.flush_rendered_epochs();
-        let _ = self.renderer.flush_removed_pipelines();
+        let _ = self.renderer.flush_pipeline_info();
         self.renderer
             .render(self.window_size)
             .expect("errors encountered during render!")

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -548,6 +548,8 @@ impl Wrench {
 
     pub fn render(&mut self) -> RendererStats {
         self.renderer.update();
+        let _ = self.renderer.flush_rendered_epochs();
+        let _ = self.renderer.flush_removed_pipelines();
         self.renderer
             .render(self.window_size)
             .expect("errors encountered during render!")


### PR DESCRIPTION
This information is useful to manage the lifetime of resources that are owned by the embedder and used by the renderer such as external images.

Fixes #2345.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2347)
<!-- Reviewable:end -->
