### PR TITLE
A few more tidy ups of frame builder context state.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -141,6 +141,7 @@ pub struct FrameState<'a> {
     pub clip_store: &'a mut ClipStore,
     pub local_clip_rects: &'a mut Vec<LayerRect>,
     pub resource_cache: &'a mut ResourceCache,
+    pub gpu_cache: &'a mut GpuCache,
 }
 
 pub struct PrimitiveRunContext<'a> {
@@ -1631,6 +1632,7 @@ impl FrameBuilder {
             clip_store: &mut self.clip_store,
             local_clip_rects,
             resource_cache,
+            gpu_cache,
         };
 
         let root_prim_run_context = PrimitiveRunContext::new(
@@ -1644,7 +1646,6 @@ impl FrameBuilder {
         self.prim_store.prepare_prim_runs(
             &prim_run_cmds,
             root_clip_scroll_node.pipeline_id,
-            gpu_cache,
             &root_prim_run_context,
             true,
             &mut child_tasks,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -139,6 +139,7 @@ pub struct FrameState<'a> {
     pub render_tasks: &'a mut RenderTaskTree,
     pub profile_counters: &'a mut FrameProfileCounters,
     pub clip_store: &'a mut ClipStore,
+    pub local_clip_rects: &'a mut Vec<LayerRect>,
 }
 
 pub struct PrimitiveRunContext<'a> {
@@ -1596,7 +1597,7 @@ impl FrameBuilder {
         profile_counters: &mut FrameProfileCounters,
         device_pixel_scale: DevicePixelScale,
         scene_properties: &SceneProperties,
-        local_rects: &mut Vec<LayerRect>,
+        local_clip_rects: &mut Vec<LayerRect>,
         node_data: &[ClipScrollNodeData],
     ) -> Option<RenderTaskId> {
         profile_scope!("cull");
@@ -1627,6 +1628,7 @@ impl FrameBuilder {
             render_tasks,
             profile_counters,
             clip_store: &mut self.clip_store,
+            local_clip_rects,
         };
 
         let root_prim_run_context = PrimitiveRunContext::new(
@@ -1647,7 +1649,6 @@ impl FrameBuilder {
             &mut child_tasks,
             None,
             SpecificPrimitiveIndex(0),
-            local_rects,
             &frame_context,
             &mut frame_state,
         );

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -140,6 +140,7 @@ pub struct FrameState<'a> {
     pub profile_counters: &'a mut FrameProfileCounters,
     pub clip_store: &'a mut ClipStore,
     pub local_clip_rects: &'a mut Vec<LayerRect>,
+    pub resource_cache: &'a mut ResourceCache,
 }
 
 pub struct PrimitiveRunContext<'a> {
@@ -1629,6 +1630,7 @@ impl FrameBuilder {
             profile_counters,
             clip_store: &mut self.clip_store,
             local_clip_rects,
+            resource_cache,
         };
 
         let root_prim_run_context = PrimitiveRunContext::new(
@@ -1643,7 +1645,6 @@ impl FrameBuilder {
             &prim_run_cmds,
             root_clip_scroll_node.pipeline_id,
             gpu_cache,
-            resource_cache,
             &root_prim_run_context,
             true,
             &mut child_tasks,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -20,7 +20,7 @@ use euclid::{SideOffsets2D, vec2};
 use frame::FrameId;
 use glyph_rasterizer::FontInstance;
 use gpu_cache::GpuCache;
-use gpu_types::{ClipScrollNodeData, PictureType};
+use gpu_types::{ClipChainRectIndex, ClipScrollNodeData, PictureType};
 use internal_types::{FastHashMap, FastHashSet, RenderPassIndex};
 use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive, PictureSurface};
 use prim_store::{BrushKind, BrushPrimitive, ImageCacheKey, YuvImagePrimitiveCpu};
@@ -148,6 +148,7 @@ pub struct PrimitiveRunContext<'a> {
     pub display_list: &'a BuiltDisplayList,
     pub clip_chain: Option<&'a ClipChain>,
     pub scroll_node: &'a ClipScrollNode,
+    pub clip_chain_rect_index: ClipChainRectIndex,
 }
 
 impl<'a> PrimitiveRunContext<'a> {
@@ -155,11 +156,13 @@ impl<'a> PrimitiveRunContext<'a> {
         display_list: &'a BuiltDisplayList,
         clip_chain: Option<&'a ClipChain>,
         scroll_node: &'a ClipScrollNode,
+        clip_chain_rect_index: ClipChainRectIndex,
     ) -> Self {
         PrimitiveRunContext {
             display_list,
             clip_chain,
             scroll_node,
+            clip_chain_rect_index,
         }
     }
 }
@@ -1639,6 +1642,7 @@ impl FrameBuilder {
             display_list,
             root_clip_scroll_node.clip_chain.as_ref(),
             root_clip_scroll_node,
+            ClipChainRectIndex(0),
         );
 
         let mut child_tasks = Vec::new();

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -13,7 +13,7 @@ use gpu_types::{BrushImageKind, PictureType};
 use prim_store::{BrushKind, BrushPrimitive, PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheKey};
 use render_task::{RenderTaskCacheKeyKind, RenderTaskId};
-use resource_cache::{CacheItem, ResourceCache};
+use resource_cache::CacheItem;
 use scene::{FilterOpHelpers, SceneProperties};
 use tiling::RenderTargetKind;
 
@@ -333,7 +333,6 @@ impl PicturePrimitive {
         prim_local_rect: &LayerRect,
         child_tasks: Vec<RenderTaskId>,
         parent_tasks: &mut Vec<RenderTaskId>,
-        resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         frame_context: &FrameContext,
         frame_state: &mut FrameState,
@@ -532,7 +531,7 @@ impl PicturePrimitive {
                 // Request the texture cache item for this box-shadow key. If it
                 // doesn't exist in the cache, the closure is invoked to build
                 // a render task chain to draw the cacheable result.
-                let cache_item = resource_cache.request_render_task(
+                let cache_item = frame_state.resource_cache.request_render_task(
                     RenderTaskCacheKey {
                         size: cache_size,
                         kind: RenderTaskCacheKeyKind::BoxShadow(cache_key),

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -8,7 +8,7 @@ use api::{BoxShadowClipMode, LayerPoint, LayerRect, LayerVector2D, Shadow};
 use api::{ClipId, PremultipliedColorF};
 use box_shadow::{BLUR_SAMPLE_SCALE, BoxShadowCacheKey};
 use frame_builder::{FrameContext, FrameState};
-use gpu_cache::{GpuCache, GpuDataRequest};
+use gpu_cache::GpuDataRequest;
 use gpu_types::{BrushImageKind, PictureType};
 use prim_store::{BrushKind, BrushPrimitive, PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheKey};
@@ -333,7 +333,6 @@ impl PicturePrimitive {
         prim_local_rect: &LayerRect,
         child_tasks: Vec<RenderTaskId>,
         parent_tasks: &mut Vec<RenderTaskId>,
-        gpu_cache: &mut GpuCache,
         frame_context: &FrameContext,
         frame_state: &mut FrameState,
     ) {
@@ -536,7 +535,7 @@ impl PicturePrimitive {
                         size: cache_size,
                         kind: RenderTaskCacheKeyKind::BoxShadow(cache_key),
                     },
-                    gpu_cache,
+                    frame_state.gpu_cache,
                     frame_state.render_tasks,
                     |render_tasks| {
                         // Quote from https://drafts.csswg.org/css-backgrounds-3/#shadow-blur

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1709,7 +1709,6 @@ impl PrimitiveStore {
         parent_tasks: &mut Vec<RenderTaskId>,
         pic_index: SpecificPrimitiveIndex,
         clip_chain_rect_index: ClipChainRectIndex,
-        local_rects: &mut Vec<LayerRect>,
         frame_context: &FrameContext,
         frame_state: &mut FrameState,
     ) -> Option<LayerRect> {
@@ -1771,7 +1770,6 @@ impl PrimitiveStore {
                 &mut child_tasks,
                 rfid,
                 cpu_prim_index,
-                local_rects,
                 frame_context,
                 frame_state,
             );
@@ -1871,7 +1869,6 @@ impl PrimitiveStore {
         parent_tasks: &mut Vec<RenderTaskId>,
         original_reference_frame_id: Option<ClipId>,
         pic_index: SpecificPrimitiveIndex,
-        local_rects: &mut Vec<LayerRect>,
         frame_context: &FrameContext,
         frame_state: &mut FrameState,
     ) -> PrimitiveRunLocalRect {
@@ -1946,8 +1943,8 @@ impl PrimitiveStore {
             let clip_chain_rect_index = match clip_chain_rect {
                 Some(rect) if rect.is_empty() => continue,
                 Some(rect) => {
-                    local_rects.push(rect);
-                    ClipChainRectIndex(local_rects.len() - 1)
+                    frame_state.local_clip_rects.push(rect);
+                    ClipChainRectIndex(frame_state.local_clip_rects.len() - 1)
                 }
                 None => ClipChainRectIndex(0), // This is no clipping.
             };
@@ -1965,7 +1962,6 @@ impl PrimitiveStore {
                     parent_tasks,
                     pic_index,
                     clip_chain_rect_index,
-                    local_rects,
                     frame_context,
                     frame_state,
                 ) {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1705,7 +1705,6 @@ impl PrimitiveStore {
         perform_culling: bool,
         parent_tasks: &mut Vec<RenderTaskId>,
         pic_index: SpecificPrimitiveIndex,
-        clip_chain_rect_index: ClipChainRectIndex,
         frame_context: &FrameContext,
         frame_state: &mut FrameState,
     ) -> Option<LayerRect> {
@@ -1812,7 +1811,7 @@ impl PrimitiveStore {
                 return None;
             }
 
-            metadata.clip_chain_rect_index = clip_chain_rect_index;
+            metadata.clip_chain_rect_index = prim_run_context.clip_chain_rect_index;
 
             (local_rect, screen_bounding_rect)
         };
@@ -1918,12 +1917,6 @@ impl PrimitiveStore {
                 .expect("No display list?")
                 .display_list;
 
-            let child_prim_run_context = PrimitiveRunContext::new(
-                display_list,
-                clip_chain,
-                scroll_node,
-            );
-
             let clip_chain_rect = match perform_culling {
                 true => get_local_clip_rect_for_nodes(scroll_node, clip_chain),
                 false => None,
@@ -1938,6 +1931,12 @@ impl PrimitiveStore {
                 None => ClipChainRectIndex(0), // This is no clipping.
             };
 
+            let child_prim_run_context = PrimitiveRunContext::new(
+                display_list,
+                clip_chain,
+                scroll_node,
+                clip_chain_rect_index,
+            );
 
             for i in 0 .. run.count {
                 let prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
@@ -1948,7 +1947,6 @@ impl PrimitiveStore {
                     perform_culling,
                     parent_tasks,
                     pic_index,
-                    clip_chain_rect_index,
                     frame_context,
                     frame_state,
                 ) {


### PR DESCRIPTION
Follow up to #2360.

Next step is to introduce ```PictureState``` to hold the remaining fields used during frame building. This is what we'll also use to store the plane splitting state when 3d transforms are present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2361)
<!-- Reviewable:end -->
