### PR TITLE
Async scene building.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -14,7 +14,7 @@ use prim_store::{ClipData, ImageMaskData};
 use resource_cache::{ImageRequest, ResourceCache};
 use util::{LayerToWorldFastTransform, MaxRect, calculate_screen_bounding_rect};
 use util::extract_inner_rect_safe;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub type ClipStore = FreeList<ClipSources>;
 pub type ClipSourcesHandle = FreeListHandle<ClipSources>;
@@ -353,7 +353,7 @@ pub fn rounded_rectangle_contains_point(point: &LayoutPoint,
     true
 }
 
-pub type ClipChainNodeRef = Option<Rc<ClipChainNode>>;
+pub type ClipChainNodeRef = Option<Arc<ClipChainNode>>;
 
 #[derive(Debug, Clone)]
 pub struct ClipChainNode {
@@ -425,7 +425,7 @@ impl ClipChain {
             self.combined_inner_screen_rect.intersection(&new_node.screen_inner_rect)
             .unwrap_or_else(DeviceIntRect::zero);
 
-        self.nodes = Some(Rc::new(new_node));
+        self.nodes = Some(Arc::new(new_node));
     }
 }
 
@@ -434,7 +434,7 @@ pub struct ClipChainNodeIter {
 }
 
 impl Iterator for ClipChainNodeIter {
-    type Item = Rc<ClipChainNode>;
+    type Item = Arc<ClipChainNode>;
 
     fn next(&mut self) -> ClipChainNodeRef {
         let previous = self.current.clone();

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -1207,6 +1207,7 @@ impl FrameContext {
                 pipeline_epochs: Vec::new(),
                 replacements: Vec::new(),
                 output_pipelines: &request.output_pipelines,
+                id_to_index_mapper: ClipIdToIndexMapper::new(),
             };
 
             roller.builder.push_root(
@@ -1214,6 +1215,7 @@ impl FrameContext {
                 &root_pipeline.viewport_size,
                 &root_pipeline.content_size,
                 roller.clip_scroll_tree,
+                &mut roller.id_to_index_mapper,
             );
 
             roller.builder.setup_viewport_offset(

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -27,6 +27,7 @@ use renderer::PipelineInfo;
 use render_backend::{SceneRequest, BuiltScene};
 
 use std::sync::Arc;
+use std::mem::replace;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Ord)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -1175,9 +1176,9 @@ impl FrameContext {
     // This will soon replace the method above and move somewhere else.
     pub fn create_frame_builder_async(
         config: &FrameBuilderConfig,
-        request: SceneRequest,
+        mut request: SceneRequest,
     ) -> BuiltScene {
-        let scene = &request.scene;
+        let scene = &mut request.scene;
         let inner_rect = request.view.inner_rect;
         let window_size = request.view.window_size;
         let device_pixel_scale = request.view.accumulated_scale_factor();
@@ -1246,6 +1247,7 @@ impl FrameContext {
             frame_builder,
             clip_scroll_tree,
             pipeline_epoch_map,
+            removed_pipelines: replace(&mut scene.removed_pipelines, Vec::new()),
             document_id: request.document_id,
             render: request.render,
         }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -1248,8 +1248,6 @@ impl FrameContext {
             clip_scroll_tree,
             pipeline_epoch_map,
             removed_pipelines: replace(&mut scene.removed_pipelines, Vec::new()),
-            document_id: request.document_id,
-            render: request.render,
         }
     }
 

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -427,7 +427,7 @@ impl<'a> FlattenContext<'a> {
             &mut self.id_to_index_mapper,
         );
 
-        let epoch = *self.scene.pipeline_epochs.get(&iframe_pipeline_id).unwrap();
+        let epoch = self.scene.pipeline_epochs[&iframe_pipeline_id];
         self.pipeline_epochs.push((iframe_pipeline_id, epoch));
 
         let bounds = item.rect();
@@ -1113,7 +1113,7 @@ impl FrameContext {
 
         let old_scrolling_states = self.reset();
 
-        let root_epoch = *scene.pipeline_epochs.get(&root_pipeline_id).unwrap();
+        let root_epoch = scene.pipeline_epochs[&root_pipeline_id];
         self.pipeline_epoch_map.insert(root_pipeline_id, root_epoch);
 
 
@@ -1183,7 +1183,7 @@ impl FrameContext {
         let window_size = request.view.window_size;
         let device_pixel_scale = request.view.accumulated_scale_factor();
 
-        // We checked that the root pipeline is available on therender backend.
+        // We checked that the root pipeline is available on the render backend.
         let root_pipeline_id = scene.root_pipeline_id.unwrap();
         let root_pipeline = scene.pipelines.get(&root_pipeline_id).unwrap();
 
@@ -1194,7 +1194,7 @@ impl FrameContext {
         let mut pipeline_epoch_map = FastHashMap::default();
         let mut clip_scroll_tree = ClipScrollTree::new();
 
-        let root_epoch = *scene.pipeline_epochs.get(&root_pipeline_id).unwrap();
+        let root_epoch = scene.pipeline_epochs[&root_pipeline_id];
         pipeline_epoch_map.insert(root_pipeline_id, root_epoch);
 
         let frame_builder = {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -24,7 +24,7 @@ use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
 use tiling::{CompositeOps, Frame};
 use renderer::PipelineInfo;
-use render_backend::SceneRequest;
+use render_backend::{SceneRequest, BuiltScene};
 
 use std::sync::Arc;
 
@@ -1037,10 +1037,15 @@ impl FrameContext {
         self.clip_scroll_tree.drain()
     }
 
-    pub fn set_clip_scroll_tree(&mut self, tree: ClipScrollTree) {
+    pub fn new_async_scene_ready(
+        &mut self,
+        clip_scroll_tree: ClipScrollTree,
+        pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+    ) {
         let old_scrolling_states = self.reset();
-        self.clip_scroll_tree = tree;
+        self.clip_scroll_tree = clip_scroll_tree;
         self.clip_scroll_tree.finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
+        self.pipeline_epoch_map = pipeline_epoch_map;
     }
 
     #[cfg(feature = "debugger")]
@@ -1165,35 +1170,31 @@ impl FrameContext {
         frame_builder
     }
 
-    // WIP: this will likely not end up in FrameContext but for now I am mostly mimicking
-    // the current code.
-    pub fn create_async(
+    // WIP: There is no reason for this to be in FrameContext other than making it easier
+    // to keep in sync with changes with the create_frame_builder method above.
+    // This will soon replace the method above and move somewhere else.
+    pub fn create_frame_builder_async(
         config: &FrameBuilderConfig,
         request: SceneRequest,
-        clip_scroll_tree: &mut ClipScrollTree,
-    ) -> Option<FrameBuilder> {
+    ) -> BuiltScene {
         let scene = &request.scene;
         let inner_rect = request.view.inner_rect;
         let window_size = request.view.window_size;
         let device_pixel_scale = request.view.accumulated_scale_factor();
 
-        let root_pipeline_id = match scene.root_pipeline_id {
-            Some(root_pipeline_id) => root_pipeline_id,
-            None => return None,
-        };
-
-        let root_pipeline = match scene.pipelines.get(&root_pipeline_id) {
-            Some(root_pipeline) => root_pipeline,
-            None => return None,
-        };
-
-        if window_size.width == 0 || window_size.height == 0 {
-            error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
-        }
+        // We checked that the root pipeline is available on therender backend.
+        let root_pipeline_id = scene.root_pipeline_id.unwrap();
+        let root_pipeline = scene.pipelines.get(&root_pipeline_id).unwrap();
 
         let background_color = root_pipeline
             .background_color
             .and_then(|color| if color.a > 0.0 { Some(color) } else { None });
+
+        let mut pipeline_epoch_map = FastHashMap::default();
+        let mut clip_scroll_tree = ClipScrollTree::new();
+
+        let root_epoch = *scene.pipeline_epochs.get(&root_pipeline_id).unwrap();
+        pipeline_epoch_map.insert(root_pipeline_id, root_epoch);
 
         let frame_builder = {
             let mut roller = FlattenContext {
@@ -1205,7 +1206,7 @@ impl FrameContext {
                     window_size,
                     *config,
                 ),
-                clip_scroll_tree,
+                clip_scroll_tree: &mut clip_scroll_tree,
                 font_instances: request.font_instances,
                 tiled_image_map: request.tiled_image_map,
                 pipeline_epochs: Vec::new(),
@@ -1236,15 +1237,18 @@ impl FrameContext {
 
             debug_assert!(roller.builder.picture_stack.is_empty());
 
-            // WIP: move this to the render backend thread I think
-            //self.pipeline_epoch_map.extend(roller.pipeline_epochs.drain(..));
+            pipeline_epoch_map.extend(roller.pipeline_epochs.drain(..));
+
             roller.builder
         };
 
-        // WIP
-        //clip_scroll_tree.finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
-
-        Some(frame_builder)
+        BuiltScene {
+            frame_builder,
+            clip_scroll_tree,
+            pipeline_epoch_map,
+            document_id: request.document_id,
+            render: request.render,
+        }
     }
 
     pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -23,10 +23,10 @@ use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
 use scene_builder::{SceneRequest, BuiltScene};
+use std::sync::Arc;
 use tiling::{CompositeOps, Frame};
 use renderer::PipelineInfo;
 
-use std::sync::Arc;
 
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Eq, Ord)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -1201,7 +1201,7 @@ impl FrameContext {
         pan: WorldPoint,
         texture_cache_profile: &mut TextureCacheProfileCounters,
         gpu_cache_profile: &mut GpuCacheProfileCounters,
-		scene_properties: &SceneProperties,
+        scene_properties: &SceneProperties,
         removed_pipelines: Vec<PipelineId>,
     ) -> (HitTester, RenderedDocument) {
         let frame = frame_builder.build(
@@ -1252,7 +1252,7 @@ pub fn build_scene(
 
         let mut roller = FlattenContext {
             scene,
-            // WIP, we're not really recycling anything here, clean this up.
+            // TODO, we're not really recycling anything here, clean this up.
             builder: FrameBuilder::empty().recycle(
                 inner_rect,
                 background_color,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -82,6 +82,7 @@ pub struct FrameBuilderConfig {
 pub struct FrameBuilder {
     screen_rect: DeviceUintRect,
     background_color: Option<ColorF>,
+    window_size: DeviceUintSize,
     prim_store: PrimitiveStore,
     pub clip_store: ClipStore,
     hit_testing_runs: Vec<HitTestingRun>,
@@ -181,6 +182,7 @@ impl FrameBuilder {
             prim_store: PrimitiveStore::new(),
             clip_store: ClipStore::new(),
             screen_rect: DeviceUintRect::zero(),
+            window_size: DeviceUintSize::zero(),
             background_color: None,
             config: FrameBuilderConfig {
                 enable_scrollbars: false,
@@ -196,6 +198,7 @@ impl FrameBuilder {
         self,
         screen_rect: DeviceUintRect,
         background_color: Option<ColorF>,
+        window_size: DeviceUintSize,
         config: FrameBuilderConfig,
     ) -> Self {
         FrameBuilder {
@@ -210,6 +213,7 @@ impl FrameBuilder {
             clip_store: self.clip_store.recycle(),
             screen_rect,
             background_color,
+            window_size,
             config,
         }
     }
@@ -1796,7 +1800,6 @@ impl FrameBuilder {
         frame_id: FrameId,
         clip_scroll_tree: &mut ClipScrollTree,
         pipelines: &FastHashMap<PipelineId, Arc<ScenePipeline>>,
-        window_size: DeviceUintSize,
         device_pixel_scale: DevicePixelScale,
         layer: DocumentLayer,
         pan: WorldPoint,
@@ -1806,7 +1809,7 @@ impl FrameBuilder {
     ) -> Frame {
         profile_scope!("build");
         debug_assert!(
-            DeviceUintRect::new(DeviceUintPoint::zero(), window_size)
+            DeviceUintRect::new(DeviceUintPoint::zero(), self.window_size)
                 .contains_rect(&self.screen_rect)
         );
 
@@ -1909,7 +1912,7 @@ impl FrameBuilder {
         resource_cache.end_frame();
 
         Frame {
-            window_size,
+            window_size: self.window_size,
             inner_rect: self.screen_rect,
             device_pixel_ratio: device_pixel_scale.0,
             background_color: self.background_color,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -32,6 +32,7 @@ use render_task::{ClearMode, RenderTask, RenderTaskId, RenderTaskLocation, Rende
 use resource_cache::{ImageRequest, ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
+use std::sync::Arc;
 use tiling::{CompositeOps, Frame, RenderPass, RenderTargetKind};
 use tiling::{RenderPassKind, RenderTargetContext, ScrollbarPrimitive};
 use util::{self, MaxRect, RectHelpers, WorldToLayerFastTransform, recycle_vec};
@@ -110,7 +111,7 @@ pub struct FrameBuilder {
 pub struct FrameContext<'a> {
     pub device_pixel_scale: DevicePixelScale,
     pub scene_properties: &'a SceneProperties,
-    pub pipelines: &'a FastHashMap<PipelineId, ScenePipeline>,
+    pub pipelines: &'a FastHashMap<PipelineId, Arc<ScenePipeline>>,
     pub screen_rect: DeviceIntRect,
     pub clip_scroll_tree: &'a ClipScrollTree,
     pub node_data: &'a [ClipScrollNodeData],
@@ -1678,7 +1679,7 @@ impl FrameBuilder {
     fn build_layer_screen_rects_and_cull_layers(
         &mut self,
         clip_scroll_tree: &ClipScrollTree,
-        pipelines: &FastHashMap<PipelineId, ScenePipeline>,
+        pipelines: &FastHashMap<PipelineId, Arc<ScenePipeline>>,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
@@ -1794,7 +1795,7 @@ impl FrameBuilder {
         gpu_cache: &mut GpuCache,
         frame_id: FrameId,
         clip_scroll_tree: &mut ClipScrollTree,
-        pipelines: &FastHashMap<PipelineId, ScenePipeline>,
+        pipelines: &FastHashMap<PipelineId, Arc<ScenePipeline>>,
         window_size: DeviceUintSize,
         device_pixel_scale: DevicePixelScale,
         layer: DocumentLayer,

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -90,6 +90,7 @@ mod render_task;
 mod renderer;
 mod resource_cache;
 mod scene;
+mod scene_builder;
 mod segment;
 mod spring;
 mod texture_allocator;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -24,7 +24,7 @@ use renderer::{MAX_VERTEX_TEXTURE_WIDTH};
 use resource_cache::{CacheItem, ImageProperties, ImageRequest, ResourceCache};
 use segment::SegmentBuilder;
 use std::{mem, usize};
-use std::rc::Rc;
+use std::sync::Arc;
 use util::{MatrixHelpers, WorldToLayerFastTransform, calculate_screen_bounding_rect};
 use util::{pack_as_float, recycle_vec};
 
@@ -1574,7 +1574,7 @@ impl PrimitiveStore {
                     combined_outer_rect = combined_outer_rect.and_then(|r| r.intersection(&outer));
                 }
 
-                Some(Rc::new(ClipChainNode {
+                Some(Arc::new(ClipChainNode {
                     work_item: ClipWorkItem {
                         scroll_node_data_index: prim_run_context.scroll_node.node_data_index,
                         clip_sources: metadata.clip_sources.weak(),

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -67,13 +67,6 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         ApiMsg::AddDocument { .. } |
         ApiMsg::DeleteDocument(..) => true,
         ApiMsg::UpdateDocument(_, ref msgs) => {
-            for msg in &msgs.scene_ops {
-                match *msg {
-                    DocumentMsg::GetScrollNodeState(..) |
-                    DocumentMsg::HitTest(..) => {}
-                    _ => { return true; }
-                }
-            }
             for msg in &msgs.frame_ops {
                 match *msg {
                     DocumentMsg::GetScrollNodeState(..) |

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -67,14 +67,14 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         ApiMsg::AddDocument { .. } |
         ApiMsg::DeleteDocument(..) => true,
         ApiMsg::UpdateDocument(_, ref msgs) => {
-            for msg in &msgs.prefix_ops {
+            for msg in &msgs.scene_ops {
                 match *msg {
                     DocumentMsg::GetScrollNodeState(..) |
                     DocumentMsg::HitTest(..) => {}
                     _ => { return true; }
                 }
             }
-            for msg in &msgs.postfix_ops {
+            for msg in &msgs.frame_ops {
                 match *msg {
                     DocumentMsg::GetScrollNodeState(..) |
                     DocumentMsg::HitTest(..) => {}

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ApiMsg, DocumentMsg};
+use api::{ApiMsg, FrameMsg};
 use bincode::{serialize, Infinite};
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::any::TypeId;
@@ -69,8 +69,8 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         ApiMsg::UpdateDocument(_, ref msgs) => {
             for msg in &msgs.frame_ops {
                 match *msg {
-                    DocumentMsg::GetScrollNodeState(..) |
-                    DocumentMsg::HitTest(..) => {}
+                    FrameMsg::GetScrollNodeState(..) |
+                    FrameMsg::HitTest(..) => {}
                     _ => { return true; }
                 }
             }

--- a/webrender/src/record.rs
+++ b/webrender/src/record.rs
@@ -67,13 +67,21 @@ pub fn should_record_msg(msg: &ApiMsg) -> bool {
         ApiMsg::AddDocument { .. } |
         ApiMsg::DeleteDocument(..) => true,
         ApiMsg::UpdateDocument(_, ref msgs) => {
-            for msg in msgs {
+            for msg in &msgs.prefix_ops {
                 match *msg {
                     DocumentMsg::GetScrollNodeState(..) |
                     DocumentMsg::HitTest(..) => {}
                     _ => { return true; }
                 }
             }
+            for msg in &msgs.postfix_ops {
+                match *msg {
+                    DocumentMsg::GetScrollNodeState(..) |
+                    DocumentMsg::HitTest(..) => {}
+                    _ => { return true; }
+                }
+            }
+
             false
         }
         _ => false,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -760,7 +760,7 @@ impl RenderBackend {
                 }
             }
 
-        return true;
+        true
     }
 
     fn update_document(
@@ -1275,7 +1275,8 @@ impl SceneBuilder {
             }
             SceneBuilderRequest::Stop => { return false; }
         }
-        return true;
+
+        true
     }
 
     pub fn build_scene(&mut self, request: SceneRequest) -> BuiltScene {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -4,9 +4,10 @@
 
 use api::{ApiMsg, BuiltDisplayList, ClearCache, DebugCommand};
 #[cfg(feature = "debugger")]
-use api::{BuiltDisplayListIter, SpecificDisplayItem, Epoch};
+use api::{BuiltDisplayListIter, SpecificDisplayItem};
 use api::{DeviceIntPoint, DevicePixelScale, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
 use api::{DocumentId, DocumentLayer, DocumentMsg, HitTestResult, IdNamespace, PipelineId};
+use api::{Epoch, TransactionMsg, ResourceUpdates};
 use api::RenderNotifier;
 use api::channel::{MsgReceiver, PayloadReceiver, PayloadReceiverHelperMethods};
 use api::channel::{PayloadSender, PayloadSenderHelperMethods};
@@ -138,10 +139,10 @@ impl Document {
 
     fn can_render(&self) -> bool { self.frame_builder.is_some() }
 
+    // TODO: We will probably get rid of this soon and always forward to the scene building thread.
     fn build_scene(&mut self, resource_cache: &mut ResourceCache) {
-        // this code is why we have `Option`, which is never `None`
         let frame_builder = self.frame_ctx.create_frame_builder(
-            self.frame_builder.take().unwrap(),
+            self.frame_builder.take().unwrap_or_else(FrameBuilder::empty),
             &self.scene,
             resource_cache,
             self.view.window_size,
@@ -153,44 +154,44 @@ impl Document {
         self.frame_builder = Some(frame_builder);
     }
 
-    // WIP: this will become build_scene and replace the one above.
-    fn build_scene_async(
+    fn forward_transaction_to_scene_builder(
         &mut self,
+        txn: TransactionMsg,
+        document_ops: &DocumentOps,
         document_id: DocumentId,
         resource_cache: &ResourceCache,
-        scene_tx: &Sender<SceneBuilderMsg>,
-        ops: &DocumentOps,
+        scene_tx: &Sender<SceneBuilderRequest>,
     ) {
         // Do as much of the error handling as possible here before dispatching to
         // the scene builder thread.
-        match self.scene.root_pipeline_id {
-            Some(id) => {
-                if !self.scene.pipelines.contains_key(&id) {
-                    return;
-                }
-            }
-            None => {
-                return;
-            }
-        }
+        let build_scene: bool = document_ops.build
+            && self.scene.root_pipeline_id.map(
+                |id| { self.scene.pipelines.contains_key(&id) }
+            ).unwrap_or(false);
 
-        if self.view.window_size.width == 0 || self.view.window_size.height == 0 {
-            error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
-            return;
-        }
+        let scene_request = if build_scene {
+            if self.view.window_size.width == 0 || self.view.window_size.height == 0 {
+                error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
+            }
 
-        scene_tx.send(SceneBuilderMsg::BuildScene(
-            SceneRequest {
+            Some(SceneRequest {
                 scene: self.scene.clone(),
                 view: self.view.clone(),
                 font_instances: resource_cache.get_font_instances(),
                 tiled_image_map: resource_cache.get_tiled_image_map(),
                 output_pipelines: self.output_pipelines.clone(),
-                document_id,
-                render: ops.render,
-                composite: ops.composite,
-            }
-        )).unwrap();
+            })
+        } else {
+            None
+        };
+
+        scene_tx.send(SceneBuilderRequest::Transaction {
+            scene: scene_request,
+            resource_updates: txn.resource_updates,
+            document_ops: txn.postfix_ops,
+            render: txn.generate_frame,
+            document_id,
+        }).unwrap();
     }
 
     fn render(
@@ -276,8 +277,8 @@ pub struct RenderBackend {
     payload_rx: PayloadReceiver,
     payload_tx: PayloadSender,
     result_tx: Sender<ResultMsg>,
-    scene_tx: Sender<SceneBuilderMsg>,
-    scene_rx: Receiver<BuiltScene>,
+    scene_tx: Sender<SceneBuilderRequest>,
+    scene_rx: Receiver<SceneBuilderMsg>,
 
     default_device_pixel_ratio: f32,
 
@@ -299,8 +300,8 @@ impl RenderBackend {
         payload_rx: PayloadReceiver,
         payload_tx: PayloadSender,
         result_tx: Sender<ResultMsg>,
-        scene_tx: Sender<SceneBuilderMsg>,
-        scene_rx: Receiver<BuiltScene>,
+        scene_tx: Sender<SceneBuilderRequest>,
+        scene_rx: Receiver<SceneBuilderMsg>,
         default_device_pixel_ratio: f32,
         resource_cache: ResourceCache,
         notifier: Box<RenderNotifier>,
@@ -335,7 +336,6 @@ impl RenderBackend {
         message: DocumentMsg,
         frame_counter: u32,
         ipc_profile_counters: &mut IpcProfileCounters,
-        resource_profile_counters: &mut ResourceProfileCounters,
     ) -> DocumentOps {
         let doc = self.documents.get_mut(&document_id).expect("No document?");
 
@@ -437,16 +437,6 @@ impl RenderBackend {
 
                 DocumentOps::build()
             }
-            DocumentMsg::UpdateResources(updates) => {
-                profile_scope!("UpdateResources");
-
-                self.resource_cache.update_resources(
-                    updates,
-                    resource_profile_counters
-                );
-
-                DocumentOps::nop()
-            }
             DocumentMsg::UpdateEpoch(pipeline_id, epoch) => {
                 doc.scene.update_epoch(pipeline_id, epoch);
                 doc.frame_ctx.update_epoch(pipeline_id, epoch);
@@ -539,20 +529,6 @@ impl RenderBackend {
                 doc.scene.properties.set_properties(property_bindings);
                 DocumentOps::build()
             }
-            DocumentMsg::GenerateFrame => {
-                let mut op = DocumentOps::nop();
-
-                if let Some(ref mut ros) = doc.render_on_scroll {
-                    *ros = true;
-                }
-
-                if doc.scene.root_pipeline_id.is_some() {
-                    op.render = true;
-                    op.composite = true;
-                }
-
-                op
-            }
         }
     }
 
@@ -566,27 +542,49 @@ impl RenderBackend {
         loop {
             profile_scope!("handle_msg");
 
-            while let Ok(mut msg) = self.scene_rx.try_recv() {
-                if let Some(doc) = self.documents.get_mut(&msg.document_id) {
-                    doc.frame_builder = Some(msg.frame_builder);
-                    doc.removed_pipelines.extend(msg.removed_pipelines.drain(..));
-                    doc.frame_ctx.new_async_scene_ready(
-                        msg.clip_scroll_tree,
-                        msg.pipeline_epoch_map,
-                    );
-                } else {
-                    // The document was removed while we were building it, skip it.
-                    continue;
-                }
-                if msg.render {
-                    self.process_api_msg(
-                        ApiMsg::UpdateDocument(
-                            msg.document_id,
-                            vec![DocumentMsg::GenerateFrame],
-                        ),
-                        &mut profile_counters,
-                        &mut frame_counter
-                    );
+            while let Ok(msg) = self.scene_rx.try_recv() {
+                match msg {
+                    SceneBuilderMsg::Transaction {
+                        document_id,
+                        mut built_scene,
+                        document_ops,
+                        render,
+                        resource_updates,
+                    } => {
+                        if let Some(doc) = self.documents.get_mut(&document_id) {
+                            if let Some(mut built_scene) = built_scene.take() {
+                                doc.frame_builder = Some(built_scene.frame_builder);
+                                doc.removed_pipelines.extend(built_scene.removed_pipelines.drain(..));
+                                doc.frame_ctx.new_async_scene_ready(
+                                    built_scene.clip_scroll_tree,
+                                    built_scene.pipeline_epoch_map,
+                                );
+                                doc.render_on_hittest = true;
+                            }
+                        } else {
+                            // The document was removed while we were building it, skip it.
+                            // TODO: we might want to just ensure that removed documents are
+                            // always forwarded to the scene builder thread to avoid this case.
+                            continue;
+                        }
+
+                        let txn = TransactionMsg {
+                            prefix_ops: Vec::new(),
+                            postfix_ops: document_ops,
+                            resource_updates,
+                            generate_frame: render,
+                            use_scene_builder_thread: false,
+                        };
+
+                        if !txn.is_empty() {
+                            self.update_document(
+                                document_id,
+                                txn,
+                                &mut frame_counter,
+                                &mut profile_counters
+                            );
+                        }
+                    }
                 }
             }
 
@@ -601,7 +599,7 @@ impl RenderBackend {
             };
 
             if !keep_going {
-                let _ = self.scene_tx.send(SceneBuilderMsg::Stop);
+                let _ = self.scene_tx.send(SceneBuilderRequest::Stop);
                 self.notifier.shut_down();
             }
         }
@@ -768,12 +766,16 @@ impl RenderBackend {
     fn update_document(
         &mut self,
         document_id: DocumentId,
-        doc_msgs: Vec<DocumentMsg>,
+        mut txn: TransactionMsg,
         frame_counter: &mut u32,
         profile_counters: &mut BackendProfileCounters,
     ) {
         let mut op = DocumentOps::nop();
-        for doc_msg in doc_msgs {
+
+        // TODO: This is a little awkward that we are applying prefix ops here, this
+        // will most likely change soon.
+        let prefix_ops = replace(&mut txn.prefix_ops, Vec::new());
+        for doc_msg in prefix_ops {
             let _timer = profile_counters.total_time.timer();
             op.combine(
                 self.process_document(
@@ -781,28 +783,60 @@ impl RenderBackend {
                     doc_msg,
                     *frame_counter,
                     &mut profile_counters.ipc,
-                    &mut profile_counters.resources,
                 )
             );
         }
 
-        debug_assert!(op.render || !op.composite);
+        if txn.use_scene_builder_thread && !txn.is_empty() {
+            let doc = self.documents.get_mut(&document_id).unwrap();
+            doc.forward_transaction_to_scene_builder(
+                txn,
+                &op,
+                document_id,
+                &self.resource_cache,
+                &self.scene_tx,
+            );
+
+            return;
+        }
+
+        self.resource_cache.update_resources(
+            txn.resource_updates,
+            &mut profile_counters.resources,
+        );
+
+        for doc_msg in txn.postfix_ops {
+            let _timer = profile_counters.total_time.timer();
+            op.combine(
+                self.process_document(
+                    document_id,
+                    doc_msg,
+                    *frame_counter,
+                    &mut profile_counters.ipc,
+                )
+            );
+        }
 
         let doc = self.documents.get_mut(&document_id).unwrap();
+
+        if txn.generate_frame {
+            if let Some(ref mut ros) = doc.render_on_scroll {
+                *ros = true;
+            }
+
+            if doc.scene.root_pipeline_id.is_some() {
+                op.render = true;
+                op.composite = true;
+            }
+        }
+
+        debug_assert!(op.render || !op.composite);
 
         if op.build {
             let _timer = profile_counters.total_time.timer();
             profile_scope!("build scene");
 
-            //doc.build_scene(&mut self.resource_cache);
-            doc.build_scene_async(
-                document_id,
-                &self.resource_cache,
-                &self.scene_tx,
-                &op,
-            );
-            op.render = false;
-            op.composite = false;
+            doc.build_scene(&mut self.resource_cache);
             doc.render_on_hittest = true;
         }
 
@@ -1134,21 +1168,36 @@ impl RenderBackend {
     }
 }
 
-pub enum SceneBuilderMsg {
-    BuildScene(SceneRequest),
+// Message from render backend to scene builder.
+pub enum SceneBuilderRequest {
+    Transaction {
+        document_id: DocumentId,
+        scene: Option<SceneRequest>,
+        resource_updates: ResourceUpdates,
+        document_ops: Vec<DocumentMsg>,
+        render: bool,
+    },
     Stop
+}
+
+// Message from scene builder to render backend.
+pub enum SceneBuilderMsg {
+    Transaction {
+        document_id: DocumentId,
+        built_scene: Option<BuiltScene>,
+        resource_updates: ResourceUpdates,
+        document_ops: Vec<DocumentMsg>,
+        render: bool,
+    },
 }
 
 /// Contains the the render backend data needed to build a scene.
 pub struct SceneRequest {
-    pub document_id: DocumentId,
     pub scene: Scene,
     pub view: DocumentView,
     pub font_instances: FontInstanceMap,
     pub tiled_image_map: TiledImageMap,
     pub output_pipelines: FastHashSet<PipelineId>,
-    pub render: bool,
-    pub composite: bool,
 }
 
 pub struct BuiltScene {
@@ -1156,19 +1205,20 @@ pub struct BuiltScene {
     pub clip_scroll_tree: ClipScrollTree,
     pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
     pub removed_pipelines: Vec<PipelineId>,
-    pub document_id: DocumentId,
-    pub render: bool,
 }
 
 pub struct SceneBuilder {
-    rx: Receiver<SceneBuilderMsg>,
-    tx: Sender<BuiltScene>,
+    rx: Receiver<SceneBuilderRequest>,
+    tx: Sender<SceneBuilderMsg>,
     api_tx: MsgSender<ApiMsg>,
     config: FrameBuilderConfig,
 }
 
 impl SceneBuilder {
-    pub fn new(config: FrameBuilderConfig, api_tx: MsgSender<ApiMsg>) -> (Self, Sender<SceneBuilderMsg>, Receiver<BuiltScene>) {
+    pub fn new(
+        config: FrameBuilderConfig,
+        api_tx: MsgSender<ApiMsg>
+    ) -> (Self, Sender<SceneBuilderRequest>, Receiver<SceneBuilderMsg>) {
         let (in_tx, in_rx) = channel();
         let (out_tx, out_rx) = channel();
         (
@@ -1198,26 +1248,37 @@ impl SceneBuilder {
         }
     }
 
-    pub fn process_message(&mut self, msg: SceneBuilderMsg) -> bool {
+    pub fn process_message(&mut self, msg: SceneBuilderRequest) -> bool {
         match msg {
-            SceneBuilderMsg::BuildScene(request) => {
-                let result = self.build_scene(request);
+            SceneBuilderRequest::Transaction {
+                document_id,
+                scene,
+                resource_updates,
+                document_ops,
+                render,
+            } => {
+                let built_scene = scene.map(|request|{
+                    self.build_scene(request)
+                });
 
-                self.tx.send(result).unwrap();
+                // TODO: pre-rasterization.
+
+                self.tx.send(SceneBuilderMsg::Transaction {
+                    document_id,
+                    built_scene,
+                    resource_updates,
+                    document_ops,
+                    render,
+                }).unwrap();
 
                 let _ = self.api_tx.send(ApiMsg::WakeUp);
             }
-            SceneBuilderMsg::Stop => { return false; }
+            SceneBuilderRequest::Stop => { return false; }
         }
         return true;
     }
 
     pub fn build_scene(&mut self, request: SceneRequest) -> BuiltScene {
-        let built_scene = FrameContext::create_frame_builder_async(&self.config, request);
-
-        // Here will go other things that could be offloaded from the render backend
-        // like some of the rasterization that we know we'd have to do in the next frame.
-
-        built_scene
+        FrameContext::create_frame_builder_async(&self.config, request)
     }
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -566,9 +566,10 @@ impl RenderBackend {
         loop {
             profile_scope!("handle_msg");
 
-            while let Ok(msg) = self.scene_rx.try_recv() {
+            while let Ok(mut msg) = self.scene_rx.try_recv() {
                 if let Some(doc) = self.documents.get_mut(&msg.document_id) {
                     doc.frame_builder = Some(msg.frame_builder);
+                    doc.removed_pipelines.extend(msg.removed_pipelines.drain(..));
                     doc.frame_ctx.new_async_scene_ready(
                         msg.clip_scroll_tree,
                         msg.pipeline_epoch_map,
@@ -1154,6 +1155,7 @@ pub struct BuiltScene {
     pub frame_builder: FrameBuilder,
     pub clip_scroll_tree: ClipScrollTree,
     pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+    pub removed_pipelines: Vec<PipelineId>,
     pub document_id: DocumentId,
     pub render: bool,
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2236,7 +2236,7 @@ impl Renderer {
             blob_image_renderer,
         )?;
 
-        let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new();
+        let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new(config);
         try! {
             thread::Builder::new().name(scene_thread_name.clone()).spawn(move || {
                 register_thread_with_profiler(scene_thread_name.clone());

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2236,7 +2236,7 @@ impl Renderer {
             blob_image_renderer,
         )?;
 
-        let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new(config);
+        let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new(config, api_tx.clone());
         try! {
             thread::Builder::new().name(scene_thread_name.clone()).spawn(move || {
                 register_thread_with_profiler(scene_thread_name.clone());

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -50,7 +50,8 @@ use profiler::{GpuProfileTag, RendererProfileCounters, RendererProfileTimers};
 use query::{GpuProfiler, GpuTimer};
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use record::ApiRecordingReceiver;
-use render_backend::{RenderBackend, SceneBuilder};
+use render_backend::RenderBackend;
+use scene_builder::SceneBuilder;
 use render_task::{RenderTaskKind, RenderTaskTree};
 use resource_cache::ResourceCache;
 #[cfg(feature = "debugger")]

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 /// re-submitting the display list itself.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
+#[derive(Clone)]
 pub struct SceneProperties {
     transform_properties: FastHashMap<PropertyBindingId, LayoutTransform>,
     float_properties: FastHashMap<PropertyBindingId, f32>,
@@ -87,6 +88,7 @@ impl SceneProperties {
 /// A representation of the layout within the display port for a given document or iframe.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
+#[derive(Clone)]
 pub struct ScenePipeline {
     pub pipeline_id: PipelineId,
     pub viewport_size: LayerSize,
@@ -95,9 +97,12 @@ pub struct ScenePipeline {
     pub display_list: BuiltDisplayList,
 }
 
+// WIP: cloning the whole scene struct is probably more than wat we structly need to
+// do the async stuff, will look into this in more details later.
 /// A complete representation of the layout bundling visible pipelines together.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
+#[derive(Clone)]
 pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipelines: FastHashMap<PipelineId, Arc<ScenePipeline>>,

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -97,8 +97,6 @@ pub struct ScenePipeline {
     pub display_list: BuiltDisplayList,
 }
 
-// WIP: cloning the whole scene struct is probably more than wat we structly need to
-// do the async stuff, will look into this in more details later.
 /// A complete representation of the layout bundling visible pipelines together.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -108,7 +108,6 @@ pub struct Scene {
     pub pipelines: FastHashMap<PipelineId, Arc<ScenePipeline>>,
     pub pipeline_epochs: FastHashMap<PipelineId, Epoch>,
     pub removed_pipelines: Vec<PipelineId>,
-    pub properties: SceneProperties,
 }
 
 impl Scene {
@@ -118,7 +117,6 @@ impl Scene {
             pipelines: FastHashMap::default(),
             removed_pipelines: Vec::new(),
             pipeline_epochs: FastHashMap::default(),
-            properties: SceneProperties::new(),
         }
     }
 

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -107,7 +107,6 @@ pub struct Scene {
     pub root_pipeline_id: Option<PipelineId>,
     pub pipelines: FastHashMap<PipelineId, Arc<ScenePipeline>>,
     pub pipeline_epochs: FastHashMap<PipelineId, Epoch>,
-    pub removed_pipelines: Vec<PipelineId>,
 }
 
 impl Scene {
@@ -115,7 +114,6 @@ impl Scene {
         Scene {
             root_pipeline_id: None,
             pipelines: FastHashMap::default(),
-            removed_pipelines: Vec::new(),
             pipeline_epochs: FastHashMap::default(),
         }
     }
@@ -150,7 +148,6 @@ impl Scene {
             self.root_pipeline_id = None;
         }
         self.pipelines.remove(&pipeline_id);
-        self.removed_pipelines.push(pipeline_id);
     }
 
     pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api::{DocumentId, PipelineId, Epoch, ApiMsg, DocumentMsg, ResourceUpdates};
+use api::channel::MsgSender;
+use frame::build_scene;
+use frame_builder::{FrameBuilderConfig, FrameBuilder};
+use clip_scroll_tree::ClipScrollTree;
+use internal_types::{FastHashMap, FastHashSet};
+use resource_cache::{FontInstanceMap, TiledImageMap};
+use render_backend::DocumentView;
+use scene::Scene;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+// Message from render backend to scene builder.
+pub enum SceneBuilderRequest {
+    Transaction {
+        document_id: DocumentId,
+        scene: Option<SceneRequest>,
+        resource_updates: ResourceUpdates,
+        frame_ops: Vec<DocumentMsg>,
+        render: bool,
+    },
+    Stop
+}
+
+// Message from scene builder to render backend.
+pub enum SceneBuilderMsg {
+    Transaction {
+        document_id: DocumentId,
+        built_scene: Option<BuiltScene>,
+        resource_updates: ResourceUpdates,
+        frame_ops: Vec<DocumentMsg>,
+        render: bool,
+    },
+}
+
+/// Contains the the render backend data needed to build a scene.
+pub struct SceneRequest {
+    pub scene: Scene,
+    pub view: DocumentView,
+    pub font_instances: FontInstanceMap,
+    pub tiled_image_map: TiledImageMap,
+    pub output_pipelines: FastHashSet<PipelineId>,
+    pub removed_pipelines: Vec<PipelineId>,
+}
+
+pub struct BuiltScene {
+    pub scene: Scene,
+    pub frame_builder: FrameBuilder,
+    pub clip_scroll_tree: ClipScrollTree,
+    pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
+    pub removed_pipelines: Vec<PipelineId>,
+}
+
+pub struct SceneBuilder {
+    rx: Receiver<SceneBuilderRequest>,
+    tx: Sender<SceneBuilderMsg>,
+    api_tx: MsgSender<ApiMsg>,
+    config: FrameBuilderConfig,
+}
+
+impl SceneBuilder {
+    pub fn new(
+        config: FrameBuilderConfig,
+        api_tx: MsgSender<ApiMsg>
+    ) -> (Self, Sender<SceneBuilderRequest>, Receiver<SceneBuilderMsg>) {
+        let (in_tx, in_rx) = channel();
+        let (out_tx, out_rx) = channel();
+        (
+            SceneBuilder {
+                rx: in_rx,
+                tx: out_tx,
+                api_tx,
+                config,
+            },
+            in_tx,
+            out_rx,
+        )
+    }
+
+    pub fn run(&mut self) {
+        loop {
+            match self.rx.recv() {
+                Ok(msg) => {
+                    if !self.process_message(msg) {
+                        return;
+                    }
+                }
+                Err(_) => {
+                    return;
+                }
+            }
+        }
+    }
+
+    fn process_message(&mut self, msg: SceneBuilderRequest) -> bool {
+        match msg {
+            SceneBuilderRequest::Transaction {
+                document_id,
+                scene,
+                resource_updates,
+                frame_ops,
+                render,
+            } => {
+                let built_scene = scene.map(|request|{
+                    build_scene(&self.config, request)
+                });
+
+                // TODO: pre-rasterization.
+
+                self.tx.send(SceneBuilderMsg::Transaction {
+                    document_id,
+                    built_scene,
+                    resource_updates,
+                    frame_ops,
+                    render,
+                }).unwrap();
+
+                let _ = self.api_tx.send(ApiMsg::WakeUp);
+            }
+            SceneBuilderRequest::Stop => { return false; }
+        }
+
+        true
+    }
+}

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DocumentId, PipelineId, Epoch, ApiMsg, DocumentMsg, ResourceUpdates};
+use api::{DocumentId, PipelineId, Epoch, ApiMsg, FrameMsg, ResourceUpdates};
 use api::channel::MsgSender;
 use frame::build_scene;
 use frame_builder::{FrameBuilderConfig, FrameBuilder};
@@ -19,7 +19,7 @@ pub enum SceneBuilderRequest {
         document_id: DocumentId,
         scene: Option<SceneRequest>,
         resource_updates: ResourceUpdates,
-        frame_ops: Vec<DocumentMsg>,
+        frame_ops: Vec<FrameMsg>,
         render: bool,
     },
     Stop
@@ -31,7 +31,7 @@ pub enum SceneBuilderResult {
         document_id: DocumentId,
         built_scene: Option<BuiltScene>,
         resource_updates: ResourceUpdates,
-        frame_ops: Vec<DocumentMsg>,
+        frame_ops: Vec<FrameMsg>,
         render: bool,
     },
 }

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -26,7 +26,7 @@ pub enum SceneBuilderRequest {
 }
 
 // Message from scene builder to render backend.
-pub enum SceneBuilderMsg {
+pub enum SceneBuilderResult {
     Transaction {
         document_id: DocumentId,
         built_scene: Option<BuiltScene>,
@@ -56,7 +56,7 @@ pub struct BuiltScene {
 
 pub struct SceneBuilder {
     rx: Receiver<SceneBuilderRequest>,
-    tx: Sender<SceneBuilderMsg>,
+    tx: Sender<SceneBuilderResult>,
     api_tx: MsgSender<ApiMsg>,
     config: FrameBuilderConfig,
 }
@@ -65,7 +65,7 @@ impl SceneBuilder {
     pub fn new(
         config: FrameBuilderConfig,
         api_tx: MsgSender<ApiMsg>
-    ) -> (Self, Sender<SceneBuilderRequest>, Receiver<SceneBuilderMsg>) {
+    ) -> (Self, Sender<SceneBuilderRequest>, Receiver<SceneBuilderResult>) {
         let (in_tx, in_rx) = channel();
         let (out_tx, out_rx) = channel();
         (
@@ -110,7 +110,7 @@ impl SceneBuilder {
 
                 // TODO: pre-rasterization.
 
-                self.tx.send(SceneBuilderMsg::Transaction {
+                self.tx.send(SceneBuilderResult::Transaction {
                     document_id,
                     built_scene,
                     resource_updates,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -131,10 +131,8 @@ impl ResourceUpdates {
 ///  - no redundant work is performed if two commands in the same transaction cause the scene or
 ///    the frame to be rebuilt.
 pub struct Transaction {
-    // Operations to apply before scene building.
-    prefix_ops: Vec<DocumentMsg>,
-    // Operations to apply after scene building.
-    postfix_ops: Vec<DocumentMsg>,
+    scene_ops: Vec<DocumentMsg>,
+    frame_ops: Vec<DocumentMsg>,
 
     // Additional display list data.
     payloads: Vec<Payload>,
@@ -152,8 +150,8 @@ pub struct Transaction {
 impl Transaction {
     pub fn new() -> Self {
         Transaction {
-            prefix_ops: Vec::new(),
-            postfix_ops: Vec::new(),
+            scene_ops: Vec::new(),
+            frame_ops: Vec::new(),
             resource_updates: ResourceUpdates::new(),
             payloads: Vec::new(),
             use_scene_builder_thread: false, // TODO: make this true by default.
@@ -174,13 +172,13 @@ impl Transaction {
 
     pub fn is_empty(&self) -> bool {
         !self.generate_frame &&
-            self.prefix_ops.is_empty() &&
-            self.postfix_ops.is_empty() &&
+            self.scene_ops.is_empty() &&
+            self.frame_ops.is_empty() &&
             self.resource_updates.updates.is_empty()
     }
 
     pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {
-        self.postfix_ops.push(DocumentMsg::UpdateEpoch(pipeline_id, epoch));
+        self.frame_ops.push(DocumentMsg::UpdateEpoch(pipeline_id, epoch));
     }
 
     /// Sets the root pipeline.
@@ -196,14 +194,14 @@ impl Transaction {
     /// # }
     /// ```
     pub fn set_root_pipeline(&mut self, pipeline_id: PipelineId) {
-        self.prefix_ops.push(DocumentMsg::SetRootPipeline(pipeline_id));
+        self.scene_ops.push(DocumentMsg::SetRootPipeline(pipeline_id));
     }
 
     /// Removes data associated with a pipeline from the internal data structures.
     /// If the specified `pipeline_id` is for the root pipeline, the root pipeline
     /// is reset back to `None`.
     pub fn remove_pipeline(&mut self, pipeline_id: PipelineId) {
-        self.prefix_ops.push(DocumentMsg::RemovePipeline(pipeline_id));
+        self.scene_ops.push(DocumentMsg::RemovePipeline(pipeline_id));
     }
 
     /// Supplies a new frame to WebRender.
@@ -237,7 +235,7 @@ impl Transaction {
         preserve_frame_state: bool,
     ) {
         let (display_list_data, list_descriptor) = display_list.into_data();
-        self.prefix_ops.push(
+        self.scene_ops.push(
             DocumentMsg::SetDisplayList {
                 epoch,
                 pipeline_id,
@@ -261,7 +259,7 @@ impl Transaction {
         inner_rect: DeviceUintRect,
         device_pixel_ratio: f32,
     ) {
-        self.prefix_ops.push(
+        self.scene_ops.push(
             DocumentMsg::SetWindowParameters {
                 window_size,
                 inner_rect,
@@ -280,7 +278,7 @@ impl Transaction {
         cursor: WorldPoint,
         phase: ScrollEventPhase,
     ) {
-        self.postfix_ops.push(DocumentMsg::Scroll(scroll_location, cursor, phase));
+        self.frame_ops.push(DocumentMsg::Scroll(scroll_location, cursor, phase));
     }
 
     pub fn scroll_node_with_id(
@@ -289,23 +287,23 @@ impl Transaction {
         id: ExternalScrollId,
         clamp: ScrollClamping,
     ) {
-        self.postfix_ops.push(DocumentMsg::ScrollNodeWithId(origin, id, clamp));
+        self.frame_ops.push(DocumentMsg::ScrollNodeWithId(origin, id, clamp));
     }
 
     pub fn set_page_zoom(&mut self, page_zoom: ZoomFactor) {
-        self.prefix_ops.push(DocumentMsg::SetPageZoom(page_zoom));
+        self.scene_ops.push(DocumentMsg::SetPageZoom(page_zoom));
     }
 
     pub fn set_pinch_zoom(&mut self, pinch_zoom: ZoomFactor) {
-        self.prefix_ops.push(DocumentMsg::SetPinchZoom(pinch_zoom));
+        self.scene_ops.push(DocumentMsg::SetPinchZoom(pinch_zoom));
     }
 
     pub fn set_pan(&mut self, pan: DeviceIntPoint) {
-        self.postfix_ops.push(DocumentMsg::SetPan(pan));
+        self.frame_ops.push(DocumentMsg::SetPan(pan));
     }
 
     pub fn tick_scrolling_bounce_animations(&mut self) {
-        self.postfix_ops.push(DocumentMsg::TickScrollingBounce);
+        self.frame_ops.push(DocumentMsg::TickScrollingBounce);
     }
 
     /// Generate a new frame.
@@ -316,20 +314,20 @@ impl Transaction {
     /// Supply a list of animated property bindings that should be used to resolve
     /// bindings in the current display list.
     pub fn update_dynamic_properties(&mut self, properties: DynamicProperties) {
-        self.postfix_ops.push(DocumentMsg::UpdateDynamicProperties(properties));
+        self.frame_ops.push(DocumentMsg::UpdateDynamicProperties(properties));
     }
 
     /// Enable copying of the output of this pipeline id to
     /// an external texture for callers to consume.
     pub fn enable_frame_output(&mut self, pipeline_id: PipelineId, enable: bool) {
-        self.postfix_ops.push(DocumentMsg::EnableFrameOutput(pipeline_id, enable));
+        self.frame_ops.push(DocumentMsg::EnableFrameOutput(pipeline_id, enable));
     }
 
     fn finalize(self) -> (TransactionMsg, Vec<Payload>) {
         (
             TransactionMsg {
-                prefix_ops: self.prefix_ops,
-                postfix_ops: self.postfix_ops,
+                scene_ops: self.scene_ops,
+                frame_ops: self.frame_ops,
                 resource_updates: self.resource_updates,
                 use_scene_builder_thread: self.use_scene_builder_thread,
                 generate_frame: self.generate_frame,
@@ -342,8 +340,8 @@ impl Transaction {
 /// Represents a transaction in the format sent through the channel.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct TransactionMsg {
-    pub prefix_ops: Vec<DocumentMsg>,
-    pub postfix_ops: Vec<DocumentMsg>,
+    pub scene_ops: Vec<DocumentMsg>,
+    pub frame_ops: Vec<DocumentMsg>,
     pub resource_updates: ResourceUpdates,
     pub generate_frame: bool,
     pub use_scene_builder_thread: bool,
@@ -352,16 +350,16 @@ pub struct TransactionMsg {
 impl TransactionMsg {
     pub fn is_empty(&self) -> bool {
         !self.generate_frame &&
-            self.prefix_ops.is_empty() &&
-            self.postfix_ops.is_empty() &&
+            self.scene_ops.is_empty() &&
+            self.frame_ops.is_empty() &&
             self.resource_updates.updates.is_empty()
     }
 
     // TODO: We only need this for a few RenderApi methods which we should remove.
     fn single_message(msg: DocumentMsg) -> Self {
         TransactionMsg {
-            prefix_ops: Vec::new(),
-            postfix_ops: vec![msg],
+            scene_ops: Vec::new(),
+            frame_ops: vec![msg],
             resource_updates: ResourceUpdates::new(),
             generate_frame: false,
             use_scene_builder_thread: false,
@@ -432,9 +430,15 @@ pub struct AddFontInstance {
     pub variations: Vec<FontVariation>,
 }
 
+// TODO: Split this in two emums.
+// I am postponing this because while it is a trivial change, it is a hard one to rebase.
 #[derive(Clone, Deserialize, Serialize)]
 pub enum DocumentMsg {
-    HitTest(Option<PipelineId>, WorldPoint, HitTestFlags, MsgSender<HitTestResult>),
+    // Scene messages (apply before building the scene).
+    SetPageZoom(ZoomFactor),
+    SetPinchZoom(ZoomFactor),
+    SetRootPipeline(PipelineId),
+    RemovePipeline(PipelineId),
     SetDisplayList {
         list_descriptor: BuiltDisplayListDescriptor,
         epoch: Epoch,
@@ -444,18 +448,17 @@ pub enum DocumentMsg {
         content_size: LayoutSize,
         preserve_frame_state: bool,
     },
-    UpdateEpoch(PipelineId, Epoch),
-    SetPageZoom(ZoomFactor),
-    SetPinchZoom(ZoomFactor),
-    SetPan(DeviceIntPoint),
-    SetRootPipeline(PipelineId),
-    RemovePipeline(PipelineId),
-    EnableFrameOutput(PipelineId, bool),
     SetWindowParameters {
         window_size: DeviceUintSize,
         inner_rect: DeviceUintRect,
         device_pixel_ratio: f32,
     },
+
+    // Frame messages (apply after building the scene).
+    HitTest(Option<PipelineId>, WorldPoint, HitTestFlags, MsgSender<HitTestResult>),
+    UpdateEpoch(PipelineId, Epoch),
+    SetPan(DeviceIntPoint),
+    EnableFrameOutput(PipelineId, bool),
     Scroll(ScrollLocation, WorldPoint, ScrollEventPhase),
     ScrollNodeWithId(LayoutPoint, ExternalScrollId, ScrollClamping),
     TickScrollingBounce,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -131,7 +131,9 @@ impl ResourceUpdates {
 ///  - no redundant work is performed if two commands in the same transaction cause the scene or
 ///    the frame to be rebuilt.
 pub struct Transaction {
+    // Operations affecting the scene (applied before scene building).
     scene_ops: Vec<DocumentMsg>,
+    // Operations affecting the generation of frames (applied after scene building).
     frame_ops: Vec<DocumentMsg>,
 
     // Additional display list data.
@@ -431,7 +433,7 @@ pub struct AddFontInstance {
 }
 
 // TODO: Split this in two emums.
-// I am postponing this because while it is a trivial change, it is a hard one to rebase.
+// Review note: this will be done just before landing.
 #[derive(Clone, Deserialize, Serialize)]
 pub enum DocumentMsg {
     // Scene messages (apply before building the scene).
@@ -879,11 +881,7 @@ impl RenderApi {
     ) {
         self.send(
             document_id,
-            DocumentMsg::SetWindowParameters {
-                window_size,
-                inner_rect,
-                device_pixel_ratio,
-            },
+            DocumentMsg::SetWindowParameters { window_size, inner_rect, device_pixel_ratio, },
         );
     }
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -156,9 +156,20 @@ impl Transaction {
             postfix_ops: Vec::new(),
             resource_updates: ResourceUpdates::new(),
             payloads: Vec::new(),
-            use_scene_builder_thread: true,
+            use_scene_builder_thread: false, // TODO: make this true by default.
             generate_frame: false,
         }
+    }
+
+    // TODO: better name?
+    pub fn skip_scene_builder(&mut self) {
+        self.use_scene_builder_thread = false;
+    }
+
+    // TODO: this is temporary, using the scene builder thread is the default for
+    // most transactions, and opt-in for specific cases like scrolling and async video.
+    pub fn use_scene_builder_thread(&mut self) {
+        self.use_scene_builder_thread = true;
     }
 
     pub fn is_empty(&self) -> bool {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -509,6 +509,9 @@ pub enum ApiMsg {
     MemoryPressure,
     /// Change debugging options.
     DebugCommand(DebugCommand),
+    /// Wakes the render backend's event loop up. Needed when an event is communicated
+    /// through another channel.
+    WakeUp,
     ShutDown,
 }
 
@@ -527,6 +530,7 @@ impl fmt::Debug for ApiMsg {
             ApiMsg::MemoryPressure => "ApiMsg::MemoryPressure",
             ApiMsg::DebugCommand(..) => "ApiMsg::DebugCommand",
             ApiMsg::ShutDown => "ApiMsg::ShutDown",
+            ApiMsg::WakeUp => "ApiMsg::WakeUp",
         })
     }
 }

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::{mem, process};
 use webrender::WEBRENDER_RECORDING_HEADER;
-use webrender::api::{ApiMsg, DocumentMsg};
+use webrender::api::{ApiMsg, SceneMsg};
 use wrench::{Wrench, WrenchThing};
 
 #[derive(Clone)]
@@ -146,11 +146,11 @@ impl WrenchThing for BinaryFrameReader {
                             }
                             for doc_msg in &txn.scene_ops {
                                 match *doc_msg {
-                                    DocumentMsg::SetDisplayList { .. } => {
+                                    SceneMsg::SetDisplayList { .. } => {
                                         found_frame_marker = false;
                                         found_display_list = true;
                                     }
-                                    DocumentMsg::SetRootPipeline(..) => {
+                                    SceneMsg::SetRootPipeline(..) => {
                                         found_frame_marker = false;
                                         found_pipeline = true;
                                     }

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -144,7 +144,7 @@ impl WrenchThing for BinaryFrameReader {
                             if txn.generate_frame {
                                 found_frame_marker = true;
                             }
-                            for doc_msg in &txn.prefix_ops {
+                            for doc_msg in &txn.scene_ops {
                                 match *doc_msg {
                                     DocumentMsg::SetDisplayList { .. } => {
                                         found_frame_marker = false;

--- a/wrench/src/binary_frame_reader.rs
+++ b/wrench/src/binary_frame_reader.rs
@@ -140,12 +140,12 @@ impl WrenchThing for BinaryFrameReader {
                     // (b) SetDisplayList
                     // (c) GenerateFrame that occurs *after* (a) and (b)
                     match msg {
-                        ApiMsg::UpdateDocument(_, ref doc_msgs) => {
-                            for doc_msg in doc_msgs {
+                        ApiMsg::UpdateDocument(_, ref txn) => {
+                            if txn.generate_frame {
+                                found_frame_marker = true;
+                            }
+                            for doc_msg in &txn.prefix_ops {
                                 match *doc_msg {
-                                    DocumentMsg::GenerateFrame => {
-                                        found_frame_marker = true;
-                                    }
                                     DocumentMsg::SetDisplayList { .. } => {
                                         found_frame_marker = false;
                                         found_display_list = true;

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -278,12 +278,10 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
         match *msg {
             ApiMsg::UpdateResources(ref updates) => self.update_resources(updates),
 
-            ApiMsg::UpdateDocument(_, ref doc_msgs) => {
-                for doc_msg in doc_msgs {
+            ApiMsg::UpdateDocument(_, ref txn) => {
+                self.update_resources(&txn.resource_updates);
+                for doc_msg in &txn.prefix_ops {
                     match *doc_msg {
-                        DocumentMsg::UpdateResources(ref resources) => {
-                            self.update_resources(resources);
-                        }
                         DocumentMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -280,7 +280,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
 
             ApiMsg::UpdateDocument(_, ref txn) => {
                 self.update_resources(&txn.resource_updates);
-                for doc_msg in &txn.prefix_ops {
+                for doc_msg in &txn.scene_ops {
                     match *doc_msg {
                         DocumentMsg::SetDisplayList {
                             ref epoch,

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -282,7 +282,7 @@ impl webrender::ApiRecordingReceiver for JsonFrameWriter {
                 self.update_resources(&txn.resource_updates);
                 for doc_msg in &txn.scene_ops {
                     match *doc_msg {
-                        DocumentMsg::SetDisplayList {
+                        SceneMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,
                             ref background,

--- a/wrench/src/ron_frame_writer.rs
+++ b/wrench/src/ron_frame_writer.rs
@@ -160,7 +160,7 @@ impl webrender::ApiRecordingReceiver for RonFrameWriter {
                 self.update_resources(&txn.resource_updates);
                 for doc_msg in &txn.scene_ops {
                     match *doc_msg {
-                        DocumentMsg::SetDisplayList {
+                        SceneMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,
                             ref background,

--- a/wrench/src/ron_frame_writer.rs
+++ b/wrench/src/ron_frame_writer.rs
@@ -158,7 +158,7 @@ impl webrender::ApiRecordingReceiver for RonFrameWriter {
             ApiMsg::UpdateResources(ref updates) => self.update_resources(updates),
             ApiMsg::UpdateDocument(_, ref txn) => {
                 self.update_resources(&txn.resource_updates);
-                for doc_msg in &txn.prefix_ops {
+                for doc_msg in &txn.scene_ops {
                     match *doc_msg {
                         DocumentMsg::SetDisplayList {
                             ref epoch,

--- a/wrench/src/ron_frame_writer.rs
+++ b/wrench/src/ron_frame_writer.rs
@@ -156,12 +156,10 @@ impl webrender::ApiRecordingReceiver for RonFrameWriter {
     fn write_msg(&mut self, _: u32, msg: &ApiMsg) {
         match *msg {
             ApiMsg::UpdateResources(ref updates) => self.update_resources(updates),
-            ApiMsg::UpdateDocument(_, ref doc_msgs) => {
-                for doc_msg in doc_msgs {
+            ApiMsg::UpdateDocument(_, ref txn) => {
+                self.update_resources(&txn.resource_updates);
+                for doc_msg in &txn.prefix_ops {
                     match *doc_msg {
-                        DocumentMsg::UpdateResources(ref resources) => {
-                            self.update_resources(resources);
-                        }
                         DocumentMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1126,7 +1126,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
             }
             ApiMsg::UpdateDocument(_, ref txn) => {
                 self.frame_writer.update_resources(&txn.resource_updates);
-                for doc_msg in &txn.prefix_ops {
+                for doc_msg in &txn.scene_ops {
                     match *doc_msg {
                         DocumentMsg::SetDisplayList {
                             ref epoch,
@@ -1154,7 +1154,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                         _ => {}
                     }
                 }
-                for doc_msg in &txn.postfix_ops {
+                for doc_msg in &txn.frame_ops {
                     match *doc_msg {
                         DocumentMsg::UpdateDynamicProperties(ref properties) => {
                             self.scene.properties.set_properties(properties);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1124,12 +1124,10 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
             ApiMsg::UpdateResources(ref updates) => {
                 self.frame_writer.update_resources(updates);
             }
-            ApiMsg::UpdateDocument(_, ref doc_msgs) => {
-                for doc_msg in doc_msgs {
+            ApiMsg::UpdateDocument(_, ref txn) => {
+                self.frame_writer.update_resources(&txn.resource_updates);
+                for doc_msg in &txn.prefix_ops {
                     match *doc_msg {
-                        DocumentMsg::UpdateResources(ref resources) => {
-                            self.frame_writer.update_resources(resources);
-                        }
                         DocumentMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,
@@ -1153,12 +1151,18 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                         DocumentMsg::RemovePipeline(ref pipeline_id) => {
                             self.scene.remove_pipeline(pipeline_id);
                         }
+                        _ => {}
+                    }
+                }
+                for doc_msg in &txn.postfix_ops {
+                    match *doc_msg {
                         DocumentMsg::UpdateDynamicProperties(ref properties) => {
                             self.scene.properties.set_properties(properties);
                         }
                         _ => {}
                     }
                 }
+
             }
             _ => {}
         }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1128,7 +1128,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 self.frame_writer.update_resources(&txn.resource_updates);
                 for doc_msg in &txn.scene_ops {
                     match *doc_msg {
-                        DocumentMsg::SetDisplayList {
+                        SceneMsg::SetDisplayList {
                             ref epoch,
                             ref pipeline_id,
                             ref background,
@@ -1145,10 +1145,10 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                                 list_descriptor,
                             );
                         }
-                        DocumentMsg::SetRootPipeline(ref pipeline_id) => {
+                        SceneMsg::SetRootPipeline(ref pipeline_id) => {
                             self.scene.set_root_pipeline_id(pipeline_id.clone());
                         }
-                        DocumentMsg::RemovePipeline(ref pipeline_id) => {
+                        SceneMsg::RemovePipeline(ref pipeline_id) => {
                             self.scene.remove_pipeline(pipeline_id);
                         }
                         _ => {}
@@ -1156,7 +1156,7 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                 }
                 for doc_msg in &txn.frame_ops {
                     match *doc_msg {
-                        DocumentMsg::UpdateDynamicProperties(ref properties) => {
+                        FrameMsg::UpdateDynamicProperties(ref properties) => {
                             self.scene.properties.set_properties(properties);
                         }
                         _ => {}

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1162,7 +1162,6 @@ impl webrender::ApiRecordingReceiver for YamlFrameWriterReceiver {
                         _ => {}
                     }
                 }
-
             }
             _ => {}
         }


### PR DESCRIPTION
## TODO

- [x] plumbing to have a dedicated thread for scene building,
- [x] remove all resource cache access from scene building,
- [x] remove access to other render-backend-only objects,
- [x] reorganize transactions to know when we need to build a scene and when we don't,
- [x] move scene building to its own thread,
- [ ] enable by default.
- [x] Clean up.

## Done 

List of (subtle) things that I am changing here (I probably won't remember all of them by the time this is ready):

 - Arc the ScenePipelines so that Scene can be somewhat cheaply cloned and sent to the building thread.
 - window_size moved from FrameContext to FrameBuilder (resizing the window always require re-layout, so the DL and window size need to be kept in sync).
 - The clip scroll tree is built in the scene builder but finalized when received in the render backend thread (needs the old scroll state which isn't available in the scene building thread).
 - Arc the clip chain nodes to make the clip scroll tree sendable (because of the item above).
 - Added ApiMsg::WakeUp so that the scene builder thread can wake the render backend up after sending the built scene from another channel (because ipc channel).
 - Making scene building stateless. Currently FrameContext is responsible for two things: managing scrolling and scene building. Now that these two happen on different threads they have to be separated. As part of that some recycling of various data structure is lost (for now).
 - Split transaction into the things that need to be applied before and after scene building, also separate resource updates which will need special treatment in the near future. Right now I kept a single DocumentMsg type for both the prefix and postfix ops which untidy but is a best effort to not touch every single line in render_backend.rs and make rebasing easier, this should change.
 - Move information not used for scene building out of the Scene struct (dynamic properties and removed pipelines moved to Document).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2362)
<!-- Reviewable:end -->
