### PR TITLE
Fix z-ordering of transformed content inside preserve-3d context.

### DIFF
--- a/wrench/reftests/split/ordering-ref.yaml
+++ b/wrench/reftests/split/ordering-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+    -
+      bounds: [15, 15, 150, 300]
+      type: rect
+      color: 255 0 0 1.0000
+    -
+      bounds: [203, 15, 150, 300]
+      type: rect
+      color: 255 0 0 1.0000
+    -
+      bounds: [0, 0, 450, 150]
+      type: rect
+      color: 0 0 0 0.6667

--- a/wrench/reftests/split/ordering.yaml
+++ b/wrench/reftests/split/ordering.yaml
@@ -1,0 +1,21 @@
+---
+root:
+  items:
+    -
+      type: "stacking-context"
+      transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 15, 15, 0, 1]
+      "transform-style": "preserve-3d"
+      perspective: [1, 0, 0, 0, 0, 1, 0, 0, -0.05, -0.1, 1, -0.00066666666, 0, 0, 0, 1]
+      items:
+        -
+          bounds: [0, 0, 150, 300]
+          type: rect
+          color: 255 0 0 1.0000
+    -
+      bounds: [203, 15, 150, 300]
+      type: rect
+      color: 255 0 0 1.0000
+    -
+      bounds: [0, 0, 450, 150]
+      type: rect
+      color: 0 0 0 0.6667

--- a/wrench/reftests/split/reftest.list
+++ b/wrench/reftests/split/reftest.list
@@ -7,3 +7,4 @@
 == intermediate-2.yaml intermediate-1-ref.yaml
 == split-intersect1.yaml split-intersect1-ref.yaml
 #== cross.yaml cross-ref.yaml #TODO: investigate sub-pixel differences
+== ordering.yaml ordering-ref.yaml


### PR DESCRIPTION
When a 3d rendering context is established, add an extra picture
(that is never composited to an intermediate surface). This extra
pictures serves as a 3d rendering context container.

Add a normal picture as a child of that container which is marked
as using an intermediate surface. Any untransformed content that
is included as part of the 3d rendering context will be placed in
here, and be rendered in the correct order. If no untransformed
content is added, then this picture won't be allocated and will
have no effect on intermediate surface allocation.

This gets us some ordering and correctness fixes. It still doesn't
dynamically avoid plane-splitting when it's not needed. However,
with this in place, and the recent changes to add PictureState,
adding this optimization will be relatively simple.

Fixes #2337.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2369)
<!-- Reviewable:end -->
