### PR TITLE
Fix YAML writer to properly write clipchains

### DIFF
--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1018,7 +1018,7 @@ impl YamlFrameWriter {
                     str_node(&mut v, "type", "clip-chain");
 
                     let id = ClipId::ClipChain(item.id);
-                    u32_node(&mut v, "id", clip_id_mapper.map_id(&id) as u32);
+                    u32_node(&mut v, "id", clip_id_mapper.add_id(id) as u32);
 
                     let clip_ids: Vec<u32> = display_list.get(base.clip_chain_items()).map(|clip_id| {
                         clip_id_mapper.map_id(&clip_id) as u32


### PR DESCRIPTION
r? @mrobinson 

Converting a binary recording to yaml was panicking, this fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2387)
<!-- Reviewable:end -->
