### PR TITLE
Don't request source image from texture cache, if pre-rendered cache is valid.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -10,7 +10,7 @@ use ellipse::Ellipse;
 use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use prim_store::{ClipData, ImageMaskData};
-use resource_cache::ResourceCache;
+use resource_cache::{ImageRequest, ResourceCache};
 use util::{MaxRect, MatrixHelpers, calculate_screen_bounding_rect, extract_inner_rect_safe};
 
 pub type ClipStore = FreeList<ClipSources>;
@@ -230,7 +230,14 @@ impl ClipSources {
             }
 
             if let ClipSource::Image(ref mask) = *source {
-                resource_cache.request_image(mask.image, ImageRendering::Auto, None, gpu_cache);
+                resource_cache.request_image(
+                    ImageRequest {
+                        key: mask.image,
+                        rendering: ImageRendering::Auto,
+                        tile: None,
+                    },
+                    gpu_cache,
+                );
             }
         }
     }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -31,7 +31,7 @@ use prim_store::{PrimitiveStore, RadialGradientPrimitiveCpu};
 use prim_store::{BrushSegmentDescriptor, PrimitiveRun, TextRunPrimitiveCpu};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_task::{ClearMode, ClipChain, RenderTask, RenderTaskId, RenderTaskTree};
-use resource_cache::ResourceCache;
+use resource_cache::{ImageRequest, ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
 use std::{mem, usize, f32};
 use tiling::{CompositeOps, Frame, RenderPass, RenderTargetKind};
@@ -1518,9 +1518,11 @@ impl FrameBuilder {
             current_epoch: Epoch::invalid(),
             source: ImageSource::Default,
             key: ImageCacheKey {
-                image_key,
-                image_rendering,
-                tile_offset,
+                request: ImageRequest {
+                    key: image_key,
+                    rendering: image_rendering,
+                    tile: tile_offset,
+                },
                 texel_rect: sub_rect.map(|texel_rect| {
                     DeviceIntRect::new(
                         DeviceIntPoint::new(

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -21,7 +21,7 @@ use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, EdgeAaSegmentMask};
 use profiler::FrameProfileCounters;
 use render_task::{BlitSource, RenderTaskAddress, RenderTaskId, RenderTaskKind};
 use render_task::{BlurTask, ClearMode, RenderTaskLocation, RenderTaskTree};
-use resource_cache::{ResourceCache};
+use resource_cache::ResourceCache;
 use std::{cmp, usize, f32, i32};
 use texture_allocator::GuillotineAllocator;
 
@@ -395,9 +395,7 @@ impl RenderTarget for ColorRenderTarget {
                     BlitSource::Image { key } => {
                         // Get the cache item for the source texture.
                         let cache_item = resolve_image(
-                            key.image_key,
-                            key.image_rendering,
-                            key.tile_offset,
+                            key.request,
                             ctx.resource_cache,
                             gpu_cache,
                             deferred_resolves,


### PR DESCRIPTION
When using pre-rendered image sources, there's no need to request the source image each frame. It just wastes room in the texture cache having the source image referenced if it's not being used. This is a minor win - but will become more important once we start handling image tiling internally within each image primitive.

Also tidied up the image request APIs slightly to pass a struct instead of various fields that make up a request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2391)
<!-- Reviewable:end -->
