### PR TITLE
Add hit testing support for ClipChains from the API

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -43,10 +43,10 @@ impl CoordinateSystemId {
     }
 }
 
-struct ClipChainDescriptor {
-    id: ClipChainId,
-    parent: Option<ClipChainId>,
-    clips: Vec<ClipId>,
+pub struct ClipChainDescriptor {
+    pub id: ClipChainId,
+    pub parent: Option<ClipChainId>,
+    pub clips: Vec<ClipId>,
 }
 
 pub struct ClipScrollTree {
@@ -55,7 +55,7 @@ pub struct ClipScrollTree {
     /// A Vec of all descriptors that describe ClipChains in the order in which they are
     /// encountered during display list flattening. ClipChains are expected to never be
     /// the children of ClipChains later in the list.
-    clip_chains_descriptors: Vec<ClipChainDescriptor>,
+    pub clip_chains_descriptors: Vec<ClipChainDescriptor>,
 
     /// A HashMap of built ClipChains that are described by `clip_chains_descriptors`.
     pub clip_chains: FastHashMap<ClipChainId, ClipChain>,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -19,7 +19,7 @@ use debug_server;
 use frame::FrameContext;
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use gpu_cache::GpuCache;
-use hit_test::HitTester;
+use hit_test::{HitTest, HitTester};
 use internal_types::{DebugOutput, FastHashMap, FastHashSet, RenderedDocument, ResultMsg};
 use profiler::{BackendProfileCounters, IpcProfileCounters, ResourceProfileCounters};
 use record::ApiRecordingReceiver;
@@ -419,7 +419,9 @@ impl RenderBackend {
             DocumentMsg::HitTest(pipeline_id, point, flags, tx) => {
 
                 let result = match doc.hit_tester {
-                    Some(ref hit_tester) => hit_tester.hit_test(pipeline_id, point, flags),
+                    Some(ref hit_tester) => {
+                        hit_tester.hit_test(HitTest::new(pipeline_id, point, flags))
+                    }
                     None => HitTestResult { items: Vec::new() },
                 };
 


### PR DESCRIPTION
Hit testing now has support for tests against items that were clipped by
API-defined ClipChains. Both clipping ClipScrollNodes nodes and
ClipChains are converted to pairs of ClipScrollNodes and ClipChains for
purposes of the HitTester. This more-or-less matches the logical next
step in ClipScrollTree design and makes the logic for HitTesting
simpler.

Fixes #2383.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2392)
<!-- Reviewable:end -->
