### PR TITLE
re-rasterize fast text shadows directly with the given shadow color

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -773,7 +773,7 @@ impl AlphaBatcher {
                         debug_assert_ne!(texture_id, SourceTexture::Invalid);
 
                         // Ignore color and only sample alpha when shadowing.
-                        if text_cpu.is_shadow() {
+                        if text_cpu.shadow {
                             glyph_format = glyph_format.ignore_color();
                         }
 
@@ -809,7 +809,7 @@ impl AlphaBatcher {
                                     } else if ctx.use_dual_source_blending {
                                         BlendMode::SubpixelDualSource
                                     } else {
-                                        BlendMode::SubpixelConstantTextColor(text_cpu.get_color())
+                                        BlendMode::SubpixelConstantTextColor(text_cpu.font.color.into())
                                     }
                                 }
                                 GlyphFormat::Alpha |

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, BorderDetails, BorderDisplayItem, BuiltDisplayList, ClipAndScrollInfo};
-use api::{ClipId, ColorF, ColorU, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixelScale};
+use api::{ClipId, ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixelScale};
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentLayer, Epoch, ExtendMode};
 use api::{ExternalScrollId, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop, ImageKey};
 use api::{ImageRendering, ItemRange, LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize};
@@ -1407,7 +1407,7 @@ impl FrameBuilder {
             glyph_gpu_blocks: Vec::new(),
             glyph_keys: Vec::new(),
             offset: run_offset,
-            shadow_color: ColorU::new(0, 0, 0, 0),
+            shadow: false,
         };
 
         // Text shadows that have a blur radius of 0 need to be rendered as normal
@@ -1425,7 +1425,8 @@ impl FrameBuilder {
             match picture_prim.kind {
                 PictureKind::TextShadow { offset, color, blur_radius, .. } if blur_radius == 0.0 => {
                     let mut text_prim = prim.clone();
-                    text_prim.shadow_color = color.into();
+                    text_prim.font.color = color.into();
+                    text_prim.shadow = true;
                     text_prim.offset += offset;
                     fast_shadow_prims.push((idx, text_prim));
                 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, BorderRadius, BuiltDisplayList, ClipAndScrollInfo, ClipMode};
-use api::{ColorF, ColorU, DeviceIntRect, DeviceIntSize, DevicePixelScale, Epoch};
+use api::{ColorF, DeviceIntRect, DeviceIntSize, DevicePixelScale, Epoch};
 use api::{ComplexClipRegion, ExtendMode, FontRenderMode};
 use api::{GlyphInstance, GlyphKey, GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag};
 use api::{LayerPoint, LayerRect, LayerSize, LayerToWorldTransform, LayerVector2D, LineOrientation};
@@ -644,7 +644,7 @@ pub struct TextRunPrimitiveCpu {
     pub glyph_count: usize,
     pub glyph_keys: Vec<GlyphKey>,
     pub glyph_gpu_blocks: Vec<GpuBlockData>,
-    pub shadow_color: ColorU,
+    pub shadow: bool,
 }
 
 impl TextRunPrimitiveCpu {
@@ -663,18 +663,6 @@ impl TextRunPrimitiveCpu {
             }
         }
         font
-    }
-
-    pub fn is_shadow(&self) -> bool {
-        self.shadow_color.a != 0
-    }
-
-    pub fn get_color(&self) -> ColorF {
-        ColorF::from(if self.is_shadow() {
-            self.shadow_color
-        } else {
-            self.font.color
-        })
     }
 
     fn prepare_for_render(
@@ -726,7 +714,7 @@ impl TextRunPrimitiveCpu {
     }
 
     fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
-        request.push(self.get_color().premultiplied());
+        request.push(ColorF::from(self.font.color).premultiplied());
         // this is the only case where we need to provide plain color to GPU
         let bg_color = ColorF::from(self.font.bg_color);
         request.push([bg_color.r, bg_color.g, bg_color.b, 1.0]);

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -20,9 +20,9 @@ fuzzy(1,100) == decorations-suite.yaml decorations-suite.png
 fuzzy(1,735) == shadow-grey.yaml shadow-grey-ref.yaml
 fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
-options(disable-aa) == shadow-atomic.yaml shadow-atomic-ref.yaml
-options(disable-aa) == shadow-clip-rect.yaml shadow-atomic-ref.yaml
-options(disable-aa) platform(linux) == shadow-ordering.yaml shadow-ordering-ref.yaml
+== shadow-atomic.yaml shadow-atomic-ref.yaml
+== shadow-clip-rect.yaml shadow-atomic-ref.yaml
+== shadow-ordering.yaml shadow-ordering-ref.yaml
 != synthetic-bold.yaml synthetic-bold-not-ref.yaml
 fuzzy(1,229) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml
 != synthetic-bold-transparent.yaml synthetic-bold.yaml

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -22,7 +22,7 @@ fuzzy(1,614) == shadow-grey-transparent.yaml shadow-grey-ref.yaml
 == subtle-shadow.yaml subtle-shadow-ref.yaml
 == shadow-atomic.yaml shadow-atomic-ref.yaml
 == shadow-clip-rect.yaml shadow-atomic-ref.yaml
-== shadow-ordering.yaml shadow-ordering-ref.yaml
+platform(linux) == shadow-ordering.yaml shadow-ordering-ref.yaml
 != synthetic-bold.yaml synthetic-bold-not-ref.yaml
 fuzzy(1,229) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml
 != synthetic-bold-transparent.yaml synthetic-bold.yaml


### PR DESCRIPTION
It seems that in the wild people are expecting unblurred text shadows to be precisely the same as if the text is drawn with the shadow color. So long as we have to deal with subpixel anti-aliasing and preblending, it is not really possible to reuse the subpixel AA masks and satisfy those constraints. Thus, we have to go back to the old method of just re-rasterizing the text shadow AA masks with the font color being exactly the shadow color, or the preblending just gets messed up.

This fixes issue #2384 and also the downstream Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1434029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2393)
<!-- Reviewable:end -->
