### PR TITLE
Assign all ClipIds during display list construction

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{ClipChainId, ClipId, DeviceIntRect, DevicePixelScale, ExternalScrollId, LayerPoint};
-use api::{LayerRect, LayerToWorldTransform, LayerVector2D, LayoutTransform, PipelineId};
-use api::{PropertyBinding, ScrollClamping, ScrollEventPhase, ScrollLocation, ScrollNodeIdType};
+use api::{LayerRect, LayerToWorldTransform, LayerVector2D, PipelineId, ScrollClamping};
+use api::{ScrollEventPhase, ScrollLocation, ScrollNodeIdType};
 use api::{ScrollNodeState, WorldPoint};
 use clip::ClipStore;
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollFrameInfo, StickyFrameInfo};
@@ -464,40 +464,6 @@ impl ClipScrollTree {
                 node.set_scroll_origin(&offset, clamping);
             }
         }
-    }
-
-    pub fn generate_new_clip_id(&mut self, pipeline_id: PipelineId) -> ClipId {
-        let new_id = ClipId::DynamicallyAddedNode(self.current_new_node_item, pipeline_id);
-        self.current_new_node_item += 1;
-        new_id
-    }
-
-    pub fn add_reference_frame(
-        &mut self,
-        rect: &LayerRect,
-        source_transform: Option<PropertyBinding<LayoutTransform>>,
-        source_perspective: Option<LayoutTransform>,
-        origin_in_parent_reference_frame: LayerVector2D,
-        pipeline_id: PipelineId,
-        parent_id: Option<ClipId>,
-        root_for_pipeline: bool,
-    ) -> ClipId {
-        let reference_frame_id = if root_for_pipeline {
-            ClipId::root_reference_frame(pipeline_id)
-        } else {
-            self.generate_new_clip_id(pipeline_id)
-        };
-
-        let node = ClipScrollNode::new_reference_frame(
-            parent_id,
-            rect,
-            source_transform,
-            source_perspective,
-            origin_in_parent_reference_frame,
-            pipeline_id,
-        );
-        self.add_node(node, reference_frame_id);
-        reference_frame_id
     }
 
     pub fn add_sticky_frame(

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -632,26 +632,25 @@ impl FrameBuilder {
 
     pub fn push_reference_frame(
         &mut self,
+        reference_frame_id: ClipId,
         parent_id: Option<ClipId>,
         pipeline_id: PipelineId,
         rect: &LayerRect,
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayerVector2D,
-        root_for_pipeline: bool,
         clip_scroll_tree: &mut ClipScrollTree,
-    ) -> ClipId {
-        let new_id = clip_scroll_tree.add_reference_frame(
+    ) {
+        let node = ClipScrollNode::new_reference_frame(
+            parent_id,
             rect,
             source_transform,
             source_perspective,
             origin_in_parent_reference_frame,
             pipeline_id,
-            parent_id,
-            root_for_pipeline,
         );
-        self.reference_frame_stack.push(new_id);
-        new_id
+        clip_scroll_tree.add_node(node, reference_frame_id);
+        self.reference_frame_stack.push(reference_frame_id);
     }
 
     pub fn current_reference_frame_id(&self) -> ClipId {
@@ -686,13 +685,13 @@ impl FrameBuilder {
     ) -> ClipId {
         let viewport_rect = LayerRect::new(LayerPoint::zero(), *viewport_size);
         self.push_reference_frame(
+            ClipId::root_reference_frame(pipeline_id),
             None,
             pipeline_id,
             &viewport_rect,
             None,
             None,
             LayerVector2D::zero(),
-            true,
             clip_scroll_tree,
         );
 

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -213,7 +213,8 @@ pub enum ScrollSensitivity {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ScrollFrameDisplayItem {
-    pub id: ClipId,
+    pub clip_id: ClipId,
+    pub scroll_frame_id: ClipId,
     pub external_id: Option<ExternalScrollId>,
     pub image_mask: Option<ImageMask>,
     pub scroll_sensitivity: ScrollSensitivity,
@@ -455,6 +456,7 @@ pub struct StackingContext {
     pub transform_style: TransformStyle,
     pub perspective: Option<LayoutTransform>,
     pub mix_blend_mode: MixBlendMode,
+    pub reference_frame_id: Option<ClipId>,
 } // IMPLICIT: filters: Vec<FilterOp>
 
 #[repr(u32)]
@@ -509,6 +511,7 @@ pub enum FilterOp {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct IframeDisplayItem {
+    pub clip_id: ClipId,
     pub pipeline_id: PipelineId,
 }
 
@@ -753,29 +756,30 @@ pub struct ClipChainId(pub u64, pub PipelineId);
 pub enum ClipId {
     Clip(u64, PipelineId),
     ClipChain(ClipChainId),
-    DynamicallyAddedNode(u64, PipelineId),
 }
+
+const ROOT_REFERENCE_FRAME_CLIP_ID: u64 = 0;
+const ROOT_SCROLL_NODE_CLIP_ID: u64 = 1;
 
 impl ClipId {
     pub fn root_scroll_node(pipeline_id: PipelineId) -> ClipId {
-        ClipId::Clip(0, pipeline_id)
+        ClipId::Clip(ROOT_SCROLL_NODE_CLIP_ID, pipeline_id)
     }
 
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ClipId {
-        ClipId::DynamicallyAddedNode(0, pipeline_id)
+        ClipId::Clip(ROOT_REFERENCE_FRAME_CLIP_ID, pipeline_id)
     }
 
     pub fn pipeline_id(&self) -> PipelineId {
         match *self {
             ClipId::Clip(_, pipeline_id) |
-            ClipId::ClipChain(ClipChainId(_, pipeline_id)) |
-            ClipId::DynamicallyAddedNode(_, pipeline_id) => pipeline_id,
+            ClipId::ClipChain(ClipChainId(_, pipeline_id)) => pipeline_id,
         }
     }
 
     pub fn is_root_scroll_node(&self) -> bool {
         match *self {
-            ClipId::Clip(0, _) => true,
+            ClipId::Clip(1, _) => true,
             _ => false,
         }
     }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -31,6 +31,9 @@ use serde::ser::{Serializer, SerializeSeq};
 // This needs to be set to (renderer::MAX_VERTEX_TEXTURE_WIDTH - VECS_PER_PRIM_HEADER - VECS_PER_TEXT_RUN) * 2
 pub const MAX_TEXT_RUN_LENGTH: usize = 2038;
 
+// We start at 2 , because the root reference is always 0 and the root scroll node is always 1.
+const FIRST_CLIP_ID: u64 = 2;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ItemRange<T> {
@@ -809,9 +812,6 @@ impl DisplayListBuilder {
     ) -> Self {
         let start_time = precise_time_ns();
 
-        // We start at 1 here, because the root scroll id is always 0.
-        const FIRST_CLIP_ID: u64 = 1;
-
         DisplayListBuilder {
             data: Vec::with_capacity(capacity),
             pipeline_id,
@@ -1312,6 +1312,12 @@ impl DisplayListBuilder {
         mix_blend_mode: MixBlendMode,
         filters: Vec<FilterOp>,
     ) {
+        let reference_frame_id = if transform.is_some() || perspective.is_some() {
+            Some(self.generate_clip_id())
+        } else {
+            None
+        };
+
         let item = SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
             stacking_context: StackingContext {
                 scroll_policy,
@@ -1319,6 +1325,7 @@ impl DisplayListBuilder {
                 transform_style,
                 perspective,
                 mix_blend_mode,
+                reference_frame_id,
             },
         });
 
@@ -1386,19 +1393,24 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
-        let id = self.generate_clip_id();
+        let clip_id = self.generate_clip_id();
+        let scroll_frame_id = self.generate_clip_id();
         let item = SpecificDisplayItem::ScrollFrame(ScrollFrameDisplayItem {
-            id,
+            clip_id,
+            scroll_frame_id,
             external_id,
             image_mask,
             scroll_sensitivity,
         });
-        let info = LayoutPrimitiveInfo::with_clip_rect(content_rect, clip_rect);
 
-        let scrollinfo = ClipAndScrollInfo::simple(parent);
-        self.push_item_with_clip_scroll_info(item, &info, scrollinfo);
+        self.push_item_with_clip_scroll_info(
+            item,
+            &LayoutPrimitiveInfo::with_clip_rect(content_rect, clip_rect),
+            ClipAndScrollInfo::simple(parent),
+        );
         self.push_iter(complex_clips);
-        id
+
+        scroll_frame_id
     }
 
     pub fn define_clip_chain<I>(
@@ -1502,7 +1514,8 @@ impl DisplayListBuilder {
 
     pub fn push_iframe(&mut self, info: &LayoutPrimitiveInfo, pipeline_id: PipelineId) {
         let item = SpecificDisplayItem::Iframe(IframeDisplayItem {
-            pipeline_id: pipeline_id,
+            clip_id: self.generate_clip_id(),
+            pipeline_id,
         });
         self.push_item(item, info);
     }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1032,7 +1032,7 @@ impl YamlFrameWriter {
                 }
                 ScrollFrame(item) => {
                     str_node(&mut v, "type", "scroll-frame");
-                    usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));
+                    usize_node(&mut v, "id", clip_id_mapper.add_id(item.scroll_frame_id));
                     size_node(&mut v, "content-size", &base.rect().size);
                     rect_node(&mut v, "bounds", &base.local_clip().clip_rect());
 


### PR DESCRIPTION
This change makes it so that all ClipIds are assigned during display
list construction. This will allow us to count the number of ClipIds in
each display list during construction, making it possible to more easily
map them onto simple array indices. The final goal of this work is to
eliminate the performance cost of hashing when flattening and rendering
display lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2402)
<!-- Reviewable:end -->
