### PR TITLE
Remove an empty api.rs file

### DIFF
--- a/webrender_api/api.rs
+++ b/webrender_api/api.rs
@@ -1,4 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-


### PR DESCRIPTION
This was probably checked in by mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2404)
<!-- Reviewable:end -->
