### PR TITLE
Only apply mip-maps if both image dimensions are > 512.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -904,7 +904,9 @@ impl ResourceCache {
                     // that is > 512 in either dimension, so it should cover
                     // the most important use cases. We may want to support
                     // mip-maps on shared cache items in the future.
-                    if !self.texture_cache.is_allowed_in_shared_cache(
+                    if descriptor.width > 512 &&
+                       descriptor.height > 512 &&
+                       !self.texture_cache.is_allowed_in_shared_cache(
                         TextureFilter::Linear,
                         &descriptor,
                     ) {


### PR DESCRIPTION
This is a hack / workaround for some test failures in gecko.

There are some test images with resolution 2048x32. These were
having mips enabled, but then failing reftests since the tests
were expecting bilinear filtering only. When these images were
being drawn with a size of 4x4 pixels, the smallest mip was
being selected, which is not what the test expects.

This workaround is a reasonable tradeoff for now - we get mip
mapping on large images, while allowing the existing tests to
pass.

In the future, we could consider some alternatives (such as a better
heuristic for enabling mips, or a different mip algorithm).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2409)
<!-- Reviewable:end -->
