### PR TITLE
Remove wrench's scrolling workaround.

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -349,8 +349,8 @@ impl RenderNotifier for Notifier {
         self.tx.send(NotifierEvent::ShutDown).unwrap();
     }
 
-    fn new_document_ready(&self, _: DocumentId, scrolled: bool, _composite_needed: bool) {
-        if !scrolled {
+    fn new_document_ready(&self, _: DocumentId, _scrolled: bool, composite_needed: bool) {
+        if composite_needed {
             self.wake_up();
         }
     }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -515,27 +515,11 @@ impl Wrench {
                 false,
             );
         }
-        // TODO(nical) - Need to separate the set_display_list from the scrolling
-        // operations into separate transactions for mysterious -but probably related
-        // to the other comment below- reasons.
-        self.api.send_transaction(self.document_id, txn);
 
-        let mut txn = Transaction::new();
         for (id, offset) in scroll_offsets {
             txn.scroll_node_with_id(*offset, *id, ScrollClamping::NoClamping);
         }
-        // TODO(nical) - Wrench does not notify frames when there was scrolling
-        // in the transaction (See RenderNotifier implementations). If we don't
-        // generate a frame after scrolling, wrench just stops and some tests
-        // will time out.
-        // I suppose this was to avoid taking the snapshot after scrolling if
-        // there was other updates coming in a subsequent messages but it's very
-        // error-prone with transactions.
-        // For now just send two transactions to avoid the deadlock, but we should
-        // figure this out.
-        self.api.send_transaction(self.document_id, txn);
 
-        let mut txn = Transaction::new();
         txn.generate_frame();
         self.api.send_transaction(self.document_id, txn);
     }


### PR DESCRIPTION
This PR makes wrench build a single transaction with the display list and scrolling information, and remove the workaround that makes wrench ignore transactions containing scrolling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2410)
<!-- Reviewable:end -->
