### PR TITLE
Support all image sampler kinds with brush_image implementation.

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -22,7 +22,13 @@ void brush_vs(
     ivec2 user_data,
     PictureTask pic_task
 ) {
-    vec2 texture_size = vec2(textureSize(sColor0, 0).xy);
+    // If this is in WR_FEATURE_TEXTURE_RECT mode, the rect and size use
+    // non-normalized texture coordinates.
+#ifdef WR_FEATURE_TEXTURE_RECT
+    vec2 texture_size = vec2(1, 1);
+#else
+    vec2 texture_size = vec2(textureSize(sColor0, 0));
+#endif
 
     ImageResource res = fetch_image_resource(user_data.x);
     vec2 uv0 = res.uv_rect.p0;
@@ -46,7 +52,7 @@ void brush_vs(
 vec4 brush_fs() {
     vec2 uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
 
-    vec4 color = texture(sColor0, vec3(uv, vUv.z));
+    vec4 color = TEX_SAMPLE(sColor0, vec3(uv, vUv.z));
 
 #ifdef WR_FEATURE_ALPHA_PASS
     color *= init_transform_fs(vLocalPos);

--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -24,7 +24,7 @@
 #define TEX_SAMPLE(sampler, tex_coord) texture(sampler, tex_coord.xy)
 #else
 // In normal case, we use textureLod(). We haven't used the lod yet. So, we always pass 0.0 now.
-#define TEX_SAMPLE(sampler, tex_coord) textureLod(sampler, tex_coord, 0.0)
+#define TEX_SAMPLE(sampler, tex_coord) texture(sampler, tex_coord)
 #endif
 
 //======================================================================================


### PR DESCRIPTION
As a follow up, we need to add better test coverage of these other
image types via a rawtest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2412)
<!-- Reviewable:end -->
