### PR TITLE
Aggressively re-use render targets in the pool

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -15,7 +15,7 @@ use gpu_cache::{GpuCache, GpuCacheAddress};
 use gpu_types::{BrushImageKind, BrushInstance, ClipChainRectIndex};
 use gpu_types::{ClipMaskInstance, ClipScrollNodeIndex};
 use gpu_types::{CompositePrimitiveInstance, PrimitiveInstance, SimplePrimitiveInstance};
-use internal_types::{FastHashMap, SourceTexture};
+use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive, PictureSurface};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{ImageSource, PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
@@ -1052,12 +1052,12 @@ impl AlphaBatchBuilder {
                                                 }
 
                                                 let secondary_id = secondary_render_task_id.expect("no secondary!?");
-                                                let render_task = &render_tasks[secondary_id];
+                                                let saved_index = render_tasks[secondary_id].saved_index.expect("no saved index!?");
+                                                debug_assert_ne!(saved_index, SavedTargetIndex::PENDING);
                                                 let secondary_task_address = render_tasks.get_task_address(secondary_id);
-                                                let render_pass_index = render_task.pass_index.expect("no render_pass_index!?");
                                                 let secondary_textures = BatchTextures {
                                                     colors: [
-                                                        SourceTexture::RenderTaskCacheRGBA8(render_pass_index),
+                                                        SourceTexture::RenderTaskCache(saved_index),
                                                         SourceTexture::Invalid,
                                                         SourceTexture::Invalid,
                                                     ],

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -438,6 +438,7 @@ pub struct Texture {
     render_target: Option<RenderTargetInfo>,
     fbo_ids: Vec<FBOId>,
     depth_rb: Option<RBOId>,
+    last_frame_used: FrameId,
 }
 
 impl Texture {
@@ -471,6 +472,10 @@ impl Texture {
 
     pub fn get_rt_info(&self) -> Option<&RenderTargetInfo> {
         self.render_target.as_ref()
+    }
+
+    pub fn used_in_frame(&self, frame_id: FrameId) -> bool {
+        self.last_frame_used == frame_id
     }
 
     #[cfg(feature = "replay")]
@@ -940,6 +945,7 @@ impl Device {
             render_target: None,
             fbo_ids: vec![],
             depth_rb: None,
+            last_frame_used: self.frame_id,
         }
     }
 
@@ -1019,6 +1025,7 @@ impl Device {
         texture.filter = filter;
         texture.layer_count = layer_count;
         texture.render_target = render_target;
+        texture.last_frame_used = self.frame_id;
 
         self.bind_texture(DEFAULT_TEXTURE, texture);
         self.set_texture_parameters(texture.target, filter);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -22,7 +22,7 @@ use glyph_rasterizer::FontInstance;
 use gpu_cache::GpuCache;
 use gpu_types::{ClipChainRectIndex, ClipScrollNodeData, PictureType};
 use hit_test::{HitTester, HitTestingItem, HitTestingRun};
-use internal_types::{FastHashMap, FastHashSet, RenderPassIndex};
+use internal_types::{FastHashMap, FastHashSet};
 use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive, PictureSurface};
 use prim_store::{BrushKind, BrushPrimitive, ImageCacheKey, YuvImagePrimitiveCpu};
 use prim_store::{GradientPrimitiveCpu, ImagePrimitiveCpu, ImageSource, PrimitiveKind};
@@ -1807,7 +1807,7 @@ impl FrameBuilder {
         let use_dual_source_blending = self.config.dual_source_blending_is_enabled &&
                                        self.config.dual_source_blending_is_supported;
 
-        for (pass_index, pass) in passes.iter_mut().enumerate() {
+        for pass in &mut passes {
             let ctx = RenderTargetContext {
                 device_pixel_scale,
                 prim_store: &self.prim_store,
@@ -1823,7 +1823,6 @@ impl FrameBuilder {
                 &mut render_tasks,
                 &mut deferred_resolves,
                 &self.clip_store,
-                RenderPassIndex(pass_index),
             );
 
             if let RenderPassKind::OffScreen { ref texture_cache, .. } = pass.kind {

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -44,7 +44,11 @@ pub struct CacheTextureId(pub usize);
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct CachedRenderTargetIndex(pub usize);
+pub struct SavedTargetIndex(pub usize);
+
+impl SavedTargetIndex {
+    pub const PENDING: Self = SavedTargetIndex(!0);
+}
 
 // Represents the source for a texture.
 // These are passed from throughout the
@@ -61,10 +65,7 @@ pub enum SourceTexture {
     External(ExternalImageData),
     CacheA8,
     CacheRGBA8,
-    //TODO: Remove this once `RenderTaskCacheA8` is used.
-    #[allow(dead_code)]
-    RenderTaskCacheA8(CachedRenderTargetIndex),
-    RenderTaskCacheRGBA8(CachedRenderTargetIndex),
+    RenderTaskCache(SavedTargetIndex),
 }
 
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -44,7 +44,7 @@ pub struct CacheTextureId(pub usize);
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct RenderPassIndex(pub usize);
+pub struct CachedRenderTargetIndex(pub usize);
 
 // Represents the source for a texture.
 // These are passed from throughout the
@@ -61,10 +61,10 @@ pub enum SourceTexture {
     External(ExternalImageData),
     CacheA8,
     CacheRGBA8,
-    // XXX Remove this once RenderTaskCacheA8 is used.
+    //TODO: Remove this once `RenderTaskCacheA8` is used.
     #[allow(dead_code)]
-    RenderTaskCacheA8(RenderPassIndex),
-    RenderTaskCacheRGBA8(RenderPassIndex),
+    RenderTaskCacheA8(CachedRenderTargetIndex),
+    RenderTaskCacheRGBA8(CachedRenderTargetIndex),
 }
 
 pub const ORTHO_NEAR_PLANE: f32 = -1000000.0;

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -368,7 +368,7 @@ impl PicturePrimitive {
                     }
                     Some(PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, color))) => {
                         let rect = (prim_local_rect.translate(&-offset) * content_scale).round().to_i32();
-                        let picture_task = RenderTask::new_picture(
+                        let mut picture_task = RenderTask::new_picture(
                             RenderTaskLocation::Dynamic(None, rect.size),
                             prim_index,
                             RenderTargetKind::Color,
@@ -378,6 +378,7 @@ impl PicturePrimitive {
                             pic_state_for_children.tasks,
                             PictureType::Image,
                         );
+                        picture_task.mark_for_saving();
 
                         let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
                         let picture_task_id = frame_state.render_tasks.add(picture_task);

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -10,7 +10,7 @@ use clip_scroll_tree::CoordinateSystemId;
 use device::TextureFilter;
 use gpu_cache::GpuCache;
 use gpu_types::{ClipScrollNodeIndex, PictureType};
-use internal_types::{FastHashMap, RenderPassIndex, SourceTexture};
+use internal_types::{CachedRenderTargetIndex, FastHashMap, SourceTexture};
 use picture::ContentOrigin;
 use prim_store::{PrimitiveIndex, ImageCacheKey};
 #[cfg(feature = "debugger")]
@@ -331,7 +331,7 @@ pub struct RenderTask {
     pub children: Vec<RenderTaskId>,
     pub kind: RenderTaskKind,
     pub clear_mode: ClearMode,
-    pub pass_index: Option<RenderPassIndex>,
+    pub cached_index: Option<CachedRenderTargetIndex>,
 }
 
 impl RenderTask {
@@ -356,7 +356,7 @@ impl RenderTask {
                 pic_type,
             }),
             clear_mode,
-            pass_index: None,
+            cached_index: None,
         }
     }
 
@@ -366,7 +366,7 @@ impl RenderTask {
             location: RenderTaskLocation::Dynamic(None, screen_rect.size),
             kind: RenderTaskKind::Readback(screen_rect),
             clear_mode: ClearMode::Transparent,
-            pass_index: None,
+            cached_index: None,
         }
     }
 
@@ -392,7 +392,7 @@ impl RenderTask {
                 source,
             }),
             clear_mode: ClearMode::Transparent,
-            pass_index: None,
+            cached_index: None,
         }
     }
 
@@ -410,7 +410,7 @@ impl RenderTask {
                 coordinate_system_id: prim_coordinate_system_id,
             }),
             clear_mode: ClearMode::One,
-            pass_index: None,
+            cached_index: None,
         }
     }
 
@@ -473,7 +473,7 @@ impl RenderTask {
                 scale_factor,
             }),
             clear_mode,
-            pass_index: None,
+            cached_index: None,
         };
 
         let blur_task_v_id = render_tasks.add(blur_task_v);
@@ -488,7 +488,7 @@ impl RenderTask {
                 scale_factor,
             }),
             clear_mode,
-            pass_index: None,
+            cached_index: None,
         };
 
         (blur_task_h, scale_factor)
@@ -507,7 +507,7 @@ impl RenderTask {
                 RenderTargetKind::Color => ClearMode::Transparent,
                 RenderTargetKind::Alpha => ClearMode::One,
             },
-            pass_index: None,
+            cached_index: None,
         }
     }
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -10,7 +10,7 @@ use clip_scroll_tree::CoordinateSystemId;
 use device::TextureFilter;
 use gpu_cache::GpuCache;
 use gpu_types::{ClipScrollNodeIndex, PictureType};
-use internal_types::{CachedRenderTargetIndex, FastHashMap, SourceTexture};
+use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::ContentOrigin;
 use prim_store::{PrimitiveIndex, ImageCacheKey};
 #[cfg(feature = "debugger")]
@@ -43,6 +43,7 @@ pub struct RenderTaskAddress(pub u32);
 pub struct RenderTaskTree {
     pub tasks: Vec<RenderTask>,
     pub task_data: Vec<RenderTaskData>,
+    next_saved: SavedTargetIndex,
 }
 
 pub type ClipChainNodeRef = Option<Rc<ClipChainNode>>;
@@ -135,6 +136,7 @@ impl RenderTaskTree {
         RenderTaskTree {
             tasks: Vec::new(),
             task_data: Vec::new(),
+            next_saved: SavedTargetIndex(0),
         }
     }
 
@@ -195,9 +197,15 @@ impl RenderTaskTree {
     }
 
     pub fn build(&mut self) {
-        for task in &mut self.tasks {
+        for task in &self.tasks {
             self.task_data.push(task.write_task_data());
         }
+    }
+
+    pub fn save_target(&mut self) -> SavedTargetIndex {
+        let id = self.next_saved;
+        self.next_saved.0 += 1;
+        id
     }
 }
 
@@ -331,7 +339,7 @@ pub struct RenderTask {
     pub children: Vec<RenderTaskId>,
     pub kind: RenderTaskKind,
     pub clear_mode: ClearMode,
-    pub cached_index: Option<CachedRenderTargetIndex>,
+    pub saved_index: Option<SavedTargetIndex>,
 }
 
 impl RenderTask {
@@ -356,7 +364,7 @@ impl RenderTask {
                 pic_type,
             }),
             clear_mode,
-            cached_index: None,
+            saved_index: None,
         }
     }
 
@@ -366,7 +374,7 @@ impl RenderTask {
             location: RenderTaskLocation::Dynamic(None, screen_rect.size),
             kind: RenderTaskKind::Readback(screen_rect),
             clear_mode: ClearMode::Transparent,
-            cached_index: None,
+            saved_index: None,
         }
     }
 
@@ -392,7 +400,7 @@ impl RenderTask {
                 source,
             }),
             clear_mode: ClearMode::Transparent,
-            cached_index: None,
+            saved_index: None,
         }
     }
 
@@ -400,7 +408,7 @@ impl RenderTask {
         outer_rect: DeviceIntRect,
         clips: Vec<ClipWorkItem>,
         prim_coordinate_system_id: CoordinateSystemId,
-    ) -> RenderTask {
+    ) -> Self {
         RenderTask {
             children: Vec::new(),
             location: RenderTaskLocation::Dynamic(None, outer_rect.size),
@@ -410,7 +418,7 @@ impl RenderTask {
                 coordinate_system_id: prim_coordinate_system_id,
             }),
             clear_mode: ClearMode::One,
-            cached_index: None,
+            saved_index: None,
         }
     }
 
@@ -473,7 +481,7 @@ impl RenderTask {
                 scale_factor,
             }),
             clear_mode,
-            cached_index: None,
+            saved_index: None,
         };
 
         let blur_task_v_id = render_tasks.add(blur_task_v);
@@ -488,7 +496,7 @@ impl RenderTask {
                 scale_factor,
             }),
             clear_mode,
-            cached_index: None,
+            saved_index: None,
         };
 
         (blur_task_h, scale_factor)
@@ -507,7 +515,7 @@ impl RenderTask {
                 RenderTargetKind::Color => ClearMode::Transparent,
                 RenderTargetKind::Alpha => ClearMode::One,
             },
-            cached_index: None,
+            saved_index: None,
         }
     }
 
@@ -674,7 +682,6 @@ impl RenderTask {
             RenderTaskKind::HorizontalBlur(..) |
             RenderTaskKind::Scaling(..) |
             RenderTaskKind::Blit(..) => false,
-
             RenderTaskKind::CacheMask(..) => true,
         }
     }
@@ -722,6 +729,19 @@ impl RenderTask {
 
         pt.end_level();
         true
+    }
+
+    /// Mark this render task for keeping the results alive up until the end of the frame.
+    pub fn mark_for_saving(&mut self) {
+        match self.location {
+            RenderTaskLocation::Fixed(..) |
+            RenderTaskLocation::Dynamic(..) => {
+                self.saved_index = Some(SavedTargetIndex::PENDING);
+            }
+            RenderTaskLocation::TextureCache(..) => {
+                panic!("Unable to mark a permanently cached task for saving!");
+            }
+        }
     }
 }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4254,6 +4254,7 @@ impl Renderer {
     fn allocate_target_texture<T: RenderTarget>(
         &mut self,
         list: &mut RenderTargetList<T>,
+        frame_id: FrameId,
     ) -> Option<ActiveTexture> {
         debug_assert_ne!(list.max_size, DeviceUintSize::zero());
         if list.targets.is_empty() {
@@ -4281,7 +4282,7 @@ impl Renderer {
         if index.is_none() {
             index = self.texture_resolver.render_target_pool
                 .iter()
-                .position(|texture| texture.get_format() == list.format);
+                .position(|texture| texture.get_format() == list.format && !texture.used_in_frame(frame_id));
         }
 
         let mut texture = match index {
@@ -4409,8 +4410,8 @@ impl Renderer {
                     (None, None)
                 }
                 RenderPassKind::OffScreen { ref mut alpha, ref mut color, ref mut texture_cache } => {
-                    let alpha_tex = self.allocate_target_texture(alpha);
-                    let color_tex = self.allocate_target_texture(color);
+                    let alpha_tex = self.allocate_target_texture(alpha, frame_id);
+                    let color_tex = self.allocate_target_texture(color, frame_id);
 
                     // If this frame has already been drawn, then any texture
                     // cache targets have already been updated and can be


### PR DESCRIPTION
Note: this is not tested on Servo/Gecko yet, but conceptually should be safe. Main problem about this improvement is coming up with a good test case / metric that would show it's efficiency.

Basically, instead of pre-allocating all the targets at the start of the frame, we only allocated them at rendering a pass. Since we return the targets back to the pool at the end of the pass, what we want to see is some of the targets being re-used multiple times per frame (in different passes).
This could be improved if, instead of finding an exact match by size, we could fall-back to finding a target that may be slightly larger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2413)
<!-- Reviewable:end -->
