### PR TITLE
Default case for shader matches

### DIFF
--- a/webrender/res/brush_line.glsl
+++ b/webrender/res/brush_line.glsl
@@ -65,6 +65,9 @@ void brush_vs(
             pos = local_rect.p0.yx;
             size = local_rect.size.yx;
             break;
+        default:
+            vAxisSelect = 0.0;
+            pos = size = vec2(0.0);
     }
 
     vLocalOrigin = pos;
@@ -108,6 +111,8 @@ void brush_vs(
                            size.y);
             break;
         }
+        default:
+            vParams = vec4(0.0);
     }
 }
 #endif
@@ -223,6 +228,7 @@ vec4 brush_fs() {
 
             break;
         }
+        default: break;
     }
 
     return vColor * alpha;

--- a/webrender/res/brush_picture.glsl
+++ b/webrender/res/brush_picture.glsl
@@ -98,6 +98,9 @@ void brush_vs(
             vParams.xy = 0.5 * local_rect.size / local_src_size;
             break;
         }
+        default:
+            vUv.xy = vec2(0.0);
+            vParams = vec4(0.0);
     }
 
     vUvBounds = vec4(uv0 + vec2(0.5), uv1 - vec2(0.5)) / texture_size.xyxy;
@@ -138,6 +141,8 @@ vec4 brush_fs() {
             uv = clamp(uv, vUvBounds.xy, vUvBounds.zw);
             break;
         }
+        default:
+            uv = vec2(0.0);
     }
 
 #if defined WR_FEATURE_COLOR_TARGET

--- a/webrender/res/cs_blur.glsl
+++ b/webrender/res/cs_blur.glsl
@@ -44,6 +44,8 @@ void main(void) {
         case DIR_VERTICAL:
             vOffsetScale = vec2(0.0, 1.0 / texture_size.y);
             break;
+        default:
+            vOffsetScale = vec2(0.0);
     }
 
     vUvRect = vec4(src_rect.p0 + vec2(0.5),

--- a/webrender/res/cs_clip_border.glsl
+++ b/webrender/res/cs_clip_border.glsl
@@ -91,6 +91,8 @@ void main(void) {
             case CORNER_BOTTOM_LEFT:
                 sign_modifier = vec2(-1.0, 1.0);
                 break;
+            default:
+                sign_modifier = vec2(0.0);
         };
 
         switch (corner.clip_mode) {
@@ -111,6 +113,10 @@ void main(void) {
                 vAlphaMask = vec2(1.0, 1.0);
                 break;
             }
+            default:
+                vPoint_Tangent0 = vPoint_Tangent1 = vec4(1.0);
+                vDotParams = vec3(0.0);
+                vAlphaMask = vec2(0.0);
         }
     }
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -368,6 +368,7 @@ Glyph fetch_glyph(int specific_prim_address,
         case SUBPX_DIR_VERTICAL:
             glyph.y = floor(glyph.y + 0.125);
             break;
+        default: break;
     }
 
     return Glyph(glyph);

--- a/webrender/res/ps_blend.glsl
+++ b/webrender/res/ps_blend.glsl
@@ -93,6 +93,7 @@ void main(void) {
           vColorOffset = data[dataOffset + 4];
           break;
         }
+        default: break;
     }
 
 

--- a/webrender/res/ps_border_corner.glsl
+++ b/webrender/res/ps_border_corner.glsl
@@ -106,6 +106,7 @@ void write_color(vec4 color0, vec4 color1, int style, vec2 delta, int instance_k
         case SIDE_SECOND:
             color1.a = 0.0;
             break;
+        default: break;
     }
 
     vColor00 = vec4(clamp(color0.rgb * modulate.x, vec3(0.0), vec3(color0.a)), color0.a);
@@ -136,6 +137,8 @@ int select_style(int color_select, vec2 fstyle) {
             return style.x;
         case SIDE_SECOND:
             return style.y;
+        default:
+            return 0;
     }
 }
 
@@ -155,7 +158,7 @@ void main(void) {
     vec2 color_delta;
     vec4 edge_mask;
 
-    // TODO(gw): Now that all border styles are supported, the switch
+    // TODO(gw): Now that all border styles are supported, the
     //           statement below can be tidied up quite a bit.
 
     switch (sub_part) {
@@ -265,6 +268,14 @@ void main(void) {
             edge_mask = vec4(1.0, 0.0, 0.0, 1.0);
             break;
         }
+        default:
+            p0 = p1 = vec2(0.0);
+            color0 = color1 = vec4(1.0);
+            vClipCenter = vClipSign = vec2(0.0);
+            style = 0;
+            edge_distances = edge_mask = vec4(0.0);
+            color_delta = vec2(0.0);
+            vIsBorderRadiusLessThanBorderWidth = 0.0;
     }
 
     switch (style) {

--- a/webrender/res/ps_border_edge.glsl
+++ b/webrender/res/ps_border_edge.glsl
@@ -145,7 +145,7 @@ void main(void) {
     BorderCorners corners = get_border_corners(border, prim.local_rect);
     vec4 color = border.colors[sub_part];
 
-    // TODO(gw): Now that all border styles are supported, the switch
+    // TODO(gw): Now that all border styles are supported, the
     //           statement below can be tidied up quite a bit.
 
     float style;
@@ -215,6 +215,11 @@ void main(void) {
             edge_mask = vec4(0.0, 1.0, 0.0, 1.0);
             break;
         }
+        default:
+            segment_rect.p0 = segment_rect.size = vec2(0.0);
+            style = 0.0;
+            color_flip = false;
+            edge_mask = vec4(0.0);
     }
 
     write_alpha_select(style);

--- a/webrender/res/ps_composite.glsl
+++ b/webrender/res/ps_composite.glsl
@@ -276,6 +276,7 @@ void main(void) {
         case MixBlendMode_Luminosity:
             result.rgb = Luminosity(Cb.rgb, Cs.rgb);
             break;
+        default: break;
     }
 
     result.rgb = (1.0 - Cb.a) * Cs.rgb + Cb.a * result.rgb;

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -147,6 +147,9 @@ void main(void) {
             vMaskSwizzle = vec2(-1.0, 1.0);
             vColor = vec4(text.color.a) * text.bg_color;
             break;
+        default:
+            vMaskSwizzle = vec2(0.0);
+            vColor = vec4(1.0);
     }
 
     vec2 texture_size = vec2(textureSize(sColor0, 0));

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -145,6 +145,11 @@ fn validate_shaders() {
 }
 
 fn validate(validator: &ShaderValidator, name: &str, source: String) {
+    // Check for each `switch` to have a `default`, see
+    // https://github.com/servo/webrender/wiki/Driver-issues#lack-of-default-case-in-a-switch
+    assert_eq!(source.matches("switch").count(), source.matches("default:").count(),
+        "Shader '{}' doesn't have all `switch` covered with `default` cases", name);
+    // Run Angle validator
     match validator.compile_and_translate(&[&source]) {
         Ok(_) => {
             println!("Shader translated succesfully: {}", name);


### PR DESCRIPTION
Addresses https://github.com/servo/webrender/wiki/Driver-issues#lack-of-default-case-in-a-switch
It's not something we **have to** do. An alternative would be to try providing upstream fixes to SPIRV-Cross, but I'm worried about the quality of my sleep given that our shaders expose UB whenever an unexpected switch value comes in.
cc @zakorgy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2414)
<!-- Reviewable:end -->
