### PR TITLE
Pack extra user data value into BrushInstance structure.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -8,7 +8,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 );
 
@@ -24,21 +24,21 @@ struct BrushInstance {
     int z;
     int segment_index;
     int edge_mask;
-    ivec2 user_data;
+    ivec3 user_data;
 };
 
 BrushInstance load_brush() {
     BrushInstance bi;
 
-    bi.picture_address = aData0.x;
+    bi.picture_address = aData0.x & 0xffff;
+    bi.clip_address = aData0.x >> 16;
     bi.prim_address = aData0.y;
-    bi.clip_chain_rect_index = aData0.z / 65536;
-    bi.scroll_node_id = aData0.z % 65536;
-    bi.clip_address = aData0.w;
-    bi.z = aData1.x;
-    bi.segment_index = aData1.y & 0xffff;
-    bi.edge_mask = aData1.y >> 16;
-    bi.user_data = aData1.zw;
+    bi.clip_chain_rect_index = aData0.z >> 16;
+    bi.scroll_node_id = aData0.z & 0xffff;
+    bi.z = aData0.w;
+    bi.segment_index = aData1.x & 0xffff;
+    bi.edge_mask = aData1.x >> 16;
+    bi.user_data = aData1.yzw;
 
     return bi;
 }

--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -20,7 +20,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     PictureTask src_task = fetch_picture_task(user_data.x);

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -19,7 +19,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     // If this is in WR_FEATURE_TEXTURE_RECT mode, the rect and size use

--- a/webrender/res/brush_line.glsl
+++ b/webrender/res/brush_line.glsl
@@ -35,7 +35,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     vLocalPos = vi.local_pos;

--- a/webrender/res/brush_mask_corner.glsl
+++ b/webrender/res/brush_mask_corner.glsl
@@ -27,7 +27,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     // Load the specific primitive.

--- a/webrender/res/brush_mask_rounded_rect.glsl
+++ b/webrender/res/brush_mask_rounded_rect.glsl
@@ -41,7 +41,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     // Load the specific primitive.

--- a/webrender/res/brush_picture.glsl
+++ b/webrender/res/brush_picture.glsl
@@ -39,7 +39,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     vImageKind = user_data.y;

--- a/webrender/res/brush_solid.glsl
+++ b/webrender/res/brush_solid.glsl
@@ -27,7 +27,7 @@ void brush_vs(
     VertexInfo vi,
     int prim_address,
     RectWithSize local_rect,
-    ivec2 user_data,
+    ivec3 user_data,
     PictureTask pic_task
 ) {
     SolidBrush prim = fetch_solid_primitive(prim_address);

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -288,7 +288,7 @@ struct ClipArea {
 ClipArea fetch_clip_area(int index) {
     ClipArea area;
 
-    if (index == 0x7FFFFFFF) { //special sentinel task index
+    if (index == 0x7FFF) { //special sentinel task index
         area.common_data = RenderTaskCommonData(
             RectWithSize(vec2(0.0), vec2(0.0)),
             0.0

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -164,22 +164,21 @@ pub struct BrushInstance {
     pub z: i32,
     pub segment_index: i32,
     pub edge_flags: EdgeAaSegmentMask,
-    pub user_data0: i32,
-    pub user_data1: i32,
+    pub user_data: [i32; 3],
 }
 
 impl From<BrushInstance> for PrimitiveInstance {
     fn from(instance: BrushInstance) -> Self {
         PrimitiveInstance {
             data: [
-                instance.picture_address.0 as i32,
+                instance.picture_address.0 as i32 | (instance.clip_task_address.0 as i32) << 16,
                 instance.prim_address.as_int(),
                 ((instance.clip_chain_rect_index.0 as i32) << 16) | instance.scroll_id.0 as i32,
-                instance.clip_task_address.0 as i32,
                 instance.z,
                 instance.segment_index | ((instance.edge_flags.bits() as i32) << 16),
-                instance.user_data0,
-                instance.user_data1,
+                instance.user_data[0],
+                instance.user_data[1],
+                instance.user_data[2],
             ]
         }
     }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -590,8 +590,7 @@ impl RenderTarget for AlphaRenderTarget {
                                             z: 0,
                                             segment_index: 0,
                                             edge_flags: EdgeAaSegmentMask::empty(),
-                                            user_data0: 0,
-                                            user_data1: 0,
+                                            user_data: [0; 3],
                                         };
                                         let brush = &ctx.prim_store.cpu_brushes[sub_metadata.cpu_prim_index.0];
                                         let batch = match brush.kind {


### PR DESCRIPTION
In order to port the YUV image shader, we will need three
user data fields (one per channel).

To enable this work, we now pack the two render task
addresses for the picture and clip task as 2x u16 into
a single u32. This is all a bit messy still, but once
we have everything converted over to use the brush vertex
format, we can define it correctly as u16 attributes and
avoid all the packing / unpacking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2415)
<!-- Reviewable:end -->
