### PR TITLE
Update YUV example to work again.

### DIFF
--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -10,158 +10,67 @@ extern crate webrender;
 mod boilerplate;
 
 use boilerplate::Example;
-use glutin::TouchPhase;
-use std::collections::HashMap;
+use gleam::gl;
 use webrender::api::*;
 
-#[derive(Debug)]
-enum Gesture {
-    None,
-    Pan,
-    Zoom,
+fn init_gl_texture(
+    id: gl::GLuint,
+    internal: gl::GLenum,
+    external: gl::GLenum,
+    bytes: &[u8],
+    gl: &gl::Gl,
+) {
+    gl.bind_texture(gl::TEXTURE_2D, id);
+    gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as gl::GLint);
+    gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as gl::GLint);
+    gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as gl::GLint);
+    gl.tex_parameter_i(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as gl::GLint);
+    gl.tex_image_2d(
+        gl::TEXTURE_2D,
+        0,
+        internal as gl::GLint,
+        100,
+        100,
+        0,
+        external,
+        gl::UNSIGNED_BYTE,
+        Some(bytes),
+    );
+    gl.bind_texture(gl::TEXTURE_2D, 0);
 }
 
-#[derive(Debug)]
-struct Touch {
-    id: u64,
-    start_x: f32,
-    start_y: f32,
-    current_x: f32,
-    current_y: f32,
+struct YuvImageProvider {
+    texture_ids: Vec<gl::GLuint>,
 }
 
-fn dist(x0: f32, y0: f32, x1: f32, y1: f32) -> f32 {
-    let dx = x0 - x1;
-    let dy = y0 - y1;
-    ((dx * dx) + (dy * dy)).sqrt()
-}
+impl YuvImageProvider {
+    fn new(gl: &gl::Gl) -> Self {
+        let texture_ids = gl.gen_textures(4);
 
-impl Touch {
-    fn distance_from_start(&self) -> f32 {
-        dist(self.start_x, self.start_y, self.current_x, self.current_y)
-    }
+        init_gl_texture(texture_ids[0], gl::RED, gl::RED, &[127; 100 * 100], gl);
+        init_gl_texture(texture_ids[1], gl::RG8, gl::RG, &[0; 100 * 100 * 2], gl);
+        init_gl_texture(texture_ids[2], gl::RED, gl::RED, &[127; 100 * 100], gl);
+        init_gl_texture(texture_ids[3], gl::RED, gl::RED, &[127; 100 * 100], gl);
 
-    fn initial_distance_from_other(&self, other: &Touch) -> f32 {
-        dist(self.start_x, self.start_y, other.start_x, other.start_y)
-    }
-
-    fn current_distance_from_other(&self, other: &Touch) -> f32 {
-        dist(
-            self.current_x,
-            self.current_y,
-            other.current_x,
-            other.current_y,
-        )
-    }
-}
-
-struct TouchState {
-    active_touches: HashMap<u64, Touch>,
-    current_gesture: Gesture,
-    start_zoom: f32,
-    current_zoom: f32,
-    start_pan: DeviceIntPoint,
-    current_pan: DeviceIntPoint,
-}
-
-enum TouchResult {
-    None,
-    Pan(DeviceIntPoint),
-    Zoom(f32),
-}
-
-impl TouchState {
-    fn new() -> TouchState {
-        TouchState {
-            active_touches: HashMap::new(),
-            current_gesture: Gesture::None,
-            start_zoom: 1.0,
-            current_zoom: 1.0,
-            start_pan: DeviceIntPoint::zero(),
-            current_pan: DeviceIntPoint::zero(),
+        YuvImageProvider {
+            texture_ids
         }
     }
+}
 
-    fn handle_event(&mut self, touch: glutin::Touch) -> TouchResult {
-        match touch.phase {
-            TouchPhase::Started => {
-                debug_assert!(!self.active_touches.contains_key(&touch.id));
-                self.active_touches.insert(
-                    touch.id,
-                    Touch {
-                        id: touch.id,
-                        start_x: touch.location.0 as f32,
-                        start_y: touch.location.1 as f32,
-                        current_x: touch.location.0 as f32,
-                        current_y: touch.location.1 as f32,
-                    },
-                );
-                self.current_gesture = Gesture::None;
-            }
-            TouchPhase::Moved => {
-                match self.active_touches.get_mut(&touch.id) {
-                    Some(active_touch) => {
-                        active_touch.current_x = touch.location.0 as f32;
-                        active_touch.current_y = touch.location.1 as f32;
-                    }
-                    None => panic!("move touch event with unknown touch id!"),
-                }
-
-                match self.current_gesture {
-                    Gesture::None => {
-                        let mut over_threshold_count = 0;
-                        let active_touch_count = self.active_touches.len();
-
-                        for (_, touch) in &self.active_touches {
-                            if touch.distance_from_start() > 8.0 {
-                                over_threshold_count += 1;
-                            }
-                        }
-
-                        if active_touch_count == over_threshold_count {
-                            if active_touch_count == 1 {
-                                self.start_pan = self.current_pan;
-                                self.current_gesture = Gesture::Pan;
-                            } else if active_touch_count == 2 {
-                                self.start_zoom = self.current_zoom;
-                                self.current_gesture = Gesture::Zoom;
-                            }
-                        }
-                    }
-                    Gesture::Pan => {
-                        let keys: Vec<u64> = self.active_touches.keys().cloned().collect();
-                        debug_assert!(keys.len() == 1);
-                        let active_touch = &self.active_touches[&keys[0]];
-                        let x = active_touch.current_x - active_touch.start_x;
-                        let y = active_touch.current_y - active_touch.start_y;
-                        self.current_pan.x = self.start_pan.x + x.round() as i32;
-                        self.current_pan.y = self.start_pan.y + y.round() as i32;
-                        return TouchResult::Pan(self.current_pan);
-                    }
-                    Gesture::Zoom => {
-                        let keys: Vec<u64> = self.active_touches.keys().cloned().collect();
-                        debug_assert!(keys.len() == 2);
-                        let touch0 = &self.active_touches[&keys[0]];
-                        let touch1 = &self.active_touches[&keys[1]];
-                        let initial_distance = touch0.initial_distance_from_other(touch1);
-                        let current_distance = touch0.current_distance_from_other(touch1);
-                        self.current_zoom = self.start_zoom * current_distance / initial_distance;
-                        return TouchResult::Zoom(self.current_zoom);
-                    }
-                }
-            }
-            TouchPhase::Ended | TouchPhase::Cancelled => {
-                self.active_touches.remove(&touch.id).unwrap();
-                self.current_gesture = Gesture::None;
-            }
+impl webrender::ExternalImageHandler for YuvImageProvider {
+    fn lock(&mut self, key: ExternalImageId, _channel_index: u8) -> webrender::ExternalImage {
+        let id = self.texture_ids[key.0 as usize];
+        webrender::ExternalImage {
+            uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
+            source: webrender::ExternalImageSource::NativeTexture(id),
         }
-
-        TouchResult::None
+    }
+    fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {
     }
 }
 
 struct App {
-    touch_state: TouchState,
 }
 
 impl Example for App {
@@ -193,25 +102,49 @@ impl Example for App {
         resources.add_image(
             yuv_chanel1,
             ImageDescriptor::new(100, 100, ImageFormat::R8, true),
-            ImageData::new(vec![127; 100 * 100]),
+            ImageData::External(ExternalImageData {
+                id: ExternalImageId(0),
+                channel_index: 0,
+                image_type: ExternalImageType::TextureHandle(
+                    TextureTarget::Default,
+                ),
+            }),
             None,
         );
         resources.add_image(
             yuv_chanel2,
             ImageDescriptor::new(100, 100, ImageFormat::RG8, true),
-            ImageData::new(vec![0; 100 * 100 * 2]),
+            ImageData::External(ExternalImageData {
+                id: ExternalImageId(1),
+                channel_index: 0,
+                image_type: ExternalImageType::TextureHandle(
+                    TextureTarget::Default,
+                ),
+            }),
             None,
         );
         resources.add_image(
             yuv_chanel2_1,
             ImageDescriptor::new(100, 100, ImageFormat::R8, true),
-            ImageData::new(vec![127; 100 * 100]),
+            ImageData::External(ExternalImageData {
+                id: ExternalImageId(2),
+                channel_index: 0,
+                image_type: ExternalImageType::TextureHandle(
+                    TextureTarget::Default,
+                ),
+            }),
             None,
         );
         resources.add_image(
             yuv_chanel3,
             ImageDescriptor::new(100, 100, ImageFormat::R8, true),
-            ImageData::new(vec![127; 100 * 100]),
+            ImageData::External(ExternalImageData {
+                id: ExternalImageId(3),
+                channel_index: 0,
+                image_type: ExternalImageType::TextureHandle(
+                    TextureTarget::Default,
+                ),
+            }),
             None,
         );
 
@@ -240,33 +173,26 @@ impl Example for App {
         builder.pop_stacking_context();
     }
 
-    fn on_event(&mut self, event: glutin::WindowEvent, api: &RenderApi, document_id: DocumentId) -> bool {
-        let mut txn = Transaction::new();
-        match event {
-            glutin::WindowEvent::Touch(touch) => match self.touch_state.handle_event(touch) {
-                TouchResult::Pan(pan) => {
-                    txn.set_pan(pan);
-                }
-                TouchResult::Zoom(zoom) => {
-                    txn.set_pinch_zoom(ZoomFactor::new(zoom));
-                }
-                TouchResult::None => {}
-            },
-            _ => (),
-        }
-
-        if !txn.is_empty() {
-            txn.generate_frame();
-            api.send_transaction(document_id, txn);
-        }
-
+    fn on_event(
+        &mut self,
+        _event: glutin::WindowEvent,
+        _api: &RenderApi,
+        _document_id: DocumentId,
+    ) -> bool {
         false
+    }
+
+    fn get_image_handlers(
+        &mut self,
+        gl: &gl::Gl,
+    ) -> (Option<Box<webrender::ExternalImageHandler>>,
+          Option<Box<webrender::OutputImageHandler>>) {
+        (Some(Box::new(YuvImageProvider::new(gl))), None)
     }
 }
 
 fn main() {
     let mut app = App {
-        touch_state: TouchState::new(),
     };
     boilerplate::main_wrapper(&mut app, None);
 }


### PR DESCRIPTION
Previously, the example created textures that were placed in
the texture cache. However, RG8 textures are no longer supported
in the texture cache.

Instead, the example now behaves more like a real video decoding
application. The YUV planes are created as native textures and
passed to WR via the external image callback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2416)
<!-- Reviewable:end -->
