### PR TITLE
Remove discard from radial gradient, apply tile/repeat on CPU.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -75,6 +75,7 @@ vec4[2] fetch_from_resource_cache_2(int address) {
 #define VECS_PER_PRIM_HEADER        2
 #define VECS_PER_TEXT_RUN           3
 #define VECS_PER_GRADIENT           3
+#define VECS_PER_RADIAL_GRADIENT    2
 #define VECS_PER_GRADIENT_STOP      2
 
 uniform HIGHP_SAMPLER_FLOAT sampler2D sClipScrollNodes;
@@ -313,27 +314,6 @@ struct Gradient {
 Gradient fetch_gradient(int address) {
     vec4 data[3] = fetch_from_resource_cache_3(address);
     return Gradient(data[0], data[1], data[2]);
-}
-
-struct GradientStop {
-    vec4 color;
-    vec4 offset;
-};
-
-GradientStop fetch_gradient_stop(int address) {
-    vec4 data[2] = fetch_from_resource_cache_2(address);
-    return GradientStop(data[0], data[1]);
-}
-
-struct RadialGradient {
-    vec4 start_end_center;
-    vec4 start_end_radius_ratio_xy_extend_mode;
-    vec4 tile_size_repeat;
-};
-
-RadialGradient fetch_radial_gradient(int address) {
-    vec4 data[3] = fetch_from_resource_cache_3(address);
-    return RadialGradient(data[0], data[1], data[2]);
 }
 
 struct Glyph {

--- a/webrender/res/ps_gradient.glsl
+++ b/webrender/res/ps_gradient.glsl
@@ -9,6 +9,16 @@ varying vec4 vColor;
 varying vec2 vLocalPos;
 
 #ifdef WR_VERTEX_SHADER
+struct GradientStop {
+    vec4 color;
+    vec4 offset;
+};
+
+GradientStop fetch_gradient_stop(int address) {
+    vec4 data[2] = fetch_from_resource_cache_2(address);
+    return GradientStop(data[0], data[1]);
+}
+
 void main(void) {
     Primitive prim = load_primitive();
     Gradient gradient = fetch_gradient(prim.specific_prim_address);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -635,8 +635,7 @@ impl<'a> GradientGpuBlockBuilder<'a> {
 pub struct RadialGradientPrimitiveCpu {
     pub stops_range: ItemRange<GradientStop>,
     pub extend_mode: ExtendMode,
-    pub gpu_data_count: i32,
-    pub gpu_blocks: [GpuBlockData; 3],
+    pub gpu_blocks: [GpuBlockData; 2],
 }
 
 impl RadialGradientPrimitiveCpu {

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -649,6 +649,22 @@ impl LocalClip {
             ),
         }
     }
+
+    pub fn clip_by(&self, rect: &LayoutRect) -> LocalClip {
+        match *self {
+            LocalClip::Rect(clip_rect) => {
+                LocalClip::Rect(
+                    clip_rect.intersection(rect).unwrap_or(LayoutRect::zero())
+                )
+            }
+            LocalClip::RoundedRect(clip_rect, complex) => {
+                LocalClip::RoundedRect(
+                    clip_rect.intersection(rect).unwrap_or(LayoutRect::zero()),
+                    complex,
+                )
+            }
+        }
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
Introduce a new method to decompose a PrimitiveInfo struct info
a (bounded) maximum number of instances based on a tile size and
repeat structure.

This allows us to remove the discard instruction from the radial
gradient shader, which means it doesn't disable early-Z.

This is a start point - in the future we'll want to expand this
to work on other gradients and images, and do a proper job
of handling edge cases with huge numbers of repetitions.

For now, this improves the common case of radial gradients, and
makes it easier to convert it to a brush shader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2426)
<!-- Reviewable:end -->
