### PR TITLE
Convert ClipIds for Clips into indices in the ClipScrollTree

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -7,7 +7,7 @@ use api::{DeviceUintRect, DeviceUintPoint, DeviceUintSize, ExternalImageType, Fi
 use api::{DeviceIntPoint, LayerPoint, SubpixelDirection, YuvColorSpace, YuvFormat};
 use api::{LayerToWorldTransform, WorldPixel};
 use border::{BorderCornerInstance, BorderCornerSide, BorderEdgeKind};
-use clip::{ClipSource, ClipStore};
+use clip::{ClipSource, ClipStore, ClipWorkItem};
 use clip_scroll_tree::{CoordinateSystemId};
 use euclid::{TypedTransform3D, vec3};
 use glyph_rasterizer::GlyphFormat;
@@ -20,9 +20,7 @@ use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{ImageSource, PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
 use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PrimitiveRun};
-use render_task::{ClipWorkItem};
-use render_task::{RenderTaskAddress, RenderTaskId};
-use render_task::{RenderTaskKind, RenderTaskTree};
+use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind, RenderTaskTree};
 use renderer::{BlendMode, ImageBufferKind};
 use renderer::BLOCKS_PER_UV_RECT;
 use resource_cache::{CacheItem, GlyphFetchResult, ImageRequest, ResourceCache};

--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BorderRadius, BorderSide, BorderStyle, BorderWidths, ClipAndScrollInfo, ColorF};
-use api::{LayerPoint, LayerRect, LayerPrimitiveInfo, LayerSize};
-use api::{NormalBorder, RepeatMode, TexelRect};
+use api::{BorderRadius, BorderSide, BorderStyle, BorderWidths, ColorF, LayerPoint};
+use api::{LayerPrimitiveInfo, LayerRect, LayerSize, NormalBorder, RepeatMode, TexelRect};
 use clip::ClipSource;
 use ellipse::Ellipse;
 use frame_builder::FrameBuilder;
 use gpu_cache::GpuDataRequest;
-use prim_store::{BorderPrimitiveCpu, BrushSegment, BrushSegmentDescriptor};
-use prim_store::{BrushClipMaskKind, EdgeAaSegmentMask, PrimitiveContainer};
+use prim_store::{BorderPrimitiveCpu, BrushClipMaskKind, BrushSegment, BrushSegmentDescriptor};
+use prim_store::{EdgeAaSegmentMask, PrimitiveContainer, ScrollNodeAndClipChain};
 use util::{lerp, pack_as_float};
 
 #[repr(u8)]
@@ -286,7 +285,7 @@ impl FrameBuilder {
         info: &LayerPrimitiveInfo,
         border: &NormalBorder,
         widths: &BorderWidths,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         corner_instances: [BorderCornerInstance; 4],
         edges: [BorderEdgeKind; 4],
         clip_sources: Vec<ClipSource>,
@@ -354,7 +353,7 @@ impl FrameBuilder {
         info: &LayerPrimitiveInfo,
         border: &NormalBorder,
         widths: &BorderWidths,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
     ) {
         // The border shader is quite expensive. For simple borders, we can just draw
         // the border with a few rectangles. This generally gives better batching, and

--- a/webrender/src/box_shadow.rs
+++ b/webrender/src/box_shadow.rs
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ColorF, LayerPoint, LayerRect, LayerSize, LayerVector2D};
-use api::{BorderRadius, BoxShadowClipMode, LayoutSize, LayerPrimitiveInfo};
-use api::{ClipMode, ClipAndScrollInfo, ComplexClipRegion, LocalClip};
-use api::{PipelineId};
+use api::{BorderRadius, BoxShadowClipMode, ClipMode, ColorF, ComplexClipRegion, LayerPoint};
+use api::{LayerPrimitiveInfo, LayerRect, LayerSize, LayerVector2D, LayoutSize, LocalClip};
+use api::PipelineId;
 use app_units::Au;
 use clip::ClipSource;
 use frame_builder::FrameBuilder;
 use gpu_types::BrushImageKind;
-use prim_store::{PrimitiveContainer};
-use prim_store::{BrushMaskKind, BrushKind, BrushPrimitive};
+use prim_store::{BrushKind, BrushMaskKind, BrushPrimitive, PrimitiveContainer};
+use prim_store::ScrollNodeAndClipChain;
 use picture::PicturePrimitive;
 use util::RectHelpers;
 use render_task::MAX_BLUR_STD_DEVIATION;
@@ -53,7 +52,7 @@ impl FrameBuilder {
     pub fn add_box_shadow(
         &mut self,
         pipeline_id: PipelineId,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         prim_info: &LayerPrimitiveInfo,
         box_offset: &LayerVector2D,
         color: &ColorF,

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -6,12 +6,15 @@ use api::{BorderRadius, ClipMode, ComplexClipRegion, DeviceIntRect, DevicePixelS
 use api::{ImageRendering, LayerRect, LayerToWorldTransform, LayoutPoint, LayoutVector2D};
 use api::LocalClip;
 use border::{BorderCornerClipSource, ensure_no_corner_overlap};
+use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId};
 use ellipse::Ellipse;
 use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
+use gpu_types::ClipScrollNodeIndex;
 use prim_store::{ClipData, ImageMaskData};
 use resource_cache::{ImageRequest, ResourceCache};
 use util::{MaxRect, MatrixHelpers, calculate_screen_bounding_rect, extract_inner_rect_safe};
+use std::rc::Rc;
 
 pub type ClipStore = FreeList<ClipSources>;
 pub type ClipSourcesHandle = FreeListHandle<ClipSources>;
@@ -349,3 +352,106 @@ pub fn rounded_rectangle_contains_point(point: &LayoutPoint,
 
     true
 }
+
+pub type ClipChainNodeRef = Option<Rc<ClipChainNode>>;
+
+#[derive(Debug, Clone)]
+pub struct ClipChainNode {
+    pub work_item: ClipWorkItem,
+    pub local_clip_rect: LayerRect,
+    pub screen_outer_rect: DeviceIntRect,
+    pub screen_inner_rect: DeviceIntRect,
+    pub prev: ClipChainNodeRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClipChain {
+    pub parent_index: Option<ClipChainIndex>,
+    pub combined_outer_screen_rect: DeviceIntRect,
+    pub combined_inner_screen_rect: DeviceIntRect,
+    pub nodes: ClipChainNodeRef,
+}
+
+impl ClipChain {
+    pub fn empty(screen_rect: &DeviceIntRect) -> ClipChain {
+        ClipChain {
+            parent_index: None,
+            combined_inner_screen_rect: *screen_rect,
+            combined_outer_screen_rect: *screen_rect,
+            nodes: None,
+        }
+    }
+
+    pub fn new_with_added_node(
+        &self,
+        work_item: ClipWorkItem,
+        local_clip_rect: LayerRect,
+        screen_outer_rect: DeviceIntRect,
+        screen_inner_rect: DeviceIntRect,
+    ) -> ClipChain {
+        // If the new node's inner rectangle completely surrounds our outer rectangle,
+        // we can discard the new node entirely since it isn't going to affect anything.
+        if screen_inner_rect.contains_rect(&self.combined_outer_screen_rect) {
+            return self.clone();
+        }
+
+        let new_node = ClipChainNode {
+            work_item,
+            local_clip_rect,
+            screen_outer_rect,
+            screen_inner_rect,
+            prev: None,
+        };
+
+        let mut new_chain = self.clone();
+        new_chain.add_node(new_node);
+        new_chain
+    }
+
+    pub fn add_node(&mut self, mut new_node: ClipChainNode) {
+        new_node.prev = self.nodes.clone();
+
+        // If this clip's outer rectangle is completely enclosed by the clip
+        // chain's inner rectangle, then the only clip that matters from this point
+        // on is this clip. We can disconnect this clip from the parent clip chain.
+        if self.combined_inner_screen_rect.contains_rect(&new_node.screen_outer_rect) {
+            new_node.prev = None;
+        }
+
+        self.combined_outer_screen_rect =
+            self.combined_outer_screen_rect.intersection(&new_node.screen_outer_rect)
+            .unwrap_or_else(DeviceIntRect::zero);
+        self.combined_inner_screen_rect =
+            self.combined_inner_screen_rect.intersection(&new_node.screen_inner_rect)
+            .unwrap_or_else(DeviceIntRect::zero);
+
+        self.nodes = Some(Rc::new(new_node));
+    }
+}
+
+pub struct ClipChainNodeIter {
+    pub current: ClipChainNodeRef,
+}
+
+impl Iterator for ClipChainNodeIter {
+    type Item = Rc<ClipChainNode>;
+
+    fn next(&mut self) -> ClipChainNodeRef {
+        let previous = self.current.clone();
+        self.current = match self.current {
+            Some(ref item) => item.prev.clone(),
+            None => return None,
+        };
+        previous
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct ClipWorkItem {
+    pub scroll_node_data_index: ClipScrollNodeIndex,
+    pub clip_sources: ClipSourcesWeakHandle,
+    pub coordinate_system_id: CoordinateSystemId,
+}
+

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -6,13 +6,12 @@ use api::{ClipId, DevicePixelScale, ExternalScrollId, LayerPixel, LayerPoint, La
 use api::{LayerSize, LayerToWorldTransform, LayerTransform, LayerVector2D, LayoutTransform};
 use api::{LayoutVector2D, PipelineId, PropertyBinding, ScrollClamping, ScrollEventPhase};
 use api::{ScrollLocation, ScrollNodeIdType, ScrollSensitivity, StickyOffsetBounds, WorldPoint};
-use clip::{ClipSourcesHandle, ClipStore};
-use clip_scroll_tree::{CoordinateSystemId, TransformUpdateState};
+use clip::{ClipChain, ClipSourcesHandle, ClipStore, ClipWorkItem};
+use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId, TransformUpdateState};
 use euclid::SideOffsets2D;
 use geometry::ray_intersects_rect;
 use gpu_cache::GpuCache;
 use gpu_types::{ClipScrollNodeIndex, ClipScrollNodeData};
-use render_task::{ClipChain, ClipWorkItem};
 use resource_cache::ResourceCache;
 use scene::SceneProperties;
 use spring::{DAMPING, STIFFNESS, Spring};
@@ -56,7 +55,10 @@ pub enum NodeType {
     ReferenceFrame(ReferenceFrameInfo),
 
     /// Other nodes just do clipping, but no transformation.
-    Clip(ClipSourcesHandle),
+    Clip {
+        handle: ClipSourcesHandle,
+        clip_chain_index: ClipChainIndex
+    },
 
     /// Transforms it's content, but doesn't clip it. Can also be adjusted
     /// by scroll events or setting scroll offsets.
@@ -106,9 +108,6 @@ pub struct ClipScrollNode {
     /// The type of this node and any data associated with that node type.
     pub node_type: NodeType,
 
-    /// The ClipChain that will be used if this node is used as the 'clipping node.'
-    pub clip_chain: Option<ClipChain>,
-
     /// True if this node is transformed by an invertible transform.  If not, display items
     /// transformed by this node will not be displayed and display items not transformed by this
     /// node will not be clipped by clips that are transformed by this node.
@@ -128,7 +127,7 @@ pub struct ClipScrollNode {
 }
 
 impl ClipScrollNode {
-    fn new(
+    pub fn new(
         pipeline_id: PipelineId,
         parent_id: Option<ClipId>,
         rect: &LayerRect,
@@ -142,7 +141,6 @@ impl ClipScrollNode {
             children: Vec::new(),
             pipeline_id,
             node_type: node_type,
-            clip_chain: None,
             invertible: true,
             coordinate_system_id: CoordinateSystemId(0),
             coordinate_system_relative_transform: TransformOrOffset::zero(),
@@ -168,15 +166,6 @@ impl ClipScrollNode {
         ));
 
         Self::new(pipeline_id, Some(parent_id), frame_rect, node_type)
-    }
-
-    pub fn new_clip_node(
-        pipeline_id: PipelineId,
-        parent_id: ClipId,
-        handle: ClipSourcesHandle,
-        clip_rect: LayerRect,
-    ) -> Self {
-        Self::new(pipeline_id, Some(parent_id), &clip_rect, NodeType::Clip(handle))
     }
 
     pub fn new_reference_frame(
@@ -271,7 +260,6 @@ impl ClipScrollNode {
         self.invertible = false;
         self.world_content_transform = LayerToWorldTransform::identity();
         self.world_viewport_transform = LayerToWorldTransform::identity();
-        self.clip_chain = None;
     }
 
     pub fn push_gpu_node_data(&mut self, node_data: &mut Vec<ClipScrollNodeData>) {
@@ -304,6 +292,7 @@ impl ClipScrollNode {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         scene_properties: &SceneProperties,
+        clip_chains: &mut Vec<ClipChain>,
     ) {
         // If any of our parents was not rendered, we are not rendered either and can just
         // quit here.
@@ -331,6 +320,7 @@ impl ClipScrollNode {
             clip_store,
             resource_cache,
             gpu_cache,
+            clip_chains,
         );
     }
 
@@ -341,11 +331,11 @@ impl ClipScrollNode {
         clip_store: &mut ClipStore,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
+        clip_chains: &mut Vec<ClipChain>,
     ) {
-        let clip_sources_handle = match self.node_type {
-            NodeType::Clip(ref handle) => handle,
+        let (clip_sources_handle, clip_chain_index) = match self.node_type {
+            NodeType::Clip { ref handle, clip_chain_index } => (handle, clip_chain_index),
             _ => {
-                self.clip_chain = Some(state.parent_clip_chain.clone());
                 self.invertible = true;
                 return;
             }
@@ -364,29 +354,22 @@ impl ClipScrollNode {
             "Clipping node didn't have outer rect."
         );
 
-        // If this clip's inner rectangle completely surrounds the existing clip
-        // chain's outer rectangle, we can discard this clip entirely since it isn't
-        // going to affect anything.
-        if screen_inner_rect.contains_rect(&state.parent_clip_chain.combined_outer_screen_rect) {
-            self.clip_chain = Some(state.parent_clip_chain.clone());
-            return;
-        }
-
         let work_item = ClipWorkItem {
             scroll_node_data_index: self.node_data_index,
             clip_sources: clip_sources_handle.weak(),
             coordinate_system_id: state.current_coordinate_system_id,
         };
 
-        let clip_chain = state.parent_clip_chain.new_with_added_node(
+        let mut clip_chain = clip_chains[state.parent_clip_chain_index.0].new_with_added_node(
             work_item,
             self.coordinate_system_relative_transform.apply(&local_outer_rect),
             screen_outer_rect,
             screen_inner_rect,
         );
 
-        self.clip_chain = Some(clip_chain.clone());
-        state.parent_clip_chain = clip_chain;
+        clip_chain.parent_index = Some(state.parent_clip_chain_index);
+        clip_chains[clip_chain_index.0] = clip_chain;
+        state.parent_clip_chain_index = clip_chain_index;
     }
 
     pub fn update_transform(
@@ -621,7 +604,7 @@ impl ClipScrollNode {
                     state.nearest_scrolling_ancestor_viewport
                        .translate(&translation);
             }
-            NodeType::Clip(..) => { }
+            NodeType::Clip{ .. } => { }
             NodeType::ScrollFrame(ref scrolling) => {
                 state.parent_accumulated_scroll_offset =
                     scrolling.offset + state.parent_accumulated_scroll_offset;

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,17 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipChainId, ClipId, DeviceIntRect, DevicePixelScale, ExternalScrollId, LayerPoint};
-use api::{LayerRect, LayerToWorldTransform, LayerVector2D, PipelineId, ScrollClamping};
-use api::{ScrollEventPhase, ScrollLocation, ScrollNodeIdType};
-use api::{ScrollNodeState, WorldPoint};
-use clip::ClipStore;
+use api::{ClipId, DeviceIntRect, DevicePixelScale, ExternalScrollId, LayerPoint, LayerRect};
+use api::{LayerToWorldTransform, LayerVector2D, PipelineId, ScrollClamping, ScrollEventPhase};
+use api::{ScrollLocation, ScrollNodeIdType, ScrollNodeState, WorldPoint};
+use clip::{ClipChain, ClipSourcesHandle, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollFrameInfo, StickyFrameInfo};
 use gpu_cache::GpuCache;
 use gpu_types::{ClipScrollNodeIndex, ClipScrollNodeData};
 use internal_types::{FastHashMap, FastHashSet};
 use print_tree::{PrintTree, PrintTreePrinter};
-use render_task::ClipChain;
 use resource_cache::ResourceCache;
 use scene::SceneProperties;
 use util::TransformOrOffset;
@@ -44,10 +42,13 @@ impl CoordinateSystemId {
 }
 
 pub struct ClipChainDescriptor {
-    pub id: ClipChainId,
-    pub parent: Option<ClipChainId>,
+    pub index: ClipChainIndex,
+    pub parent: Option<ClipChainIndex>,
     pub clips: Vec<ClipId>,
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ClipChainIndex(pub usize);
 
 pub struct ClipScrollTree {
     pub nodes: FastHashMap<ClipId, ClipScrollNode>,
@@ -57,8 +58,9 @@ pub struct ClipScrollTree {
     /// the children of ClipChains later in the list.
     pub clip_chains_descriptors: Vec<ClipChainDescriptor>,
 
-    /// A HashMap of built ClipChains that are described by `clip_chains_descriptors`.
-    pub clip_chains: FastHashMap<ClipChainId, ClipChain>,
+    /// A vector of all ClipChains in this ClipScrollTree including those from
+    /// ClipChainDescriptors and also those defined by the clipping node hierarchy.
+    pub clip_chains: Vec<ClipChain>,
 
     pub pending_scroll_offsets: FastHashMap<ScrollNodeIdType, (LayerPoint, ScrollClamping)>,
 
@@ -90,7 +92,9 @@ pub struct TransformUpdateState {
     pub parent_accumulated_scroll_offset: LayerVector2D,
     pub nearest_scrolling_ancestor_offset: LayerVector2D,
     pub nearest_scrolling_ancestor_viewport: LayerRect,
-    pub parent_clip_chain: ClipChain,
+
+    /// The index of the current parent's clip chain.
+    pub parent_clip_chain_index: ClipChainIndex,
 
     /// An id for keeping track of the axis-aligned space of this node. This is used in
     /// order to to track what kinds of clip optimizations can be done for a particular
@@ -113,7 +117,7 @@ impl ClipScrollTree {
         ClipScrollTree {
             nodes: FastHashMap::default(),
             clip_chains_descriptors: Vec::new(),
-            clip_chains: FastHashMap::default(),
+            clip_chains: vec![ClipChain::empty(&DeviceIntRect::zero())],
             pending_scroll_offsets: FastHashMap::default(),
             currently_scrolling_node_id: None,
             root_reference_frame_id: ClipId::root_reference_frame(dummy_pipeline),
@@ -211,7 +215,7 @@ impl ClipScrollTree {
         }
 
         self.pipelines_to_discard.clear();
-        self.clip_chains.clear();
+        self.clip_chains = vec![ClipChain::empty(&DeviceIntRect::zero())];
         self.clip_chains_descriptors.clear();
         scroll_states
     }
@@ -321,6 +325,8 @@ impl ClipScrollTree {
             return;
         }
 
+        self.clip_chains[0] = ClipChain::empty(screen_rect);
+
         let root_reference_frame_id = self.root_reference_frame_id();
         let mut state = TransformUpdateState {
             parent_reference_frame_transform: LayerToWorldTransform::create_translation(
@@ -331,7 +337,7 @@ impl ClipScrollTree {
             parent_accumulated_scroll_offset: LayerVector2D::zero(),
             nearest_scrolling_ancestor_offset: LayerVector2D::zero(),
             nearest_scrolling_ancestor_viewport: LayerRect::zero(),
-            parent_clip_chain: ClipChain::empty(screen_rect),
+            parent_clip_chain_index: ClipChainIndex(0),
             current_coordinate_system_id: CoordinateSystemId::root(),
             coordinate_system_relative_transform: TransformOrOffset::zero(),
             invertible: true,
@@ -384,6 +390,7 @@ impl ClipScrollTree {
                 resource_cache,
                 gpu_cache,
                 scene_properties,
+                &mut self.clip_chains,
             );
 
             node.push_gpu_node_data(gpu_node_data);
@@ -417,21 +424,28 @@ impl ClipScrollTree {
             // ClipScrollNode clipping nodes. Here we start the ClipChain with a clone of the
             // parent's node, if necessary.
             let mut chain = match descriptor.parent {
-                Some(id) => self.clip_chains[&id].clone(),
+                Some(index) => self.clip_chains[index.0].clone(),
                 None => ClipChain::empty(screen_rect),
             };
 
             // Now we walk through each ClipScrollNode in the vector of clip nodes and
             // extract their ClipChain nodes to construct the final list.
             for clip_id in &descriptor.clips {
-                if let Some(ref node_chain) = self.nodes[&clip_id].clip_chain {
-                    if let Some(ref nodes) = node_chain.nodes {
-                        chain.add_node((**nodes).clone());
+                let node_clip_chain_index = match self.nodes[&clip_id].node_type {
+                    NodeType::Clip { clip_chain_index, .. } => clip_chain_index,
+                    _ => {
+                        warn!("Tried to create a clip chain with non-clipping node.");
+                        continue;
                     }
+                };
+
+                if let Some(ref nodes) = self.clip_chains[node_clip_chain_index.0].nodes {
+                    chain.add_node((**nodes).clone());
                 }
             }
 
-            self.clip_chains.insert(descriptor.id, chain);
+            chain.parent_index = descriptor.parent;
+            self.clip_chains[descriptor.index.0] = chain;
         }
     }
 
@@ -466,6 +480,20 @@ impl ClipScrollTree {
         }
     }
 
+    pub fn add_clip_node(
+        &mut self,
+        id: ClipId,
+        parent_id: ClipId,
+        handle: ClipSourcesHandle,
+        clip_rect: LayerRect,
+    )  -> ClipChainIndex {
+        let clip_chain_index = self.allocate_clip_chain();
+        let node_type = NodeType::Clip { handle, clip_chain_index };
+        let node = ClipScrollNode::new(id.pipeline_id(), Some(parent_id), &clip_rect, node_type);
+        self.add_node(node, id);
+        clip_chain_index
+    }
+
     pub fn add_sticky_frame(
         &mut self,
         id: ClipId,
@@ -484,11 +512,12 @@ impl ClipScrollTree {
 
     pub fn add_clip_chain_descriptor(
         &mut self,
-        id: ClipChainId,
-        parent: Option<ClipChainId>,
+        parent: Option<ClipChainIndex>,
         clips: Vec<ClipId>
-    ) {
-        self.clip_chains_descriptors.push(ClipChainDescriptor { id, parent, clips });
+    ) -> ClipChainIndex {
+        let index = self.allocate_clip_chain();
+        self.clip_chains_descriptors.push(ClipChainDescriptor { index, parent, clips });
+        index
     }
 
     pub fn add_node(&mut self, node: ClipScrollNode, id: ClipId) {
@@ -515,11 +544,11 @@ impl ClipScrollTree {
         let node = self.nodes.get(id).unwrap();
 
         match node.node_type {
-            NodeType::Clip(ref clip_sources_handle) => {
+            NodeType::Clip { ref handle, .. } => {
                 pt.new_level("Clip".to_owned());
 
                 pt.add_item(format!("id: {:?}", id));
-                let clips = clip_store.get(&clip_sources_handle).clips();
+                let clips = clip_store.get(&handle).clips();
                 pt.new_level(format!("Clip Sources [{}]", clips.len()));
                 for source in clips {
                     pt.add_item(format!("{:?}", source));
@@ -581,11 +610,15 @@ impl ClipScrollTree {
         }
     }
 
-    pub fn get_clip_chain(&self, id: &ClipId) -> Option<&ClipChain> {
-        match id {
-            &ClipId::ClipChain(clip_chain_id) => Some(&self.clip_chains[&clip_chain_id]),
-            _ => self.nodes[id].clip_chain.as_ref(),
-        }
+    pub fn allocate_clip_chain(&mut self) -> ClipChainIndex {
+        debug_assert!(!self.clip_chains.is_empty());
+        let new_clip_chain =self.clip_chains[0].clone();
+        self.clip_chains.push(new_clip_chain);
+        ClipChainIndex(self.clip_chains.len() - 1)
+    }
+
+    pub fn get_clip_chain(&self, index: ClipChainIndex) -> &ClipChain {
+        &self.clip_chains[index.0]
     }
 
 }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -3,21 +3,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BuiltDisplayListIter, ClipAndScrollInfo, ClipId, ColorF, ComplexClipRegion};
-use api::{DevicePixelScale, DeviceUintRect, DeviceUintSize, DisplayItemRef, DocumentLayer, Epoch};
-use api::{ExternalScrollId, FilterOp, IframeDisplayItem, ImageDisplayItem, ItemRange, LayerPoint};
+use api::{BuiltDisplayListIter, ClipId, ColorF, ComplexClipRegion, DevicePixelScale};
+use api::{DeviceUintRect, DeviceUintSize, DisplayItemRef, DocumentLayer, Epoch, ExternalScrollId};
+use api::{FilterOp, IframeDisplayItem, ImageDisplayItem, ItemRange, LayerPoint};
 use api::{LayerPrimitiveInfo, LayerRect, LayerSize, LayerVector2D, LayoutSize, PipelineId};
 use api::{ScrollClamping, ScrollEventPhase, ScrollFrameDisplayItem, ScrollLocation};
 use api::{ScrollNodeIdType, ScrollNodeState, ScrollPolicy, ScrollSensitivity, SpecificDisplayItem};
 use api::{StackingContext, TileOffset, TransformStyle, WorldPoint};
 use clip::ClipRegion;
 use clip_scroll_node::StickyFrameInfo;
-use clip_scroll_tree::{ClipScrollTree, ScrollStates};
+use clip_scroll_tree::{ClipChainIndex, ClipScrollTree, ScrollStates};
 use euclid::rect;
 use frame_builder::{FrameBuilder, FrameBuilderConfig, ScrollbarInfo};
 use gpu_cache::GpuCache;
 use hit_test::HitTester;
 use internal_types::{FastHashMap, FastHashSet, RenderedDocument};
+use prim_store::ScrollNodeAndClipChain;
 use profiler::{GpuCacheProfileCounters, TextureCacheProfileCounters};
 use resource_cache::{FontInstanceMap,ResourceCache, TiledImageMap};
 use scene::{Scene, StackingContextHelpers, ScenePipeline, SceneProperties};
@@ -36,6 +37,53 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF {
     a: 0.6,
 };
 
+/// A data structure that keeps track of mapping between API clip ids and the indices
+/// used internally in the ClipScrollTree to avoid having to do HashMap lookups. This
+/// also includes a small LRU cache. Currently the cache is small (1 entry), but in the
+/// future we could use uluru here to do something more involved.
+pub struct ClipIdToIndexMapper {
+    map: FastHashMap<ClipId, ClipChainIndex>,
+    cached_index: Option<(ClipId, ClipChainIndex)>,
+}
+
+impl ClipIdToIndexMapper {
+    fn new() -> ClipIdToIndexMapper {
+        ClipIdToIndexMapper {
+            map: FastHashMap::default(),
+            cached_index: None,
+        }
+    }
+
+    pub fn add(&mut self, id: ClipId, index: ClipChainIndex) {
+        debug_assert!(!self.map.contains_key(&id));
+        self.map.insert(id, index);
+    }
+
+    pub fn map_to_parent_clip_chain(&mut self, id: ClipId, parent_id: &ClipId) {
+        let parent_chain_index = self.map_clip_id(parent_id);
+        self.add(id, parent_chain_index);
+    }
+
+    pub fn map_clip_id(&mut self, id: &ClipId) -> ClipChainIndex {
+        match self.cached_index {
+            Some((cached_id, cached_index)) if cached_id == *id => return cached_index,
+            _ => {}
+        }
+
+        self.map[id]
+    }
+
+    pub fn map_clip_id_and_cache_result(&mut self, id: &ClipId) -> ClipChainIndex {
+        let index = self.map_clip_id(id);
+        self.cached_index = Some((*id, index));
+        index
+    }
+
+    pub fn simple_scroll_and_clip_chain(&mut self, id: &ClipId) -> ScrollNodeAndClipChain {
+        ScrollNodeAndClipChain::new(*id, self.map_clip_id(&id))
+    }
+}
+
 struct FlattenContext<'a> {
     scene: &'a Scene,
     builder: FrameBuilder,
@@ -45,6 +93,7 @@ struct FlattenContext<'a> {
     pipeline_epochs: Vec<(PipelineId, Epoch)>,
     replacements: Vec<(ClipId, ClipId)>,
     output_pipelines: &'a FastHashSet<PipelineId>,
+    id_to_index_mapper: ClipIdToIndexMapper,
 }
 
 impl<'a> FlattenContext<'a> {
@@ -104,13 +153,23 @@ impl<'a> FlattenContext<'a> {
         let root_reference_frame_id = ClipId::root_reference_frame(pipeline_id);
         let root_scroll_frame_id = ClipId::root_scroll_node(pipeline_id);
 
+        let root_clip_chain_index =
+            self.id_to_index_mapper.map_clip_id_and_cache_result(&root_reference_frame_id);
+        let root_reference_frame_clip_and_scroll = ScrollNodeAndClipChain::new(
+            root_reference_frame_id,
+            root_clip_chain_index,
+        );
+
         self.builder.push_stacking_context(
             pipeline_id,
             CompositeOps::default(),
             TransformStyle::Flat,
             true,
             true,
-            ClipAndScrollInfo::simple(root_scroll_frame_id),
+            ScrollNodeAndClipChain::new(
+                ClipId::root_scroll_node(pipeline_id),
+                root_clip_chain_index,
+            ),
             self.output_pipelines,
         );
 
@@ -122,7 +181,7 @@ impl<'a> FlattenContext<'a> {
                     let root_bounds = LayerRect::new(LayerPoint::zero(), *frame_size);
                     let info = LayerPrimitiveInfo::new(root_bounds);
                     self.builder.add_solid_rectangle(
-                        ClipAndScrollInfo::simple(root_reference_frame_id),
+                        root_reference_frame_clip_and_scroll,
                         &info,
                         bg_color,
                         None,
@@ -142,7 +201,7 @@ impl<'a> FlattenContext<'a> {
             let scrollbar_rect = LayerRect::new(LayerPoint::zero(), LayerSize::new(10.0, 70.0));
             let container_rect = LayerRect::new(LayerPoint::zero(), *frame_size);
             self.builder.add_scroll_bar(
-                ClipAndScrollInfo::simple(root_reference_frame_id),
+                root_reference_frame_clip_and_scroll,
                 &LayerPrimitiveInfo::new(scrollbar_rect),
                 DEFAULT_SCROLLBAR_COLOR,
                 ScrollbarInfo(root_scroll_frame_id, container_rect),
@@ -184,19 +243,13 @@ impl<'a> FlattenContext<'a> {
         }
     }
 
-    fn flatten_clip(
-        &mut self,
-        pipeline_id: PipelineId,
-        parent_id: &ClipId,
-        new_clip_id: &ClipId,
-        clip_region: ClipRegion,
-    ) {
+    fn flatten_clip(&mut self, parent_id: &ClipId, new_clip_id: &ClipId, clip_region: ClipRegion) {
         self.builder.add_clip_node(
             *new_clip_id,
             *parent_id,
-            pipeline_id,
             clip_region,
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
     }
 
@@ -205,7 +258,7 @@ impl<'a> FlattenContext<'a> {
         item: &DisplayItemRef,
         info: &ScrollFrameDisplayItem,
         pipeline_id: PipelineId,
-        clip_and_scroll: &ClipAndScrollInfo,
+        clip_and_scroll: &ScrollNodeAndClipChain,
         reference_frame_relative_offset: &LayerVector2D,
     ) {
         let complex_clips = self.get_complex_clips(pipeline_id, item.complex_clip().0);
@@ -229,9 +282,9 @@ impl<'a> FlattenContext<'a> {
         self.builder.add_clip_node(
             info.clip_id,
             clip_and_scroll.scroll_node_id,
-            pipeline_id,
             clip_region,
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
 
         self.builder.add_scroll_frame(
@@ -243,6 +296,7 @@ impl<'a> FlattenContext<'a> {
             &content_rect.size,
             info.scroll_sensitivity,
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
     }
 
@@ -250,7 +304,8 @@ impl<'a> FlattenContext<'a> {
         &mut self,
         traversal: &mut BuiltDisplayListIter<'a>,
         pipeline_id: PipelineId,
-        context_scroll_node_id: ClipId,
+        unreplaced_scroll_id: ClipId,
+        clip_and_scroll: ScrollNodeAndClipChain,
         mut reference_frame_relative_offset: LayerVector2D,
         bounds: &LayerRect,
         stacking_context: &StackingContext,
@@ -279,7 +334,7 @@ impl<'a> FlattenContext<'a> {
 
         if stacking_context.scroll_policy == ScrollPolicy::Fixed {
             self.replacements.push((
-                context_scroll_node_id,
+                unreplaced_scroll_id,
                 self.builder.current_reference_frame_id(),
             ));
         }
@@ -296,30 +351,33 @@ impl<'a> FlattenContext<'a> {
             );
 
             let reference_frame_bounds = LayerRect::new(LayerPoint::zero(), bounds.size);
-            let mut parent_id = self.apply_scroll_frame_id_replacement(context_scroll_node_id);
             self.builder.push_reference_frame(
                 reference_frame_id,
-                Some(parent_id),
+                Some(clip_and_scroll.scroll_node_id),
                 pipeline_id,
                 &reference_frame_bounds,
                 stacking_context.transform,
                 stacking_context.perspective,
                 reference_frame_relative_offset,
                 self.clip_scroll_tree,
+                &mut self.id_to_index_mapper,
             );
-            self.replacements.push((context_scroll_node_id, reference_frame_id));
+            self.replacements.push((unreplaced_scroll_id, reference_frame_id));
             reference_frame_relative_offset = LayerVector2D::zero();
         }
 
-        let sc_scroll_node_id = self.apply_scroll_frame_id_replacement(context_scroll_node_id);
-
+        // We apply the replacements one more time in case we need to set it to a replacement
+        // that we just pushed above.
+        let new_scroll_node = self.apply_scroll_frame_id_replacement(unreplaced_scroll_id);
+        let stacking_context_clip_and_scroll =
+            self.id_to_index_mapper.simple_scroll_and_clip_chain(&new_scroll_node);
         self.builder.push_stacking_context(
             pipeline_id,
             composition_operations,
             stacking_context.transform_style,
             is_backface_visible,
             false,
-            ClipAndScrollInfo::simple(sc_scroll_node_id),
+            stacking_context_clip_and_scroll,
             self.output_pipelines,
         );
 
@@ -345,8 +403,7 @@ impl<'a> FlattenContext<'a> {
         &mut self,
         item: &DisplayItemRef,
         info: &IframeDisplayItem,
-        parent_pipeline_id: PipelineId,
-        clip_and_scroll: &ClipAndScrollInfo,
+        clip_and_scroll: &ScrollNodeAndClipChain,
         reference_frame_relative_offset: &LayerVector2D,
     ) {
         let iframe_pipeline_id = info.pipeline_id;
@@ -358,12 +415,12 @@ impl<'a> FlattenContext<'a> {
         self.builder.add_clip_node(
             info.clip_id,
             clip_and_scroll.scroll_node_id,
-            parent_pipeline_id,
             ClipRegion::create_for_clip_node_with_local_clip(
                 &item.local_clip(),
                 &reference_frame_relative_offset
             ),
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
 
         self.pipeline_epochs.push((iframe_pipeline_id, pipeline.epoch));
@@ -380,6 +437,7 @@ impl<'a> FlattenContext<'a> {
             None,
             origin,
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
 
         self.builder.add_scroll_frame(
@@ -391,6 +449,7 @@ impl<'a> FlattenContext<'a> {
             &pipeline.content_size,
             ScrollSensitivity::ScriptAndInputEvents,
             self.clip_scroll_tree,
+            &mut self.id_to_index_mapper,
         );
 
         self.flatten_root(&mut pipeline.display_list.iter(), iframe_pipeline_id, &iframe_rect.size);
@@ -404,7 +463,11 @@ impl<'a> FlattenContext<'a> {
         pipeline_id: PipelineId,
         reference_frame_relative_offset: LayerVector2D,
     ) -> Option<BuiltDisplayListIter<'a>> {
-        let mut clip_and_scroll = item.clip_and_scroll();
+        let clip_and_scroll = item.clip_and_scroll();
+        let mut clip_and_scroll = ScrollNodeAndClipChain::new(
+            clip_and_scroll.scroll_node_id,
+            self.id_to_index_mapper.map_clip_id_and_cache_result(&clip_and_scroll.clip_node_id()),
+        );
 
         let unreplaced_scroll_id = clip_and_scroll.scroll_node_id;
         clip_and_scroll.scroll_node_id =
@@ -557,6 +620,7 @@ impl<'a> FlattenContext<'a> {
                     &mut subtraversal,
                     pipeline_id,
                     unreplaced_scroll_id,
+                    clip_and_scroll,
                     reference_frame_relative_offset,
                     &item.rect(),
                     &info.stacking_context,
@@ -569,7 +633,6 @@ impl<'a> FlattenContext<'a> {
                 self.flatten_iframe(
                     &item,
                     info,
-                    pipeline_id,
                     &clip_and_scroll,
                     &reference_frame_relative_offset
                 );
@@ -582,16 +645,16 @@ impl<'a> FlattenContext<'a> {
                     info.image_mask,
                     &reference_frame_relative_offset,
                 );
-                self.flatten_clip(
-                    pipeline_id,
-                    &clip_and_scroll.scroll_node_id,
-                    &info.id,
-                    clip_region,
-                );
+                self.flatten_clip(&clip_and_scroll.scroll_node_id, &info.id, clip_region);
             }
             SpecificDisplayItem::ClipChain(ref info) => {
                 let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items());
-                self.clip_scroll_tree.add_clip_chain_descriptor(info.id, info.parent, items);
+                let parent = info.parent.map(|id|
+                     self.id_to_index_mapper.map_clip_id(&ClipId::ClipChain(id))
+                );
+                let clip_chain_index =
+                    self.clip_scroll_tree.add_clip_chain_descriptor(parent, items);
+                self.id_to_index_mapper.add(ClipId::ClipChain(info.id), clip_chain_index);
             },
             SpecificDisplayItem::ScrollFrame(ref info) => {
                 self.flatten_scroll_frame(
@@ -610,12 +673,14 @@ impl<'a> FlattenContext<'a> {
                     info.horizontal_offset_bounds,
                     info.previously_applied_offset,
                 );
+                let parent_id = clip_and_scroll.scroll_node_id;
                 self.clip_scroll_tree.add_sticky_frame(
                     info.id,
-                    clip_and_scroll.scroll_node_id, /* parent id */
+                    parent_id,
                     frame_rect,
                     sticky_frame_info
                 );
+                self.id_to_index_mapper.map_to_parent_clip_chain(info.id, &parent_id);
             }
 
             // Do nothing; these are dummy items for the display list parser
@@ -650,7 +715,7 @@ impl<'a> FlattenContext<'a> {
     /// takes care of the decomposition required by the internal tiling of the image.
     fn decompose_image(
         &mut self,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         prim_info: &LayerPrimitiveInfo,
         info: &ImageDisplayItem,
         image_size: DeviceUintSize,
@@ -696,7 +761,7 @@ impl<'a> FlattenContext<'a> {
 
     fn decompose_image_row(
         &mut self,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         prim_info: &LayerPrimitiveInfo,
         info: &ImageDisplayItem,
         image_size: DeviceUintSize,
@@ -742,7 +807,7 @@ impl<'a> FlattenContext<'a> {
 
     fn decompose_tiled_image(
         &mut self,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         prim_info: &LayerPrimitiveInfo,
         info: &ImageDisplayItem,
         image_size: DeviceUintSize,
@@ -878,7 +943,7 @@ impl<'a> FlattenContext<'a> {
 
     fn add_tile_primitive(
         &mut self,
-        clip_and_scroll: ClipAndScrollInfo,
+        clip_and_scroll: ScrollNodeAndClipChain,
         prim_info: &LayerPrimitiveInfo,
         info: &ImageDisplayItem,
         tile_offset: TileOffset,
@@ -1056,6 +1121,7 @@ impl FrameContext {
                 pipeline_epochs: Vec::new(),
                 replacements: Vec::new(),
                 output_pipelines,
+                id_to_index_mapper: ClipIdToIndexMapper::new(),
             };
 
             roller.builder.push_root(
@@ -1063,6 +1129,7 @@ impl FrameContext {
                 &root_pipeline.viewport_size,
                 &root_pipeline.content_size,
                 roller.clip_scroll_tree,
+                &mut roller.id_to_index_mapper,
             );
 
             roller.builder.setup_viewport_offset(

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ColorF, ClipAndScrollInfo, FilterOp, MixBlendMode};
-use api::{DeviceIntPoint, DeviceIntRect, LayerToWorldScale, PipelineId};
-use api::{BoxShadowClipMode, LayerPoint, LayerRect, LayerVector2D, Shadow};
-use api::{ClipId, PremultipliedColorF};
+use api::{BoxShadowClipMode, ClipId, ColorF, DeviceIntPoint, DeviceIntRect, FilterOp, LayerPoint};
+use api::{LayerRect, LayerToWorldScale, LayerVector2D, MixBlendMode, PipelineId};
+use api::{PremultipliedColorF, Shadow};
 use box_shadow::{BLUR_SAMPLE_SCALE, BoxShadowCacheKey};
 use frame_builder::{FrameContext, FrameState, PictureState};
 use gpu_cache::GpuDataRequest;
 use gpu_types::{BrushImageKind, PictureType};
 use prim_store::{BrushKind, BrushPrimitive, PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
+use prim_store::ScrollNodeAndClipChain;
 use render_task::{ClearMode, RenderTask, RenderTaskCacheKey};
 use render_task::{RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
 use resource_cache::CacheItem;
@@ -230,7 +230,7 @@ impl PicturePrimitive {
     pub fn add_primitive(
         &mut self,
         prim_index: PrimitiveIndex,
-        clip_and_scroll: ClipAndScrollInfo
+        clip_and_scroll: ScrollNodeAndClipChain
     ) {
         if let Some(ref mut run) = self.runs.last_mut() {
             if run.clip_and_scroll == clip_and_scroll &&


### PR DESCRIPTION
During display list flattening, we convert ClipIds for the clipping node
into ClipChainIndex (as well as allocating space for them in the
ClipChain array in the ClipScrollTree). This allows us to avoid doing a
HashMap lookup for the ClipChain for every primitive run. It also moves
us a little closer to a universal representation of ClipChains (both
API-defined ClipChains and ones derived from the hierarchy of the
ClipScroll tree).

This causes the amount of time spend doing HashMap lookups to decrease
in the profile, though they are still done for the positioning node. A
second patch will reduce HashMap lookups for positioning nodes as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2427)
<!-- Reviewable:end -->
