### PR TITLE
Add brush flags and allow selection of perspective interpolation per brush instance.

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -624,7 +624,8 @@ VertexInfo write_transform_vertex(RectWithSize local_segment_rect,
                                   vec4 clip_edge_mask,
                                   float z,
                                   ClipScrollNode scroll_node,
-                                  PictureTask task) {
+                                  PictureTask task,
+                                  bool do_perspective_interpolation) {
     // Calculate a clip rect from local_rect + local clip
     RectWithEndpoint clip_rect = to_rect_with_endpoint(local_clip_rect);
     RectWithEndpoint segment_rect = to_rect_with_endpoint(local_segment_rect);
@@ -661,9 +662,10 @@ VertexInfo write_transform_vertex(RectWithSize local_segment_rect,
     vec2 device_pos = world_pos.xy / world_pos.w * uDevicePixelRatio;
     vec2 task_offset = task.common_data.task_rect.p0 - task.content_origin;
 
-#ifdef FORCE_NO_PERSPECTIVE
-    world_pos.w = 1.0;
-#endif
+    // Force w = 1, if we don't want perspective interpolation (for
+    // example, drawing a screen-space quad on an element with a
+    // perspective transform).
+    world_pos.w = mix(1.0, world_pos.w, do_perspective_interpolation);
 
     // We want the world space coords to be perspective divided by W.
     // We also want that to apply to any interpolators. However, we
@@ -696,7 +698,8 @@ VertexInfo write_transform_vertex_primitive(Primitive prim) {
         vec4(1.0),
         prim.z,
         prim.scroll_node,
-        prim.task
+        prim.task,
+        true
     );
 }
 

--- a/webrender/res/ps_border_corner.glsl
+++ b/webrender/res/ps_border_corner.glsl
@@ -320,7 +320,8 @@ void main(void) {
                                            edge_mask,
                                            prim.z,
                                            prim.scroll_node,
-                                           prim.task);
+                                           prim.task,
+                                           true);
 #else
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,

--- a/webrender/res/ps_border_edge.glsl
+++ b/webrender/res/ps_border_edge.glsl
@@ -233,7 +233,8 @@ void main(void) {
                                            edge_mask,
                                            prim.z,
                                            prim.scroll_node,
-                                           prim.task);
+                                           prim.task,
+                                           true);
 #else
     VertexInfo vi = write_vertex(segment_rect,
                                  prim.local_clip_rect,

--- a/webrender/res/ps_gradient.glsl
+++ b/webrender/res/ps_gradient.glsl
@@ -73,7 +73,8 @@ void main(void) {
                                            vec4(1.0),
                                            prim.z,
                                            prim.scroll_node,
-                                           prim.task);
+                                           prim.task,
+                                           true);
     vLocalPos = vi.local_pos;
     vec2 f = (vi.local_pos.xy - prim.local_rect.p0) / prim.local_rect.size;
 #else

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -12,7 +12,7 @@ use clip_scroll_tree::{CoordinateSystemId};
 use euclid::{TypedTransform3D, vec3};
 use glyph_rasterizer::GlyphFormat;
 use gpu_cache::{GpuCache, GpuCacheAddress};
-use gpu_types::{BrushImageKind, BrushInstance, ClipChainRectIndex};
+use gpu_types::{BrushFlags, BrushImageKind, BrushInstance, ClipChainRectIndex};
 use gpu_types::{ClipMaskInstance, ClipScrollNodeIndex};
 use gpu_types::{CompositePrimitiveInstance, PrimitiveInstance, SimplePrimitiveInstance};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
@@ -953,6 +953,7 @@ impl AlphaBatchBuilder {
                                     z,
                                     segment_index: 0,
                                     edge_flags: EdgeAaSegmentMask::empty(),
+                                    brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
                                     user_data: [
                                         cache_task_address.0 as i32,
                                         BrushImageKind::Simple as i32,
@@ -1039,6 +1040,7 @@ impl AlphaBatchBuilder {
                                                     z,
                                                     segment_index: 0,
                                                     edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
                                                     user_data: [
                                                         cache_task_address.0 as i32,
                                                         BrushImageKind::Simple as i32,
@@ -1116,6 +1118,7 @@ impl AlphaBatchBuilder {
                                                     z,
                                                     segment_index: 0,
                                                     edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::empty(),
                                                     user_data: [
                                                         cache_task_address.0 as i32,
                                                         filter_mode,
@@ -1155,6 +1158,7 @@ impl AlphaBatchBuilder {
                                             z,
                                             segment_index: 0,
                                             edge_flags: EdgeAaSegmentMask::empty(),
+                                            brush_flags: BrushFlags::empty(),
                                             user_data: [
                                                 mode as u32 as i32,
                                                 backdrop_task_address.0 as i32,
@@ -1324,6 +1328,7 @@ impl AlphaBatchBuilder {
             z,
             segment_index: 0,
             edge_flags: EdgeAaSegmentMask::all(),
+            brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
             user_data,
         };
 

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -147,6 +147,14 @@ impl From<CompositePrimitiveInstance> for PrimitiveInstance {
     }
 }
 
+bitflags! {
+    /// Flags that define how the common brush shader
+    /// code should process this instance.
+    pub struct BrushFlags: u8 {
+        const PERSPECTIVE_INTERPOLATION = 0x1;
+    }
+}
+
 // TODO(gw): While we are comverting things over, we
 //           need to have the instance be the same
 //           size as an old PrimitiveInstance. In the
@@ -164,6 +172,7 @@ pub struct BrushInstance {
     pub z: i32,
     pub segment_index: i32,
     pub edge_flags: EdgeAaSegmentMask,
+    pub brush_flags: BrushFlags,
     pub user_data: [i32; 3],
 }
 
@@ -175,7 +184,9 @@ impl From<BrushInstance> for PrimitiveInstance {
                 instance.prim_address.as_int(),
                 ((instance.clip_chain_rect_index.0 as i32) << 16) | instance.scroll_id.0 as i32,
                 instance.z,
-                instance.segment_index | ((instance.edge_flags.bits() as i32) << 16),
+                instance.segment_index |
+                    ((instance.edge_flags.bits() as i32) << 16) |
+                    ((instance.brush_flags.bits() as i32) << 24),
                 instance.user_data[0],
                 instance.user_data[1],
                 instance.user_data[2],

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -11,7 +11,7 @@ use clip::{ClipStore};
 use clip_scroll_tree::{ClipScrollTree};
 use device::{FrameId, Texture};
 use gpu_cache::{GpuCache};
-use gpu_types::{BlurDirection, BlurInstance, BrushInstance, ClipChainRectIndex};
+use gpu_types::{BlurDirection, BlurInstance, BrushFlags, BrushInstance, ClipChainRectIndex};
 use gpu_types::{ClipScrollNodeData, ClipScrollNodeIndex};
 use gpu_types::{PrimitiveInstance};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
@@ -587,6 +587,7 @@ impl RenderTarget for AlphaRenderTarget {
                                             clip_task_address: RenderTaskAddress(0),
                                             z: 0,
                                             segment_index: 0,
+                                            brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
                                             edge_flags: EdgeAaSegmentMask::empty(),
                                             user_data: [0; 3],
                                         };


### PR DESCRIPTION
This is a step towards removing ps_hardware_composite shader
completely, which will allow fixing some existing drop-shadow bugs.

By selecting whether the source image needs perspective
interpolation or not, we can collapse ps_hardware_composite into
the brush_image shader.

This will then mean that hardware composites get the same
benefits as brush_blend and brush_mix_blend (reduced pixel
counts for transformed primitives, opt-in clip masks, edge AA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2432)
<!-- Reviewable:end -->
