### PR TITLE
Remove ScrollNodeIdType

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -5,7 +5,7 @@
 use api::{ClipId, DevicePixelScale, ExternalScrollId, LayerPixel, LayerPoint, LayerRect};
 use api::{LayerSize, LayerToWorldTransform, LayerTransform, LayerVector2D, LayoutTransform};
 use api::{LayoutVector2D, PipelineId, PropertyBinding, ScrollClamping, ScrollEventPhase};
-use api::{ScrollLocation, ScrollNodeIdType, ScrollSensitivity, StickyOffsetBounds, WorldPoint};
+use api::{ScrollLocation, ScrollSensitivity, StickyOffsetBounds, WorldPoint};
 use clip::{ClipChain, ClipSourcesHandle, ClipStore, ClipWorkItem};
 use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId, TransformUpdateState};
 use euclid::SideOffsets2D;
@@ -751,12 +751,7 @@ impl ClipScrollNode {
         }
     }
 
-    pub fn matches_id(&self, node_id: ClipId, id_to_match: ScrollNodeIdType) -> bool {
-        let external_id = match id_to_match {
-            ScrollNodeIdType::ExternalScrollId(id) => id,
-            ScrollNodeIdType::ClipId(clip_id) => return node_id == clip_id,
-        };
-
+    pub fn matches_external_id(&self, external_id: ExternalScrollId) -> bool {
         match self.node_type {
             NodeType::ScrollFrame(info) if info.external_id == Some(external_id) => true,
             _ => false,

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -8,8 +8,8 @@ use api::{DeviceUintRect, DeviceUintSize, DisplayItemRef, DocumentLayer, Epoch, 
 use api::{FilterOp, IframeDisplayItem, ImageDisplayItem, ItemRange, LayerPoint};
 use api::{LayerPrimitiveInfo, LayerRect, LayerSize, LayerVector2D, LayoutSize, PipelineId};
 use api::{ScrollClamping, ScrollEventPhase, ScrollFrameDisplayItem, ScrollLocation};
-use api::{ScrollNodeIdType, ScrollNodeState, ScrollPolicy, ScrollSensitivity, SpecificDisplayItem};
-use api::{StackingContext, TileOffset, TransformStyle, WorldPoint};
+use api::{ScrollNodeState, ScrollPolicy, ScrollSensitivity, SpecificDisplayItem, StackingContext};
+use api::{TileOffset, TransformStyle, WorldPoint};
 use clip::ClipRegion;
 use clip_scroll_node::StickyFrameInfo;
 use clip_scroll_tree::{ClipChainIndex, ClipScrollTree, ScrollStates};
@@ -1048,7 +1048,7 @@ impl FrameContext {
     pub fn scroll_node(
         &mut self,
         origin: LayerPoint,
-        id: ScrollNodeIdType,
+        id: ExternalScrollId,
         clamp: ScrollClamping
     ) -> bool {
         self.clip_scroll_tree.scroll_node(origin, id, clamp)

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::u32;
-use {BuiltDisplayList, BuiltDisplayListDescriptor, ClipId, ColorF, DeviceIntPoint, DeviceUintRect};
+use {BuiltDisplayList, BuiltDisplayListDescriptor, ColorF, DeviceIntPoint, DeviceUintRect};
 use {DeviceUintSize, ExternalScrollId, FontInstanceKey, FontInstanceOptions};
 use {FontInstancePlatformOptions, FontKey, FontVariation, GlyphDimensions, GlyphKey, ImageData};
 use {ImageDescriptor, ImageKey, ItemTag, LayoutPoint, LayoutSize, LayoutTransform, LayoutVector2D};
@@ -254,7 +254,7 @@ impl Transaction {
     pub fn scroll_node_with_id(
         &mut self,
         origin: LayoutPoint,
-        id: ScrollNodeIdType,
+        id: ExternalScrollId,
         clamp: ScrollClamping,
     ) {
         self.ops.push(DocumentMsg::ScrollNodeWithId(origin, id, clamp));
@@ -384,35 +384,11 @@ pub enum DocumentMsg {
         device_pixel_ratio: f32,
     },
     Scroll(ScrollLocation, WorldPoint, ScrollEventPhase),
-    ScrollNodeWithId(LayoutPoint, ScrollNodeIdType, ScrollClamping),
+    ScrollNodeWithId(LayoutPoint, ExternalScrollId, ScrollClamping),
     TickScrollingBounce,
     GetScrollNodeState(MsgSender<Vec<ScrollNodeState>>),
     GenerateFrame,
     UpdateDynamicProperties(DynamicProperties),
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum ScrollNodeIdType {
-    ExternalScrollId(ExternalScrollId),
-    ClipId(ClipId),
-}
-
-impl From<ExternalScrollId> for ScrollNodeIdType {
-    fn from(id: ExternalScrollId) -> Self {
-        ScrollNodeIdType::ExternalScrollId(id)
-    }
-}
-
-impl From<ClipId> for ScrollNodeIdType {
-    fn from(id: ClipId) -> Self {
-        ScrollNodeIdType::ClipId(id)
-    }
-}
-
-impl<'a> From<&'a ClipId> for ScrollNodeIdType {
-    fn from(id: &'a ClipId) -> Self {
-        ScrollNodeIdType::ClipId(*id)
-    }
 }
 
 impl fmt::Debug for DocumentMsg {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -502,7 +502,7 @@ impl Wrench {
         &mut self,
         frame_number: u32,
         display_lists: Vec<(PipelineId, LayerSize, BuiltDisplayList)>,
-        scroll_offsets: &HashMap<ClipId, LayerPoint>,
+        scroll_offsets: &HashMap<ExternalScrollId, LayerPoint>,
     ) {
         let root_background_color = Some(ColorF::new(1.0, 1.0, 1.0, 1.0));
 
@@ -523,7 +523,7 @@ impl Wrench {
 
         let mut txn = Transaction::new();
         for (id, offset) in scroll_offsets {
-            txn.scroll_node_with_id(*offset, id.into(), ScrollClamping::NoClamping);
+            txn.scroll_node_with_id(*offset, *id, ScrollClamping::NoClamping);
         }
         // TODO(nical) - Wrench does not notify frames when there was scrolling
         // in the transaction (See RenderNotifier implementations). If we don't


### PR DESCRIPTION
This was a nice API feature, but it's used by neither Gecko nor Servo.
It also makes removing HashMap accesses much more difficult in the
ClipScrollTree. This change just removes the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2435)
<!-- Reviewable:end -->
