### PR TITLE
Reduce the GPU cache size of pictures.

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 5
+#define VECS_PER_SPECIFIC_BRUSH 1
 #define FORCE_NO_PERSPECTIVE
 
 #include shared,prim_shared,brush
@@ -83,9 +83,10 @@ void brush_vs(
         }
         case 10: {
             // Color Matrix
-            vec4 data[4] = fetch_from_resource_cache_4(prim_address + 1);
-            vColorMat = mat4(amount, data[0], data[1], data[2]);
-            vColorOffset = data[3];
+            vec4 mat_data[4] = fetch_from_resource_cache_4(user_data.z);
+            vec4 offset_data = fetch_from_resource_cache_1(user_data.z + 4);
+            vColorMat = mat4(mat_data[0], mat_data[1], mat_data[2], mat_data[3]);
+            vColorOffset = offset_data;
             break;
         }
         default: break;

--- a/webrender/res/brush_mix_blend.glsl
+++ b/webrender/res/brush_mix_blend.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 5
+#define VECS_PER_SPECIFIC_BRUSH 1
 
 #include shared,prim_shared,brush
 

--- a/webrender/res/brush_picture.glsl
+++ b/webrender/res/brush_picture.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 5
+#define VECS_PER_SPECIFIC_BRUSH 1
 
 #include shared,prim_shared,brush
 

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -969,6 +969,7 @@ impl AlphaBatchBuilder {
                                 is_in_3d_context,
                                 reference_frame_id,
                                 real_local_rect,
+                                ref extra_gpu_data_handle,
                                 ..
                             } => {
                                 // If this picture is participating in a 3D rendering context,
@@ -1093,18 +1094,20 @@ impl AlphaBatchBuilder {
                                                     BatchTextures::render_target_cache(),
                                                 );
 
-                                                let filter_mode = match filter {
-                                                    FilterOp::Blur(..) => 0,
-                                                    FilterOp::Contrast(..) => 1,
-                                                    FilterOp::Grayscale(..) => 2,
-                                                    FilterOp::HueRotate(..) => 3,
-                                                    FilterOp::Invert(..) => 4,
-                                                    FilterOp::Saturate(..) => 5,
-                                                    FilterOp::Sepia(..) => 6,
-                                                    FilterOp::Brightness(..) => 7,
-                                                    FilterOp::Opacity(..) => 8,
-                                                    FilterOp::DropShadow(..) => 9,
-                                                    FilterOp::ColorMatrix(..) => 10,
+                                                let (filter_mode, extra_cache_address) = match filter {
+                                                    FilterOp::Blur(..) => (0, 0),
+                                                    FilterOp::Contrast(..) => (1, 0),
+                                                    FilterOp::Grayscale(..) => (2, 0),
+                                                    FilterOp::HueRotate(..) => (3, 0),
+                                                    FilterOp::Invert(..) => (4, 0),
+                                                    FilterOp::Saturate(..) => (5, 0),
+                                                    FilterOp::Sepia(..) => (6, 0),
+                                                    FilterOp::Brightness(..) => (7, 0),
+                                                    FilterOp::Opacity(..) => (8, 0),
+                                                    FilterOp::DropShadow(..) => (9, 0),
+                                                    FilterOp::ColorMatrix(..) => {
+                                                        (10, extra_gpu_data_handle.as_int(gpu_cache))
+                                                    }
                                                 };
 
                                                 let instance = BrushInstance {
@@ -1120,7 +1123,7 @@ impl AlphaBatchBuilder {
                                                     user_data: [
                                                         cache_task_address.0 as i32,
                                                         filter_mode,
-                                                        0,
+                                                        extra_cache_address,
                                                     ],
                                                 };
 


### PR DESCRIPTION
For the rare case of color matrix, store the color matrix as a
separate piece of GPU cache data.

This allows a smaller GPU cache size for the majority of picture
types. This is important to allow collapsing the brush_image and
ps_hw_composite code paths into one, which is the next step to
fixing up some drop-shadow bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2440)
<!-- Reviewable:end -->
