### PR TITLE
Use FastTransform almost everywhere

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -811,7 +811,7 @@ impl AlphaBatchBuilder {
                 let font_transform = if is_shadow {
                     None
                 } else {
-                    Some(&scroll_node.transform)
+                    Some(scroll_node.transform)
                 };
 
                 let font = text_cpu.get_font(
@@ -977,8 +977,10 @@ impl AlphaBatchBuilder {
                                 if is_in_3d_context {
                                     // Push into parent plane splitter.
 
-                                    let real_xf = &ctx.clip_scroll_tree.nodes[&reference_frame_id].world_content_transform;
-
+                                    let real_xf = &ctx.clip_scroll_tree
+                                        .nodes[&reference_frame_id]
+                                        .world_content_transform
+                                        .into();
                                     let polygon = make_polygon(
                                         real_local_rect,
                                         &real_xf,

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, ClipMode, ComplexClipRegion, DeviceIntRect, DevicePixelScale, ImageMask};
-use api::{ImageRendering, LayerRect, LayerToWorldTransform, LayoutPoint, LayoutVector2D};
-use api::LocalClip;
+use api::{ImageRendering, LayerRect, LayoutPoint, LayoutVector2D, LocalClip};
 use border::{BorderCornerClipSource, ensure_no_corner_overlap};
 use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId};
 use ellipse::Ellipse;
@@ -13,7 +12,8 @@ use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use gpu_types::ClipScrollNodeIndex;
 use prim_store::{ClipData, ImageMaskData};
 use resource_cache::{ImageRequest, ResourceCache};
-use util::{MaxRect, MatrixHelpers, calculate_screen_bounding_rect, extract_inner_rect_safe};
+use util::{LayerToWorldFastTransform, MaxRect, calculate_screen_bounding_rect};
+use util::extract_inner_rect_safe;
 use std::rc::Rc;
 
 pub type ClipStore = FreeList<ClipSources>;
@@ -252,7 +252,7 @@ impl ClipSources {
 
     pub fn get_screen_bounds(
         &self,
-        transform: &LayerToWorldTransform,
+        transform: &LayerToWorldFastTransform,
         device_pixel_scale: DevicePixelScale,
     ) -> (DeviceIntRect, Option<DeviceIntRect>) {
         // If this translation isn't axis aligned or has a perspective component, don't try to

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, ClipId, ClipMode, HitTestFlags, HitTestItem, HitTestResult, ItemTag};
-use api::{LayerPoint, LayerPrimitiveInfo, LayerRect, LayerToWorldTransform, LocalClip, PipelineId};
-use api::WorldPoint;
+use api::{LayerPoint, LayerPrimitiveInfo, LayerRect, LocalClip, PipelineId, WorldPoint};
 use clip::{ClipSource, ClipStore, Contains, rounded_rectangle_contains_point};
 use clip_scroll_node::{ClipScrollNode, NodeType};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollTree};
 use internal_types::FastHashMap;
 use prim_store::ScrollNodeAndClipChain;
+use util::LayerToWorldFastTransform;
 
 /// A copy of important clip scroll node data to use during hit testing. This a copy of
 /// data from the ClipScrollTree that will persist as a new frame is under construction,
@@ -20,10 +20,10 @@ pub struct HitTestClipScrollNode {
     regions: Vec<HitTestRegion>,
 
     /// World transform for content transformed by this node.
-    world_content_transform: LayerToWorldTransform,
+    world_content_transform: LayerToWorldFastTransform,
 
     /// World viewport transform for content transformed by this node.
-    world_viewport_transform: LayerToWorldTransform,
+    world_viewport_transform: LayerToWorldFastTransform,
 
     /// Origin of the viewport of the node, used to calculate node-relative positions.
     node_origin: LayerPoint,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{AlphaType, BorderRadius, BuiltDisplayList, ClipId, ClipMode, ColorF, C
 use api::{DeviceIntRect, DeviceIntSize, DevicePixelScale, Epoch, ExtendMode, FontRenderMode};
 use api::{GlyphInstance, GlyphKey, GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag};
 use api::{LayerPoint, LayerRect, LayerSize, LayerToWorldTransform, LayerVector2D, LineOrientation};
-use api::{LineStyle, PremultipliedColorF, WorldToLayerTransform, YuvColorSpace, YuvFormat};
+use api::{LineStyle, PremultipliedColorF, YuvColorSpace, YuvFormat};
 use border::{BorderCornerInstance, BorderEdgeKind};
 use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId};
 use clip_scroll_node::ClipScrollNode;
@@ -25,8 +25,8 @@ use resource_cache::{CacheItem, ImageProperties, ImageRequest, ResourceCache};
 use segment::SegmentBuilder;
 use std::{mem, usize};
 use std::rc::Rc;
-use util::{MatrixHelpers, calculate_screen_bounding_rect, pack_as_float};
-use util::recycle_vec;
+use util::{MatrixHelpers, WorldToLayerFastTransform, calculate_screen_bounding_rect};
+use util::{pack_as_float, recycle_vec};
 
 
 const MIN_BRUSH_SPLIT_AREA: f32 = 128.0 * 128.0;
@@ -670,7 +670,7 @@ impl TextRunPrimitiveCpu {
     pub fn get_font(
         &self,
         device_pixel_scale: DevicePixelScale,
-        transform: Option<&LayerToWorldTransform>,
+        transform: Option<LayerToWorldTransform>,
     ) -> FontInstance {
         let mut font = self.font.clone();
         font.size = font.size.scale_by(device_pixel_scale.0);
@@ -678,7 +678,7 @@ impl TextRunPrimitiveCpu {
             if transform.has_perspective_component() || !transform.has_2d_inverse() {
                 font.render_mode = font.render_mode.limit_by(FontRenderMode::Alpha);
             } else {
-                font.transform = FontTransform::from(transform).quantize();
+                font.transform = FontTransform::from(&transform).quantize();
             }
         }
         font
@@ -688,7 +688,7 @@ impl TextRunPrimitiveCpu {
         &mut self,
         resource_cache: &mut ResourceCache,
         device_pixel_scale: DevicePixelScale,
-        transform: Option<&LayerToWorldTransform>,
+        transform: Option<LayerToWorldTransform>,
         display_list: &BuiltDisplayList,
         gpu_cache: &mut GpuCache,
     ) {
@@ -1146,7 +1146,7 @@ impl PrimitiveStore {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
                 // The transform only makes sense for screen space rasterization
                 let transform = if pic_context.draw_text_transformed {
-                    Some(&prim_run_context.scroll_node.world_content_transform)
+                    Some(prim_run_context.scroll_node.world_content_transform.into())
                 } else {
                     None
                 };
@@ -1471,14 +1471,14 @@ impl PrimitiveStore {
                 let local_clip_rect = if clip_item.scroll_node_data_index == prim_run_context.scroll_node.node_data_index {
                     local_clip_rect
                 } else {
-                    let clip_transform_data = &frame_context
-                        .node_data[clip_item.scroll_node_data_index.0 as usize];
+                    let clip_transform = frame_context
+                        .node_data[clip_item.scroll_node_data_index.0 as usize]
+                        .transform;
                     let prim_transform = &prim_run_context.scroll_node.world_content_transform;
-
                     let relative_transform = prim_transform
                         .inverse()
-                        .unwrap_or(WorldToLayerTransform::identity())
-                        .pre_mul(&clip_transform_data.transform);
+                        .unwrap_or(WorldToLayerFastTransform::identity())
+                        .pre_mul(&clip_transform.into());
 
                     relative_transform.transform_rect(&local_clip_rect)
                 };
@@ -2061,8 +2061,7 @@ fn get_local_clip_rect_for_nodes(
     );
 
     match local_rect {
-        Some(local_rect) =>
-            Some(scroll_node.coordinate_system_relative_transform.unapply(&local_rect)),
+        Some(local_rect) => scroll_node.coordinate_system_relative_transform.unapply(&local_rect),
         None => None,
     }
 }


### PR DESCRIPTION
This helps to avoid the cost of expensive matrix math and allows us to
more liberally call things like `inverse()` on our transformations,
since the worst case is that we will be retrieving the already-cached
inverted matrix. This decreases the amount of time that
FrameBuilder::build takes in my local CPU profiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2444)
<!-- Reviewable:end -->
