### PR TITLE
Fix external texture UVs that are inverted with image brush shader.

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -40,7 +40,12 @@ void brush_vs(
     vUv.xy = mix(uv0, uv1, f);
     vUv.xy /= texture_size;
 
-    vUvBounds = vec4(uv0 + vec2(0.5), uv1 - vec2(0.5)) / texture_size.xyxy;
+    // Handle case where the UV coords are inverted (e.g. from an
+    // external image).
+    vUvBounds = vec4(
+        min(uv0, uv1) + vec2(0.5),
+        max(uv0, uv1) - vec2(0.5)
+    ) / texture_size.xyxy;
 
 #ifdef WR_FEATURE_ALPHA_PASS
     vLocalPos = vi.local_pos;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2447)
<!-- Reviewable:end -->
