### PR TITLE
Remove unused distance-to-Bézier-curve code.

### DIFF
--- a/webrender/res/brush_line.glsl
+++ b/webrender/res/brush_line.glsl
@@ -121,37 +121,6 @@ void brush_vs(
 
 #define MAGIC_WAVY_LINE_AA_SNAP         0.7
 
-float det(vec2 a, vec2 b) {
-    return a.x * b.y - b.x * a.y;
-}
-
-// From: http://research.microsoft.com/en-us/um/people/hoppe/ravg.pdf
-vec2 get_distance_vector(vec2 b0, vec2 b1, vec2 b2) {
-    float a = det(b0, b2);
-    float b = 2.0 * det(b1, b0);
-    float d = 2.0 * det(b2, b1);
-
-    float f = b * d - a * a;
-    vec2 d21 = b2 - b1;
-    vec2 d10 = b1 - b0;
-    vec2 d20 = b2 - b0;
-
-    vec2 gf = 2.0 * (b *d21 + d * d10 + a * d20);
-    gf = vec2(gf.y,-gf.x);
-    vec2 pp = -f * gf / dot(gf, gf);
-    vec2 d0p = b0 - pp;
-    float ap = det(d0p, d20);
-    float bp = 2.0 * det(d10, d0p);
-
-    float t = clamp((ap + bp) / (2.0 * a + b + d), 0.0, 1.0);
-    return mix(mix(b0, b1, t), mix(b1,b2,t), t);
-}
-
-// Approximate distance from point to quadratic bezier.
-float approx_distance(vec2 p, vec2 b0, vec2 b1, vec2 b2) {
-    return length(get_distance_vector(b0 - p, b1 - p, b2 - p));
-}
-
 vec4 brush_fs() {
     // Find the appropriate distance to apply the step over.
     vec2 local_pos = vLocalPos;


### PR DESCRIPTION
This code was used for wavy lines at one point but is no longer
relevant. Pathfinder uses a different technique to compute distance to
the curve.

r? @glennw 
cc @Gankro

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2448)
<!-- Reviewable:end -->
