### PR TITLE
Store ClipScrollNodes in a vector

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -486,7 +486,7 @@ impl AlphaBatchBuilder {
 
         // Add each run in this picture to the batch.
         for run in &pic.runs {
-            let scroll_node = &ctx.clip_scroll_tree.nodes[&run.clip_and_scroll.scroll_node_id];
+            let scroll_node = &ctx.clip_scroll_tree.nodes[run.clip_and_scroll.scroll_node_id.0];
             let scroll_id = scroll_node.node_data_index;
             self.add_run_to_batch(
                 run,
@@ -967,7 +967,7 @@ impl AlphaBatchBuilder {
                                 composite_mode,
                                 secondary_render_task_id,
                                 is_in_3d_context,
-                                reference_frame_id,
+                                reference_frame_index,
                                 real_local_rect,
                                 ref extra_gpu_data_handle,
                                 ..
@@ -979,7 +979,7 @@ impl AlphaBatchBuilder {
                                     // Push into parent plane splitter.
 
                                     let real_xf = &ctx.clip_scroll_tree
-                                        .nodes[&reference_frame_id]
+                                        .nodes[reference_frame_index.0]
                                         .world_content_transform
                                         .into();
                                     let polygon = make_polygon(

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, DeviceIntRect, DevicePixelScale, ExternalScrollId, LayerPoint, LayerRect};
-use api::{LayerVector2D, PipelineId, ScrollClamping, ScrollEventPhase, ScrollLocation};
-use api::{ScrollNodeState, WorldPoint};
+use api::{DeviceIntRect, DevicePixelScale, ExternalScrollId, LayerPoint, LayerRect, LayerVector2D};
+use api::{PipelineId, ScrollClamping, ScrollEventPhase, ScrollLocation, ScrollNodeState};
+use api::WorldPoint;
 use clip::{ClipChain, ClipSourcesHandle, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, ScrollFrameInfo, StickyFrameInfo};
 use gpu_cache::GpuCache;
-use gpu_types::{ClipScrollNodeIndex, ClipScrollNodeData};
+use gpu_types::{ClipScrollNodeIndex as GPUClipScrollNodeIndex, ClipScrollNodeData};
 use internal_types::{FastHashMap, FastHashSet};
 use print_tree::{PrintTree, PrintTreePrinter};
 use resource_cache::ResourceCache;
@@ -25,6 +25,12 @@ pub type ScrollStates = FastHashMap<ExternalScrollId, ScrollFrameInfo>;
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct CoordinateSystemId(pub u32);
+
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub struct ClipScrollNodeIndex(pub usize);
+
+const ROOT_REFERENCE_FRAME_INDEX: ClipScrollNodeIndex = ClipScrollNodeIndex(0);
+const TOPMOST_SCROLL_NODE_INDEX: ClipScrollNodeIndex = ClipScrollNodeIndex(1);
 
 impl CoordinateSystemId {
     pub fn root() -> Self {
@@ -44,14 +50,14 @@ impl CoordinateSystemId {
 pub struct ClipChainDescriptor {
     pub index: ClipChainIndex,
     pub parent: Option<ClipChainIndex>,
-    pub clips: Vec<ClipId>,
+    pub clips: Vec<ClipScrollNodeIndex>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClipChainIndex(pub usize);
 
 pub struct ClipScrollTree {
-    pub nodes: FastHashMap<ClipId, ClipScrollNode>,
+    pub nodes: Vec<ClipScrollNode>,
 
     /// A Vec of all descriptors that describe ClipChains in the order in which they are
     /// encountered during display list flattening. ClipChains are expected to never be
@@ -66,20 +72,12 @@ pub struct ClipScrollTree {
 
     /// The ClipId of the currently scrolling node. Used to allow the same
     /// node to scroll even if a touch operation leaves the boundaries of that node.
-    pub currently_scrolling_node_id: Option<ClipId>,
+    pub currently_scrolling_node_index: Option<ClipScrollNodeIndex>,
 
     /// The current frame id, used for giving a unique id to all new dynamically
     /// added frames and clips. The ClipScrollTree increments this by one every
     /// time a new dynamic frame is created.
     current_new_node_item: u64,
-
-    /// The root reference frame, which is the true root of the ClipScrollTree. Initially
-    /// this ID is not valid, which is indicated by ```node``` being empty.
-    pub root_reference_frame_id: ClipId,
-
-    /// The root scroll node which is the first child of the root reference frame.
-    /// Initially this ID is not valid, which is indicated by ```nodes``` being empty.
-    pub topmost_scrolling_node_id: ClipId,
 
     /// A set of pipelines which should be discarded the next time this
     /// tree is drained.
@@ -113,40 +111,39 @@ pub struct TransformUpdateState {
 
 impl ClipScrollTree {
     pub fn new() -> Self {
-        let dummy_pipeline = PipelineId::dummy();
         ClipScrollTree {
-            nodes: FastHashMap::default(),
+            nodes: Vec::new(),
             clip_chains_descriptors: Vec::new(),
             clip_chains: vec![ClipChain::empty(&DeviceIntRect::zero())],
             pending_scroll_offsets: FastHashMap::default(),
-            currently_scrolling_node_id: None,
-            root_reference_frame_id: ClipId::root_reference_frame(dummy_pipeline),
-            topmost_scrolling_node_id: ClipId::root_scroll_node(dummy_pipeline),
+            currently_scrolling_node_index: None,
             current_new_node_item: 1,
             pipelines_to_discard: FastHashSet::default(),
         }
     }
 
-    pub fn root_reference_frame_id(&self) -> ClipId {
+    /// The root reference frame, which is the true root of the ClipScrollTree. Initially
+    /// this ID is not valid, which is indicated by ```nodes``` being empty.
+    pub fn root_reference_frame_index(&self) -> ClipScrollNodeIndex {
         // TODO(mrobinson): We should eventually make this impossible to misuse.
         debug_assert!(!self.nodes.is_empty());
-        debug_assert!(self.nodes.contains_key(&self.root_reference_frame_id));
-        self.root_reference_frame_id
+        ROOT_REFERENCE_FRAME_INDEX
     }
 
-    pub fn topmost_scrolling_node_id(&self) -> ClipId {
+    /// The root scroll node which is the first child of the root reference frame.
+    /// Initially this ID is not valid, which is indicated by ```nodes``` being empty.
+    pub fn topmost_scroll_node_index(&self) -> ClipScrollNodeIndex {
         // TODO(mrobinson): We should eventually make this impossible to misuse.
-        debug_assert!(!self.nodes.is_empty());
-        debug_assert!(self.nodes.contains_key(&self.topmost_scrolling_node_id));
-        self.topmost_scrolling_node_id
+        debug_assert!(self.nodes.len() >= 1);
+        TOPMOST_SCROLL_NODE_INDEX
     }
 
-    pub fn collect_nodes_bouncing_back(&self) -> FastHashSet<ClipId> {
+    pub fn collect_nodes_bouncing_back(&self) -> FastHashSet<ClipScrollNodeIndex> {
         let mut nodes_bouncing_back = FastHashSet::default();
-        for (clip_id, node) in self.nodes.iter() {
+        for (index, node) in self.nodes.iter().enumerate() {
             if let NodeType::ScrollFrame(ref scrolling) = node.node_type {
                 if scrolling.bouncing_back {
-                    nodes_bouncing_back.insert(*clip_id);
+                    nodes_bouncing_back.insert(ClipScrollNodeIndex(index));
                 }
             }
         }
@@ -156,38 +153,36 @@ impl ClipScrollTree {
     fn find_scrolling_node_at_point_in_node(
         &self,
         cursor: &WorldPoint,
-        clip_id: ClipId,
-    ) -> Option<ClipId> {
-        self.nodes.get(&clip_id).and_then(|node| {
-            for child_layer_id in node.children.iter().rev() {
-                if let Some(layer_id) =
-                    self.find_scrolling_node_at_point_in_node(cursor, *child_layer_id)
-                {
-                    return Some(layer_id);
-                }
+        index: ClipScrollNodeIndex,
+    ) -> Option<ClipScrollNodeIndex> {
+        let node = &self.nodes[index.0];
+        for child_index in node.children.iter().rev() {
+            let found_index = self.find_scrolling_node_at_point_in_node(cursor, *child_index);
+            if found_index.is_some() {
+                return found_index;
             }
+        }
 
-            match node.node_type {
-                NodeType::ScrollFrame(state) if state.sensitive_to_input_events() => {}
-                _ => return None,
-            }
+        match node.node_type {
+            NodeType::ScrollFrame(state) if state.sensitive_to_input_events() => {}
+            _ => return None,
+        }
 
-            if node.ray_intersects_node(cursor) {
-                Some(clip_id)
-            } else {
-                None
-            }
-        })
+        if node.ray_intersects_node(cursor) {
+            Some(index)
+        } else {
+            None
+        }
     }
 
-    pub fn find_scrolling_node_at_point(&self, cursor: &WorldPoint) -> ClipId {
-        self.find_scrolling_node_at_point_in_node(cursor, self.root_reference_frame_id())
-            .unwrap_or(self.topmost_scrolling_node_id())
+    pub fn find_scrolling_node_at_point(&self, cursor: &WorldPoint) -> ClipScrollNodeIndex {
+        self.find_scrolling_node_at_point_in_node(cursor, self.root_reference_frame_index())
+            .unwrap_or(self.topmost_scroll_node_index())
     }
 
     pub fn get_scroll_node_state(&self) -> Vec<ScrollNodeState> {
         let mut result = vec![];
-        for node in self.nodes.values() {
+        for node in &self.nodes {
             if let NodeType::ScrollFrame(info) = node.node_type {
                 if let Some(id) = info.external_id {
                     result.push(ScrollNodeState { id, scroll_offset: info.offset })
@@ -201,8 +196,8 @@ impl ClipScrollTree {
         self.current_new_node_item = 1;
 
         let mut scroll_states = FastHashMap::default();
-        for (node_id, old_node) in &mut self.nodes.drain() {
-            if self.pipelines_to_discard.contains(&node_id.pipeline_id()) {
+        for old_node in &mut self.nodes.drain(..) {
+            if self.pipelines_to_discard.contains(&old_node.pipeline_id) {
                 continue;
             }
 
@@ -226,7 +221,7 @@ impl ClipScrollTree {
         id: ExternalScrollId,
         clamp: ScrollClamping
     ) -> bool {
-        for node in &mut self.nodes.values_mut() {
+        for node in &mut self.nodes {
             if node.matches_external_id(id) {
                 return node.set_scroll_origin(&origin, clamp);
             }
@@ -246,37 +241,38 @@ impl ClipScrollTree {
             return false;
         }
 
-        let clip_id = match (
+        let node_index = match (
             phase,
             self.find_scrolling_node_at_point(&cursor),
-            self.currently_scrolling_node_id,
+            self.currently_scrolling_node_index,
         ) {
-            (ScrollEventPhase::Start, scroll_node_at_point_id, _) => {
-                self.currently_scrolling_node_id = Some(scroll_node_at_point_id);
-                scroll_node_at_point_id
+            (ScrollEventPhase::Start, scroll_node_at_point_index, _) => {
+                self.currently_scrolling_node_index = Some(scroll_node_at_point_index);
+                scroll_node_at_point_index
             }
-            (_, scroll_node_at_point_id, Some(cached_clip_id)) => {
-                let clip_id = match self.nodes.get(&cached_clip_id) {
-                    Some(_) => cached_clip_id,
+            (_, scroll_node_at_point_index, Some(cached_node_index)) => {
+                let node_index = match self.nodes.get(cached_node_index.0) {
+                    Some(_) => cached_node_index,
                     None => {
-                        self.currently_scrolling_node_id = Some(scroll_node_at_point_id);
-                        scroll_node_at_point_id
+                        self.currently_scrolling_node_index = Some(scroll_node_at_point_index);
+                        scroll_node_at_point_index
                     }
                 };
-                clip_id
+                node_index
             }
             (_, _, None) => return false,
         };
 
-        let topmost_scrolling_node_id = self.topmost_scrolling_node_id();
-        let non_root_overscroll = if clip_id != topmost_scrolling_node_id {
-            self.nodes.get(&clip_id).unwrap().is_overscrolling()
+        let topmost_scroll_node_index = self.topmost_scroll_node_index();
+        let non_root_overscroll = if node_index != topmost_scroll_node_index {
+            self.nodes[node_index.0].is_overscrolling()
         } else {
             false
         };
 
         let mut switch_node = false;
-        if let Some(node) = self.nodes.get_mut(&clip_id) {
+        {
+            let node = &mut self.nodes[node_index.0];
             if let NodeType::ScrollFrame(ref mut scrolling) = node.node_type {
                 match phase {
                     ScrollEventPhase::Start => {
@@ -298,16 +294,13 @@ impl ClipScrollTree {
             }
         }
 
-        let clip_id = if switch_node {
-            topmost_scrolling_node_id
+        let node_index = if switch_node {
+            topmost_scroll_node_index
         } else {
-            clip_id
+            node_index
         };
 
-        self.nodes
-            .get_mut(&clip_id)
-            .unwrap()
-            .scroll(scroll_location, phase)
+        self.nodes[node_index.0].scroll(scroll_location, phase)
     }
 
     pub fn update_tree(
@@ -327,7 +320,7 @@ impl ClipScrollTree {
 
         self.clip_chains[0] = ClipChain::empty(screen_rect);
 
-        let root_reference_frame_id = self.root_reference_frame_id();
+        let root_reference_frame_index = self.root_reference_frame_index();
         let mut state = TransformUpdateState {
             parent_reference_frame_transform: LayerVector2D::new(pan.x, pan.y).into(),
             parent_accumulated_scroll_offset: LayerVector2D::zero(),
@@ -340,7 +333,7 @@ impl ClipScrollTree {
         };
         let mut next_coordinate_system_id = state.current_coordinate_system_id.next();
         self.update_node(
-            root_reference_frame_id,
+            root_reference_frame_index,
             &mut state,
             &mut next_coordinate_system_id,
             device_pixel_scale,
@@ -356,7 +349,7 @@ impl ClipScrollTree {
 
     fn update_node(
         &mut self,
-        layer_id: ClipId,
+        node_index: ClipScrollNodeIndex,
         state: &mut TransformUpdateState,
         next_coordinate_system_id: &mut CoordinateSystemId,
         device_pixel_scale: DevicePixelScale,
@@ -370,13 +363,13 @@ impl ClipScrollTree {
         //           Restructure this to avoid the clones!
         let mut state = state.clone();
         let node_children = {
-            let node = match self.nodes.get_mut(&layer_id) {
+            let node = match self.nodes.get_mut(node_index.0) {
                 Some(node) => node,
                 None => return,
             };
 
             // We set this early so that we can use it to populate the ClipChain.
-            node.node_data_index = ClipScrollNodeIndex(gpu_node_data.len() as u32);
+            node.node_data_index = GPUClipScrollNodeIndex(gpu_node_data.len() as u32);
 
             node.update(
                 &mut state,
@@ -399,9 +392,9 @@ impl ClipScrollTree {
             node.children.clone()
         };
 
-        for child_node_id in node_children {
+        for child_node_index in node_children {
             self.update_node(
-                child_node_id,
+                child_node_index,
                 &mut state,
                 next_coordinate_system_id,
                 device_pixel_scale,
@@ -426,8 +419,8 @@ impl ClipScrollTree {
 
             // Now we walk through each ClipScrollNode in the vector of clip nodes and
             // extract their ClipChain nodes to construct the final list.
-            for clip_id in &descriptor.clips {
-                let node_clip_chain_index = match self.nodes[&clip_id].node_type {
+            for clip_index in &descriptor.clips {
+                let node_clip_chain_index = match self.nodes[clip_index.0].node_type {
                     NodeType::Clip { clip_chain_index, .. } => clip_chain_index,
                     _ => {
                         warn!("Tried to create a clip chain with non-clipping node.");
@@ -446,13 +439,13 @@ impl ClipScrollTree {
     }
 
     pub fn tick_scrolling_bounce_animations(&mut self) {
-        for (_, node) in &mut self.nodes {
+        for node in &mut self.nodes {
             node.tick_scrolling_bounce_animation()
         }
     }
 
     pub fn finalize_and_apply_pending_scroll_offsets(&mut self, old_states: ScrollStates) {
-        for node in self.nodes.values_mut() {
+        for node in &mut self.nodes {
             let external_id = match node.node_type {
                 NodeType::ScrollFrame(ScrollFrameInfo { external_id: Some(id), ..} ) => id,
                 _ => continue,
@@ -462,7 +455,6 @@ impl ClipScrollTree {
                 node.apply_old_scrolling_state(scrolling_state);
             }
 
-
             if let Some((offset, clamping)) = self.pending_scroll_offsets.remove(&external_id) {
                 node.set_scroll_origin(&offset, clamping);
             }
@@ -471,72 +463,97 @@ impl ClipScrollTree {
 
     pub fn add_clip_node(
         &mut self,
-        id: ClipId,
-        parent_id: ClipId,
+        index: ClipScrollNodeIndex,
+        parent_index: ClipScrollNodeIndex,
         handle: ClipSourcesHandle,
         clip_rect: LayerRect,
+        pipeline_id: PipelineId,
     )  -> ClipChainIndex {
         let clip_chain_index = self.allocate_clip_chain();
         let node_type = NodeType::Clip { handle, clip_chain_index };
-        let node = ClipScrollNode::new(id.pipeline_id(), Some(parent_id), &clip_rect, node_type);
-        self.add_node(node, id);
+        let node = ClipScrollNode::new(pipeline_id, Some(parent_index), &clip_rect, node_type);
+        self.add_node(node, index);
         clip_chain_index
     }
 
     pub fn add_sticky_frame(
         &mut self,
-        id: ClipId,
-        parent_id: ClipId,
+        index: ClipScrollNodeIndex,
+        parent_index: ClipScrollNodeIndex,
         frame_rect: LayerRect,
         sticky_frame_info: StickyFrameInfo,
+        pipeline_id: PipelineId,
     ) {
         let node = ClipScrollNode::new_sticky_frame(
-            parent_id,
+            parent_index,
             frame_rect,
             sticky_frame_info,
-            id.pipeline_id(),
+            pipeline_id,
         );
-        self.add_node(node, id);
+        self.add_node(node, index);
     }
 
     pub fn add_clip_chain_descriptor(
         &mut self,
         parent: Option<ClipChainIndex>,
-        clips: Vec<ClipId>
+        clips: Vec<ClipScrollNodeIndex>
     ) -> ClipChainIndex {
         let index = self.allocate_clip_chain();
         self.clip_chains_descriptors.push(ClipChainDescriptor { index, parent, clips });
         index
     }
 
-    pub fn add_node(&mut self, node: ClipScrollNode, id: ClipId) {
+    pub fn add_node(&mut self, node: ClipScrollNode, index: ClipScrollNodeIndex) {
         // When the parent node is None this means we are adding the root.
-        match node.parent {
-            Some(parent_id) => self.nodes.get_mut(&parent_id).unwrap().add_child(id),
-            None => self.root_reference_frame_id = id,
+        if let Some(parent_index) = node.parent {
+            self.nodes[parent_index.0].add_child(index);
         }
 
-        debug_assert!(!self.nodes.contains_key(&id));
-        self.nodes.insert(id, node);
+        if index.0 == self.nodes.len() {
+            self.nodes.push(node);
+            return;
+        }
+
+
+        if let Some(empty_node) = self.nodes.get_mut(index.0) {
+            *empty_node = node;
+            return
+        }
+
+        let length_to_reserve = index.0 + 1 - self.nodes.len();
+        self.nodes.reserve_exact(length_to_reserve);
+
+        // We would like to use `Vec::resize` here, but the Clone trait is not supported
+        // for ClipScrollNodes. We can fix this either by splitting the clip nodes out into
+        // their own tree or when support is added for something like `Vec::resize_default`.
+        let length_to_extend = self.nodes.len() .. index.0;
+        self.nodes.extend(length_to_extend.map(|_| ClipScrollNode::empty()));
+
+        self.nodes.push(node);
     }
 
     pub fn discard_frame_state_for_pipeline(&mut self, pipeline_id: PipelineId) {
         self.pipelines_to_discard.insert(pipeline_id);
 
-        match self.currently_scrolling_node_id {
-            Some(id) if id.pipeline_id() == pipeline_id => self.currently_scrolling_node_id = None,
-            _ => {}
+        if let Some(index) = self.currently_scrolling_node_index {
+            if self.nodes[index.0].pipeline_id == pipeline_id {
+                self.currently_scrolling_node_index = None;
+            }
         }
     }
 
-    fn print_node<T: PrintTreePrinter>(&self, id: &ClipId, pt: &mut T, clip_store: &ClipStore) {
-        let node = self.nodes.get(id).unwrap();
-
+    fn print_node<T: PrintTreePrinter>(
+        &self,
+        index: ClipScrollNodeIndex,
+        pt: &mut T,
+        clip_store: &ClipStore
+    ) {
+        let node = &self.nodes[index.0];
         match node.node_type {
             NodeType::Clip { ref handle, .. } => {
                 pt.new_level("Clip".to_owned());
 
-                pt.add_item(format!("id: {:?}", id));
+                pt.add_item(format!("index: {:?}", index));
                 let clips = clip_store.get(&handle).clips();
                 pt.new_level(format!("Clip Sources [{}]", clips.len()));
                 for source in clips {
@@ -546,40 +563,29 @@ impl ClipScrollTree {
             }
             NodeType::ReferenceFrame(ref info) => {
                 pt.new_level(format!("ReferenceFrame {:?}", info.resolved_transform));
-                pt.add_item(format!("id: {:?}", id));
+                pt.add_item(format!("index: {:?}", index));
             }
             NodeType::ScrollFrame(scrolling_info) => {
                 pt.new_level(format!("ScrollFrame"));
-                pt.add_item(format!("id: {:?}", id));
+                pt.add_item(format!("index: {:?}", index));
                 pt.add_item(format!("scrollable_size: {:?}", scrolling_info.scrollable_size));
                 pt.add_item(format!("scroll.offset: {:?}", scrolling_info.offset));
             }
             NodeType::StickyFrame(ref sticky_frame_info) => {
                 pt.new_level(format!("StickyFrame"));
-                pt.add_item(format!("id: {:?}", id));
+                pt.add_item(format!("index: {:?}", index));
                 pt.add_item(format!("sticky info: {:?}", sticky_frame_info));
             }
+            NodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
         }
 
-        pt.add_item(format!(
-            "local_viewport_rect: {:?}",
-            node.local_viewport_rect
-        ));
-        pt.add_item(format!(
-            "world_viewport_transform: {:?}",
-            node.world_viewport_transform
-        ));
-        pt.add_item(format!(
-            "world_content_transform: {:?}",
-            node.world_content_transform
-        ));
-        pt.add_item(format!(
-            "coordinate_system_id: {:?}",
-            node.coordinate_system_id
-        ));
+        pt.add_item(format!("local_viewport_rect: {:?}", node.local_viewport_rect));
+        pt.add_item(format!("world_viewport_transform: {:?}", node.world_viewport_transform));
+        pt.add_item(format!("world_content_transform: {:?}", node.world_content_transform));
+        pt.add_item(format!("coordinate_system_id: {:?}", node.coordinate_system_id));
 
-        for child_id in &node.children {
-            self.print_node(child_id, pt, clip_store);
+        for child_index in &node.children {
+            self.print_node(*child_index, pt, clip_store);
         }
 
         pt.end_level();
@@ -595,7 +601,7 @@ impl ClipScrollTree {
 
     pub fn print_with<T: PrintTreePrinter>(&self, clip_store: &ClipStore, pt: &mut T) {
         if !self.nodes.is_empty() {
-            self.print_node(&self.root_reference_frame_id, pt, clip_store);
+            self.print_node(self.root_reference_frame_index(), pt, clip_store);
         }
     }
 
@@ -609,5 +615,4 @@ impl ClipScrollTree {
     pub fn get_clip_chain(&self, index: ClipChainIndex) -> &ClipChain {
         &self.clip_chains[index.0]
     }
-
 }

--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -3,20 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BuiltDisplayListIter, ClipId, ColorF, ComplexClipRegion, DeviceUintSize, DisplayItemRef};
-use api::{Epoch, ExternalScrollId, FilterOp, IframeDisplayItem, ImageDisplayItem, ItemRange};
-use api::{LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize, LayerVector2D, LayoutSize};
-use api::{PipelineId, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity};
-use api::{SpecificDisplayItem, StackingContext, TileOffset, TransformStyle};
+use api::{BuiltDisplayListIter, ClipAndScrollInfo, ClipId, ColorF, ComplexClipRegion};
+use api::{DeviceUintSize, DisplayItemRef, Epoch, ExternalScrollId, FilterOp, IframeDisplayItem};
+use api::{ImageDisplayItem, ItemRange, LayerPoint, LayerPrimitiveInfo, LayerRect, LayerSize};
+use api::{LayerVector2D, LayoutSize, PipelineId, ScrollFrameDisplayItem, ScrollPolicy};
+use api::{ScrollSensitivity, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem};
+use api::{TileOffset, TransformStyle};
 use clip::ClipRegion;
 use clip_scroll_node::StickyFrameInfo;
-use clip_scroll_tree::{ClipChainIndex, ClipScrollTree};
+use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
 use euclid::rect;
 use frame_builder::{FrameBuilder, FrameBuilderConfig, ScrollbarInfo};
 use internal_types::{FastHashMap, FastHashSet};
 use prim_store::ScrollNodeAndClipChain;
 use resource_cache::{FontInstanceMap, TiledImageMap};
-use scene::{Scene, StackingContextHelpers};
+use scene::{Scene, ScenePipeline, StackingContextHelpers};
 use scene_builder::{SceneRequest, BuiltScene};
 use tiling::{CompositeOps};
 use render_backend::DocumentView;
@@ -28,50 +29,96 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF {
     a: 0.6,
 };
 
-/// A data structure that keeps track of mapping between API clip ids and the indices
-/// used internally in the ClipScrollTree to avoid having to do HashMap lookups. This
-/// also includes a small LRU cache. Currently the cache is small (1 entry), but in the
-/// future we could use uluru here to do something more involved.
+/// A data structure that keeps track of mapping between API ClipIds and the indices used
+/// internally in the ClipScrollTree to avoid having to do HashMap lookups. ClipIdToIndexMapper is
+/// responsible for mapping both ClipId to ClipChainIndex and ClipId to ClipScrollNodeIndex.  We
+/// also include two small LRU caches. Currently the caches are small (1 entry), but in the future
+/// we could use uluru here to do something more involved.
+#[derive(Default)]
 pub struct ClipIdToIndexMapper {
-    map: FastHashMap<ClipId, ClipChainIndex>,
-    cached_index: Option<(ClipId, ClipChainIndex)>,
+    /// A map which converts a ClipId for a clipping node or an API-defined ClipChain into
+    /// a ClipChainIndex, which is the index used internally in the ClipScrollTree to
+    /// identify ClipChains.
+    clip_chain_map: FastHashMap<ClipId, ClipChainIndex>,
+
+    /// The last mapped ClipChainIndex, used to avoid having to do lots of consecutive
+    /// HashMap lookups.
+    cached_clip_chain_index: Option<(ClipId, ClipChainIndex)>,
+
+    /// The offset in the ClipScrollTree's array of ClipScrollNodes for a particular pipeline.
+    /// This is used to convert a ClipId into a ClipScrollNodeIndex.
+    pipeline_offsets: FastHashMap<PipelineId, usize>,
+
+    /// The last mapped pipeline offset for this mapper. This is used to avoid having to
+    /// consult `pipeline_offsets` repeatedly when flattening the display list.
+    cached_pipeline_offset: Option<(PipelineId, usize)>,
+
+    /// The next available pipeline offset for ClipScrollNodeIndex. When we encounter a pipeline
+    /// we will use this value and increment it by the total number of ClipScrollNodes in the
+    /// pipeline's display list.
+    next_available_offset: usize,
 }
 
 impl ClipIdToIndexMapper {
-    fn new() -> ClipIdToIndexMapper {
-        ClipIdToIndexMapper {
-            map: FastHashMap::default(),
-            cached_index: None,
-        }
-    }
-
-    pub fn add(&mut self, id: ClipId, index: ClipChainIndex) {
-        debug_assert!(!self.map.contains_key(&id));
-        self.map.insert(id, index);
+    pub fn add_clip_chain(&mut self, id: ClipId, index: ClipChainIndex) {
+        debug_assert!(!self.clip_chain_map.contains_key(&id));
+        self.clip_chain_map.insert(id, index);
     }
 
     pub fn map_to_parent_clip_chain(&mut self, id: ClipId, parent_id: &ClipId) {
-        let parent_chain_index = self.map_clip_id(parent_id);
-        self.add(id, parent_chain_index);
+        let parent_chain_index = self.get_clip_chain_index(parent_id);
+        self.add_clip_chain(id, parent_chain_index);
     }
 
-    pub fn map_clip_id(&mut self, id: &ClipId) -> ClipChainIndex {
-        match self.cached_index {
-            Some((cached_id, cached_index)) if cached_id == *id => return cached_index,
+    pub fn get_clip_chain_index(&mut self, id: &ClipId) -> ClipChainIndex {
+        match self.cached_clip_chain_index {
+            Some((cached_id, cached_clip_chain_index)) if cached_id == *id =>
+                return cached_clip_chain_index,
             _ => {}
         }
 
-        self.map[id]
+        self.clip_chain_map[id]
     }
 
-    pub fn map_clip_id_and_cache_result(&mut self, id: &ClipId) -> ClipChainIndex {
-        let index = self.map_clip_id(id);
-        self.cached_index = Some((*id, index));
+    pub fn get_clip_chain_index_and_cache_result(&mut self, id: &ClipId) -> ClipChainIndex {
+        let index = self.get_clip_chain_index(id);
+        self.cached_clip_chain_index = Some((*id, index));
         index
     }
 
+    pub fn map_clip_and_scroll(&mut self, info: &ClipAndScrollInfo) -> ScrollNodeAndClipChain {
+        ScrollNodeAndClipChain::new(
+            self.get_node_index(info.scroll_node_id),
+            self.get_clip_chain_index_and_cache_result(&info.clip_node_id())
+        )
+    }
+
     pub fn simple_scroll_and_clip_chain(&mut self, id: &ClipId) -> ScrollNodeAndClipChain {
-        ScrollNodeAndClipChain::new(*id, self.map_clip_id(&id))
+        self.map_clip_and_scroll(&ClipAndScrollInfo::simple(*id))
+    }
+
+    pub fn initialize_for_pipeline(&mut self, pipeline: &ScenePipeline) {
+        debug_assert!(!self.pipeline_offsets.contains_key(&pipeline.pipeline_id));
+        self.pipeline_offsets.insert(pipeline.pipeline_id, self.next_available_offset);
+        self.next_available_offset += pipeline.display_list.total_clip_ids();
+    }
+
+    pub fn get_node_index(&mut self, id: ClipId) -> ClipScrollNodeIndex {
+        let (index, pipeline_id) = match id {
+            ClipId::Clip(index, pipeline_id) => (index, pipeline_id),
+            ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
+        };
+
+        let pipeline_offset = match self.cached_pipeline_offset {
+            Some((last_used_id, offset)) if last_used_id == pipeline_id => offset,
+            _ => {
+                let offset = self.pipeline_offsets[&pipeline_id];
+                self.cached_pipeline_offset = Some((pipeline_id, offset));
+                offset
+            }
+        };
+
+        ClipScrollNodeIndex(pipeline_offset + index)
     }
 }
 
@@ -127,8 +174,10 @@ impl<'a> FlattenContext<'a> {
                 pipeline_epochs: Vec::new(),
                 replacements: Vec::new(),
                 output_pipelines,
-                id_to_index_mapper: ClipIdToIndexMapper::new(),
+                id_to_index_mapper: ClipIdToIndexMapper::default(),
             };
+
+            roller.id_to_index_mapper.initialize_for_pipeline(root_pipeline);
 
             roller.builder.push_root(
                 root_pipeline_id,
@@ -144,11 +193,7 @@ impl<'a> FlattenContext<'a> {
                 roller.clip_scroll_tree,
             );
 
-            roller.flatten_root(
-                &mut root_pipeline.display_list.iter(),
-                root_pipeline.pipeline_id,
-                &root_pipeline.viewport_size,
-            );
+            roller.flatten_root(root_pipeline, &root_pipeline.viewport_size);
 
             debug_assert!(roller.builder.picture_stack.is_empty());
 
@@ -164,10 +209,10 @@ impl<'a> FlattenContext<'a> {
     /// we need to apply this table of id replacements only to the id that affects the
     /// position of a node. We can eventually remove this when clients start handling
     /// reference frames themselves. This method applies these replacements.
-    fn apply_scroll_frame_id_replacement(&self, id: ClipId) -> ClipId {
+    fn apply_scroll_frame_id_replacement(&self, index: ClipId) -> ClipId {
         match self.replacements.last() {
-            Some(&(to_replace, replacement)) if to_replace == id => replacement,
-            _ => id,
+            Some(&(to_replace, replacement)) if to_replace == index => replacement,
+            _ => index,
         }
     }
 
@@ -207,20 +252,13 @@ impl<'a> FlattenContext<'a> {
             .collect()
     }
 
-    fn flatten_root(
-        &mut self,
-        traversal: &mut BuiltDisplayListIter<'a>,
-        pipeline_id: PipelineId,
-        frame_size: &LayoutSize,
-    ) {
-        let root_reference_frame_id = ClipId::root_reference_frame(pipeline_id);
-        let root_scroll_frame_id = ClipId::root_scroll_node(pipeline_id);
-
-        let root_clip_chain_index =
-            self.id_to_index_mapper.map_clip_id_and_cache_result(&root_reference_frame_id);
-        let root_reference_frame_clip_and_scroll = ScrollNodeAndClipChain::new(
-            root_reference_frame_id,
-            root_clip_chain_index,
+    fn flatten_root(&mut self, pipeline: &'a ScenePipeline, frame_size: &LayoutSize) {
+        let pipeline_id = pipeline.pipeline_id;
+        let reference_frame_info = self.id_to_index_mapper.simple_scroll_and_clip_chain(
+            &ClipId::root_reference_frame(pipeline_id)
+        );
+        let scroll_frame_info = self.id_to_index_mapper.simple_scroll_and_clip_chain(
+            &ClipId::root_scroll_node(pipeline_id)
         );
 
         self.builder.push_stacking_context(
@@ -229,10 +267,7 @@ impl<'a> FlattenContext<'a> {
             TransformStyle::Flat,
             true,
             true,
-            ScrollNodeAndClipChain::new(
-                ClipId::root_scroll_node(pipeline_id),
-                root_clip_chain_index,
-            ),
+            scroll_frame_info,
             self.output_pipelines,
         );
 
@@ -244,7 +279,7 @@ impl<'a> FlattenContext<'a> {
                     let root_bounds = LayerRect::new(LayerPoint::zero(), *frame_size);
                     let info = LayerPrimitiveInfo::new(root_bounds);
                     self.builder.add_solid_rectangle(
-                        root_reference_frame_clip_and_scroll,
+                        reference_frame_info,
                         &info,
                         bg_color,
                         None,
@@ -253,21 +288,16 @@ impl<'a> FlattenContext<'a> {
             }
         }
 
-
-        self.flatten_items(
-            traversal,
-            pipeline_id,
-            LayerVector2D::zero(),
-        );
+        self.flatten_items(&mut pipeline.display_list.iter(), pipeline_id, LayerVector2D::zero());
 
         if self.builder.config.enable_scrollbars {
             let scrollbar_rect = LayerRect::new(LayerPoint::zero(), LayerSize::new(10.0, 70.0));
             let container_rect = LayerRect::new(LayerPoint::zero(), *frame_size);
             self.builder.add_scroll_bar(
-                root_reference_frame_clip_and_scroll,
+                reference_frame_info,
                 &LayerPrimitiveInfo::new(scrollbar_rect),
                 DEFAULT_SCROLLBAR_COLOR,
-                ScrollbarInfo(root_scroll_frame_id, container_rect),
+                ScrollbarInfo(scroll_frame_info.scroll_node_id, container_rect),
             );
         }
 
@@ -306,14 +336,31 @@ impl<'a> FlattenContext<'a> {
         }
     }
 
-    fn flatten_clip(&mut self, parent_id: &ClipId, new_clip_id: &ClipId, clip_region: ClipRegion) {
-        self.builder.add_clip_node(
-            *new_clip_id,
-            *parent_id,
-            clip_region,
-            self.clip_scroll_tree,
-            &mut self.id_to_index_mapper,
+    fn flatten_sticky_frame(
+        &mut self,
+        item: &DisplayItemRef,
+        info: &StickyFrameDisplayItem,
+        clip_and_scroll: &ScrollNodeAndClipChain,
+        parent_id: &ClipId,
+        reference_frame_relative_offset: &LayerVector2D,
+    ) {
+        let frame_rect = item.rect().translate(&reference_frame_relative_offset);
+        let sticky_frame_info = StickyFrameInfo::new(
+            info.margins,
+            info.vertical_offset_bounds,
+            info.horizontal_offset_bounds,
+            info.previously_applied_offset,
         );
+
+        let index = self.id_to_index_mapper.get_node_index(info.id);
+        self.clip_scroll_tree.add_sticky_frame(
+            index,
+            clip_and_scroll.scroll_node_id, /* parent id */
+            frame_rect,
+            sticky_frame_info,
+            info.id.pipeline_id(),
+        );
+        self.id_to_index_mapper.map_to_parent_clip_chain(info.id, &parent_id);
     }
 
     fn flatten_scroll_frame(
@@ -321,7 +368,7 @@ impl<'a> FlattenContext<'a> {
         item: &DisplayItemRef,
         info: &ScrollFrameDisplayItem,
         pipeline_id: PipelineId,
-        clip_and_scroll: &ScrollNodeAndClipChain,
+        clip_and_scroll_ids: &ClipAndScrollInfo,
         reference_frame_relative_offset: &LayerVector2D,
     ) {
         let complex_clips = self.get_complex_clips(pipeline_id, item.complex_clip().0);
@@ -344,7 +391,7 @@ impl<'a> FlattenContext<'a> {
 
         self.builder.add_clip_node(
             info.clip_id,
-            clip_and_scroll.scroll_node_id,
+            clip_and_scroll_ids.scroll_node_id,
             clip_region,
             self.clip_scroll_tree,
             &mut self.id_to_index_mapper,
@@ -368,7 +415,7 @@ impl<'a> FlattenContext<'a> {
         traversal: &mut BuiltDisplayListIter<'a>,
         pipeline_id: PipelineId,
         unreplaced_scroll_id: ClipId,
-        clip_and_scroll: ScrollNodeAndClipChain,
+        scroll_node_id: ClipId,
         mut reference_frame_relative_offset: LayerVector2D,
         bounds: &LayerRect,
         stacking_context: &StackingContext,
@@ -416,7 +463,7 @@ impl<'a> FlattenContext<'a> {
             let reference_frame_bounds = LayerRect::new(LayerPoint::zero(), bounds.size);
             self.builder.push_reference_frame(
                 reference_frame_id,
-                Some(clip_and_scroll.scroll_node_id),
+                Some(scroll_node_id),
                 pipeline_id,
                 &reference_frame_bounds,
                 stacking_context.transform,
@@ -431,9 +478,9 @@ impl<'a> FlattenContext<'a> {
 
         // We apply the replacements one more time in case we need to set it to a replacement
         // that we just pushed above.
-        let new_scroll_node = self.apply_scroll_frame_id_replacement(unreplaced_scroll_id);
+        let sc_scroll_node = self.apply_scroll_frame_id_replacement(unreplaced_scroll_id);
         let stacking_context_clip_and_scroll =
-            self.id_to_index_mapper.simple_scroll_and_clip_chain(&new_scroll_node);
+            self.id_to_index_mapper.simple_scroll_and_clip_chain(&sc_scroll_node);
         self.builder.push_stacking_context(
             pipeline_id,
             composition_operations,
@@ -466,7 +513,7 @@ impl<'a> FlattenContext<'a> {
         &mut self,
         item: &DisplayItemRef,
         info: &IframeDisplayItem,
-        clip_and_scroll: &ScrollNodeAndClipChain,
+        clip_and_scroll_ids: &ClipAndScrollInfo,
         reference_frame_relative_offset: &LayerVector2D,
     ) {
         let iframe_pipeline_id = info.pipeline_id;
@@ -475,9 +522,11 @@ impl<'a> FlattenContext<'a> {
             None => return,
         };
 
+        self.id_to_index_mapper.initialize_for_pipeline(pipeline);
+
         self.builder.add_clip_node(
             info.clip_id,
-            clip_and_scroll.scroll_node_id,
+            clip_and_scroll_ids.scroll_node_id,
             ClipRegion::create_for_clip_node_with_local_clip(
                 &item.local_clip(),
                 &reference_frame_relative_offset
@@ -516,7 +565,7 @@ impl<'a> FlattenContext<'a> {
             &mut self.id_to_index_mapper,
         );
 
-        self.flatten_root(&mut pipeline.display_list.iter(), iframe_pipeline_id, &iframe_rect.size);
+        self.flatten_root(pipeline, &iframe_rect.size);
 
         self.builder.pop_reference_frame();
     }
@@ -527,15 +576,11 @@ impl<'a> FlattenContext<'a> {
         pipeline_id: PipelineId,
         reference_frame_relative_offset: LayerVector2D,
     ) -> Option<BuiltDisplayListIter<'a>> {
-        let clip_and_scroll = item.clip_and_scroll();
-        let mut clip_and_scroll = ScrollNodeAndClipChain::new(
-            clip_and_scroll.scroll_node_id,
-            self.id_to_index_mapper.map_clip_id_and_cache_result(&clip_and_scroll.clip_node_id()),
-        );
-
-        let unreplaced_scroll_id = clip_and_scroll.scroll_node_id;
-        clip_and_scroll.scroll_node_id =
-            self.apply_scroll_frame_id_replacement(clip_and_scroll.scroll_node_id);
+        let mut clip_and_scroll_ids = item.clip_and_scroll();
+        let unreplaced_scroll_id = clip_and_scroll_ids.scroll_node_id;
+        clip_and_scroll_ids.scroll_node_id =
+            self.apply_scroll_frame_id_replacement(clip_and_scroll_ids.scroll_node_id);
+        let clip_and_scroll = self.id_to_index_mapper.map_clip_and_scroll(&clip_and_scroll_ids);
 
         let prim_info = item.get_layer_primitive_info(&reference_frame_relative_offset);
         match *item.item() {
@@ -684,7 +729,7 @@ impl<'a> FlattenContext<'a> {
                     &mut subtraversal,
                     pipeline_id,
                     unreplaced_scroll_id,
-                    clip_and_scroll,
+                    clip_and_scroll_ids.scroll_node_id,
                     reference_frame_relative_offset,
                     &item.rect(),
                     &info.stacking_context,
@@ -697,7 +742,7 @@ impl<'a> FlattenContext<'a> {
                 self.flatten_iframe(
                     &item,
                     info,
-                    &clip_and_scroll,
+                    &clip_and_scroll_ids,
                     &reference_frame_relative_offset
                 );
             }
@@ -709,42 +754,43 @@ impl<'a> FlattenContext<'a> {
                     info.image_mask,
                     &reference_frame_relative_offset,
                 );
-                self.flatten_clip(&clip_and_scroll.scroll_node_id, &info.id, clip_region);
+                self.builder.add_clip_node(
+                    info.id,
+                    clip_and_scroll_ids.scroll_node_id,
+                    clip_region,
+                    &mut self.clip_scroll_tree,
+                    &mut self.id_to_index_mapper,
+                );
             }
             SpecificDisplayItem::ClipChain(ref info) => {
-                let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items());
+                let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items())
+                                .iter()
+                                .map(|id| self.id_to_index_mapper.get_node_index(*id))
+                                .collect();
                 let parent = info.parent.map(|id|
-                     self.id_to_index_mapper.map_clip_id(&ClipId::ClipChain(id))
+                     self.id_to_index_mapper.get_clip_chain_index(&ClipId::ClipChain(id))
                 );
                 let clip_chain_index =
                     self.clip_scroll_tree.add_clip_chain_descriptor(parent, items);
-                self.id_to_index_mapper.add(ClipId::ClipChain(info.id), clip_chain_index);
+                self.id_to_index_mapper.add_clip_chain(ClipId::ClipChain(info.id), clip_chain_index);
             },
             SpecificDisplayItem::ScrollFrame(ref info) => {
                 self.flatten_scroll_frame(
                     &item,
                     info,
                     pipeline_id,
-                    &clip_and_scroll,
+                    &clip_and_scroll_ids,
                     &reference_frame_relative_offset
                 );
             }
             SpecificDisplayItem::StickyFrame(ref info) => {
-                let frame_rect = item.rect().translate(&reference_frame_relative_offset);
-                let sticky_frame_info = StickyFrameInfo::new(
-                    info.margins,
-                    info.vertical_offset_bounds,
-                    info.horizontal_offset_bounds,
-                    info.previously_applied_offset,
+                self.flatten_sticky_frame(
+                    &item,
+                    info,
+                    &clip_and_scroll,
+                    &clip_and_scroll_ids.scroll_node_id,
+                    &reference_frame_relative_offset
                 );
-                let parent_id = clip_and_scroll.scroll_node_id;
-                self.clip_scroll_tree.add_sticky_frame(
-                    info.id,
-                    parent_id,
-                    frame_rect,
-                    sticky_frame_info
-                );
-                self.id_to_index_mapper.map_to_parent_clip_chain(info.id, &parent_id);
             }
 
             // Do nothing; these are dummy items for the display list parser

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, DeviceUintRect, DocumentId};
-use api::{ExternalImageData, ExternalImageId};
+use api::{DebugCommand, DeviceUintRect, DocumentId, ExternalImageData, ExternalImageId};
 use api::ImageFormat;
-use api::DebugCommand;
+use clip_scroll_tree::ClipScrollNodeIndex;
 use device::TextureFilter;
 use renderer::PipelineInfo;
 use gpu_cache::GpuCacheUpdateList;
@@ -140,7 +139,7 @@ pub struct RenderedDocument {
     /// - Pipelines that were removed from the scene.
     pub pipeline_info: PipelineInfo,
     /// The layers that are currently affected by the over-scrolling animation.
-    pub layers_bouncing_back: FastHashSet<ClipId>,
+    pub layers_bouncing_back: FastHashSet<ClipScrollNodeIndex>,
 
     pub frame: tiling::Frame,
 }
@@ -148,7 +147,7 @@ pub struct RenderedDocument {
 impl RenderedDocument {
     pub fn new(
         pipeline_info: PipelineInfo,
-        layers_bouncing_back: FastHashSet<ClipId>,
+        layers_bouncing_back: FastHashSet<ClipScrollNodeIndex>,
         frame: tiling::Frame,
     ) -> Self {
         RenderedDocument {

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{BoxShadowClipMode, ClipId, ColorF, DeviceIntPoint, DeviceIntRect, FilterOp, LayerPoint};
+use api::{BoxShadowClipMode, ColorF, DeviceIntPoint, DeviceIntRect, FilterOp, LayerPoint};
 use api::{LayerRect, LayerToWorldScale, LayerVector2D, MixBlendMode, PipelineId};
 use api::{PremultipliedColorF, Shadow};
 use box_shadow::{BLUR_SAMPLE_SCALE, BoxShadowCacheKey};
+use clip_scroll_tree::ClipScrollNodeIndex;
 use frame_builder::{FrameContext, FrameState, PictureState};
 use gpu_cache::{GpuCacheHandle, GpuDataRequest};
 use gpu_types::{BrushImageKind, PictureType};
@@ -86,7 +87,7 @@ pub enum PictureKind {
         // The original reference frame ID for this picture.
         // It is only different if this is part of a 3D
         // rendering context.
-        reference_frame_id: ClipId,
+        reference_frame_index: ClipScrollNodeIndex,
         real_local_rect: LayerRect,
         // An optional cache handle for storing extra data
         // in the GPU cache, depending on the type of
@@ -208,7 +209,7 @@ impl PicturePrimitive {
         composite_mode: Option<PictureCompositeMode>,
         is_in_3d_context: bool,
         pipeline_id: PipelineId,
-        reference_frame_id: ClipId,
+        reference_frame_index: ClipScrollNodeIndex,
         frame_output_pipeline_id: Option<PipelineId>,
     ) -> Self {
         PicturePrimitive {
@@ -219,7 +220,7 @@ impl PicturePrimitive {
                 composite_mode,
                 is_in_3d_context,
                 frame_output_pipeline_id,
-                reference_frame_id,
+                reference_frame_index,
                 real_local_rect: LayerRect::zero(),
                 extra_gpu_data_handle: GpuCacheHandle::new(),
             },

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ClipId, ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use api::{DevicePixelScale, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
-use api::{DocumentLayer, FilterOp, ImageFormat};
-use api::{LayerRect, MixBlendMode, PipelineId};
+use api::{ColorF, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixelScale, DeviceUintPoint};
+use api::{DeviceUintRect, DeviceUintSize, DocumentLayer, FilterOp, ImageFormat, LayerRect};
+use api::{MixBlendMode, PipelineId};
 use batch::{AlphaBatchBuilder, AlphaBatchContainer, ClipBatcher, resolve_image};
 use clip::{ClipStore};
-use clip_scroll_tree::{ClipScrollTree};
+use clip_scroll_tree::{ClipScrollTree, ClipScrollNodeIndex};
 use device::{FrameId, Texture};
 use gpu_cache::{GpuCache};
 use gpu_types::{BlurDirection, BlurInstance, BrushFlags, BrushInstance, ClipChainRectIndex};
-use gpu_types::{ClipScrollNodeData, ClipScrollNodeIndex};
+use gpu_types::{ClipScrollNodeData, ClipScrollNodeIndex as GPUClipScrollNodeIndex};
 use gpu_types::{PrimitiveInstance};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{PictureKind};
@@ -29,7 +28,7 @@ const MIN_TARGET_SIZE: u32 = 2048;
 
 #[derive(Debug)]
 pub struct ScrollbarPrimitive {
-    pub clip_id: ClipId,
+    pub scroll_frame_index: ClipScrollNodeIndex,
     pub prim_index: PrimitiveIndex,
     pub frame_rect: LayerRect,
 }
@@ -584,7 +583,7 @@ impl RenderTarget for AlphaRenderTarget {
                                             //           transform primitives, these
                                             //           will need to be filled out!
                                             clip_chain_rect_index: ClipChainRectIndex(0),
-                                            scroll_id: ClipScrollNodeIndex(0),
+                                            scroll_id: GPUClipScrollNodeIndex(0),
                                             clip_task_address: RenderTaskAddress(0),
                                             z: 0,
                                             segment_index: 0,

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -769,12 +769,12 @@ pub struct ClipChainId(pub u64, pub PipelineId);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ClipId {
-    Clip(u64, PipelineId),
+    Clip(usize, PipelineId),
     ClipChain(ClipChainId),
 }
 
-const ROOT_REFERENCE_FRAME_CLIP_ID: u64 = 0;
-const ROOT_SCROLL_NODE_CLIP_ID: u64 = 1;
+const ROOT_REFERENCE_FRAME_CLIP_ID: usize = 0;
+const ROOT_SCROLL_NODE_CLIP_ID: usize = 1;
 
 impl ClipId {
     pub fn root_scroll_node(pipeline_id: PipelineId) -> ClipId {


### PR DESCRIPTION
Instead of storing ClipScrollNodes in a HashMap, store them in a vector.
This removes the CPU cost of accessing any particular ClipScrollNode. In
its place is a somewhat clunky system of translating a ClipId into a
ClipScrollIndex. These are allocated based on the total number of
ClipIds per display list, so the translation should be fairly cheap. A
per-pipeline offset and cache is stored, so the number of HashMap
lookups for display list flattening should be the same order as the
number of pipelines.

The big trade off here is that when descending into iframes, we need to
allocate space in the ClipScrollNode array ahead of time. If these
memory allocations turn out to be a problem, we can modify the code to
try to mutate existing nodes or to use a more complicated system of sub
vectors or slices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2449)
<!-- Reviewable:end -->
