### PR TITLE
Share gradient GPU cache entries for repeated gradient primitives.

### DIFF
--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -16,7 +16,7 @@ use gpu_types::{ClipScrollNodeData, ClipScrollNodeIndex};
 use gpu_types::{PrimitiveInstance};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{PictureKind};
-use prim_store::{PrimitiveIndex, PrimitiveKind, PrimitiveStore};
+use prim_store::{CachedGradient, PrimitiveIndex, PrimitiveKind, PrimitiveStore};
 use prim_store::{BrushMaskKind, BrushKind, DeferredResolve, EdgeAaSegmentMask};
 use profiler::FrameProfileCounters;
 use render_task::{BlitSource, RenderTaskAddress, RenderTaskId, RenderTaskKind};
@@ -46,6 +46,7 @@ pub struct RenderTargetContext<'a> {
     pub clip_scroll_tree: &'a ClipScrollTree,
     pub use_dual_source_blending: bool,
     pub node_data: &'a [ClipScrollNodeData],
+    pub cached_gradients: &'a [CachedGradient],
 }
 
 #[cfg_attr(feature = "capture", derive(Serialize))]


### PR DESCRIPTION
This is a potential fix for the intermittent failures here:
https://github.com/servo/webrender/pull/2441#issuecomment-367211596

I still can't reproduce them locally. However, I could see that the
GPU cache size in that test was getting dangerously close to the
maximum size of the texture supported by the GL implementation.

That would fit with the issues we're seeing on CI, where there
seems to be items not being drawn, and they are affected even
though the test in question doesn't draw any gradients.

This is not a very elegant fix - however it will hopefully fix
the issues we are seeing on CI for now. We can revisit this
later to consider a better fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2454)
<!-- Reviewable:end -->
