### PR TITLE
Properly handle optimized ClipChain in custom ClipChain nodes

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -382,29 +382,15 @@ impl ClipChain {
         }
     }
 
-    pub fn new_with_added_node(
-        &self,
-        work_item: ClipWorkItem,
-        local_clip_rect: LayerRect,
-        screen_outer_rect: DeviceIntRect,
-        screen_inner_rect: DeviceIntRect,
-    ) -> ClipChain {
+    pub fn new_with_added_node(&self, new_node: &ClipChainNode) -> ClipChain {
         // If the new node's inner rectangle completely surrounds our outer rectangle,
         // we can discard the new node entirely since it isn't going to affect anything.
-        if screen_inner_rect.contains_rect(&self.combined_outer_screen_rect) {
+        if new_node.screen_inner_rect.contains_rect(&self.combined_outer_screen_rect) {
             return self.clone();
         }
 
-        let new_node = ClipChainNode {
-            work_item,
-            local_clip_rect,
-            screen_outer_rect,
-            screen_inner_rect,
-            prev: None,
-        };
-
         let mut new_chain = self.clone();
-        new_chain.add_node(new_node);
+        new_chain.add_node(new_node.clone());
         new_chain
     }
 

--- a/wrench/reftests/clip/custom-clip-chain-node-ancestors-ref.yaml
+++ b/wrench/reftests/clip/custom-clip-chain-node-ancestors-ref.yaml
@@ -1,0 +1,9 @@
+---
+root:
+  items:
+    -
+      bounds: [10, 10, 100, 100]
+      "clip-rect": [10, 10, 100, 100]
+      "backface-visible": true
+      type: rect
+      color: 0 255 0 1

--- a/wrench/reftests/clip/custom-clip-chain-node-ancestors.yaml
+++ b/wrench/reftests/clip/custom-clip-chain-node-ancestors.yaml
@@ -1,0 +1,33 @@
+# This test ensures that custom clip chains are not affected by the ancestors
+# of their clipping nodes. In this case the node, 3, will probably be optimized
+# away since its ancestor 2 has a tighter bounding rect. On the other hand, a
+# clip chain which includes 3 should only get the rectangle specified by that
+# node and not be affected by 2 at all.
+---
+root:
+  items:
+    -
+      bounds: [25, 25, 50, 50]
+      "clip-rect": [25, 25, 50, 50]
+      "clip-and-scroll": 0
+      type: clip
+      id: 2
+    -
+      bounds: [10, 10, 100, 100]
+      clip-rect: [10, 10, 100, 100]
+      clip-and-scroll: 2
+      type: clip
+      id: 3
+      "content-size": [800, 1000]
+    -
+      bounds: [0, 0, 0, 0]
+      clip-rect: [0, 0, 0, 0]
+      type: "clip-chain"
+      id: 10
+      clips: [3]
+    -
+      bounds: [0, 0, 200, 200]
+      clip-rect: [0, 0, 200, 200]
+      clip-and-scroll: [0, 10]
+      type: rect
+      color: 0 255 0 1

--- a/wrench/reftests/clip/reftest.list
+++ b/wrench/reftests/clip/reftest.list
@@ -4,4 +4,5 @@
 == clip-3d-transform.yaml clip-3d-transform-ref.yaml
 == clip-corner-overlap.yaml clip-corner-overlap-ref.yaml
 == custom-clip-chains.yaml custom-clip-chains-ref.yaml
+== custom-clip-chain-node-ancestors.yaml custom-clip-chain-node-ancestors-ref.yaml
 == segmentation-with-other-coordinate-system-clip.yaml segmentation-with-other-coordinate-system-clip-ref.yaml


### PR DESCRIPTION
When a node included in a ClipScrollNode ClipChain is optimized away, we need to
ensure that custom ClipChains that rely on that node are using the
original node and not one of the parents. In order to achieve this, we
store a copy of the original ClipChainNode in the ClipScrollNode and use
it when building custom ClipChains.

Fixes #2388.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2455)
<!-- Reviewable:end -->
