### PR TITLE
Properly clip fixed position children

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -415,7 +415,7 @@ impl<'a> FlattenContext<'a> {
         traversal: &mut BuiltDisplayListIter<'a>,
         pipeline_id: PipelineId,
         unreplaced_scroll_id: ClipId,
-        scroll_node_id: ClipId,
+        mut scroll_node_id: ClipId,
         mut reference_frame_relative_offset: LayerVector2D,
         bounds: &LayerRect,
         stacking_context: &StackingContext,
@@ -443,10 +443,8 @@ impl<'a> FlattenContext<'a> {
         };
 
         if stacking_context.scroll_policy == ScrollPolicy::Fixed {
-            self.replacements.push((
-                unreplaced_scroll_id,
-                self.builder.current_reference_frame_id(),
-            ));
+            scroll_node_id = self.builder.current_reference_frame_id();
+            self.replacements.push((unreplaced_scroll_id, scroll_node_id));
         }
 
         reference_frame_relative_offset += bounds.origin.to_vector();

--- a/wrench/reftests/clip/fixed-position-clipping-ref.yaml
+++ b/wrench/reftests/clip/fixed-position-clipping-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+    -
+      bounds: [10, 10, 100, 100]
+      clip-rect: [10, 10, 100, 100]
+      type: rect
+      color: 0 256 0 1.0
+    -
+      bounds: [110, 10, 100, 100]
+      clip-rect: [110, 10, 100, 100]
+      type: rect
+      color: 0 256 0 1.0
+  id: [0, 1]
+pipelines: []

--- a/wrench/reftests/clip/fixed-position-clipping.yaml
+++ b/wrench/reftests/clip/fixed-position-clipping.yaml
@@ -1,0 +1,50 @@
+# This test ensures that children of fixed position stacking contexts are not
+# clipped by parent clipping nodes. The contents of the fixed position stacking
+# contexts below should not be clipped by their parent clipping nodes, but
+# instead should be promoted to be children of the top-level reference frame.
+---
+root:
+  items:
+    -
+      clip-rect: [15, 15, 30, 30]
+      type: scroll-frame
+      id: 1
+      content-size: [60, 60]
+      bounds: [15, 15, 30, 30]
+    -
+      bounds: [10, 10, 100, 100]
+      clip-rect: [10, 10, 100, 100]
+      clip-and-scroll: 1
+      type: stacking-context
+      scroll-policy: fixed
+      items:
+        -
+          bounds: [0, 0, 100, 100]
+          clip-rect: [0, 0, 100, 100]
+          clip-and-scroll: 1
+          type: rect
+          color: 0 256 0 1.0
+    # The same test as above, except this time the stacking context also starts its
+    # own reference frame.
+    -
+      clip-rect: [115, 15, 30, 30]
+      type: scroll-frame
+      id: 2
+      content-size: [60, 60]
+      bounds: [115, 15, 30, 30]
+    -
+      bounds: [110, 10, 100, 100]
+      clip-rect: [110, 10, 100, 100]
+      clip-and-scroll: 2
+      type: stacking-context
+      scroll-policy: fixed
+      transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+      items:
+        -
+          bounds: [0, 0, 100, 100]
+          clip-rect: [0, 0, 100, 100]
+          clip-and-scroll: 2
+          type: rect
+          color: 0 256 0 1.0
+  id: [0, 1]
+pipelines: []

--- a/wrench/reftests/clip/reftest.list
+++ b/wrench/reftests/clip/reftest.list
@@ -5,4 +5,5 @@
 == clip-corner-overlap.yaml clip-corner-overlap-ref.yaml
 == custom-clip-chains.yaml custom-clip-chains-ref.yaml
 == custom-clip-chain-node-ancestors.yaml custom-clip-chain-node-ancestors-ref.yaml
+== fixed-position-clipping.yaml fixed-position-clipping-ref.yaml
 == segmentation-with-other-coordinate-system-clip.yaml segmentation-with-other-coordinate-system-clip-ref.yaml


### PR DESCRIPTION
At some point, fixed position stacking contexts that also created
reference frames stopped being parented properly. This change fixes this
issue and adds a test verifying the behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2460)
<!-- Reviewable:end -->
