### PR TITLE
Track pipeline epochs in two places rather than three.

### DIFF
--- a/webrender/src/frame.rs
+++ b/webrender/src/frame.rs
@@ -1116,6 +1116,8 @@ impl<'a> FlattenContext<'a> {
 }
 
 pub fn build_scene(config: &FrameBuilderConfig, request: SceneRequest) -> BuiltScene {
+    // TODO: mutably pass the scene and update its own pipeline epoch map instead of
+    // creating a new one here.
     let mut pipeline_epoch_map = FastHashMap::default();
     let mut clip_scroll_tree = ClipScrollTree::new();
 
@@ -1131,11 +1133,13 @@ pub fn build_scene(config: &FrameBuilderConfig, request: SceneRequest) -> BuiltS
         &mut pipeline_epoch_map
     );
 
+    let mut scene = request.scene;
+    scene.pipeline_epochs = pipeline_epoch_map;
+
     BuiltScene {
-        scene: request.scene,
+        scene,
         frame_builder,
         clip_scroll_tree,
-        pipeline_epoch_map,
         removed_pipelines: request.removed_pipelines,
     }
 }

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DocumentId, PipelineId, Epoch, ApiMsg, FrameMsg, ResourceUpdates};
+use api::{DocumentId, PipelineId, ApiMsg, FrameMsg, ResourceUpdates};
 use api::channel::MsgSender;
 use frame::build_scene;
 use frame_builder::{FrameBuilderConfig, FrameBuilder};
 use clip_scroll_tree::ClipScrollTree;
-use internal_types::{FastHashMap, FastHashSet};
+use internal_types::FastHashSet;
 use resource_cache::{FontInstanceMap, TiledImageMap};
 use render_backend::DocumentView;
 use scene::Scene;
@@ -50,7 +50,6 @@ pub struct BuiltScene {
     pub scene: Scene,
     pub frame_builder: FrameBuilder,
     pub clip_scroll_tree: ClipScrollTree,
-    pub pipeline_epoch_map: FastHashMap<PipelineId, Epoch>,
     pub removed_pipelines: Vec<PipelineId>,
 }
 


### PR DESCRIPTION
Also make sure that both the current and pending scenes get updated at the right time:
 - The pending scene should have all epoch information as soon as the transaction is received
 - The current scene should receive epoch updates at the end of the transaction (if scenes are built asynchronously it means when receiving the transaction from the scene builder thread).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2461)
<!-- Reviewable:end -->
