### PR TITLE
Properly free resources on wrench reftests

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -68,6 +68,7 @@ use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::ptr;
 use std::rc::Rc;
 use std::sync::mpsc::{channel, Sender, Receiver};
@@ -412,7 +413,6 @@ fn main() {
         return;
     } else if let Some(subargs) = args.subcommand_matches("reftest") {
         let dim = window.get_inner_size();
-        let harness = ReftestHarness::new(&mut wrench, &mut window, rx.unwrap());
         let base_manifest = Path::new("reftests/reftest.list");
         let specific_reftest = subargs.value_of("REFTEST").map(|x| Path::new(x));
         let mut reftest_options = ReftestOptions::default();
@@ -420,8 +420,11 @@ fn main() {
             reftest_options.allow_max_difference = allow_max_diff.parse().unwrap_or(1);
             reftest_options.allow_num_differences = dim.width as usize * dim.height as usize;
         }
-        harness.run(base_manifest, specific_reftest, &reftest_options);
-        return;
+        let num_failures = ReftestHarness::new(&mut wrench, &mut window, rx.unwrap())
+            .run(base_manifest, specific_reftest, &reftest_options);
+        wrench.renderer.deinit();
+        // exit with an error code to fail on CI
+        process::exit(num_failures as _);
     } else if let Some(_) = args.subcommand_matches("rawtest") {
         {
             let harness = RawtestHarness::new(&mut wrench, &mut window, rx.unwrap());

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -299,7 +299,7 @@ impl<'a> ReftestHarness<'a> {
         ReftestHarness { wrench, window, rx }
     }
 
-    pub fn run(mut self, base_manifest: &Path, reftests: Option<&Path>, options: &ReftestOptions) {
+    pub fn run(mut self, base_manifest: &Path, reftests: Option<&Path>, options: &ReftestOptions) -> usize {
         let manifest = ReftestManifest::new(base_manifest, options);
         let reftests = manifest.find(reftests.unwrap_or(&PathBuf::new()));
 
@@ -328,8 +328,7 @@ impl<'a> ReftestHarness<'a> {
             }
         }
 
-        // panic here so that we fail CI
-        assert!(failing.is_empty());
+        failing.len()
     }
 
     fn run_reftest(&mut self, t: &Reftest) -> bool {


### PR DESCRIPTION
some graphics debuggers are not happy to capture stuff that doesn't have resources properly cleaned up
r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2462)
<!-- Reviewable:end -->
