### PR TITLE
Port drop-shadow and blur filter to use brush_image.

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 0
+#define VECS_PER_SPECIFIC_BRUSH 1
 
 #include shared,prim_shared,brush
 
@@ -12,8 +12,13 @@ varying vec2 vLocalPos;
 
 varying vec3 vUv;
 flat varying vec4 vUvBounds;
-
+flat varying vec4 vColor;
+flat varying vec2 vSelect;
 #ifdef WR_VERTEX_SHADER
+
+#define IMAGE_SOURCE_COLOR              0
+#define IMAGE_SOURCE_ALPHA              1
+#define IMAGE_SOURCE_MASK_FROM_COLOR    2
 
 void brush_vs(
     VertexInfo vi,
@@ -35,6 +40,7 @@ void brush_vs(
     vec2 uv1 = res.uv_rect.p1;
 
     vUv.z = res.layer;
+    vColor = res.color;
 
     vec2 f = (vi.local_pos - local_rect.p0) / local_rect.size;
     vUv.xy = mix(uv0, uv1, f);
@@ -47,6 +53,18 @@ void brush_vs(
         max(uv0, uv1) - vec2(0.5)
     ) / texture_size.xyxy;
 
+    switch (user_data.y) {
+        case IMAGE_SOURCE_COLOR:
+            vSelect = vec2(0.0, 0.0);
+            break;
+        case IMAGE_SOURCE_ALPHA:
+            vSelect = vec2(0.0, 1.0);
+            break;
+        case IMAGE_SOURCE_MASK_FROM_COLOR:
+            vSelect = vec2(1.0, 1.0);
+            break;
+    }
+
 #ifdef WR_FEATURE_ALPHA_PASS
     vLocalPos = vi.local_pos;
 #endif
@@ -57,7 +75,9 @@ void brush_vs(
 vec4 brush_fs() {
     vec2 uv = clamp(vUv.xy, vUvBounds.xy, vUvBounds.zw);
 
-    vec4 color = TEX_SAMPLE(sColor0, vec3(uv, vUv.z));
+    vec4 texel = TEX_SAMPLE(sColor0, vec3(uv, vUv.z));
+    vec4 mask = mix(texel.rrrr, texel.aaaa, vSelect.x);
+    vec4 color = mix(texel, vColor * mask, vSelect.y);
 
 #ifdef WR_FEATURE_ALPHA_PASS
     color *= init_transform_fs(vLocalPos);

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -116,6 +116,14 @@ vec4[3] fetch_from_resource_cache_3(int address) {
     );
 }
 
+vec4[3] fetch_from_resource_cache_3_direct(ivec2 address) {
+    return vec4[3](
+        TEXEL_FETCH(sResourceCache, address, 0, ivec2(0, 0)),
+        TEXEL_FETCH(sResourceCache, address, 0, ivec2(1, 0)),
+        TEXEL_FETCH(sResourceCache, address, 0, ivec2(2, 0))
+    );
+}
+
 vec4[4] fetch_from_resource_cache_4_direct(ivec2 address) {
     return vec4[4](
         TEXEL_FETCH(sResourceCache, address, 0, ivec2(0, 0)),
@@ -688,19 +696,20 @@ struct ImageResource {
     RectWithEndpoint uv_rect;
     float layer;
     vec3 user_data;
+    vec4 color;
 };
 
 ImageResource fetch_image_resource(int address) {
     //Note: number of blocks has to match `renderer::BLOCKS_PER_UV_RECT`
-    vec4 data[2] = fetch_from_resource_cache_2(address);
+    vec4 data[3] = fetch_from_resource_cache_3(address);
     RectWithEndpoint uv_rect = RectWithEndpoint(data[0].xy, data[0].zw);
-    return ImageResource(uv_rect, data[1].x, data[1].yzw);
+    return ImageResource(uv_rect, data[1].x, data[1].yzw, data[2]);
 }
 
 ImageResource fetch_image_resource_direct(ivec2 address) {
-    vec4 data[2] = fetch_from_resource_cache_2_direct(address);
+    vec4 data[3] = fetch_from_resource_cache_3_direct(address);
     RectWithEndpoint uv_rect = RectWithEndpoint(data[0].xy, data[0].zw);
-    return ImageResource(uv_rect, data[1].x, data[1].yzw);
+    return ImageResource(uv_rect, data[1].x, data[1].yzw, data[2]);
 }
 
 struct TextRun {

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{LayerToWorldTransform};
-use gpu_cache::GpuCacheAddress;
+use api::{DevicePoint, LayerToWorldTransform, PremultipliedColorF};
+use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use prim_store::EdgeAaSegmentMask;
 use render_task::RenderTaskAddress;
 
@@ -244,4 +244,34 @@ pub enum PictureType {
     Image = 1,
     TextShadow = 2,
     BoxShadow = 3,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[repr(C)]
+pub struct ImageSource {
+    pub p0: DevicePoint,
+    pub p1: DevicePoint,
+    pub texture_layer: f32,
+    pub user_data: [f32; 3],
+    pub color: PremultipliedColorF,
+}
+
+impl ImageSource {
+    pub fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
+        request.push([
+            self.p0.x,
+            self.p0.y,
+            self.p1.x,
+            self.p1.y,
+        ]);
+        request.push([
+            self.texture_layer,
+            self.user_data[0],
+            self.user_data[1],
+            self.user_data[2],
+        ]);
+        request.push(self.color);
+    }
 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -333,8 +333,10 @@ impl BrushPrimitive {
         // has to match VECS_PER_SPECIFIC_BRUSH
         match self.kind {
             BrushKind::Picture |
-            BrushKind::Image { .. } |
             BrushKind::YuvImage { .. } => {
+            }
+            BrushKind::Image { .. } => {
+                request.push([0.0; 4]);
             }
             BrushKind::Solid { color } => {
                 request.push(color.premultiplied());

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -867,6 +867,10 @@ impl RenderPass {
                             };
                         }
 
+                        // Give the render task an opportunity to add any
+                        // information to the GPU cache, if appropriate.
+                        task.prepare_for_render(gpu_cache);
+
                         (target_kind, texture_target)
                     };
 


### PR DESCRIPTION
There are a couple of goals that will come out of this work:

 * We want to remove brush_picture shader altogether, collapsing
   it into brush_image. This is the first part of that. The final
   part is modifying box-shadows to draw with segments so that we
   don't have to tweak the UVs in the fragment shader. Fixing this
   will also simplify a number of other tasks related to existing
   box-shadow bugs.
 * Output descriptors of render tasks are written into the GPU cache
   as a normal ImageResource structure, the same format as items in
   the texture cache. The idea here is to allow the image drawing
   shader to not care whether the source is a render task or a
   normal static image. This simplifies the image drawing shader,
   and also helps get the code into a better position to cache
   the outputs of more render task types in the texture cache.

Adding a color to every texture cache item isn't ideal. I did some
profiling and it didn't make any noticeable performance impact.
In the future, if we notice a cost to it, we could add a separate
shader feature for A8 vs RGBA8 images, and have a different
texture cache item format for each of those shaders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2466)
<!-- Reviewable:end -->
