### PR TITLE
Use a dedicated thread to buffer payloads, so avoiding deadlock

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -19,6 +19,7 @@ use api::ApiMsg;
 use api::DebugCommand;
 #[cfg(not(feature = "debugger"))]
 use api::channel::MsgSender;
+use api::channel::PayloadReceiverHelperMethods;
 use batch::{BatchKey, BatchKind, BatchTextures, BrushBatchKind};
 use batch::{TransformBatchKind};
 #[cfg(any(feature = "capture", feature = "replay"))]
@@ -2175,7 +2176,7 @@ impl Renderer {
         // First set the flags to default and later call set_debug_flags to ensure any
         // potential transition when enabling a flag is run.
         let debug_flags = DebugFlags::default();
-        let payload_tx_for_backend = payload_tx.clone();
+        let payload_rx_for_backend = payload_rx.to_mpsc_receiver();
         let recorder = options.recorder;
         let thread_listener = Arc::new(options.thread_listener);
         let thread_listener_for_rayon_start = thread_listener.clone();
@@ -2238,8 +2239,7 @@ impl Renderer {
                 }
                 let mut backend = RenderBackend::new(
                     api_rx,
-                    payload_rx,
-                    payload_tx_for_backend,
+                    payload_rx_for_backend,
                     result_tx,
                     scene_tx,
                     scene_rx,

--- a/webrender_api/src/channel.rs
+++ b/webrender_api/src/channel.rs
@@ -6,6 +6,7 @@ use api::{Epoch, PipelineId};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{Cursor, Read};
 use std::mem;
+use std::sync::mpsc::Receiver;
 
 #[derive(Clone)]
 pub struct Payload {
@@ -74,6 +75,10 @@ pub trait PayloadSenderHelperMethods {
 
 pub trait PayloadReceiverHelperMethods {
     fn recv_payload(&self) -> Result<Payload, Error>;
+
+    // For an MPSC receiver, this is the identity function,
+    // for an IPC receiver, it routes to a new mpsc receiver
+    fn to_mpsc_receiver(self) -> Receiver<Payload>;
 }
 
 #[cfg(not(feature = "ipc"))]

--- a/webrender_api/src/channel_mpsc.rs
+++ b/webrender_api/src/channel_mpsc.rs
@@ -25,6 +25,10 @@ impl PayloadReceiverHelperMethods for PayloadReceiver {
     fn recv_payload(&self) -> Result<Payload, Error> {
         self.recv()
     }
+
+    fn to_mpsc_receiver(self) -> Receiver<Payload> {
+        self.rx
+    }
 }
 
 pub struct MsgReceiver<T> {


### PR DESCRIPTION
Fixes #2478 

The problem is that sending a transaction first sends the payloads, then the transaction. This causes deadlock if sending the payload blocks, since the transaction is never sent, so the payloads are never removed from the buffer.

This PR fixes that, by adding a dedicated thread that routes from the payload IPC channel to a payload mpsc channel. It also removes a hot loop in the case of missing payloads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2480)
<!-- Reviewable:end -->
