### PR TITLE
Fix ordering of resource cache operations during capturing

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1060,9 +1060,6 @@ impl ResourceCache {
 
         info!("saving resource cache");
         let res = &self.resources;
-        if !root.is_dir() {
-            fs::create_dir_all(root).unwrap()
-        }
         let path_fonts = root.join("fonts");
         if !path_fonts.is_dir() {
             fs::create_dir(&path_fonts).unwrap();


### PR DESCRIPTION
This PR captures the resource cache *after* the captured frames are re-built, which makes it consistent with the frames.
r? @glennw or anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2483)
<!-- Reviewable:end -->
