### PR TITLE
Synchronously shut the render backend down after reftests and rawtests.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -695,8 +695,9 @@ impl RenderBackend {
 
     pub fn run(&mut self, mut profile_counters: BackendProfileCounters) {
         let mut frame_counter: u32 = 0;
+        let mut keep_going = true;
 
-        loop {
+        while keep_going {
             profile_scope!("handle_msg");
 
             while let Ok(msg) = self.scene_rx.try_recv() {
@@ -740,7 +741,7 @@ impl RenderBackend {
                 }
             }
 
-            let keep_going = match self.api_rx.recv() {
+            keep_going = match self.api_rx.recv() {
                 Ok(msg) => {
                     if let Some(ref mut r) = self.recorder {
                         r.write_msg(frame_counter, &msg);
@@ -749,13 +750,10 @@ impl RenderBackend {
                 }
                 Err(..) => { false }
             };
-
-            if !keep_going {
-                let _ = self.scene_tx.send(SceneBuilderRequest::Stop);
-                self.notifier.shut_down();
-                break;
-            }
         }
+
+        let _ = self.scene_tx.send(SceneBuilderRequest::Stop);
+        self.notifier.shut_down();
     }
 
     fn process_api_msg(

--- a/wrench/src/perf.rs
+++ b/wrench/src/perf.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use NotifierEvent;
 use WindowWrapper;
 use serde_json;
 use std::collections::{HashMap, HashSet};
@@ -123,11 +124,11 @@ impl Profile {
 pub struct PerfHarness<'a> {
     wrench: &'a mut Wrench,
     window: &'a mut WindowWrapper,
-    rx: Receiver<()>,
+    rx: Receiver<NotifierEvent>,
 }
 
 impl<'a> PerfHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<NotifierEvent>) -> Self {
         PerfHarness { wrench, window, rx }
     }
 

--- a/wrench/src/png.rs
+++ b/wrench/src/png.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use WindowWrapper;
+use {WindowWrapper, NotifierEvent};
 use image::png::PNGEncoder;
 use image::{self, ColorType, GenericImage};
 use std::fs::File;
@@ -77,7 +77,7 @@ pub fn png(
     surface: ReadSurface,
     window: &mut WindowWrapper,
     mut reader: YamlFrameReader,
-    rx: Receiver<()>,
+    rx: Receiver<NotifierEvent>,
 ) {
     reader.do_frame(wrench);
 

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use WindowWrapper;
+use {WindowWrapper, NotifierEvent};
 use blob;
 use euclid::{TypedRect, TypedSize2D, TypedPoint2D};
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use wrench::Wrench;
 
 pub struct RawtestHarness<'a> {
     wrench: &'a mut Wrench,
-    rx: Receiver<()>,
+    rx: &'a Receiver<NotifierEvent>,
     window: &'a mut WindowWrapper,
 }
 
@@ -30,7 +30,7 @@ fn rect<T: Copy, U>(x: T, y: T, width: T, height: T) -> TypedRect<T, U> {
 }
 
 impl<'a> RawtestHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: &'a Receiver<NotifierEvent>) -> Self {
         RawtestHarness {
             wrench,
             rx,

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use WindowWrapper;
+use {WindowWrapper, NotifierEvent};
 use base64;
 use image::load as load_piston_image;
 use image::png::PNGEncoder;
@@ -292,10 +292,10 @@ impl ReftestManifest {
 pub struct ReftestHarness<'a> {
     wrench: &'a mut Wrench,
     window: &'a mut WindowWrapper,
-    rx: Receiver<()>,
+    rx: &'a Receiver<NotifierEvent>,
 }
 impl<'a> ReftestHarness<'a> {
-    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: Receiver<()>) -> Self {
+    pub fn new(wrench: &'a mut Wrench, window: &'a mut WindowWrapper, rx: &'a Receiver<NotifierEvent>) -> Self {
         ReftestHarness { wrench, window, rx }
     }
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -16,12 +16,13 @@ use ron_frame_writer::RonFrameWriter;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::sync::mpsc::Receiver;
 use time;
 use webrender;
 use webrender::api::*;
 use webrender::{DebugFlags, RendererStats};
 use yaml_frame_writer::YamlFrameWriterReceiver;
-use {WindowWrapper, BLACK_COLOR, WHITE_COLOR};
+use {WindowWrapper, NotifierEvent, BLACK_COLOR, WHITE_COLOR};
 
 // TODO(gw): This descriptor matches what we currently support for fonts
 //           but is quite a mess. We should at least document and
@@ -589,5 +590,19 @@ impl Wrench {
                 y += self.device_pixel_ratio * dr.line_height();
             }
         }
+    }
+
+    pub fn shut_down(self, rx: Receiver<NotifierEvent>) {
+        self.api.shut_down();
+
+        loop {
+            match rx.recv() {
+                Ok(NotifierEvent::ShutDown) => { break; }
+                Ok(_) => {}
+                Err(e) => { panic!("Did not shut down properly: {:?}.", e); }
+            }
+        }
+
+        self.renderer.deinit();
     }
 }


### PR DESCRIPTION
To avoid going through the debacle of the infinite render backend loop after the async scene building PR, let's make sure we do get at least a test that checks that the render backend does not spin forever.

The first commit rearranges the the condition that breaks out of the render backend loop in a way that is slightly less error prone.

The second commit makes sure we wait for the shut down notification to have been propagated to the render notifier before exiting reftests and rawtests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2485)
<!-- Reviewable:end -->
