### PR TITLE
Move ClipScrollNode inverse calculation back to CPU

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -286,6 +286,14 @@ impl ClipScrollNode {
             return;
         }
 
+        let inv_transform = match self.world_content_transform.inverse() {
+            Some(inverted) => inverted.to_transform(),
+            None => {
+                node_data.push(ClipScrollNodeData::invalid());
+                return;
+            }
+        };
+
         let transform_kind = if self.world_content_transform.preserves_2d_axis_alignment() {
             TransformedRectKind::AxisAligned
         } else {
@@ -293,6 +301,7 @@ impl ClipScrollNode {
         };
         let data = ClipScrollNodeData {
             transform: self.world_content_transform.into(),
+            inv_transform,
             transform_kind: transform_kind as u32 as f32,
             padding: [0.0; 3],
         };

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DevicePoint, LayerToWorldTransform, PremultipliedColorF};
+use api::{DevicePoint, LayerToWorldTransform, PremultipliedColorF, WorldToLayerTransform};
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use prim_store::EdgeAaSegmentMask;
 use render_task::RenderTaskAddress;
@@ -217,6 +217,7 @@ pub struct ClipScrollNodeIndex(pub u32);
 #[repr(C)]
 pub struct ClipScrollNodeData {
     pub transform: LayerToWorldTransform,
+    pub inv_transform: WorldToLayerTransform,
     pub transform_kind: f32,
     pub padding: [f32; 3],
 }
@@ -225,6 +226,7 @@ impl ClipScrollNodeData {
     pub fn invalid() -> Self {
         ClipScrollNodeData {
             transform: LayerToWorldTransform::identity(),
+            inv_transform: WorldToLayerTransform::identity(),
             transform_kind: 0.0,
             padding: [0.0; 3],
         }


### PR DESCRIPTION
We have the ability to avoid expensive matrix math in most cases and,
where we cannot, we calculate this value on the CPU anyway, so avoid
calculating it on the GPU as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2488)
<!-- Reviewable:end -->
