### PR TITLE
util: Remove redundant parens.

### DIFF
--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -401,7 +401,7 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         match (self, other) {
             (&FastTransform::Offset(ref offset), &FastTransform::Offset(ref other_offset)) => {
                 let offset = TypedVector2D::from_untyped(&offset.to_untyped());
-                FastTransform::Offset((offset + *other_offset))
+                FastTransform::Offset(offset + *other_offset)
             }
             _ => {
                 let new_transform = self.to_transform().pre_mul(&other.to_transform());


### PR DESCRIPTION
Just a warning I noticed while building central this morning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2489)
<!-- Reviewable:end -->
