### PR TITLE
Revert "textureSize() workaround for Angle/NV"

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -86,16 +86,6 @@ uniform HIGHP_SAMPLER_FLOAT sampler2D sRenderTasks;
 in ivec4 aData0;
 in ivec4 aData1;
 
-// Work around Angle bug that forgets to update sampler metadata,
-// by making the use of those samplers uniform across programs.
-// https://github.com/servo/webrender/wiki/Driver-issues#texturesize-in-vertex-shaders
-void markCacheTexturesUsed() {
-    vec2 size = vec2(textureSize(sCacheA8, 0)) + vec2(textureSize(sCacheRGBA8, 0));
-    if (size.x > 1000000.0) {
-        gl_Position = vec4(0.0);
-    }
-}
-
 // get_fetch_uv is a macro to work around a macOS Intel driver parsing bug.
 // TODO: convert back to a function once the driver issues are resolved, if ever.
 // https://github.com/servo/webrender/pull/623
@@ -377,8 +367,6 @@ PrimitiveInstance fetch_prim_instance() {
     pi.user_data1 = aData1.z;
     pi.user_data2 = aData1.w;
 
-    markCacheTexturesUsed();
-
     return pi;
 }
 
@@ -405,8 +393,6 @@ CompositeInstance fetch_composite_instance() {
     ci.user_data1 = aData1.y;
     ci.user_data2 = aData1.z;
     ci.user_data3 = aData1.w;
-
-    markCacheTexturesUsed();
 
     return ci;
 }


### PR DESCRIPTION
This reverts #2491 for apparently causing https://bugzilla.mozilla.org/show_bug.cgi?id=1444076
Must be some real confusion by the driver, since the code changes are semantically harmless.
I'll come up with a better fix.
r? @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2499)
<!-- Reviewable:end -->
