### PR TITLE
Force sampler metadata reset at program change on Windows/Angle

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -929,6 +929,22 @@ impl Device {
         }
     }
 
+    //TODO: remove once the Angle workaround is no longer needed
+    pub fn reset_angle_sampler_metadata(&mut self, texture: &Texture) {
+        self.bind_texture(DEFAULT_TEXTURE, texture);
+        self.gl.tex_parameter_f(
+            texture.target,
+            gl::TEXTURE_BASE_LEVEL,
+            1.0 as _,
+        );
+        self.gl.draw_arrays(gl::TRIANGLES, 0, 1); // dummy draw
+        self.gl.tex_parameter_f(
+            texture.target,
+            gl::TEXTURE_BASE_LEVEL,
+            0.0 as _, // assumes 0.0 is the normal value for this texture
+        );
+    }
+
     pub fn create_texture(
         &mut self,
         target: TextureTarget,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3093,6 +3093,14 @@ impl Renderer {
         textures: &BatchTextures,
         stats: &mut RendererStats,
     ) {
+        // Work around Angle bug that forgets to update sampler metadata,
+        // by making the use of those samplers uniform across programs.
+        // https://github.com/servo/webrender/wiki/Driver-issues#texturesize-in-vertex-shaders
+        let work_around_angle_bug = cfg!(windows);
+        if work_around_angle_bug {
+            self.device.reset_angle_sampler_metadata(&self.texture_resolver.dummy_cache_texture);
+        }
+
         for i in 0 .. textures.colors.len() {
             self.texture_resolver.bind(
                 &textures.colors[i],


### PR DESCRIPTION
This is a third workaround for the same flickering issue (first wasn't PRed for being too big, second got backed out). It forces Angle to invalidate the driver constants by attempting to draw with a changed base level of a texture. This is done after every shader bind on Windows, but no real GPU work is expected (since 1 vertex of a triangle primitive makes no polygons).

Try push: https://treeherder.mozilla.org/#/jobs?repo=try&revision=e654714eeaf5118e969cf95346c457d61663a82e

r? @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2504)
<!-- Reviewable:end -->
