### PR TITLE
Move the image decomposition code out of DisplayListFlattener.

### DIFF
--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use ws;
 use base64::encode;
-use image;
+use image_loader;
 
 // Messages that are sent from the render backend to the renderer
 // debug command queue. These are sent in a separate queue so
@@ -279,8 +279,8 @@ impl Screenshot {
     pub fn new(width: u32, height: u32, data: Vec<u8>) -> Self {
         let mut output = Vec::with_capacity((width * height) as usize);
         {
-            let encoder = image::png::PNGEncoder::new(&mut output);
-            encoder.encode(&data, width, height, image::ColorType::RGBA(8)).unwrap();
+            let encoder = image_loader::png::PNGEncoder::new(&mut output);
+            encoder.encode(&data, width, height, image_loader::ColorType::RGBA(8)).unwrap();
         }
 
         let data = encode(&output);

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -5,10 +5,10 @@
 
 use api::{AlphaType, BorderDetails, BorderDisplayItem, BuiltDisplayListIter};
 use api::{ClipAndScrollInfo, ClipId, ColorF, ComplexClipRegion, DeviceIntPoint, DeviceIntRect};
-use api::{DeviceIntSize, DevicePixelScale, DeviceUintRect, DeviceUintSize};
+use api::{DeviceIntSize, DevicePixelScale, DeviceUintRect};
 use api::{DisplayItemRef, Epoch, ExtendMode, ExternalScrollId, FilterOp};
 use api::{FontInstanceKey, FontRenderMode, GlyphInstance, GlyphOptions, GradientStop};
-use api::{IframeDisplayItem, ImageDisplayItem, ImageKey, ImageRendering, ItemRange, LayerPoint};
+use api::{IframeDisplayItem, ImageKey, ImageRendering, ItemRange, LayerPoint};
 use api::{LayerPrimitiveInfo, LayerRect, LayerSize, LayerVector2D, LayoutSize, LayoutTransform};
 use api::{LayoutVector2D, LineOrientation, LineStyle, LocalClip, PipelineId};
 use api::{PropertyBinding, RepeatMode, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity};
@@ -19,10 +19,11 @@ use border::ImageBorderSegment;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, StickyFrameInfo};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
-use euclid::{SideOffsets2D, rect, vec2};
+use euclid::{SideOffsets2D, vec2};
 use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use glyph_rasterizer::FontInstance;
 use hit_test::{HitTestingItem, HitTestingRun};
+use image::{decompose_image, TiledImageInfo};
 use internal_types::{FastHashMap, FastHashSet};
 use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
 use prim_store::{BrushKind, BrushPrimitive, BrushSegmentDescriptor, CachedGradient};
@@ -638,12 +639,29 @@ impl<'a> DisplayListFlattener<'a> {
                     Some(tiling) => {
                         // The image resource is tiled. We have to generate an image primitive
                         // for each tile.
-                        self.decompose_image(
-                            clip_and_scroll,
-                            &prim_info,
-                            info,
-                            tiling.image_size,
-                            tiling.tile_size as u32,
+                        decompose_image(
+                            &TiledImageInfo {
+                                rect: prim_info.rect,
+                                tile_spacing: info.tile_spacing,
+                                stretch_size: info.stretch_size,
+                                device_image_size: tiling.image_size,
+                                device_tile_size: tiling.tile_size as u32,
+                            },
+                            &mut|tile| {
+                                let mut prim_info = prim_info.clone();
+                                prim_info.rect = tile.rect;
+                                self.add_image(
+                                    clip_and_scroll,
+                                    &prim_info,
+                                    tile.stretch_size,
+                                    info.tile_spacing,
+                                    None,
+                                    info.image_key,
+                                    info.image_rendering,
+                                    info.alpha_type,
+                                    Some(tile.tile_offset),
+                                );
+                            }
                         );
                     }
                     None => {
@@ -841,308 +859,6 @@ impl<'a> DisplayListFlattener<'a> {
             }
         }
         None
-    }
-
-    /// Decomposes an image display item that is repeated into an image per individual repetition.
-    /// We need to do this when we are unable to perform the repetition in the shader,
-    /// for example if the image is tiled.
-    ///
-    /// In all of the "decompose" methods below, we independently handle horizontal and vertical
-    /// decomposition. This lets us generate the minimum amount of primitives by, for  example,
-    /// decompositing the repetition horizontally while repeating vertically in the shader (for
-    /// an image where the width is too bug but the height is not).
-    ///
-    /// decompose_image and decompose_image_row handle image repetitions while decompose_tiled_image
-    /// takes care of the decomposition required by the internal tiling of the image.
-    fn decompose_image(
-        &mut self,
-        clip_and_scroll: ScrollNodeAndClipChain,
-        prim_info: &LayerPrimitiveInfo,
-        info: &ImageDisplayItem,
-        image_size: DeviceUintSize,
-        tile_size: u32,
-    ) {
-        let no_vertical_tiling = image_size.height <= tile_size;
-        let no_vertical_spacing = info.tile_spacing.height == 0.0;
-        let item_rect = prim_info.rect;
-        if no_vertical_tiling && no_vertical_spacing {
-            self.decompose_image_row(
-                clip_and_scroll,
-                prim_info,
-                info,
-                image_size,
-                tile_size,
-            );
-            return;
-        }
-
-        // Decompose each vertical repetition into rows.
-        let layout_stride = info.stretch_size.height + info.tile_spacing.height;
-        let num_repetitions = (item_rect.size.height / layout_stride).ceil() as u32;
-        for i in 0 .. num_repetitions {
-            if let Some(row_rect) = rect(
-                item_rect.origin.x,
-                item_rect.origin.y + (i as f32) * layout_stride,
-                item_rect.size.width,
-                info.stretch_size.height,
-            ).intersection(&item_rect)
-            {
-                let mut prim_info = prim_info.clone();
-                prim_info.rect = row_rect;
-                self.decompose_image_row(
-                    clip_and_scroll,
-                    &prim_info,
-                    info,
-                    image_size,
-                    tile_size,
-                );
-            }
-        }
-    }
-
-    fn decompose_image_row(
-        &mut self,
-        clip_and_scroll: ScrollNodeAndClipChain,
-        prim_info: &LayerPrimitiveInfo,
-        info: &ImageDisplayItem,
-        image_size: DeviceUintSize,
-        tile_size: u32,
-    ) {
-        let no_horizontal_tiling = image_size.width <= tile_size;
-        let no_horizontal_spacing = info.tile_spacing.width == 0.0;
-        if no_horizontal_tiling && no_horizontal_spacing {
-            self.decompose_tiled_image(
-                clip_and_scroll,
-                prim_info,
-                info,
-                image_size,
-                tile_size,
-            );
-            return;
-        }
-
-        // Decompose each horizontal repetition.
-        let item_rect = prim_info.rect;
-        let layout_stride = info.stretch_size.width + info.tile_spacing.width;
-        let num_repetitions = (item_rect.size.width / layout_stride).ceil() as u32;
-        for i in 0 .. num_repetitions {
-            if let Some(decomposed_rect) = rect(
-                item_rect.origin.x + (i as f32) * layout_stride,
-                item_rect.origin.y,
-                info.stretch_size.width,
-                item_rect.size.height,
-            ).intersection(&item_rect)
-            {
-                let mut prim_info = prim_info.clone();
-                prim_info.rect = decomposed_rect;
-                self.decompose_tiled_image(
-                    clip_and_scroll,
-                    &prim_info,
-                    info,
-                    image_size,
-                    tile_size,
-                );
-            }
-        }
-    }
-
-    fn decompose_tiled_image(
-        &mut self,
-        clip_and_scroll: ScrollNodeAndClipChain,
-        prim_info: &LayerPrimitiveInfo,
-        info: &ImageDisplayItem,
-        image_size: DeviceUintSize,
-        tile_size: u32,
-    ) {
-        // The image resource is tiled. We have to generate an image primitive
-        // for each tile.
-        // We need to do this because the image is broken up into smaller tiles in the texture
-        // cache and the image shader is not able to work with this type of sparse representation.
-
-        // The tiling logic works as follows:
-        //
-        //  ###################-+  -+
-        //  #    |    |    |//# |   | image size
-        //  #    |    |    |//# |   |
-        //  #----+----+----+--#-+   |  -+
-        //  #    |    |    |//# |   |   | regular tile size
-        //  #    |    |    |//# |   |   |
-        //  #----+----+----+--#-+   |  -+-+
-        //  #////|////|////|//# |   |     | "leftover" height
-        //  ################### |  -+  ---+
-        //  #----+----+----+----+
-        //
-        // In the ascii diagram above, a large image is plit into tiles of almost regular size.
-        // The tiles on the right and bottom edges (hatched in the diagram) are smaller than
-        // the regular tiles and are handled separately in the code see leftover_width/height.
-        // each generated image primitive corresponds to a tile in the texture cache, with the
-        // assumption that the smaller tiles with leftover sizes are sized to fit their own
-        // irregular size in the texture cache.
-        //
-        // For the case where we don't tile along an axis, we can still perform the repetition in
-        // the shader (for this particular axis), and it is worth special-casing for this to avoid
-        // generating many primitives.
-        // This can happen with very tall and thin images used as a repeating background.
-        // Apparently web authors do that...
-
-        let item_rect = prim_info.rect;
-        let needs_repeat_x = info.stretch_size.width < item_rect.size.width;
-        let needs_repeat_y = info.stretch_size.height < item_rect.size.height;
-
-        let tiled_in_x = image_size.width > tile_size;
-        let tiled_in_y = image_size.height > tile_size;
-
-        // If we don't actually tile in this dimension, repeating can be done in the shader.
-        let shader_repeat_x = needs_repeat_x && !tiled_in_x;
-        let shader_repeat_y = needs_repeat_y && !tiled_in_y;
-
-        let tile_size_f32 = tile_size as f32;
-
-        // Note: this rounds down so it excludes the partially filled tiles on the right and
-        // bottom edges (we handle them separately below).
-        let num_tiles_x = (image_size.width / tile_size) as u16;
-        let num_tiles_y = (image_size.height / tile_size) as u16;
-
-        // Ratio between (image space) tile size and image size.
-        let img_dw = tile_size_f32 / (image_size.width as f32);
-        let img_dh = tile_size_f32 / (image_size.height as f32);
-
-        // Strected size of the tile in layout space.
-        let stretched_tile_size = LayerSize::new(
-            img_dw * info.stretch_size.width,
-            img_dh * info.stretch_size.height,
-        );
-
-        // The size in pixels of the tiles on the right and bottom edges, smaller
-        // than the regular tile size if the image is not a multiple of the tile size.
-        // Zero means the image size is a multiple of the tile size.
-        let leftover =
-            DeviceUintSize::new(image_size.width % tile_size, image_size.height % tile_size);
-
-        for ty in 0 .. num_tiles_y {
-            for tx in 0 .. num_tiles_x {
-                self.add_tile_primitive(
-                    clip_and_scroll,
-                    prim_info,
-                    info,
-                    TileOffset::new(tx, ty),
-                    stretched_tile_size,
-                    1.0,
-                    1.0,
-                    shader_repeat_x,
-                    shader_repeat_y,
-                );
-            }
-            if leftover.width != 0 {
-                // Tiles on the right edge that are smaller than the tile size.
-                self.add_tile_primitive(
-                    clip_and_scroll,
-                    prim_info,
-                    info,
-                    TileOffset::new(num_tiles_x, ty),
-                    stretched_tile_size,
-                    (leftover.width as f32) / tile_size_f32,
-                    1.0,
-                    shader_repeat_x,
-                    shader_repeat_y,
-                );
-            }
-        }
-
-        if leftover.height != 0 {
-            for tx in 0 .. num_tiles_x {
-                // Tiles on the bottom edge that are smaller than the tile size.
-                self.add_tile_primitive(
-                    clip_and_scroll,
-                    prim_info,
-                    info,
-                    TileOffset::new(tx, num_tiles_y),
-                    stretched_tile_size,
-                    1.0,
-                    (leftover.height as f32) / tile_size_f32,
-                    shader_repeat_x,
-                    shader_repeat_y,
-                );
-            }
-
-            if leftover.width != 0 {
-                // Finally, the bottom-right tile with a "leftover" size.
-                self.add_tile_primitive(
-                    clip_and_scroll,
-                    prim_info,
-                    info,
-                    TileOffset::new(num_tiles_x, num_tiles_y),
-                    stretched_tile_size,
-                    (leftover.width as f32) / tile_size_f32,
-                    (leftover.height as f32) / tile_size_f32,
-                    shader_repeat_x,
-                    shader_repeat_y,
-                );
-            }
-        }
-    }
-
-    fn add_tile_primitive(
-        &mut self,
-        clip_and_scroll: ScrollNodeAndClipChain,
-        prim_info: &LayerPrimitiveInfo,
-        info: &ImageDisplayItem,
-        tile_offset: TileOffset,
-        stretched_tile_size: LayerSize,
-        tile_ratio_width: f32,
-        tile_ratio_height: f32,
-        shader_repeat_x: bool,
-        shader_repeat_y: bool,
-    ) {
-        // If the the image is tiled along a given axis, we can't have the shader compute
-        // the image repetition pattern. In this case we base the primitive's rectangle size
-        // on the stretched tile size which effectively cancels the repetion (and repetition
-        // has to be emulated by generating more primitives).
-        // If the image is not tiled along this axis, we can perform the repetition in the
-        // shader. in this case we use the item's size in the primitive (on that particular
-        // axis).
-        // See the shader_repeat_x/y code below.
-
-        let stretched_size = LayerSize::new(
-            stretched_tile_size.width * tile_ratio_width,
-            stretched_tile_size.height * tile_ratio_height,
-        );
-
-        let mut prim_rect = LayerRect::new(
-            prim_info.rect.origin +
-                LayerVector2D::new(
-                    tile_offset.x as f32 * stretched_tile_size.width,
-                    tile_offset.y as f32 * stretched_tile_size.height,
-                ),
-            stretched_size,
-        );
-
-        if shader_repeat_x {
-            assert_eq!(tile_offset.x, 0);
-            prim_rect.size.width = prim_info.rect.size.width;
-        }
-
-        if shader_repeat_y {
-            assert_eq!(tile_offset.y, 0);
-            prim_rect.size.height = prim_info.rect.size.height;
-        }
-
-        // Fix up the primitive's rect if it overflows the original item rect.
-        if let Some(prim_rect) = prim_rect.intersection(&prim_info.rect) {
-            let mut prim_info = prim_info.clone();
-            prim_info.rect = prim_rect;
-            self.add_image(
-                clip_and_scroll,
-                &prim_info,
-                stretched_size,
-                info.tile_spacing,
-                None,
-                info.image_key,
-                info.image_rendering,
-                info.alpha_type,
-                Some(tile_offset),
-            );
-        }
     }
 
     /// Create a primitive and add it to the prim store. This method doesn't

--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api::{TileOffset, LayerRect, LayerSize, LayerVector2D, DeviceUintSize};
+use euclid::rect;
+
+pub struct DecomposedTile {
+    pub rect: LayerRect,
+    pub stretch_size: LayerSize,
+    pub tile_offset: TileOffset,
+}
+
+pub struct TiledImageInfo {
+    /// The bounds of the item in layout space.
+    pub rect: LayerRect,
+    /// The space between each repeated pattern in layout space.
+    pub tile_spacing: LayerSize,
+    /// The size in layout space of each repetition of the image.
+    pub stretch_size: LayerSize,
+
+    /// The size the image occupies in the cache in device space.
+    pub device_image_size: DeviceUintSize,
+    /// The size of the tiles in the cache in device pixels.
+    pub device_tile_size: u32,
+}
+
+/// Decomposes an image that is repeated into an image per individual repetition.
+/// We need to do this when we are unable to perform the repetition in the shader,
+/// for example if the image is tiled.
+///
+/// In all of the "decompose" methods below, we independently handle horizontal and vertical
+/// decomposition. This lets us generate the minimum amount of primitives by, for  example,
+/// decompositing the repetition horizontally while repeating vertically in the shader (for
+/// an image where the width is too bug but the height is not).
+///
+/// decompose_image and decompose_row handle image repetitions while decompose_cache_tiles
+/// takes care of the decomposition required by the internal tiling of the image in the cache.
+///
+/// Note that the term tiling is overloaded: There is the tiling we get from repeating images
+/// in layout space, and the tiling that we do in the texture cache (to avoid hitting texture
+/// size limits). The latter is referred to as "device" tiling here to disambiguate.
+pub fn decompose_image(info: &TiledImageInfo, callback: &mut FnMut(&DecomposedTile)) {
+
+    let no_vertical_tiling = info.device_image_size.height <= info.device_tile_size;
+    let no_vertical_spacing = info.tile_spacing.height == 0.0;
+
+    if no_vertical_tiling && no_vertical_spacing {
+        decompose_row(&info.rect, info, callback);
+        return;
+    }
+
+    // Decompose each vertical repetition into rows.
+    let layout_stride = info.stretch_size.height + info.tile_spacing.height;
+    let num_repetitions = (info.rect.size.height / layout_stride).ceil() as u32;
+
+    for i in 0 .. num_repetitions {
+        let row_rect = rect(
+            info.rect.origin.x,
+            info.rect.origin.y + (i as f32) * layout_stride,
+            info.rect.size.width,
+            info.stretch_size.height,
+        ).intersection(&info.rect);
+
+        if let Some(row_rect) = row_rect {
+            decompose_row(&row_rect, info, callback);
+        }
+    }
+}
+
+
+fn decompose_row(item_rect: &LayerRect, info: &TiledImageInfo, callback: &mut FnMut(&DecomposedTile)) {
+
+    let no_horizontal_tiling = info.device_image_size.width <= info.device_tile_size;
+    let no_horizontal_spacing = info.tile_spacing.width == 0.0;
+
+    if no_horizontal_tiling && no_horizontal_spacing {
+        decompose_cache_tiles(item_rect, info, callback);
+        return;
+    }
+
+    // Decompose each horizontal repetition.
+    let layout_stride = info.stretch_size.width + info.tile_spacing.width;
+    let num_repetitions = (item_rect.size.width / layout_stride).ceil() as u32;
+
+    for i in 0 .. num_repetitions {
+        let decomposed_rect = rect(
+            item_rect.origin.x + (i as f32) * layout_stride,
+            item_rect.origin.y,
+            info.stretch_size.width,
+            item_rect.size.height,
+        ).intersection(&item_rect);
+
+        if let Some(decomposed_rect) = decomposed_rect {
+            decompose_cache_tiles(&decomposed_rect, info, callback);
+        }
+    }
+}
+
+fn decompose_cache_tiles(
+    item_rect: &LayerRect,
+    info: &TiledImageInfo,
+    callback: &mut FnMut(&DecomposedTile),
+) {
+    // The image resource is tiled. We have to generate an image primitive
+    // for each tile.
+    // We need to do this because the image is broken up into smaller tiles in the texture
+    // cache and the image shader is not able to work with this type of sparse representation.
+
+    // The tiling logic works as follows:
+    //
+    //  ###################-+  -+
+    //  #    |    |    |//# |   | image size
+    //  #    |    |    |//# |   |
+    //  #----+----+----+--#-+   |  -+
+    //  #    |    |    |//# |   |   | regular tile size
+    //  #    |    |    |//# |   |   |
+    //  #----+----+----+--#-+   |  -+-+
+    //  #////|////|////|//# |   |     | "leftover" height
+    //  ################### |  -+  ---+
+    //  #----+----+----+----+
+    //
+    // In the ascii diagram above, a large image is plit into tiles of almost regular size.
+    // The tiles on the right and bottom edges (hatched in the diagram) are smaller than
+    // the regular tiles and are handled separately in the code see leftover_width/height.
+    // each generated image primitive corresponds to a tile in the texture cache, with the
+    // assumption that the smaller tiles with leftover sizes are sized to fit their own
+    // irregular size in the texture cache.
+    //
+    // For the case where we don't tile along an axis, we can still perform the repetition in
+    // the shader (for this particular axis), and it is worth special-casing for this to avoid
+    // generating many primitives.
+    // This can happen with very tall and thin images used as a repeating background.
+    // Apparently web authors do that...
+
+    let needs_repeat_x = info.stretch_size.width < item_rect.size.width;
+    let needs_repeat_y = info.stretch_size.height < item_rect.size.height;
+
+    let tiled_in_x = info.device_image_size.width > info.device_tile_size;
+    let tiled_in_y = info.device_image_size.height > info.device_tile_size;
+
+    // If we don't actually tile in this dimension, repeating can be done in the shader.
+    let shader_repeat_x = needs_repeat_x && !tiled_in_x;
+    let shader_repeat_y = needs_repeat_y && !tiled_in_y;
+
+    let tile_size_f32 = info.device_tile_size as f32;
+
+    // Note: this rounds down so it excludes the partially filled tiles on the right and
+    // bottom edges (we handle them separately below).
+    let num_tiles_x = (info.device_image_size.width / info.device_tile_size) as u16;
+    let num_tiles_y = (info.device_image_size.height / info.device_tile_size) as u16;
+
+    // Ratio between (image space) tile size and image size.
+    let img_dw = tile_size_f32 / (info.device_image_size.width as f32);
+    let img_dh = tile_size_f32 / (info.device_image_size.height as f32);
+
+    // Strected size of the tile in layout space.
+    let stretched_tile_size = LayerSize::new(
+        img_dw * info.stretch_size.width,
+        img_dh * info.stretch_size.height,
+    );
+
+    // The size in pixels of the tiles on the right and bottom edges, smaller
+    // than the regular tile size if the image is not a multiple of the tile size.
+    // Zero means the image size is a multiple of the tile size.
+    let leftover = DeviceUintSize::new(
+        info.device_image_size.width % info.device_tile_size,
+        info.device_image_size.height % info.device_tile_size
+    );
+
+    for ty in 0 .. num_tiles_y {
+        for tx in 0 .. num_tiles_x {
+            add_device_tile(
+                item_rect,
+                stretched_tile_size,
+                TileOffset::new(tx, ty),
+                1.0,
+                1.0,
+                shader_repeat_x,
+                shader_repeat_y,
+                callback,
+            );
+        }
+        if leftover.width != 0 {
+            // Tiles on the right edge that are smaller than the tile size.
+            add_device_tile(
+                item_rect,
+                stretched_tile_size,
+                TileOffset::new(num_tiles_x, ty),
+                (leftover.width as f32) / tile_size_f32,
+                1.0,
+                shader_repeat_x,
+                shader_repeat_y,
+                callback,
+            );
+        }
+    }
+
+    if leftover.height != 0 {
+        for tx in 0 .. num_tiles_x {
+            // Tiles on the bottom edge that are smaller than the tile size.
+            add_device_tile(
+                item_rect,
+                stretched_tile_size,
+                TileOffset::new(tx, num_tiles_y),
+                1.0,
+                (leftover.height as f32) / tile_size_f32,
+                shader_repeat_x,
+                shader_repeat_y,
+                callback,
+            );
+        }
+
+        if leftover.width != 0 {
+            // Finally, the bottom-right tile with a "leftover" size.
+            add_device_tile(
+                item_rect,
+                stretched_tile_size,
+                TileOffset::new(num_tiles_x, num_tiles_y),
+                (leftover.width as f32) / tile_size_f32,
+                (leftover.height as f32) / tile_size_f32,
+                shader_repeat_x,
+                shader_repeat_y,
+                callback,
+            );
+        }
+    }
+}
+
+fn add_device_tile(
+    item_rect: &LayerRect,
+    stretched_tile_size: LayerSize,
+    tile_offset: TileOffset,
+    tile_ratio_width: f32,
+    tile_ratio_height: f32,
+    shader_repeat_x: bool,
+    shader_repeat_y: bool,
+    callback: &mut FnMut(&DecomposedTile),
+) {
+    // If the the image is tiled along a given axis, we can't have the shader compute
+    // the image repetition pattern. In this case we base the primitive's rectangle size
+    // on the stretched tile size which effectively cancels the repetion (and repetition
+    // has to be emulated by generating more primitives).
+    // If the image is not tiled along this axis, we can perform the repetition in the
+    // shader. in this case we use the item's size in the primitive (on that particular
+    // axis).
+    // See the shader_repeat_x/y code below.
+
+    let stretch_size = LayerSize::new(
+        stretched_tile_size.width * tile_ratio_width,
+        stretched_tile_size.height * tile_ratio_height,
+    );
+
+    let mut prim_rect = LayerRect::new(
+        item_rect.origin + LayerVector2D::new(
+            tile_offset.x as f32 * stretched_tile_size.width,
+            tile_offset.y as f32 * stretched_tile_size.height,
+        ),
+        stretch_size,
+    );
+
+    if shader_repeat_x {
+        assert_eq!(tile_offset.x, 0);
+        prim_rect.size.width = item_rect.size.width;
+    }
+
+    if shader_repeat_y {
+        assert_eq!(tile_offset.y, 0);
+        prim_rect.size.height = item_rect.size.height;
+    }
+
+    // Fix up the primitive's rect if it overflows the original item rect.
+    if let Some(rect) = prim_rect.intersection(&item_rect) {
+        callback(&DecomposedTile {
+            tile_offset,
+            rect,
+            stretch_size,
+        });
+    }
+}

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -157,7 +157,7 @@ extern crate time;
 #[cfg(feature = "debugger")]
 extern crate ws;
 #[cfg(feature = "debugger")]
-extern crate image;
+extern crate image as image_loader;
 #[cfg(feature = "debugger")]
 extern crate base64;
 #[cfg(all(feature = "capture", feature = "png"))]

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -78,6 +78,7 @@ mod glyph_rasterizer;
 mod gpu_cache;
 mod gpu_types;
 mod hit_test;
+mod image;
 mod internal_types;
 mod picture;
 mod prim_store;


### PR DESCRIPTION
This is a preamble for the task of doing lazy image decomposition during frame building. This PR should not change the current behavior. Decoupling the decomposition code from DisplayListFlattener will make it easier to move it to frame building as a followup.

There is a comment in prim_store.rs about creating `image.rs` and moving image sepcific logic there so I went ahead and created the file, which now holds the decomposition code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2507)
<!-- Reviewable:end -->
