### PR TITLE
No longer allow clipping items by complex clips

### DIFF
--- a/direct-composition/src/main_windows.rs
+++ b/direct-composition/src/main_windows.rs
@@ -131,15 +131,18 @@ impl Rectangle {
         let mut builder = api::DisplayListBuilder::new(pipeline_id, layout_size);
 
         let rect = euclid::TypedRect::new(euclid::TypedPoint2D::zero(), layout_size);
-        builder.push_rect(
-            &api::PrimitiveInfo::with_clip(
-                rect,
-                api::LocalClip::RoundedRect(rect, api::ComplexClipRegion::new(
-                    rect, api::BorderRadius::uniform(20.), api::ClipMode::Clip,
-                ))
-            ),
-            self.color,
+
+        let region = api::ComplexClipRegion::new(
+            rect,
+            api::BorderRadius::uniform(20.),
+            api::ClipMode::Clip
         );
+        let clip_id = builder.define_clip(rect, vec![region], None);
+        builder.push_clip_id(clip_id);
+
+        builder.push_rect(&api::PrimitiveInfo::new(rect), self.color);
+
+        builder.pop_clip_id();
 
         let mut transaction = api::Transaction::new();
         transaction.set_display_list(

--- a/webrender/examples/alpha_perf.rs
+++ b/webrender/examples/alpha_perf.rs
@@ -29,10 +29,7 @@ impl Example for App {
         _document_id: DocumentId,
     ) {
         let bounds = (0, 0).to(1920, 1080);
-        let info = LayoutPrimitiveInfo {
-            local_clip: LocalClip::Rect(bounds),
-            .. LayoutPrimitiveInfo::new(bounds)
-        };
+        let info = LayoutPrimitiveInfo::new(bounds);
 
         builder.push_stacking_context(
             &info,

--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -41,20 +41,12 @@ impl Example for App {
     ) {
         // Create a 200x200 stacking context with an animated transform property.
         let bounds = (0, 0).to(200, 200);
-        let complex_clip = ComplexClipRegion {
-            rect: bounds,
-            radii: BorderRadius::uniform(50.0),
-            mode: ClipMode::Clip,
-        };
-        let info = LayoutPrimitiveInfo {
-            local_clip: LocalClip::RoundedRect(bounds, complex_clip),
-            .. LayoutPrimitiveInfo::new(bounds)
-        };
 
         let filters = vec![
             FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key), self.opacity),
         ];
 
+        let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
             ScrollPolicy::Scrollable,
@@ -65,8 +57,18 @@ impl Example for App {
             filters,
         );
 
+        let complex_clip = ComplexClipRegion {
+            rect: bounds,
+            radii: BorderRadius::uniform(50.0),
+            mode: ClipMode::Clip,
+        };
+        let clip_id = builder.define_clip(bounds, vec![complex_clip], None);
+        builder.push_clip_id(clip_id);
+
         // Fill it with a white rect
         builder.push_rect(&info, ColorF::new(0.0, 1.0, 0.0, 1.0));
+
+        builder.pop_clip_id();
 
         builder.pop_stacking_context();
     }

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -421,32 +421,11 @@ impl From<LayerRect> for Geometry {
     }
 }
 
-pub trait Contains {
-    fn contains(&self, point: &LayoutPoint) -> bool;
-}
-
-impl Contains for LocalClip {
-    fn contains(&self, point: &LayoutPoint) -> bool {
-        if !self.clip_rect().contains(point) {
-            return false;
-        }
-        match self {
-            &LocalClip::Rect(..) => true,
-            &LocalClip::RoundedRect(_, complex_clip) => complex_clip.contains(point),
-        }
-    }
-}
-
-impl Contains for ComplexClipRegion {
-    fn contains(&self, point: &LayoutPoint) -> bool {
-        rounded_rectangle_contains_point(point, &self.rect, &self.radii)
-    }
-}
-
-pub fn rounded_rectangle_contains_point(point: &LayoutPoint,
-                                        rect: &LayerRect,
-                                        radii: &BorderRadius)
-                                        -> bool {
+pub fn rounded_rectangle_contains_point(
+    point: &LayoutPoint,
+    rect: &LayerRect,
+    radii: &BorderRadius
+) -> bool {
     if !rect.contains(point) {
         return false;
     }

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{BorderRadius, ClipMode, HitTestFlags, HitTestItem, HitTestResult, ItemTag, LayerPoint};
-use api::{LayerPrimitiveInfo, LayerRect, LocalClip, PipelineId, WorldPoint};
-use clip::{ClipSource, ClipStore, Contains, rounded_rectangle_contains_point};
+use api::{LayerPrimitiveInfo, LayerRect, PipelineId, WorldPoint};
+use clip::{ClipSource, ClipStore, rounded_rectangle_contains_point};
 use clip_scroll_node::{ClipScrollNode, NodeType};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
 use internal_types::FastHashMap;
@@ -55,7 +55,7 @@ impl HitTestClipChainDescriptor {
 #[derive(Clone)]
 pub struct HitTestingItem {
     rect: LayerRect,
-    clip: LocalClip,
+    clip_rect: LayerRect,
     tag: ItemTag,
 }
 
@@ -63,7 +63,7 @@ impl HitTestingItem {
     pub fn new(tag: ItemTag, info: &LayerPrimitiveInfo) -> HitTestingItem {
         HitTestingItem {
             rect: info.rect,
-            clip: info.local_clip,
+            clip_rect: info.clip_rect,
             tag: tag,
         }
     }
@@ -239,7 +239,8 @@ impl HitTester {
 
             let mut clipped_in = false;
             for item in items.iter().rev() {
-                if !item.rect.contains(&point_in_layer) || !item.clip.contains(&point_in_layer) {
+                if !item.rect.contains(&point_in_layer) ||
+                    !item.clip_rect.contains(&point_in_layer) {
                     continue;
                 }
 

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -64,7 +64,7 @@ pub type DisplayItem = GenericDisplayItem<SpecificDisplayItem>;
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PrimitiveInfo<T> {
     pub rect: TypedRect<f32, T>,
-    pub local_clip: LocalClip,
+    pub clip_rect: TypedRect<f32, T>,
     pub is_backface_visible: bool,
     pub tag: Option<ItemTag>,
 }
@@ -78,13 +78,9 @@ impl LayerPrimitiveInfo {
         rect: TypedRect<f32, LayerPixel>,
         clip_rect: TypedRect<f32, LayerPixel>,
     ) -> Self {
-        Self::with_clip(rect, LocalClip::from(clip_rect))
-    }
-
-    pub fn with_clip(rect: TypedRect<f32, LayerPixel>, clip: LocalClip) -> Self {
         PrimitiveInfo {
-            rect: rect,
-            local_clip: clip,
+            rect,
+            clip_rect,
             is_backface_visible: true,
             tag: None,
         }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -19,8 +19,8 @@ use {ColorF, ComplexClipRegion, DisplayItem, ExtendMode, ExternalScrollId, Filte
 use {FontInstanceKey, GlyphInstance, GlyphOptions, Gradient, GradientDisplayItem, GradientStop};
 use {IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering, LayerPrimitiveInfo};
 use {LayoutPoint, LayoutPrimitiveInfo, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
-use {LineDisplayItem, LineOrientation, LineStyle, LocalClip, MixBlendMode, PipelineId};
-use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
+use {LineDisplayItem, LineOrientation, LineStyle, MixBlendMode, PipelineId, PropertyBinding};
+use {PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
 use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity, Shadow};
 use {SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, StickyOffsetBounds};
 use {TextDisplayItem, TransformStyle, YuvColorSpace, YuvData, YuvImageDisplayItem};
@@ -336,14 +336,14 @@ impl<'a, 'b> DisplayItemRef<'a, 'b> {
         let info = self.iter.cur_item.info;
         LayerPrimitiveInfo {
             rect: info.rect.translate(&offset),
-            local_clip: info.local_clip.create_with_offset(offset),
+            clip_rect: info.clip_rect.translate(&offset),
             is_backface_visible: info.is_backface_visible,
             tag: info.tag,
         }
     }
 
-    pub fn local_clip(&self) -> &LocalClip {
-        &self.iter.cur_item.info.local_clip
+    pub fn clip_rect(&self) -> &LayoutRect {
+        &self.iter.cur_item.info.clip_rect
     }
 
     pub fn clip_and_scroll(&self) -> ClipAndScrollInfo {

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -602,13 +602,6 @@ impl<'a> RawtestHarness<'a> {
             )
         };
 
-        // Add a rounded 100x100 rectangle at 200,0.
-        let rect = LayoutRect::new(LayoutPoint::new(200., 0.), LayoutSize::new(100., 100.));
-        let mut info = LayoutPrimitiveInfo::with_clip(
-            rect, LocalClip::RoundedRect(rect, make_rounded_complex_clip(&rect, 20.)));
-        info.tag = Some((0, 3));
-        builder.push_rect(&info, ColorF::new(1.0, 1.0, 1.0, 1.0));
-
 
         // Add a rectangle that is clipped by a rounded rect clip item.
         let rect = LayoutRect::new(LayoutPoint::new(100., 100.), LayoutSize::new(100., 100.));
@@ -687,7 +680,6 @@ impl<'a> RawtestHarness<'a> {
             assert_hit_test(bottom_right, vec![(0, 1)]);
         };
 
-        test_rounded_rectangle(WorldPoint::new(200., 0.), WorldSize::new(100., 100.), (0, 3));
         test_rounded_rectangle(WorldPoint::new(100., 100.), WorldSize::new(100., 100.), (0, 4));
         test_rounded_rectangle(WorldPoint::new(200., 100.), WorldSize::new(100., 100.), (0, 5));
     }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -665,10 +665,7 @@ impl YamlFrameWriter {
             let mut v = new_table();
             rect_node(&mut v, "bounds", &base.rect());
 
-            rect_node(&mut v, "clip-rect", base.local_clip().clip_rect());
-            if let &LocalClip::RoundedRect(_, ref region) = base.local_clip() {
-                yaml_node(&mut v, "complex-clip", self.make_complex_clip_node(region));
-            }
+            rect_node(&mut v, "clip-rect", base.clip_rect());
 
             let clip_and_scroll_yaml = match clip_id_mapper.map_info(&base.clip_and_scroll()) {
                 (scroll_id, Some(clip_id)) => {
@@ -1034,7 +1031,7 @@ impl YamlFrameWriter {
                     str_node(&mut v, "type", "scroll-frame");
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.scroll_frame_id));
                     size_node(&mut v, "content-size", &base.rect().size);
-                    rect_node(&mut v, "bounds", &base.local_clip().clip_rect());
+                    rect_node(&mut v, "bounds", &base.clip_rect());
 
                     let (complex_clips, complex_clip_count) = base.complex_clip();
                     if let Some(complex) = self.make_complex_clips_node(
@@ -1052,7 +1049,7 @@ impl YamlFrameWriter {
                 StickyFrame(item) => {
                     str_node(&mut v, "type", "sticky-frame");
                     usize_node(&mut v, "id", clip_id_mapper.add_id(item.id));
-                    rect_node(&mut v, "bounds", &base.local_clip().clip_rect());
+                    rect_node(&mut v, "bounds", &base.clip_rect());
 
                     if let Some(margin) = item.margins.top {
                         f32_node(&mut v, "margin-top", margin);


### PR DESCRIPTION
This is part of an API simplification which should hopefully lead to
less code complexity in the future.

Fixes #1742.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2512)
<!-- Reviewable:end -->
