### PR TITLE
delete platform fonts, font instances, and cached glyphs in ResourceCache::clear_namespace

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -392,6 +392,8 @@ impl ResourceCache {
     pub fn delete_font_template(&mut self, font_key: FontKey) {
         self.glyph_rasterizer.delete_font(font_key);
         self.resources.font_templates.remove(&font_key);
+        self.cached_glyphs
+            .clear_fonts(|font| font.font_key == font_key);
         if let Some(ref mut r) = self.blob_image_renderer {
             r.delete_font(font_key);
         }
@@ -956,13 +958,19 @@ impl ResourceCache {
             .image_templates
             .images
             .retain(|key, _| key.0 != namespace);
+        self.cached_images
+            .clear_keys(|request| request.key.0 == namespace);
 
+        self.resources.font_instances
+            .write()
+            .unwrap()
+            .retain(|key, _| key.0 == namespace);
+        for &key in self.resources.font_templates.keys().filter(|key| key.0 == namespace) {
+            self.glyph_rasterizer.delete_font(key);
+        }
         self.resources
             .font_templates
             .retain(|key, _| key.0 != namespace);
-
-        self.cached_images
-            .clear_keys(|request| request.key.0 == namespace);
         self.cached_glyphs
             .clear_fonts(|font| font.font_key.0 == namespace);
     }


### PR DESCRIPTION
In Gecko, when a tab is destroyed, we rely on clear_namespace() to tear down all fonts for that tab, as opposed to individually calling delete_font_template() for every available font from the Gecko side. However, clear_namespace() has a bug in that unlike delete_font_template() it doesn't ensure glyph_rasterizer.delete_font() is called, nor does it clear out font_instances (which corresponds to Gecko ScaledFonts). This fixes that, in addition to a related problem in delete_font_template() where cached_glyphs wasn't getting cleared out either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2516)
<!-- Reviewable:end -->
