### PR TITLE
Refactor the way picture and brush primitives are stored.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -19,7 +19,7 @@ use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{ContentOrigin, PictureCompositeMode, PictureKind, PicturePrimitive};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{CachedGradient, ImageSource, PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
-use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PrimitiveRun};
+use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PictureIndex, PrimitiveRun};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind, RenderTaskTree};
 use renderer::{BlendMode, ImageBufferKind};
 use renderer::BLOCKS_PER_UV_RECT;
@@ -518,7 +518,8 @@ impl AlphaBatchBuilder {
                 BatchTextures::no_texture(),
             );
             let pic_metadata = &ctx.prim_store.cpu_metadata[prim_index.0];
-            let pic = &ctx.prim_store.cpu_pictures[pic_metadata.cpu_prim_index.0];
+            let brush = &ctx.prim_store.cpu_brushes[pic_metadata.cpu_prim_index.0];
+            let pic = &ctx.prim_store.pictures[brush.get_picture_index().0];
             let batch = self.batch_list.get_suitable_batch(key, &pic_metadata.screen_rect.as_ref().expect("bug").clipped);
 
             let render_task_id = pic.surface.expect("BUG: unexpected surface in splitting");
@@ -671,30 +672,365 @@ impl AlphaBatchBuilder {
         match prim_metadata.prim_kind {
             PrimitiveKind::Brush => {
                 let brush = &ctx.prim_store.cpu_brushes[prim_metadata.cpu_prim_index.0];
-                if let Some((batch_kind, textures, user_data)) = brush.get_batch_params(
-                    ctx.resource_cache,
-                    gpu_cache,
-                    deferred_resolves,
-                    &ctx.cached_gradients,
-                ) {
-                    self.add_brush_to_batch(
-                        brush,
-                        prim_metadata,
-                        batch_kind,
-                        specified_blend_mode,
-                        non_segmented_blend_mode,
-                        textures,
-                        clip_chain_rect_index,
-                        clip_task_address,
-                        &task_relative_bounding_rect,
-                        prim_cache_address,
-                        scroll_id,
-                        task_address,
-                        transform_kind,
-                        z,
-                        render_tasks,
-                        user_data,
-                    );
+
+                match brush.kind {
+                    BrushKind::Picture { pic_index } => {
+                        let picture =
+                            &ctx.prim_store.pictures[pic_index.0];
+
+                        match picture.surface {
+                            Some(cache_task_id) => {
+                                let cache_task_address = render_tasks.get_task_address(cache_task_id);
+                                let textures = BatchTextures::render_target_cache();
+
+                                match picture.kind {
+                                    PictureKind::TextShadow { .. } => {
+                                        let kind = BatchKind::Brush(
+                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
+                                        );
+                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+
+                                        let uv_rect_address = render_tasks[cache_task_id]
+                                            .get_texture_handle()
+                                            .as_int(gpu_cache);
+
+                                        let instance = BrushInstance {
+                                            picture_address: task_address,
+                                            prim_address: prim_cache_address,
+                                            clip_chain_rect_index,
+                                            scroll_id,
+                                            clip_task_address,
+                                            z,
+                                            segment_index: 0,
+                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                            brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
+                                            user_data: [
+                                                uv_rect_address,
+                                                BrushImageSourceKind::Color as i32,
+                                                RasterizationSpace::Local as i32,
+                                            ],
+                                        };
+                                        batch.push(PrimitiveInstance::from(instance));
+                                    }
+                                    PictureKind::Image {
+                                        composite_mode,
+                                        secondary_render_task_id,
+                                        is_in_3d_context,
+                                        reference_frame_index,
+                                        real_local_rect,
+                                        ref extra_gpu_data_handle,
+                                        ..
+                                    } => {
+                                        // If this picture is participating in a 3D rendering context,
+                                        // then don't add it to any batches here. Instead, create a polygon
+                                        // for it and add it to the current plane splitter.
+                                        if is_in_3d_context {
+                                            // Push into parent plane splitter.
+
+                                            let real_xf = &ctx.clip_scroll_tree
+                                                .nodes[reference_frame_index.0]
+                                                .world_content_transform
+                                                .into();
+                                            let polygon = make_polygon(
+                                                real_local_rect,
+                                                &real_xf,
+                                                prim_index.0,
+                                            );
+
+                                            splitter.add(polygon);
+
+                                            return;
+                                        }
+
+                                        // Depending on the composite mode of the picture, we generate the
+                                        // old style Composite primitive instances. In the future, we'll
+                                        // remove these and pass them through the brush batching pipeline.
+                                        // This will allow us to unify some of the shaders, apply clip masks
+                                        // when compositing pictures, and also correctly apply pixel snapping
+                                        // to picture compositing operations.
+                                        let source_id = cache_task_id;
+
+                                        match composite_mode.expect("bug: only composites here") {
+                                            PictureCompositeMode::Filter(filter) => {
+                                                match filter {
+                                                    FilterOp::Blur(..) => {
+                                                        let kind = BatchKind::Brush(
+                                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
+                                                        );
+                                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+
+                                                        let uv_rect_address = render_tasks[cache_task_id]
+                                                            .get_texture_handle()
+                                                            .as_int(gpu_cache);
+
+                                                        let instance = BrushInstance {
+                                                            picture_address: task_address,
+                                                            prim_address: prim_cache_address,
+                                                            clip_chain_rect_index,
+                                                            scroll_id,
+                                                            clip_task_address,
+                                                            z,
+                                                            segment_index: 0,
+                                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                                            brush_flags: BrushFlags::empty(),
+                                                            user_data: [
+                                                                uv_rect_address,
+                                                                BrushImageSourceKind::Color as i32,
+                                                                RasterizationSpace::Screen as i32,
+                                                            ],
+                                                        };
+                                                        batch.push(PrimitiveInstance::from(instance));
+                                                    }
+                                                    FilterOp::DropShadow(offset, _, _) => {
+                                                        let kind = BatchKind::Brush(
+                                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray),
+                                                        );
+                                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+
+                                                        let uv_rect_address = render_tasks[cache_task_id]
+                                                            .get_texture_handle()
+                                                            .as_int(gpu_cache);
+
+                                                        let instance = BrushInstance {
+                                                            picture_address: task_address,
+                                                            prim_address: prim_cache_address,
+                                                            clip_chain_rect_index,
+                                                            scroll_id,
+                                                            clip_task_address,
+                                                            z,
+                                                            segment_index: 0,
+                                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                                            brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
+                                                            user_data: [
+                                                                uv_rect_address,
+                                                                BrushImageSourceKind::ColorAlphaMask as i32,
+                                                                // TODO(gw): This is totally wrong, but the drop-shadow code itself
+                                                                //           is completely wrong, and doesn't work correctly with
+                                                                //           transformed Picture sources. I'm leaving this as is for
+                                                                //           now, and will fix drop-shadows properly, as a follow up.
+                                                                RasterizationSpace::Local as i32,
+                                                            ],
+                                                        };
+
+                                                        {
+                                                            let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                            batch.push(PrimitiveInstance::from(instance));
+                                                        }
+
+                                                        let secondary_id = secondary_render_task_id.expect("no secondary!?");
+                                                        let saved_index = render_tasks[secondary_id].saved_index.expect("no saved index!?");
+                                                        debug_assert_ne!(saved_index, SavedTargetIndex::PENDING);
+                                                        let secondary_task_address = render_tasks.get_task_address(secondary_id);
+                                                        let secondary_textures = BatchTextures {
+                                                            colors: [
+                                                                SourceTexture::RenderTaskCache(saved_index),
+                                                                SourceTexture::Invalid,
+                                                                SourceTexture::Invalid,
+                                                            ],
+                                                        };
+                                                        let key = BatchKey::new(
+                                                            BatchKind::HardwareComposite,
+                                                            BlendMode::PremultipliedAlpha,
+                                                            secondary_textures,
+                                                        );
+                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                        let content_rect = prim_metadata.local_rect.translate(&-offset);
+                                                        let rect =
+                                                            (content_rect * LayerToWorldScale::new(1.0) * ctx.device_pixel_scale).round()
+                                                                                                                                 .to_i32();
+
+                                                        let instance = CompositePrimitiveInstance::new(
+                                                            task_address,
+                                                            secondary_task_address,
+                                                            RenderTaskAddress(0),
+                                                            rect.origin.x,
+                                                            rect.origin.y,
+                                                            z,
+                                                            rect.size.width,
+                                                            rect.size.height,
+                                                        );
+
+                                                        batch.push(PrimitiveInstance::from(instance));
+                                                    }
+                                                    _ => {
+                                                        let key = BatchKey::new(
+                                                            BatchKind::Brush(BrushBatchKind::Blend),
+                                                            BlendMode::PremultipliedAlpha,
+                                                            BatchTextures::render_target_cache(),
+                                                        );
+
+                                                        let filter_mode = match filter {
+                                                            FilterOp::Blur(..) => 0,
+                                                            FilterOp::Contrast(..) => 1,
+                                                            FilterOp::Grayscale(..) => 2,
+                                                            FilterOp::HueRotate(..) => 3,
+                                                            FilterOp::Invert(..) => 4,
+                                                            FilterOp::Saturate(..) => 5,
+                                                            FilterOp::Sepia(..) => 6,
+                                                            FilterOp::Brightness(..) => 7,
+                                                            FilterOp::Opacity(..) => 8,
+                                                            FilterOp::DropShadow(..) => 9,
+                                                            FilterOp::ColorMatrix(..) => 10,
+                                                        };
+
+                                                        let user_data = match filter {
+                                                            FilterOp::Contrast(amount) |
+                                                            FilterOp::Grayscale(amount) |
+                                                            FilterOp::Invert(amount) |
+                                                            FilterOp::Saturate(amount) |
+                                                            FilterOp::Sepia(amount) |
+                                                            FilterOp::Brightness(amount) |
+                                                            FilterOp::Opacity(_, amount) => {
+                                                                (amount * 65536.0) as i32
+                                                            }
+                                                            FilterOp::HueRotate(angle) => {
+                                                                (0.01745329251 * angle * 65536.0) as i32
+                                                            }
+                                                            // Go through different paths
+                                                            FilterOp::Blur(..) |
+                                                            FilterOp::DropShadow(..) => {
+                                                                unreachable!();
+                                                            }
+                                                            FilterOp::ColorMatrix(_) => {
+                                                                extra_gpu_data_handle.as_int(gpu_cache)
+                                                            }
+                                                        };
+
+                                                        let instance = BrushInstance {
+                                                            picture_address: task_address,
+                                                            prim_address: prim_cache_address,
+                                                            clip_chain_rect_index,
+                                                            scroll_id,
+                                                            clip_task_address,
+                                                            z,
+                                                            segment_index: 0,
+                                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                                            brush_flags: BrushFlags::empty(),
+                                                            user_data: [
+                                                                cache_task_address.0 as i32,
+                                                                filter_mode,
+                                                                user_data,
+                                                            ],
+                                                        };
+
+                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                        batch.push(PrimitiveInstance::from(instance));
+                                                    }
+                                                }
+                                            }
+                                            PictureCompositeMode::MixBlend(mode) => {
+                                                let backdrop_id = secondary_render_task_id.expect("no backdrop!?");
+
+                                                let key = BatchKey::new(
+                                                    BatchKind::Brush(
+                                                        BrushBatchKind::MixBlend {
+                                                            task_id,
+                                                            source_id,
+                                                            backdrop_id,
+                                                        },
+                                                    ),
+                                                    BlendMode::PremultipliedAlpha,
+                                                    BatchTextures::no_texture(),
+                                                );
+                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
+                                                let source_task_address = render_tasks.get_task_address(source_id);
+
+                                                let instance = BrushInstance {
+                                                    picture_address: task_address,
+                                                    prim_address: prim_cache_address,
+                                                    clip_chain_rect_index,
+                                                    scroll_id,
+                                                    clip_task_address,
+                                                    z,
+                                                    segment_index: 0,
+                                                    edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::empty(),
+                                                    user_data: [
+                                                        mode as u32 as i32,
+                                                        backdrop_task_address.0 as i32,
+                                                        source_task_address.0 as i32,
+                                                    ],
+                                                };
+
+                                                batch.push(PrimitiveInstance::from(instance));
+                                            }
+                                            PictureCompositeMode::Blit => {
+                                                let kind = BatchKind::Brush(
+                                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
+                                                );
+                                                let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+
+                                                let uv_rect_address = render_tasks[cache_task_id]
+                                                    .get_texture_handle()
+                                                    .as_int(gpu_cache);
+
+                                                let instance = BrushInstance {
+                                                    picture_address: task_address,
+                                                    prim_address: prim_cache_address,
+                                                    clip_chain_rect_index,
+                                                    scroll_id,
+                                                    clip_task_address,
+                                                    z,
+                                                    segment_index: 0,
+                                                    edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::empty(),
+                                                    user_data: [
+                                                        uv_rect_address,
+                                                        BrushImageSourceKind::Color as i32,
+                                                        RasterizationSpace::Screen as i32,
+                                                    ],
+                                                };
+                                                batch.push(PrimitiveInstance::from(instance));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            None => {
+                                // If this picture is being drawn into an existing target (i.e. with
+                                // no composition operation), recurse and add to the current batch list.
+                                self.add_pic_to_batch(
+                                    picture,
+                                    task_id,
+                                    ctx,
+                                    gpu_cache,
+                                    render_tasks,
+                                    deferred_resolves,
+                                );
+                            }
+                        }
+                    }
+                    _ => {
+                        if let Some((batch_kind, textures, user_data)) = brush.get_batch_params(
+                                ctx.resource_cache,
+                                gpu_cache,
+                                deferred_resolves,
+                                &ctx.cached_gradients,
+                        ) {
+                            self.add_brush_to_batch(
+                                brush,
+                                prim_metadata,
+                                batch_kind,
+                                specified_blend_mode,
+                                non_segmented_blend_mode,
+                                textures,
+                                clip_chain_rect_index,
+                                clip_task_address,
+                                &task_relative_bounding_rect,
+                                prim_cache_address,
+                                scroll_id,
+                                task_address,
+                                transform_kind,
+                                z,
+                                render_tasks,
+                                user_data,
+                            );
+                        }
+                    }
                 }
             }
             PrimitiveKind::Border => {
@@ -885,336 +1221,6 @@ impl AlphaBatchBuilder {
                     },
                 );
             }
-            PrimitiveKind::Picture => {
-                let picture =
-                    &ctx.prim_store.cpu_pictures[prim_metadata.cpu_prim_index.0];
-
-                match picture.surface {
-                    Some(cache_task_id) => {
-                        let cache_task_address = render_tasks.get_task_address(cache_task_id);
-                        let textures = BatchTextures::render_target_cache();
-
-                        match picture.kind {
-                            PictureKind::TextShadow { .. } => {
-                                let kind = BatchKind::Brush(
-                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
-                                );
-                                let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-
-                                let uv_rect_address = render_tasks[cache_task_id]
-                                    .get_texture_handle()
-                                    .as_int(gpu_cache);
-
-                                let instance = BrushInstance {
-                                    picture_address: task_address,
-                                    prim_address: prim_cache_address,
-                                    clip_chain_rect_index,
-                                    scroll_id,
-                                    clip_task_address,
-                                    z,
-                                    segment_index: 0,
-                                    edge_flags: EdgeAaSegmentMask::empty(),
-                                    brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-                                    user_data: [
-                                        uv_rect_address,
-                                        BrushImageSourceKind::Color as i32,
-                                        RasterizationSpace::Local as i32,
-                                    ],
-                                };
-                                batch.push(PrimitiveInstance::from(instance));
-                            }
-                            PictureKind::Image {
-                                composite_mode,
-                                secondary_render_task_id,
-                                is_in_3d_context,
-                                reference_frame_index,
-                                real_local_rect,
-                                ref extra_gpu_data_handle,
-                                ..
-                            } => {
-                                // If this picture is participating in a 3D rendering context,
-                                // then don't add it to any batches here. Instead, create a polygon
-                                // for it and add it to the current plane splitter.
-                                if is_in_3d_context {
-                                    // Push into parent plane splitter.
-
-                                    let real_xf = &ctx.clip_scroll_tree
-                                        .nodes[reference_frame_index.0]
-                                        .world_content_transform
-                                        .into();
-                                    let polygon = make_polygon(
-                                        real_local_rect,
-                                        &real_xf,
-                                        prim_index.0,
-                                    );
-
-                                    splitter.add(polygon);
-
-                                    return;
-                                }
-
-                                // Depending on the composite mode of the picture, we generate the
-                                // old style Composite primitive instances. In the future, we'll
-                                // remove these and pass them through the brush batching pipeline.
-                                // This will allow us to unify some of the shaders, apply clip masks
-                                // when compositing pictures, and also correctly apply pixel snapping
-                                // to picture compositing operations.
-                                let source_id = cache_task_id;
-
-                                match composite_mode.expect("bug: only composites here") {
-                                    PictureCompositeMode::Filter(filter) => {
-                                        match filter {
-                                            FilterOp::Blur(..) => {
-                                                let kind = BatchKind::Brush(
-                                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
-                                                );
-                                                let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-
-                                                let uv_rect_address = render_tasks[cache_task_id]
-                                                    .get_texture_handle()
-                                                    .as_int(gpu_cache);
-
-                                                let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
-                                                    clip_task_address,
-                                                    z,
-                                                    segment_index: 0,
-                                                    edge_flags: EdgeAaSegmentMask::empty(),
-                                                    brush_flags: BrushFlags::empty(),
-                                                    user_data: [
-                                                        uv_rect_address,
-                                                        BrushImageSourceKind::Color as i32,
-                                                        RasterizationSpace::Screen as i32,
-                                                    ],
-                                                };
-                                                batch.push(PrimitiveInstance::from(instance));
-                                            }
-                                            FilterOp::DropShadow(offset, _, _) => {
-                                                let kind = BatchKind::Brush(
-                                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray),
-                                                );
-                                                let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-
-                                                let uv_rect_address = render_tasks[cache_task_id]
-                                                    .get_texture_handle()
-                                                    .as_int(gpu_cache);
-
-                                                let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
-                                                    clip_task_address,
-                                                    z,
-                                                    segment_index: 0,
-                                                    edge_flags: EdgeAaSegmentMask::empty(),
-                                                    brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-                                                    user_data: [
-                                                        uv_rect_address,
-                                                        BrushImageSourceKind::ColorAlphaMask as i32,
-                                                        // TODO(gw): This is totally wrong, but the drop-shadow code itself
-                                                        //           is completely wrong, and doesn't work correctly with
-                                                        //           transformed Picture sources. I'm leaving this as is for
-                                                        //           now, and will fix drop-shadows properly, as a follow up.
-                                                        RasterizationSpace::Local as i32,
-                                                    ],
-                                                };
-
-                                                {
-                                                    let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                    batch.push(PrimitiveInstance::from(instance));
-                                                }
-
-                                                let secondary_id = secondary_render_task_id.expect("no secondary!?");
-                                                let saved_index = render_tasks[secondary_id].saved_index.expect("no saved index!?");
-                                                debug_assert_ne!(saved_index, SavedTargetIndex::PENDING);
-                                                let secondary_task_address = render_tasks.get_task_address(secondary_id);
-                                                let secondary_textures = BatchTextures {
-                                                    colors: [
-                                                        SourceTexture::RenderTaskCache(saved_index),
-                                                        SourceTexture::Invalid,
-                                                        SourceTexture::Invalid,
-                                                    ],
-                                                };
-                                                let key = BatchKey::new(
-                                                    BatchKind::HardwareComposite,
-                                                    BlendMode::PremultipliedAlpha,
-                                                    secondary_textures,
-                                                );
-                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                let content_rect = prim_metadata.local_rect.translate(&-offset);
-                                                let rect =
-                                                    (content_rect * LayerToWorldScale::new(1.0) * ctx.device_pixel_scale).round()
-                                                                                                                         .to_i32();
-
-                                                let instance = CompositePrimitiveInstance::new(
-                                                    task_address,
-                                                    secondary_task_address,
-                                                    RenderTaskAddress(0),
-                                                    rect.origin.x,
-                                                    rect.origin.y,
-                                                    z,
-                                                    rect.size.width,
-                                                    rect.size.height,
-                                                );
-
-                                                batch.push(PrimitiveInstance::from(instance));
-                                            }
-                                            _ => {
-                                                let key = BatchKey::new(
-                                                    BatchKind::Brush(BrushBatchKind::Blend),
-                                                    BlendMode::PremultipliedAlpha,
-                                                    BatchTextures::render_target_cache(),
-                                                );
-
-                                                let filter_mode = match filter {
-                                                    FilterOp::Blur(..) => 0,
-                                                    FilterOp::Contrast(..) => 1,
-                                                    FilterOp::Grayscale(..) => 2,
-                                                    FilterOp::HueRotate(..) => 3,
-                                                    FilterOp::Invert(..) => 4,
-                                                    FilterOp::Saturate(..) => 5,
-                                                    FilterOp::Sepia(..) => 6,
-                                                    FilterOp::Brightness(..) => 7,
-                                                    FilterOp::Opacity(..) => 8,
-                                                    FilterOp::DropShadow(..) => 9,
-                                                    FilterOp::ColorMatrix(..) => 10,
-                                                };
-
-                                                let user_data = match filter {
-                                                    FilterOp::Contrast(amount) |
-                                                    FilterOp::Grayscale(amount) |
-                                                    FilterOp::Invert(amount) |
-                                                    FilterOp::Saturate(amount) |
-                                                    FilterOp::Sepia(amount) |
-                                                    FilterOp::Brightness(amount) |
-                                                    FilterOp::Opacity(_, amount) => {
-                                                        (amount * 65536.0) as i32
-                                                    }
-                                                    FilterOp::HueRotate(angle) => {
-                                                        (0.01745329251 * angle * 65536.0) as i32
-                                                    }
-                                                    // Go through different paths
-                                                    FilterOp::Blur(..) |
-                                                    FilterOp::DropShadow(..) => {
-                                                        unreachable!();
-                                                    }
-                                                    FilterOp::ColorMatrix(_) => {
-                                                        extra_gpu_data_handle.as_int(gpu_cache)
-                                                    }
-                                                };
-
-                                                let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
-                                                    clip_task_address,
-                                                    z,
-                                                    segment_index: 0,
-                                                    edge_flags: EdgeAaSegmentMask::empty(),
-                                                    brush_flags: BrushFlags::empty(),
-                                                    user_data: [
-                                                        cache_task_address.0 as i32,
-                                                        filter_mode,
-                                                        user_data,
-                                                    ],
-                                                };
-
-                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                batch.push(PrimitiveInstance::from(instance));
-                                            }
-                                        }
-                                    }
-                                    PictureCompositeMode::MixBlend(mode) => {
-                                        let backdrop_id = secondary_render_task_id.expect("no backdrop!?");
-
-                                        let key = BatchKey::new(
-                                            BatchKind::Brush(
-                                                BrushBatchKind::MixBlend {
-                                                    task_id,
-                                                    source_id,
-                                                    backdrop_id,
-                                                },
-                                            ),
-                                            BlendMode::PremultipliedAlpha,
-                                            BatchTextures::no_texture(),
-                                        );
-                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                        let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
-                                        let source_task_address = render_tasks.get_task_address(source_id);
-
-                                        let instance = BrushInstance {
-                                            picture_address: task_address,
-                                            prim_address: prim_cache_address,
-                                            clip_chain_rect_index,
-                                            scroll_id,
-                                            clip_task_address,
-                                            z,
-                                            segment_index: 0,
-                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                            brush_flags: BrushFlags::empty(),
-                                            user_data: [
-                                                mode as u32 as i32,
-                                                backdrop_task_address.0 as i32,
-                                                source_task_address.0 as i32,
-                                            ],
-                                        };
-
-                                        batch.push(PrimitiveInstance::from(instance));
-                                    }
-                                    PictureCompositeMode::Blit => {
-                                        let kind = BatchKind::Brush(
-                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
-                                        );
-                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-
-                                        let uv_rect_address = render_tasks[cache_task_id]
-                                            .get_texture_handle()
-                                            .as_int(gpu_cache);
-
-                                        let instance = BrushInstance {
-                                            picture_address: task_address,
-                                            prim_address: prim_cache_address,
-                                            clip_chain_rect_index,
-                                            scroll_id,
-                                            clip_task_address,
-                                            z,
-                                            segment_index: 0,
-                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                            brush_flags: BrushFlags::empty(),
-                                            user_data: [
-                                                uv_rect_address,
-                                                BrushImageSourceKind::Color as i32,
-                                                RasterizationSpace::Screen as i32,
-                                            ],
-                                        };
-                                        batch.push(PrimitiveInstance::from(instance));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    None => {
-                        // If this picture is being drawn into an existing target (i.e. with
-                        // no composition operation), recurse and add to the current batch list.
-                        self.add_pic_to_batch(
-                            picture,
-                            task_id,
-                            ctx,
-                            gpu_cache,
-                            render_tasks,
-                            deferred_resolves,
-                        );
-                    }
-                }
-            }
         }
     }
 
@@ -1314,6 +1320,17 @@ impl AlphaBatchBuilder {
 }
 
 impl BrushPrimitive {
+    pub fn get_picture_index(&self) -> PictureIndex {
+        match self.kind {
+            BrushKind::Picture { pic_index } => {
+                pic_index
+            }
+            _ => {
+                panic!("bug: not a picture brush!!");
+            }
+        }
+    }
+
     fn get_batch_params(
         &self,
         resource_cache: &ResourceCache,
@@ -1353,7 +1370,7 @@ impl BrushPrimitive {
                     ))
                 }
             }
-            BrushKind::Picture => {
+            BrushKind::Picture { .. } => {
                 panic!("bug: get_batch_key is handled at higher level for pictures");
             }
             BrushKind::Solid { .. } => {
@@ -1463,12 +1480,8 @@ impl AlphaBatchHelpers for PrimitiveStore {
     fn get_blend_mode(&self, metadata: &PrimitiveMetadata) -> BlendMode {
         match metadata.prim_kind {
             // Can only resolve the TextRun's blend mode once glyphs are fetched.
-            PrimitiveKind::TextRun => {
-                BlendMode::PremultipliedAlpha
-            }
-
             PrimitiveKind::Border |
-            PrimitiveKind::Picture => {
+            PrimitiveKind::TextRun => {
                 BlendMode::PremultipliedAlpha
             }
 
@@ -1489,7 +1502,7 @@ impl AlphaBatchHelpers for PrimitiveStore {
                     BrushKind::YuvImage { .. } |
                     BrushKind::RadialGradient { .. } |
                     BrushKind::LinearGradient { .. } |
-                    BrushKind::Picture => {
+                    BrushKind::Picture { .. } => {
                         BlendMode::PremultipliedAlpha
                     }
                 }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -25,10 +25,10 @@ use glyph_rasterizer::FontInstance;
 use hit_test::{HitTestingItem, HitTestingRun};
 use image::{decompose_image, TiledImageInfo};
 use internal_types::{FastHashMap, FastHashSet};
-use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
+use picture::{PictureCompositeMode, PictureKind};
 use prim_store::{BrushKind, BrushPrimitive, BrushSegmentDescriptor, CachedGradient};
 use prim_store::{CachedGradientIndex, ImageCacheKey, ImagePrimitiveCpu, ImageSource};
-use prim_store::{PrimitiveContainer, PrimitiveIndex, PrimitiveKind, PrimitiveStore};
+use prim_store::{PictureIndex, PrimitiveContainer, PrimitiveIndex, PrimitiveKind, PrimitiveStore};
 use prim_store::{ScrollNodeAndClipChain, TextRunPrimitiveCpu};
 use render_backend::{DocumentView};
 use resource_cache::{FontInstanceMap, ImageRequest, TiledImageMap};
@@ -185,7 +185,7 @@ pub struct DisplayListFlattener<'a> {
     sc_stack: Vec<FlattenedStackingContext>,
 
     /// A stack of the current pictures.
-    picture_stack: Vec<PrimitiveIndex>,
+    picture_stack: Vec<PictureIndex>,
 
     /// A list of scrollbar primitives.
     pub scrollbar_prims: Vec<ScrollbarPrimitive>,
@@ -930,15 +930,9 @@ impl<'a> DisplayListFlattener<'a> {
         clip_and_scroll: ScrollNodeAndClipChain,
     ) {
         // Add primitive to the top-most Picture on the stack.
-        // TODO(gw): Let's consider removing the extra indirection
-        //           needed to get a specific primitive index...
-        let pic_prim_index = self.picture_stack.last().unwrap();
-        let metadata = &self.prim_store.cpu_metadata[pic_prim_index.0];
-        let pic = &mut self.prim_store.cpu_pictures[metadata.cpu_prim_index.0];
-        pic.add_primitive(
-            prim_index,
-            clip_and_scroll
-        );
+        let pic_index = self.picture_stack.last().unwrap();
+        let pic = &mut self.prim_store.pictures[pic_index.0];
+        pic.add_primitive(prim_index, clip_and_scroll);
     }
 
     /// Convenience interface that creates a primitive entry and adds it
@@ -981,12 +975,12 @@ impl<'a> DisplayListFlattener<'a> {
         // If there is no root picture, create one for the main framebuffer.
         if self.sc_stack.is_empty() {
             // Should be no pictures at all if the stack is empty...
-            debug_assert!(self.prim_store.cpu_pictures.is_empty());
+            debug_assert!(self.prim_store.pictures.is_empty());
             debug_assert_eq!(transform_style, TransformStyle::Flat);
 
             // This picture stores primitive runs for items on the
             // main framebuffer.
-            let pic = PicturePrimitive::new_image(
+            let pic_index = self.prim_store.add_image_picture(
                 None,
                 false,
                 pipeline_id,
@@ -994,20 +988,7 @@ impl<'a> DisplayListFlattener<'a> {
                 None,
             );
 
-            // Add root picture primitive. The provided layer rect
-            // is zero, because we don't yet know the size of the
-            // picture. Instead, this is calculated recursively
-            // when we cull primitives.
-            let prim_index = self.prim_store.add_primitive(
-                &LayerRect::zero(),
-                &max_clip,
-                true,
-                None,
-                None,
-                PrimitiveContainer::Picture(pic),
-            );
-
-            self.picture_stack.push(prim_index);
+            self.picture_stack.push(pic_index);
         } else if composite_ops.mix_blend_mode.is_some() && self.sc_stack.len() > 2 {
             // If we have a mix-blend-mode, and we aren't the primary framebuffer,
             // the stacking context needs to be isolated to blend correctly as per
@@ -1015,9 +996,8 @@ impl<'a> DisplayListFlattener<'a> {
             // TODO(gw): The way we detect not being the primary framebuffer (len > 2)
             //           is hacky and depends on how we create a root stacking context
             //           during flattening.
-            let current_pic_prim_index = self.picture_stack.last().unwrap();
-            let pic_cpu_prim_index = self.prim_store.cpu_metadata[current_pic_prim_index.0].cpu_prim_index;
-            let parent_pic = &mut self.prim_store.cpu_pictures[pic_cpu_prim_index.0];
+            let parent_pic_index = self.picture_stack.last().unwrap();
+            let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
 
             match parent_pic.kind {
                 PictureKind::Image { ref mut composite_mode, .. } => {
@@ -1058,11 +1038,11 @@ impl<'a> DisplayListFlattener<'a> {
             participating_in_3d_context &&
             parent_transform_style == TransformStyle::Flat;
 
-        let rendering_context_3d_prim_index = if establishes_3d_context {
+        let rendering_context_3d_pic_index = if establishes_3d_context {
             // If establishing a 3d context, we need to add a picture
             // that will be the container for all the planes and any
             // un-transformed content.
-            let container = PicturePrimitive::new_image(
+            let container_index = self.prim_store.add_image_picture(
                 None,
                 false,
                 pipeline_id,
@@ -1070,31 +1050,33 @@ impl<'a> DisplayListFlattener<'a> {
                 None,
             );
 
+            let prim = BrushPrimitive::new_picture(container_index);
+
             let prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
                 &max_clip,
                 is_backface_visible,
                 None,
                 None,
-                PrimitiveContainer::Picture(container),
+                PrimitiveContainer::Brush(prim),
             );
 
-            let parent_pic_prim_index = *self.picture_stack.last().unwrap();
-            let pic_prim_index = self.prim_store.cpu_metadata[parent_pic_prim_index.0].cpu_prim_index;
-            let pic = &mut self.prim_store.cpu_pictures[pic_prim_index.0];
+            let parent_pic_index = *self.picture_stack.last().unwrap();
+
+            let pic = &mut self.prim_store.pictures[parent_pic_index.0];
             pic.add_primitive(
                 prim_index,
                 clip_and_scroll,
             );
 
-            self.picture_stack.push(prim_index);
+            self.picture_stack.push(container_index);
 
-            Some(prim_index)
+            Some(container_index)
         } else {
             None
         };
 
-        let mut parent_pic_prim_index = if !establishes_3d_context && participating_in_3d_context {
+        let mut parent_pic_index = if !establishes_3d_context && participating_in_3d_context {
             // If we're in a 3D context, we will parent the picture
             // to the first stacking context we find that is a
             // 3D rendering context container. This follows the spec
@@ -1103,8 +1085,8 @@ impl<'a> DisplayListFlattener<'a> {
             self.sc_stack
                 .iter()
                 .rev()
-                .find(|sc| sc.rendering_context_3d_prim_index.is_some())
-                .map(|sc| sc.rendering_context_3d_prim_index.unwrap())
+                .find(|sc| sc.rendering_context_3d_pic_index.is_some())
+                .map(|sc| sc.rendering_context_3d_pic_index.unwrap())
                 .unwrap()
         } else {
             *self.picture_stack.last().unwrap()
@@ -1112,7 +1094,7 @@ impl<'a> DisplayListFlattener<'a> {
 
         // For each filter, create a new image with that composite mode.
         for filter in composite_ops.filters.iter().rev() {
-            let src_prim = PicturePrimitive::new_image(
+            let src_pic_index = self.prim_store.add_image_picture(
                 Some(PictureCompositeMode::Filter(*filter)),
                 false,
                 pipeline_id,
@@ -1120,29 +1102,30 @@ impl<'a> DisplayListFlattener<'a> {
                 None,
             );
 
+            let src_prim = BrushPrimitive::new_picture(src_pic_index);
+
             let src_prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
                 &max_clip,
                 is_backface_visible,
                 None,
                 None,
-                PrimitiveContainer::Picture(src_prim),
+                PrimitiveContainer::Brush(src_prim),
             );
 
-            let pic_prim_index = self.prim_store.cpu_metadata[parent_pic_prim_index.0].cpu_prim_index;
-            parent_pic_prim_index = src_prim_index;
-            let pic = &mut self.prim_store.cpu_pictures[pic_prim_index.0];
-            pic.add_primitive(
+            let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
+            parent_pic_index = src_pic_index;
+            parent_pic.add_primitive(
                 src_prim_index,
                 clip_and_scroll,
             );
 
-            self.picture_stack.push(src_prim_index);
+            self.picture_stack.push(src_pic_index);
         }
 
         // Same for mix-blend-mode.
         if let Some(mix_blend_mode) = composite_ops.mix_blend_mode {
-            let src_prim = PicturePrimitive::new_image(
+            let src_pic_index = self.prim_store.add_image_picture(
                 Some(PictureCompositeMode::MixBlend(mix_blend_mode)),
                 false,
                 pipeline_id,
@@ -1150,24 +1133,25 @@ impl<'a> DisplayListFlattener<'a> {
                 None,
             );
 
+            let src_prim = BrushPrimitive::new_picture(src_pic_index);
+
             let src_prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
                 &max_clip,
                 is_backface_visible,
                 None,
                 None,
-                PrimitiveContainer::Picture(src_prim),
+                PrimitiveContainer::Brush(src_prim),
             );
 
-            let pic_prim_index = self.prim_store.cpu_metadata[parent_pic_prim_index.0].cpu_prim_index;
-            parent_pic_prim_index = src_prim_index;
-            let pic = &mut self.prim_store.cpu_pictures[pic_prim_index.0];
-            pic.add_primitive(
+            let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
+            parent_pic_index = src_pic_index;
+            parent_pic.add_primitive(
                 src_prim_index,
                 clip_and_scroll,
             );
 
-            self.picture_stack.push(src_prim_index);
+            self.picture_stack.push(src_pic_index);
         }
 
         // By default, this picture will be collapsed into
@@ -1194,7 +1178,7 @@ impl<'a> DisplayListFlattener<'a> {
         }
 
         // Add picture for this actual stacking context contents to render into.
-        let sc_prim = PicturePrimitive::new_image(
+        let pic_index = self.prim_store.add_image_picture(
             composite_mode,
             participating_in_3d_context,
             pipeline_id,
@@ -1202,24 +1186,24 @@ impl<'a> DisplayListFlattener<'a> {
             frame_output_pipeline_id,
         );
 
+        // Create a brush primitive that draws this picture.
+        let sc_prim = BrushPrimitive::new_picture(pic_index);
+
+        // Add the brush to the parent picture.
         let sc_prim_index = self.prim_store.add_primitive(
             &LayerRect::zero(),
             &max_clip,
             is_backface_visible,
             None,
             None,
-            PrimitiveContainer::Picture(sc_prim),
+            PrimitiveContainer::Brush(sc_prim),
         );
 
-        let pic_prim_index = self.prim_store.cpu_metadata[parent_pic_prim_index.0].cpu_prim_index;
-        let sc_pic = &mut self.prim_store.cpu_pictures[pic_prim_index.0];
-        sc_pic.add_primitive(
-            sc_prim_index,
-            clip_and_scroll,
-        );
+        let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
+        parent_pic.add_primitive(sc_prim_index, clip_and_scroll);
 
         // Add this as the top-most picture for primitives to be added to.
-        self.picture_stack.push(sc_prim_index);
+        self.picture_stack.push(pic_index);
 
         // TODO(gw): This is super conservative. We can expand on this a lot
         //           once all the picture code is in place and landed.
@@ -1234,7 +1218,7 @@ impl<'a> DisplayListFlattener<'a> {
             pipeline_id,
             allow_subpixel_aa,
             transform_style,
-            rendering_context_3d_prim_index,
+            rendering_context_3d_pic_index,
         };
 
         self.sc_stack.push(sc);
@@ -1250,7 +1234,7 @@ impl<'a> DisplayListFlattener<'a> {
         pop_count += sc.composite_ops.count();
 
         // Remove the 3d context container if created
-        if sc.rendering_context_3d_prim_index.is_some() {
+        if sc.rendering_context_3d_pic_index.is_some() {
             pop_count += 1;
         }
 
@@ -1410,7 +1394,9 @@ impl<'a> DisplayListFlattener<'a> {
         info: &LayerPrimitiveInfo,
     ) {
         let pipeline_id = self.sc_stack.last().unwrap().pipeline_id;
-        let prim = PicturePrimitive::new_text_shadow(shadow, pipeline_id);
+        let pic_index = self.prim_store.add_shadow_picture(shadow, pipeline_id);
+
+        let prim = BrushPrimitive::new_picture(pic_index);
 
         // Create an empty shadow primitive. Insert it into
         // the draw lists immediately so that it will be drawn
@@ -1419,7 +1405,7 @@ impl<'a> DisplayListFlattener<'a> {
         let prim_index = self.create_primitive(
             info,
             Vec::new(),
-            PrimitiveContainer::Picture(prim),
+            PrimitiveContainer::Brush(prim),
         );
 
         let pending = vec![(prim_index, clip_and_scroll)];
@@ -1549,7 +1535,8 @@ impl<'a> DisplayListFlattener<'a> {
         let mut fast_shadow_prims = Vec::new();
         for (idx, &(shadow_prim_index, _)) in self.shadow_prim_stack.iter().enumerate() {
             let shadow_metadata = &self.prim_store.cpu_metadata[shadow_prim_index.0];
-            let picture = &self.prim_store.cpu_pictures[shadow_metadata.cpu_prim_index.0];
+            let brush = &self.prim_store.cpu_brushes[shadow_metadata.cpu_prim_index.0];
+            let picture = &self.prim_store.pictures[brush.get_picture_index().0];
             match picture.kind {
                 PictureKind::TextShadow { offset, color, blur_radius, .. } if blur_radius == 0.0 => {
                     fast_shadow_prims.push((idx, offset, color));
@@ -1597,9 +1584,9 @@ impl<'a> DisplayListFlattener<'a> {
 
         for &(shadow_prim_index, _) in &self.shadow_prim_stack {
             let shadow_metadata = &mut self.prim_store.cpu_metadata[shadow_prim_index.0];
-            debug_assert_eq!(shadow_metadata.prim_kind, PrimitiveKind::Picture);
-            let picture =
-                &mut self.prim_store.cpu_pictures[shadow_metadata.cpu_prim_index.0];
+            debug_assert_eq!(shadow_metadata.prim_kind, PrimitiveKind::Brush);
+            let brush = &self.prim_store.cpu_brushes[shadow_metadata.cpu_prim_index.0];
+            let picture = &mut self.prim_store.pictures[brush.get_picture_index().0];
 
             match picture.kind {
                 // Only run real blurs here (fast path zero blurs are handled above).
@@ -2147,7 +2134,8 @@ impl<'a> DisplayListFlattener<'a> {
         let mut fast_shadow_prims = Vec::new();
         for (idx, &(shadow_prim_index, _)) in self.shadow_prim_stack.iter().enumerate() {
             let shadow_metadata = &self.prim_store.cpu_metadata[shadow_prim_index.0];
-            let picture_prim = &self.prim_store.cpu_pictures[shadow_metadata.cpu_prim_index.0];
+            let brush = &self.prim_store.cpu_brushes[shadow_metadata.cpu_prim_index.0];
+            let picture_prim = &self.prim_store.pictures[brush.get_picture_index().0];
             match picture_prim.kind {
                 PictureKind::TextShadow { offset, color, blur_radius, .. } if blur_radius == 0.0 => {
                     let mut text_prim = prim.clone();
@@ -2201,9 +2189,9 @@ impl<'a> DisplayListFlattener<'a> {
         // the indices as sub-primitives to the shadow primitives.
         for &(shadow_prim_index, _) in &self.shadow_prim_stack {
             let shadow_metadata = &mut self.prim_store.cpu_metadata[shadow_prim_index.0];
-            debug_assert_eq!(shadow_metadata.prim_kind, PrimitiveKind::Picture);
-            let picture =
-                &mut self.prim_store.cpu_pictures[shadow_metadata.cpu_prim_index.0];
+            debug_assert_eq!(shadow_metadata.prim_kind, PrimitiveKind::Brush);
+            let brush = &self.prim_store.cpu_brushes[shadow_metadata.cpu_prim_index.0];
+            let picture = &mut self.prim_store.pictures[brush.get_picture_index().0];
 
             match picture.kind {
                 // Only run real blurs here (fast path zero blurs are handled above).
@@ -2443,9 +2431,9 @@ struct FlattenedStackingContext {
     transform_style: TransformStyle,
 
     /// If Some(..), this stacking context establishes a new
-    /// 3d rendering context, and the value is the primitive
+    /// 3d rendering context, and the value is the picture
     // index of the 3d context container.
-    rendering_context_3d_prim_index: Option<PrimitiveIndex>,
+    rendering_context_3d_pic_index: Option<PictureIndex>,
 }
 
 #[derive(Debug)]

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -168,7 +168,7 @@ impl FrameBuilder {
     ) -> Option<RenderTaskId> {
         profile_scope!("cull");
 
-        if self.prim_store.cpu_pictures.is_empty() {
+        if self.prim_store.pictures.is_empty() {
             return None
         }
 
@@ -203,7 +203,7 @@ impl FrameBuilder {
         let pic_context = PictureContext {
             pipeline_id: root_clip_scroll_node.pipeline_id,
             perform_culling: true,
-            prim_runs: mem::replace(&mut self.prim_store.cpu_pictures[0].runs, Vec::new()),
+            prim_runs: mem::replace(&mut self.prim_store.pictures[0].runs, Vec::new()),
             original_reference_frame_index: None,
             display_list,
             draw_text_transformed: true,
@@ -220,7 +220,7 @@ impl FrameBuilder {
             &mut frame_state,
         );
 
-        let pic = &mut self.prim_store.cpu_pictures[0];
+        let pic = &mut self.prim_store.pictures[0];
         pic.runs = pic_context.prim_runs;
 
         let root_render_task = RenderTask::new_picture(
@@ -298,7 +298,7 @@ impl FrameBuilder {
 
         let mut node_data = Vec::with_capacity(clip_scroll_tree.nodes.len());
         let total_prim_runs =
-            self.prim_store.cpu_pictures.iter().fold(1, |count, ref pic| count + pic.runs.len());
+            self.prim_store.pictures.iter().fold(1, |count, ref pic| count + pic.runs.len());
         let mut clip_chain_local_clip_rects = Vec::with_capacity(total_prim_runs);
         clip_chain_local_clip_rects.push(LayerRect::max_rect());
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -11,7 +11,7 @@ use clip_scroll_tree::ClipScrollNodeIndex;
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState};
 use gpu_cache::{GpuCacheHandle, GpuDataRequest};
 use gpu_types::{PictureType};
-use prim_store::{BrushKind, BrushPrimitive, PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
+use prim_store::{PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
 use prim_store::{PrimitiveMetadata, ScrollNodeAndClipChain};
 use render_task::{ClearMode, RenderTask};
 use render_task::{RenderTaskId, RenderTaskLocation, to_cache_size};
@@ -110,15 +110,6 @@ pub struct PicturePrimitive {
     // picture. For text shadows and box shadows, we want to
     // unconditionally draw them.
     pub cull_children: bool,
-
-    // The brush primitive that will be used to draw this
-    // picture.
-    // TODO(gw): Having a brush primitive embedded here
-    //           makes the code complex in a few places.
-    //           Consider a better way to structure this.
-    //           Maybe embed the PicturePrimitive inside
-    //           the BrushKind enum instead?
-    pub brush: BrushPrimitive,
 }
 
 impl PicturePrimitive {
@@ -134,10 +125,6 @@ impl PicturePrimitive {
             },
             pipeline_id,
             cull_children: false,
-            brush: BrushPrimitive::new(
-                BrushKind::Picture,
-                None,
-            ),
         }
     }
 
@@ -184,10 +171,6 @@ impl PicturePrimitive {
             },
             pipeline_id,
             cull_children: true,
-            brush: BrushPrimitive::new(
-                BrushKind::Picture,
-                None,
-            ),
         }
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -6,7 +6,7 @@ use api::{AlphaType, BorderRadius, BoxShadowClipMode, BuiltDisplayList, ClipMode
 use api::{DeviceIntRect, DeviceIntSize, DevicePixelScale, Epoch, ExtendMode, FontRenderMode};
 use api::{GlyphInstance, GlyphKey, GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag};
 use api::{LayerPoint, LayerRect, LayerSize, LayerToWorldTransform, LayerVector2D, LineOrientation};
-use api::{LineStyle, PremultipliedColorF, YuvColorSpace, YuvFormat};
+use api::{LineStyle, PipelineId, PremultipliedColorF, Shadow, YuvColorSpace, YuvFormat};
 use border::{BorderCornerInstance, BorderEdgeKind};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, CoordinateSystemId};
 use clip_scroll_node::ClipScrollNode;
@@ -18,7 +18,7 @@ use glyph_rasterizer::{FontInstance, FontTransform};
 use gpu_cache::{GpuBlockData, GpuCache, GpuCacheAddress, GpuCacheHandle, GpuDataRequest,
                 ToGpuBlocks};
 use gpu_types::{ClipChainRectIndex};
-use picture::{PictureKind, PicturePrimitive};
+use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
 use render_task::{BlitSource, RenderTask, RenderTaskCacheKey, RenderTaskCacheKeyKind};
 use render_task::RenderTaskId;
 use renderer::{MAX_VERTEX_TEXTURE_WIDTH};
@@ -134,12 +134,16 @@ pub struct SpecificPrimitiveIndex(pub usize);
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PrimitiveIndex(pub usize);
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct PictureIndex(pub usize);
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum PrimitiveKind {
     TextRun,
     Image,
     Border,
-    Picture,
     Brush,
 }
 
@@ -200,7 +204,9 @@ pub enum BrushKind {
         style: LineStyle,
         orientation: LineOrientation,
     },
-    Picture,
+    Picture {
+        pic_index: PictureIndex,
+    },
     Image {
         request: ImageRequest,
         current_epoch: Epoch,
@@ -237,7 +243,7 @@ impl BrushKind {
     fn supports_segments(&self) -> bool {
         match *self {
             BrushKind::Solid { .. } |
-            BrushKind::Picture |
+            BrushKind::Picture { .. } |
             BrushKind::Image { .. } |
             BrushKind::YuvImage { .. } |
             BrushKind::RadialGradient { .. } |
@@ -318,10 +324,25 @@ impl BrushPrimitive {
         }
     }
 
-    fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
+    pub fn new_picture(pic_index: PictureIndex) -> BrushPrimitive {
+        BrushPrimitive {
+            kind: BrushKind::Picture {
+                pic_index,
+            },
+            segment_desc: None,
+        }
+    }
+
+    fn write_gpu_blocks(
+        &self,
+        request: &mut GpuDataRequest,
+        pictures: &[PicturePrimitive],
+    ) {
         // has to match VECS_PER_SPECIFIC_BRUSH
         match self.kind {
-            BrushKind::Picture |
+            BrushKind::Picture { pic_index } => {
+                pictures[pic_index.0].write_gpu_blocks(request);
+            }
             BrushKind::YuvImage { .. } => {
             }
             BrushKind::Image { .. } => {
@@ -895,7 +916,6 @@ pub enum PrimitiveContainer {
     TextRun(TextRunPrimitiveCpu),
     Image(ImagePrimitiveCpu),
     Border(BorderPrimitiveCpu),
-    Picture(PicturePrimitive),
     Brush(BrushPrimitive),
 }
 
@@ -903,10 +923,11 @@ pub struct PrimitiveStore {
     /// CPU side information only.
     pub cpu_brushes: Vec<BrushPrimitive>,
     pub cpu_text_runs: Vec<TextRunPrimitiveCpu>,
-    pub cpu_pictures: Vec<PicturePrimitive>,
     pub cpu_images: Vec<ImagePrimitiveCpu>,
     pub cpu_metadata: Vec<PrimitiveMetadata>,
     pub cpu_borders: Vec<BorderPrimitiveCpu>,
+
+    pub pictures: Vec<PicturePrimitive>,
 }
 
 impl PrimitiveStore {
@@ -915,9 +936,10 @@ impl PrimitiveStore {
             cpu_metadata: Vec::new(),
             cpu_brushes: Vec::new(),
             cpu_text_runs: Vec::new(),
-            cpu_pictures: Vec::new(),
             cpu_images: Vec::new(),
             cpu_borders: Vec::new(),
+
+            pictures: Vec::new(),
         }
     }
 
@@ -926,10 +948,49 @@ impl PrimitiveStore {
             cpu_metadata: recycle_vec(self.cpu_metadata),
             cpu_brushes: recycle_vec(self.cpu_brushes),
             cpu_text_runs: recycle_vec(self.cpu_text_runs),
-            cpu_pictures: recycle_vec(self.cpu_pictures),
             cpu_images: recycle_vec(self.cpu_images),
             cpu_borders: recycle_vec(self.cpu_borders),
+
+            pictures: recycle_vec(self.pictures),
         }
+    }
+
+    pub fn add_image_picture(
+        &mut self,
+        composite_mode: Option<PictureCompositeMode>,
+        is_in_3d_context: bool,
+        pipeline_id: PipelineId,
+        reference_frame_index: ClipScrollNodeIndex,
+        frame_output_pipeline_id: Option<PipelineId>,
+    ) -> PictureIndex {
+        let pic = PicturePrimitive::new_image(
+            composite_mode,
+            is_in_3d_context,
+            pipeline_id,
+            reference_frame_index,
+            frame_output_pipeline_id,
+        );
+
+        let pic_index = PictureIndex(self.pictures.len());
+        self.pictures.push(pic);
+
+        pic_index
+    }
+
+    pub fn add_shadow_picture(
+        &mut self,
+        shadow: Shadow,
+        pipeline_id: PipelineId,
+    ) -> PictureIndex {
+        let pic = PicturePrimitive::new_text_shadow(
+            shadow,
+            pipeline_id,
+        );
+
+        let pic_index = PictureIndex(self.pictures.len());
+        self.pictures.push(pic);
+
+        pic_index
     }
 
     pub fn add_primitive(
@@ -968,11 +1029,7 @@ impl PrimitiveStore {
                     BrushKind::YuvImage { .. } => PrimitiveOpacity::opaque(),
                     BrushKind::RadialGradient { .. } => PrimitiveOpacity::translucent(),
                     BrushKind::LinearGradient { .. } => PrimitiveOpacity::translucent(),
-                    BrushKind::Picture => {
-                        // TODO(gw): This is not currently used. In the future
-                        //           we should detect opaque pictures.
-                        unreachable!();
-                    }
+                    BrushKind::Picture { .. } => PrimitiveOpacity::translucent(),
                 };
 
                 let metadata = PrimitiveMetadata {
@@ -995,17 +1052,6 @@ impl PrimitiveStore {
                 };
 
                 self.cpu_text_runs.push(text_cpu);
-                metadata
-            }
-            PrimitiveContainer::Picture(picture) => {
-                let metadata = PrimitiveMetadata {
-                    opacity: PrimitiveOpacity::translucent(),
-                    prim_kind: PrimitiveKind::Picture,
-                    cpu_prim_index: SpecificPrimitiveIndex(self.cpu_pictures.len()),
-                    ..base_metadata
-                };
-
-                self.cpu_pictures.push(picture);
                 metadata
             }
             PrimitiveContainer::Image(image_cpu) => {
@@ -1058,17 +1104,6 @@ impl PrimitiveStore {
         let metadata = &mut self.cpu_metadata[prim_index.0];
         match metadata.prim_kind {
             PrimitiveKind::Border => {}
-            PrimitiveKind::Picture => {
-                self.cpu_pictures[metadata.cpu_prim_index.0]
-                    .prepare_for_render(
-                        prim_index,
-                        metadata,
-                        pic_state_for_children,
-                        pic_state,
-                        frame_context,
-                        frame_state,
-                    );
-            }
             PrimitiveKind::TextRun => {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
                 // The transform only makes sense for screen space rasterization
@@ -1257,10 +1292,20 @@ impl PrimitiveStore {
                             );
                         }
                     }
+                    BrushKind::Picture { pic_index } => {
+                        self.pictures[pic_index.0]
+                            .prepare_for_render(
+                                prim_index,
+                                metadata,
+                                pic_state_for_children,
+                                pic_state,
+                                frame_context,
+                                frame_state,
+                            );
+                    }
                     BrushKind::Solid { .. } |
                     BrushKind::Clear |
-                    BrushKind::Line { .. } |
-                    BrushKind::Picture { .. } => {}
+                    BrushKind::Line { .. } => {}
                 }
             }
         }
@@ -1284,27 +1329,9 @@ impl PrimitiveStore {
                     let text = &self.cpu_text_runs[metadata.cpu_prim_index.0];
                     text.write_gpu_blocks(&mut request);
                 }
-                PrimitiveKind::Picture => {
-                    let pic = &self.cpu_pictures[metadata.cpu_prim_index.0];
-                    pic.write_gpu_blocks(&mut request);
-
-                    let brush = &pic.brush;
-                    brush.write_gpu_blocks(&mut request);
-                    match brush.segment_desc {
-                        Some(ref segment_desc) => {
-                            for segment in &segment_desc.segments {
-                                // has to match VECS_PER_SEGMENT
-                                request.write_segment(segment.local_rect);
-                            }
-                        }
-                        None => {
-                            request.write_segment(metadata.local_rect);
-                        }
-                    }
-                }
                 PrimitiveKind::Brush => {
                     let brush = &self.cpu_brushes[metadata.cpu_prim_index.0];
-                    brush.write_gpu_blocks(&mut request);
+                    brush.write_gpu_blocks(&mut request, &self.pictures);
                     match brush.segment_desc {
                         Some(ref segment_desc) => {
                             for segment in &segment_desc.segments {
@@ -1481,9 +1508,6 @@ impl PrimitiveStore {
         let brush = match metadata.prim_kind {
             PrimitiveKind::Brush => {
                 &mut self.cpu_brushes[metadata.cpu_prim_index.0]
-            }
-            PrimitiveKind::Picture => {
-                &mut self.cpu_pictures[metadata.cpu_prim_index.0].brush
             }
             _ => {
                 return false;
@@ -1705,59 +1729,61 @@ impl PrimitiveStore {
         // For example, scrolling may affect the location of an item in
         // local space, which may force us to render this item on a larger
         // picture target, if being composited.
-        if let PrimitiveKind::Picture = prim_kind {
-            let pic_context_for_children = {
-                let pic = &mut self.cpu_pictures[cpu_prim_index.0];
+        if let PrimitiveKind::Brush = prim_kind {
+            if let BrushKind::Picture { pic_index } = self.cpu_brushes[cpu_prim_index.0].kind {
+                let pic_context_for_children = {
+                    let pic = &mut self.pictures[pic_index.0];
 
-                if !pic.resolve_scene_properties(frame_context.scene_properties) {
-                    return None;
-                }
-
-                let (draw_text_transformed, original_reference_frame_index) = match pic.kind {
-                    PictureKind::Image { reference_frame_index, composite_mode, .. } => {
-                        may_need_clip_mask = composite_mode.is_some();
-                        (true, Some(reference_frame_index))
+                    if !pic.resolve_scene_properties(frame_context.scene_properties) {
+                        return None;
                     }
-                    PictureKind::TextShadow { .. } => {
-                        (false, None)
+
+                    let (draw_text_transformed, original_reference_frame_index) = match pic.kind {
+                        PictureKind::Image { reference_frame_index, composite_mode, .. } => {
+                            may_need_clip_mask = composite_mode.is_some();
+                            (true, Some(reference_frame_index))
+                        }
+                        PictureKind::TextShadow { .. } => {
+                            (false, None)
+                        }
+                    };
+
+                    let display_list = &frame_context
+                        .pipelines
+                        .get(&pic.pipeline_id)
+                        .expect("No display list?")
+                        .display_list;
+
+                    let inv_world_transform = prim_run_context
+                        .scroll_node
+                        .world_content_transform
+                        .inverse();
+
+                    PictureContext {
+                        pipeline_id: pic.pipeline_id,
+                        perform_culling: pic.cull_children,
+                        prim_runs: mem::replace(&mut pic.runs, Vec::new()),
+                        original_reference_frame_index,
+                        display_list,
+                        draw_text_transformed,
+                        inv_world_transform,
                     }
                 };
 
-                let display_list = &frame_context
-                    .pipelines
-                    .get(&pic.pipeline_id)
-                    .expect("No display list?")
-                    .display_list;
+                let result = self.prepare_prim_runs(
+                    &pic_context_for_children,
+                    &mut pic_state_for_children,
+                    frame_context,
+                    frame_state,
+                );
 
-                let inv_world_transform = prim_run_context
-                    .scroll_node
-                    .world_content_transform
-                    .inverse();
+                // Restore the dependencies (borrow check dance)
+                let pic = &mut self.pictures[pic_index.0];
+                pic.runs = pic_context_for_children.prim_runs;
 
-                PictureContext {
-                    pipeline_id: pic.pipeline_id,
-                    perform_culling: pic.cull_children,
-                    prim_runs: mem::replace(&mut pic.runs, Vec::new()),
-                    original_reference_frame_index,
-                    display_list,
-                    draw_text_transformed,
-                    inv_world_transform,
-                }
-            };
-
-            let result = self.prepare_prim_runs(
-                &pic_context_for_children,
-                &mut pic_state_for_children,
-                frame_context,
-                frame_state,
-            );
-
-            // Restore the dependencies (borrow check dance)
-            let pic = &mut self.cpu_pictures[cpu_prim_index.0];
-            pic.runs = pic_context_for_children.prim_runs;
-
-            let metadata = &mut self.cpu_metadata[prim_index.0];
-            metadata.local_rect = pic.update_local_rect(result);
+                let metadata = &mut self.cpu_metadata[prim_index.0];
+                metadata.local_rect = pic.update_local_rect(result);
+            }
         }
 
         let (local_rect, unclipped_device_rect) = {


### PR DESCRIPTION
Previously, Picture was a separate primitive type, and it contained
a BrushPrimitive structure. Now there is a separate array of Picture
structures, and there is a BrushPrimitive::Picture type that refers
to a Picture by index.

This PR doesn't contain any functional changes - I think it will
be easier to get this reviewed and landed, and then work on the
functional changes as a separate patch.

The idea is to separate the concept of a Picture (a collection of
primitives, with children, optionally drawn into an intermediate
surface) from how that picture is drawn into the parent picture
(via BrushPrimitive::Picture).

What this means in the future is that a Picture can be referenced
by multiple Brush::Picture primitives and composited in a different
way. The primary use for this is for drop shadows - where we need
to draw the picture both as normal content, and also as an alpha
mask in a separate primitive, that has an offset / spread radius.

To achieve this, we'll move some fields currently on Picture (such
as filters, frame output) to the Brush::Picture primitive instance.

The benefits of such a change are:
 * We can reference a picture multiple times in the scene on a
   different primitive, which will allow us to fix outstanding
   drop-shadow bugs.
 * Since the Picture elements are now stored outside the primitive
   tree, we can start caching these across frames. This will form
   the basis of caching text-shadows, opacity filters etc.
 * We create fewer Picture instances (rather than one per filter
   stage as we do now). This helps debugging primarily.
 * Allowing a Picture to be referenced multiple times is more
   applicable to how SVG filter graphs work (when we implement those).

Since this is an intermediate patch, it introduces a bit of extra
indirection and duplication in places. I expect these to be resolved
by the follow up changes referenced above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2517)
<!-- Reviewable:end -->
