### PR TITLE
fix ResourceCache::clear_namespace handling of font instances

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -964,7 +964,7 @@ impl ResourceCache {
         self.resources.font_instances
             .write()
             .unwrap()
-            .retain(|key, _| key.0 == namespace);
+            .retain(|key, _| key.0 != namespace);
         for &key in self.resources.font_templates.keys().filter(|key| key.0 == namespace) {
             self.glyph_rasterizer.delete_font(key);
         }


### PR DESCRIPTION
PR #2516 accidentally introduced a small bug where the retain condition for font_instances was inverted. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2520)
<!-- Reviewable:end -->
