### PR TITLE
Early out from scene building if view is too large.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -172,9 +172,18 @@ impl Document {
 
     // TODO: We will probably get rid of this soon and always forward to the scene building thread.
     fn build_scene(&mut self, resource_cache: &mut ResourceCache) {
+        let max_texture_size = resource_cache.max_texture_size();
 
-        if self.view.window_size.width == 0 || self.view.window_size.height == 0 {
-            error!("ERROR: Invalid window dimensions! Please call api.set_window_size()");
+        if self.view.window_size.width == 0 ||
+           self.view.window_size.height == 0 ||
+           self.view.window_size.width > max_texture_size ||
+           self.view.window_size.height > max_texture_size {
+            error!("ERROR: Invalid window dimensions {}x{}. Please call api.set_window_size()",
+                self.view.window_size.width,
+                self.view.window_size.height,
+            );
+
+            return;
         }
 
         let old_builder = self.frame_builder.take().unwrap_or_else(FrameBuilder::empty);


### PR DESCRIPTION
If the requested view size is larger than the maximum texture
size supported by the hardware, early exit and fail to render.

In the future, we could potentially render the scene in tiles,
however this is a quick fix for an existing crash.

Specifically, if Gecko is asked to open a very large window by
JS, the first frame has a very large window size. On subsequent
frames Gecko supplies a window size that is clamped to the
actual monitor resolution.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1441392 and
potentially https://bugzilla.mozilla.org/show_bug.cgi?id=1442921.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2524)
<!-- Reviewable:end -->
