### PR TITLE
Attempt to configure servo-tidy in a way that doesn't mess everything up.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - python --version
   - pip install mako voluptuous PyYAML servo-tidy
 script:
-#  - servo-tidy
+  - servo-tidy
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_api && cargo test --verbose --features "ipc"); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features profiler,capture); fi

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -1,10 +1,11 @@
 [configs]
 skip-check-length = false
 skip-check-licenses = false
+check-alphabetical-order = false
 
 [ignore]
 # Ignored packages with duplicated versions
-packages = []
+packages = ["gdi32-sys", "winapi", "gl_generator", "log", "core-foundation", "core-foundation-sys", "yaml-rust", "user32-sys", "lazy_static", "core-graphics"]
 
 # Files that are ignored for all tidy and lint checks.
 files = [ ]


### PR DESCRIPTION
Turn off alphabetical checks (\o/) and  whitelist duplicated packages. As far as I can see they come from dev-dependencies (mostly glutin). Ideally we would not have too many duplicated deps in our dev dependencies because it adds to the build times when building wrench and the examples, but we can live with them for now and they should not interfere with gecko.

updating glutin remvoes a lot of dupes, but also requires an update of winapi in a lot of packages which I suspect is going to be a pain. 

It would be nice if servo-tidy could be set to ignore dev-dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2525)
<!-- Reviewable:end -->
