### PR TITLE
Disable servo-tidy on taskcluster CI as well

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -63,7 +63,6 @@ tasks:
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          servo-tidy &&
           (cd wrench && python script/headless.py reftest) &&
           (cd wrench && cargo build --release)
     routes:
@@ -95,7 +94,6 @@ tasks:
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          servo-tidy &&
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
           (cd webrender && cargo build --verbose --features capture,profiler) &&
@@ -136,7 +134,7 @@ tasks:
           rm -rf webrender &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate && servo-tidy &&
+          source ../servotidy-venv/bin/activate &&
           export RUST_BACKTRACE=1 &&
           export RUSTFLAGS='--deny warnings' &&
           export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&
@@ -167,7 +165,7 @@ tasks:
           rm -rf webrender &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate && servo-tidy &&
+          source ../servotidy-venv/bin/activate &&
           export RUST_BACKTRACE=1 &&
           export RUSTFLAGS='--deny warnings' &&
           export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&


### PR DESCRIPTION
In order to get #2525 passing taskcluster CI we need to update the version of servo-tidy on the taskcluster machines/images. But if we do that without #2525 we're going to run into failures. So we need to disable servo-tidy temporarily while we do the update, and then re-enable it as part of #2525.

servo-tidy is currently disabled on travis CI as well so it's not like taskcluster is "special" in that sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2526)
<!-- Reviewable:end -->
