### PR TITLE
Re-enable servo-tidy with a passing configuration

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,7 +22,7 @@ tasks:
   # ---
   #   FROM ubuntu:16.04
   #   RUN apt-get -y update && apt-get install -y curl git python python-pip cmake pkg-config libx11-dev libgl1-mesa-dev libfontconfig1-dev
-  #   RUN pip install mako servo-tidy
+  #   RUN pip install mako voluptuous PyYAML servo-tidy
   #   RUN useradd -d /home/worker -s /bin/bash -m worker
   #   USER worker
   #   WORKDIR /home/worker
@@ -63,6 +63,7 @@ tasks:
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
+          servo-tidy &&
           (cd wrench && python script/headless.py reftest) &&
           (cd wrench && cargo build --release)
     routes:
@@ -94,6 +95,7 @@ tasks:
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
+          servo-tidy &&
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
           (cd webrender && cargo build --verbose --features capture,profiler) &&
@@ -107,7 +109,7 @@ tasks:
   # Talk to :kats or :jrmuizel if you need more details about this. The machines
   # are hooked up to taskcluster using taskcluster-worker; they use a worker-type
   # of kats-webrender-ci-osx. They are set up with all the dependencies needed
-  # to build and test webrender, including Rust (currently 1.20), servo-tidy,
+  # to build and test webrender, including Rust (currently 1.24), servo-tidy,
   # mako, zlib, etc. Note that unlike the docker-worker used for Linux, these
   # machines WILL persist state from one run to the next, so any cleanup needs
   # to be handled explicitly.
@@ -134,7 +136,7 @@ tasks:
           rm -rf webrender &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate &&
+          source ../servotidy-venv/bin/activate && servo-tidy &&
           export RUST_BACKTRACE=1 &&
           export RUSTFLAGS='--deny warnings' &&
           export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&
@@ -165,7 +167,7 @@ tasks:
           rm -rf webrender &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate &&
+          source ../servotidy-venv/bin/activate && servo-tidy &&
           export RUST_BACKTRACE=1 &&
           export RUSTFLAGS='--deny warnings' &&
           export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - python --version
   - pip install mako voluptuous PyYAML servo-tidy
 script:
-#  - servo-tidy
+  - servo-tidy
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_api && cargo test --verbose --features "ipc"); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features profiler,capture); fi

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -1,10 +1,22 @@
 [configs]
 skip-check-length = false
 skip-check-licenses = false
+check-alphabetical-order = false
 
 [ignore]
 # Ignored packages with duplicated versions
-packages = []
+packages = [
+    "gdi32-sys",
+    "winapi",
+    "gl_generator",
+    "log",
+    "core-foundation",
+    "core-foundation-sys",
+    "yaml-rust",
+    "user32-sys",
+    "lazy_static",
+    "core-graphics"
+]
 
 # Files that are ignored for all tidy and lint checks.
 files = [ ]

--- a/wrench/src/cgfont_to_data.rs
+++ b/wrench/src/cgfont_to_data.rs
@@ -29,7 +29,7 @@ fn calc_table_checksum<D: Read>(mut data: D) -> u32 {
 fn max_pow_2_less_than(a: u16) -> u16 {
     let x = 1;
     let mut shift = 0;
-    while (x << (shift + 1)) < a {
+    while a > (x << (shift + 1)) {
         shift += 1;
     }
     shift


### PR DESCRIPTION
This takes @nical's patch from servo/webrender#2525, fixes an additional
lint error in wrench, and updates the .taskcluster.yml to re-enable the
updated servo-tidy.

r? @nical

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2527)
<!-- Reviewable:end -->
