### PR TITLE
Add ANGLE rendering in Wrench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ version = "0.1.0"
 dependencies = [
  "euclid 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.57.0",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1271,7 +1271,7 @@ dependencies = [
  "image 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "plane-split 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1384,6 +1384,7 @@ dependencies = [
  "image 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6d19442734abd7d780b981c590c325680d933e99795fe1f693f0686c9ed48022"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum mozangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b41d9b5488bd3bf519736839a5b573953bc20b093f9a444a02ca1c8956fe59f"
+"checksum mozangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd4f04e5f59cbc97802e707a17a261044e56a73f4b95040de8d6a4b2ff1ac3c4"
 "checksum net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "5edf9cb6be97212423aed9413dd4729d62b370b5e1c571750e882cebbbc1e3e2"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -19,7 +19,9 @@ packages = [
 ]
 
 # Files that are ignored for all tidy and lint checks.
-files = [ ]
+files = [
+    "./wrench/src/egl.rs",  # Copied from glutin
+]
 
 # Many directories are currently ignored while we tidy things up
 # gradually.

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -38,6 +38,7 @@ headless = [ "osmesa-sys", "osmesa-src" ]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.4.1"
+mozangle = {version = "0.1.5", features = ["egl"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 font-loader = "0.6"

--- a/wrench/src/angle.rs
+++ b/wrench/src/angle.rs
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use glutin;
+use glutin::{WindowBuilder, ContextBuilder, EventsLoop, Window, CreationError};
+
+#[cfg(not(windows))]
+pub enum Context {}
+
+#[cfg(windows)]
+pub use ::egl::Context;
+
+impl Context {
+    #[cfg(not(windows))]
+    pub fn with_window(
+        _: WindowBuilder,
+        _: ContextBuilder,
+        _: &EventsLoop,
+    ) -> Result<(Window, Self), CreationError> {
+        Err(CreationError::PlatformSpecific("ANGLE rendering is only supported on Windows".into()))
+    }
+
+    #[cfg(windows)]
+    pub fn with_window(
+        window_builder: WindowBuilder,
+        context_builder: ContextBuilder,
+        events_loop: &EventsLoop,
+    ) -> Result<(Window, Self), CreationError> {
+        use glutin::os::windows::WindowExt;
+
+        // FIXME: &context_builder.pf_reqs  https://github.com/tomaka/glutin/pull/1002
+        let pf_reqs = &glutin::PixelFormatRequirements::default();
+        let gl_attr = &context_builder.gl_attr.map_sharing(|_| unimplemented!());
+        let window = window_builder.build(events_loop)?;
+        Self::new(pf_reqs, gl_attr)
+            .and_then(|p| p.finish(window.get_hwnd() as _))
+            .map(|context| (window, context))
+    }
+}
+
+#[cfg(not(windows))]
+impl glutin::GlContext for Context {
+    unsafe fn make_current(&self) -> Result<(), glutin::ContextError> {
+        match *self {}
+    }
+
+    fn is_current(&self) -> bool {
+        match *self {}
+    }
+
+    fn get_proc_address(&self, _: &str) -> *const () {
+        match *self {}
+    }
+
+    fn swap_buffers(&self) -> Result<(), glutin::ContextError> {
+        match *self {}
+    }
+
+    fn get_api(&self) -> glutin::Api {
+        match *self {}
+    }
+
+    fn get_pixel_format(&self) -> glutin::PixelFormat {
+        match *self {}
+    }
+
+    fn resize(&self, _: u32, _: u32) {
+        match *self {}
+    }
+}
+

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -44,6 +44,9 @@ args:
       short: h
       long: headless
       help: Enable headless rendering
+  - angle:
+      long: angle
+      help: Enable ANGLE rendering (on Windows only)
   - dp_ratio:
       short: p
       long: device-pixel-ratio

--- a/wrench/src/egl.rs
+++ b/wrench/src/egl.rs
@@ -1,0 +1,617 @@
+// Licensed under the Apache License, Version 2.0.
+// This file may not be copied, modified, or distributed except according to those terms.
+
+//! Based on https://github.com/tomaka/glutin/blob/1b2d62c0e9/src/api/egl/mod.rs
+#![cfg(windows)]
+#![allow(unused_variables)]
+
+use glutin::ContextError;
+use glutin::CreationError;
+use glutin::GlAttributes;
+use glutin::GlContext;
+use glutin::GlRequest;
+use glutin::PixelFormat;
+use glutin::PixelFormatRequirements;
+use glutin::ReleaseBehavior;
+use glutin::Robustness;
+use glutin::Api;
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_int;
+use std::{mem, ptr};
+use std::cell::Cell;
+
+use mozangle::egl::ffi as egl;
+mod ffi {
+    pub use mozangle::egl::ffi as egl;
+    pub use mozangle::egl::ffi::*;
+}
+
+pub struct Context {
+    display: ffi::egl::types::EGLDisplay,
+    context: ffi::egl::types::EGLContext,
+    surface: Cell<ffi::egl::types::EGLSurface>,
+    api: Api,
+    pixel_format: PixelFormat,
+}
+
+impl Context {
+    /// Start building an EGL context.
+    ///
+    /// This function initializes some things and chooses the pixel format.
+    ///
+    /// To finish the process, you must call `.finish(window)` on the `ContextPrototype`.
+    pub fn new<'a>(
+        pf_reqs: &PixelFormatRequirements,
+        opengl: &'a GlAttributes<&'a Context>,
+    ) -> Result<ContextPrototype<'a>, CreationError>
+    {
+        if opengl.sharing.is_some() {
+            unimplemented!()
+        }
+
+        // calling `eglGetDisplay` or equivalent
+        let display = unsafe { egl::GetDisplay(ptr::null_mut()) };
+
+        if display.is_null() {
+            return Err(CreationError::OsError("Could not create EGL display object".to_string()));
+        }
+
+        let egl_version = unsafe {
+            let mut major: ffi::egl::types::EGLint = mem::uninitialized();
+            let mut minor: ffi::egl::types::EGLint = mem::uninitialized();
+
+            if egl::Initialize(display, &mut major, &mut minor) == 0 {
+                return Err(CreationError::OsError(format!("eglInitialize failed")))
+            }
+
+            (major, minor)
+        };
+
+        // the list of extensions supported by the client once initialized is different from the
+        // list of extensions obtained earlier
+        let extensions = if egl_version >= (1, 2) {
+            let p = unsafe { CStr::from_ptr(egl::QueryString(display, ffi::egl::EXTENSIONS as i32)) };
+            let list = String::from_utf8(p.to_bytes().to_vec()).unwrap_or_else(|_| format!(""));
+            list.split(' ').map(|e| e.to_string()).collect::<Vec<_>>()
+
+        } else {
+            vec![]
+        };
+
+        // binding the right API and choosing the version
+        let (version, api) = unsafe {
+            match opengl.version {
+                GlRequest::Latest => {
+                    if egl_version >= (1, 4) {
+                        if egl::BindAPI(ffi::egl::OPENGL_API) != 0 {
+                            (None, Api::OpenGl)
+                        } else if egl::BindAPI(ffi::egl::OPENGL_ES_API) != 0 {
+                            (None, Api::OpenGlEs)
+                        } else {
+                            return Err(CreationError::OpenGlVersionNotSupported);
+                        }
+                    } else {
+                        (None, Api::OpenGlEs)
+                    }
+                },
+                GlRequest::Specific(Api::OpenGlEs, version) => {
+                    if egl_version >= (1, 2) {
+                        if egl::BindAPI(ffi::egl::OPENGL_ES_API) == 0 {
+                            return Err(CreationError::OpenGlVersionNotSupported);
+                        }
+                    }
+                    (Some(version), Api::OpenGlEs)
+                },
+                GlRequest::Specific(Api::OpenGl, version) => {
+                    if egl_version < (1, 4) {
+                        return Err(CreationError::OpenGlVersionNotSupported);
+                    }
+                    if egl::BindAPI(ffi::egl::OPENGL_API) == 0 {
+                        return Err(CreationError::OpenGlVersionNotSupported);
+                    }
+                    (Some(version), Api::OpenGl)
+                },
+                GlRequest::Specific(_, _) => return Err(CreationError::OpenGlVersionNotSupported),
+                GlRequest::GlThenGles { opengles_version, opengl_version } => {
+                    if egl_version >= (1, 4) {
+                        if egl::BindAPI(ffi::egl::OPENGL_API) != 0 {
+                            (Some(opengl_version), Api::OpenGl)
+                        } else if egl::BindAPI(ffi::egl::OPENGL_ES_API) != 0 {
+                            (Some(opengles_version), Api::OpenGlEs)
+                        } else {
+                            return Err(CreationError::OpenGlVersionNotSupported);
+                        }
+                    } else {
+                        (Some(opengles_version), Api::OpenGlEs)
+                    }
+                },
+            }
+        };
+
+        let (config_id, pixel_format) = unsafe {
+            try!(choose_fbconfig(display, &egl_version, api, version, pf_reqs))
+        };
+
+        Ok(ContextPrototype {
+            opengl: opengl,
+            display: display,
+            egl_version: egl_version,
+            extensions: extensions,
+            api: api,
+            version: version,
+            config_id: config_id,
+            pixel_format: pixel_format,
+        })
+    }
+}
+
+impl GlContext for Context {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
+        let ret = egl::MakeCurrent(self.display, self.surface.get(), self.surface.get(), self.context);
+
+        if ret == 0 {
+            match egl::GetError() as u32 {
+                ffi::egl::CONTEXT_LOST => return Err(ContextError::ContextLost),
+                err => panic!("eglMakeCurrent failed (eglGetError returned 0x{:x})", err)
+            }
+
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn is_current(&self) -> bool {
+        unsafe { egl::GetCurrentContext() == self.context }
+    }
+
+    fn get_proc_address(&self, addr: &str) -> *const () {
+        let addr = CString::new(addr.as_bytes()).unwrap();
+        let addr = addr.as_ptr();
+        unsafe {
+            egl::GetProcAddress(addr) as *const _
+        }
+    }
+
+    #[inline]
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        if self.surface.get() == ffi::egl::NO_SURFACE {
+            return Err(ContextError::ContextLost);
+        }
+
+        let ret = unsafe {
+            egl::SwapBuffers(self.display, self.surface.get())
+        };
+
+        if ret == 0 {
+            match unsafe { egl::GetError() } as u32 {
+                ffi::egl::CONTEXT_LOST => return Err(ContextError::ContextLost),
+                err => panic!("eglSwapBuffers failed (eglGetError returned 0x{:x})", err)
+            }
+
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn get_api(&self) -> Api {
+        self.api
+    }
+
+    #[inline]
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.pixel_format.clone()
+    }
+
+    #[inline]
+    fn resize(&self, _: u32, _: u32) {}
+}
+
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe {
+            // we don't call MakeCurrent(0, 0) because we are not sure that the context
+            // is still the current one
+            egl::DestroyContext(self.display, self.context);
+            egl::DestroySurface(self.display, self.surface.get());
+            egl::Terminate(self.display);
+        }
+    }
+}
+
+pub struct ContextPrototype<'a> {
+    opengl: &'a GlAttributes<&'a Context>,
+    display: ffi::egl::types::EGLDisplay,
+    egl_version: (ffi::egl::types::EGLint, ffi::egl::types::EGLint),
+    extensions: Vec<String>,
+    api: Api,
+    version: Option<(u8, u8)>,
+    config_id: ffi::egl::types::EGLConfig,
+    pixel_format: PixelFormat,
+}
+
+impl<'a> ContextPrototype<'a> {
+    pub fn get_native_visual_id(&self) -> ffi::egl::types::EGLint {
+        let mut value = unsafe { mem::uninitialized() };
+        let ret = unsafe { egl::GetConfigAttrib(self.display, self.config_id,
+                                                    ffi::egl::NATIVE_VISUAL_ID
+                                                    as ffi::egl::types::EGLint, &mut value) };
+        if ret == 0 { panic!("eglGetConfigAttrib failed") };
+        value
+    }
+
+    pub fn finish(self, native_window: ffi::EGLNativeWindowType)
+                  -> Result<Context, CreationError>
+    {
+        let surface = unsafe {
+            let surface = egl::CreateWindowSurface(self.display, self.config_id, native_window,
+                                                       ptr::null());
+            if surface.is_null() {
+                return Err(CreationError::OsError(format!("eglCreateWindowSurface failed")))
+            }
+            surface
+        };
+
+        self.finish_impl(surface)
+    }
+
+    pub fn finish_pbuffer(self, dimensions: (u32, u32)) -> Result<Context, CreationError> {
+        let attrs = &[
+            ffi::egl::WIDTH as c_int, dimensions.0 as c_int,
+            ffi::egl::HEIGHT as c_int, dimensions.1 as c_int,
+            ffi::egl::NONE as c_int,
+        ];
+
+        let surface = unsafe {
+            let surface = egl::CreatePbufferSurface(self.display, self.config_id,
+                                                        attrs.as_ptr());
+            if surface.is_null() {
+                return Err(CreationError::OsError(format!("eglCreatePbufferSurface failed")))
+            }
+            surface
+        };
+
+        self.finish_impl(surface)
+    }
+
+    fn finish_impl(self, surface: ffi::egl::types::EGLSurface)
+                   -> Result<Context, CreationError>
+    {
+        let context = unsafe {
+            if let Some(version) = self.version {
+                try!(create_context(self.display, &self.egl_version,
+                                    &self.extensions, self.api, version, self.config_id,
+                                    self.opengl.debug, self.opengl.robustness))
+
+            } else if self.api == Api::OpenGlEs {
+                if let Ok(ctxt) = create_context(self.display, &self.egl_version,
+                                                 &self.extensions, self.api, (2, 0), self.config_id,
+                                                 self.opengl.debug, self.opengl.robustness)
+                {
+                    ctxt
+                } else if let Ok(ctxt) = create_context(self.display, &self.egl_version,
+                                                        &self.extensions, self.api, (1, 0),
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
+                {
+                    ctxt
+                } else {
+                    return Err(CreationError::OpenGlVersionNotSupported);
+                }
+
+            } else {
+                if let Ok(ctxt) = create_context(self.display, &self.egl_version,
+                                                 &self.extensions, self.api, (3, 2), self.config_id,
+                                                 self.opengl.debug, self.opengl.robustness)
+                {
+                    ctxt
+                } else if let Ok(ctxt) = create_context(self.display, &self.egl_version,
+                                                        &self.extensions, self.api, (3, 1),
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
+                {
+                    ctxt
+                } else if let Ok(ctxt) = create_context(self.display, &self.egl_version,
+                                                        &self.extensions, self.api, (1, 0),
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
+                {
+                    ctxt
+                } else {
+                    return Err(CreationError::OpenGlVersionNotSupported);
+                }
+            }
+        };
+
+        Ok(Context {
+            display: self.display,
+            context: context,
+            surface: Cell::new(surface),
+            api: self.api,
+            pixel_format: self.pixel_format,
+        })
+    }
+}
+
+unsafe fn choose_fbconfig(display: ffi::egl::types::EGLDisplay,
+                          egl_version: &(ffi::egl::types::EGLint, ffi::egl::types::EGLint),
+                          api: Api, version: Option<(u8, u8)>, reqs: &PixelFormatRequirements)
+                          -> Result<(ffi::egl::types::EGLConfig, PixelFormat), CreationError>
+{
+    let descriptor = {
+        let mut out: Vec<c_int> = Vec::with_capacity(37);
+
+        if egl_version >= &(1, 2) {
+            out.push(ffi::egl::COLOR_BUFFER_TYPE as c_int);
+            out.push(ffi::egl::RGB_BUFFER as c_int);
+        }
+
+        out.push(ffi::egl::SURFACE_TYPE as c_int);
+        // TODO: Some versions of Mesa report a BAD_ATTRIBUTE error
+        // if we ask for PBUFFER_BIT as well as WINDOW_BIT
+        out.push((ffi::egl::WINDOW_BIT) as c_int);
+
+        match (api, version) {
+            (Api::OpenGlEs, Some((3, _))) => {
+                if egl_version < &(1, 3) { return Err(CreationError::NoAvailablePixelFormat); }
+                out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                out.push(ffi::egl::OPENGL_ES3_BIT as c_int);
+                out.push(ffi::egl::CONFORMANT as c_int);
+                out.push(ffi::egl::OPENGL_ES3_BIT as c_int);
+            },
+            (Api::OpenGlEs, Some((2, _))) => {
+                if egl_version < &(1, 3) { return Err(CreationError::NoAvailablePixelFormat); }
+                out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                out.push(ffi::egl::OPENGL_ES2_BIT as c_int);
+                out.push(ffi::egl::CONFORMANT as c_int);
+                out.push(ffi::egl::OPENGL_ES2_BIT as c_int);
+            },
+            (Api::OpenGlEs, Some((1, _))) => {
+                if egl_version >= &(1, 3) {
+                    out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                    out.push(ffi::egl::OPENGL_ES_BIT as c_int);
+                    out.push(ffi::egl::CONFORMANT as c_int);
+                    out.push(ffi::egl::OPENGL_ES_BIT as c_int);
+                }
+            },
+            (Api::OpenGlEs, _) => unimplemented!(),
+            (Api::OpenGl, _) => {
+                if egl_version < &(1, 3) { return Err(CreationError::NoAvailablePixelFormat); }
+                out.push(ffi::egl::RENDERABLE_TYPE as c_int);
+                out.push(ffi::egl::OPENGL_BIT as c_int);
+                out.push(ffi::egl::CONFORMANT as c_int);
+                out.push(ffi::egl::OPENGL_BIT as c_int);
+            },
+            (_, _) => unimplemented!(),
+        };
+
+        if let Some(hardware_accelerated) = reqs.hardware_accelerated {
+            out.push(ffi::egl::CONFIG_CAVEAT as c_int);
+            out.push(if hardware_accelerated {
+                ffi::egl::NONE as c_int
+            } else {
+                ffi::egl::SLOW_CONFIG as c_int
+            });
+        }
+
+        if let Some(color) = reqs.color_bits {
+            out.push(ffi::egl::RED_SIZE as c_int);
+            out.push((color / 3) as c_int);
+            out.push(ffi::egl::GREEN_SIZE as c_int);
+            out.push((color / 3 + if color % 3 != 0 { 1 } else { 0 }) as c_int);
+            out.push(ffi::egl::BLUE_SIZE as c_int);
+            out.push((color / 3 + if color % 3 == 2 { 1 } else { 0 }) as c_int);
+        }
+
+        if let Some(alpha) = reqs.alpha_bits {
+            out.push(ffi::egl::ALPHA_SIZE as c_int);
+            out.push(alpha as c_int);
+        }
+
+        if let Some(depth) = reqs.depth_bits {
+            out.push(ffi::egl::DEPTH_SIZE as c_int);
+            out.push(depth as c_int);
+        }
+
+        if let Some(stencil) = reqs.stencil_bits {
+            out.push(ffi::egl::STENCIL_SIZE as c_int);
+            out.push(stencil as c_int);
+        }
+
+        if let Some(true) = reqs.double_buffer {
+            return Err(CreationError::NoAvailablePixelFormat);
+        }
+
+        if let Some(multisampling) = reqs.multisampling {
+            out.push(ffi::egl::SAMPLES as c_int);
+            out.push(multisampling as c_int);
+        }
+
+        if reqs.stereoscopy {
+            return Err(CreationError::NoAvailablePixelFormat);
+        }
+
+        // FIXME: srgb is not taken into account
+
+        match reqs.release_behavior {
+            ReleaseBehavior::Flush => (),
+            ReleaseBehavior::None => {
+                // TODO: with EGL you need to manually set the behavior
+                unimplemented!()
+            },
+        }
+
+        out.push(ffi::egl::NONE as c_int);
+        out
+    };
+
+    // calling `eglChooseConfig`
+    let mut config_id = mem::uninitialized();
+    let mut num_configs = mem::uninitialized();
+    if egl::ChooseConfig(display, descriptor.as_ptr(), &mut config_id, 1, &mut num_configs) == 0 {
+        return Err(CreationError::OsError(format!("eglChooseConfig failed")));
+    }
+    if num_configs == 0 {
+        return Err(CreationError::NoAvailablePixelFormat);
+    }
+
+    // analyzing each config
+    macro_rules! attrib {
+        ($display:expr, $config:expr, $attr:expr) => (
+            {
+                let mut value = mem::uninitialized();
+                let res = egl::GetConfigAttrib($display, $config,
+                                               $attr as ffi::egl::types::EGLint, &mut value);
+                if res == 0 {
+                    return Err(CreationError::OsError(format!("eglGetConfigAttrib failed")));
+                }
+                value
+            }
+        )
+    };
+
+    let desc = PixelFormat {
+        hardware_accelerated: attrib!(display, config_id, ffi::egl::CONFIG_CAVEAT)
+                                      != ffi::egl::SLOW_CONFIG as i32,
+        color_bits: attrib!(display, config_id, ffi::egl::RED_SIZE) as u8 +
+                    attrib!(display, config_id, ffi::egl::BLUE_SIZE) as u8 +
+                    attrib!(display, config_id, ffi::egl::GREEN_SIZE) as u8,
+        alpha_bits: attrib!(display, config_id, ffi::egl::ALPHA_SIZE) as u8,
+        depth_bits: attrib!(display, config_id, ffi::egl::DEPTH_SIZE) as u8,
+        stencil_bits: attrib!(display, config_id, ffi::egl::STENCIL_SIZE) as u8,
+        stereoscopy: false,
+        double_buffer: true,
+        multisampling: match attrib!(display, config_id, ffi::egl::SAMPLES) {
+            0 | 1 => None,
+            a => Some(a as u16),
+        },
+        srgb: false,        // TODO: use EGL_KHR_gl_colorspace to know that
+    };
+
+    Ok((config_id, desc))
+}
+
+unsafe fn create_context(display: ffi::egl::types::EGLDisplay,
+                         egl_version: &(ffi::egl::types::EGLint, ffi::egl::types::EGLint),
+                         extensions: &[String], api: Api, version: (u8, u8),
+                         config_id: ffi::egl::types::EGLConfig, gl_debug: bool,
+                         gl_robustness: Robustness)
+                         -> Result<ffi::egl::types::EGLContext, CreationError>
+{
+    let mut context_attributes = Vec::with_capacity(10);
+    let mut flags = 0;
+
+    if egl_version >= &(1, 5) || extensions.iter().find(|s| s == &"EGL_KHR_create_context")
+                                                  .is_some()
+    {
+        context_attributes.push(ffi::egl::CONTEXT_MAJOR_VERSION as i32);
+        context_attributes.push(version.0 as i32);
+        context_attributes.push(ffi::egl::CONTEXT_MINOR_VERSION as i32);
+        context_attributes.push(version.1 as i32);
+
+        // handling robustness
+        let supports_robustness = egl_version >= &(1, 5) ||
+                                  extensions.iter()
+                                            .find(|s| s == &"EGL_EXT_create_context_robustness")
+                                            .is_some();
+
+        match gl_robustness {
+            Robustness::NotRobust => (),
+
+            Robustness::NoError => {
+                if extensions.iter().find(|s| s == &"EGL_KHR_create_context_no_error").is_some() {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_NO_ERROR_KHR as c_int);
+                    context_attributes.push(1);
+                }
+            },
+
+            Robustness::RobustNoResetNotification => {
+                if supports_robustness {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
+                                            as c_int);
+                    context_attributes.push(ffi::egl::NO_RESET_NOTIFICATION as c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as c_int;
+                } else {
+                    return Err(CreationError::RobustnessNotSupported);
+                }
+            },
+
+            Robustness::TryRobustNoResetNotification => {
+                if supports_robustness {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
+                                            as c_int);
+                    context_attributes.push(ffi::egl::NO_RESET_NOTIFICATION as c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as c_int;
+                }
+            },
+
+            Robustness::RobustLoseContextOnReset => {
+                if supports_robustness {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
+                                            as c_int);
+                    context_attributes.push(ffi::egl::LOSE_CONTEXT_ON_RESET as c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as c_int;
+                } else {
+                    return Err(CreationError::RobustnessNotSupported);
+                }
+            },
+
+            Robustness::TryRobustLoseContextOnReset => {
+                if supports_robustness {
+                    context_attributes.push(ffi::egl::CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY
+                                            as c_int);
+                    context_attributes.push(ffi::egl::LOSE_CONTEXT_ON_RESET as c_int);
+                    flags = flags | ffi::egl::CONTEXT_OPENGL_ROBUST_ACCESS as c_int;
+                }
+            },
+        }
+
+        if gl_debug {
+            if egl_version >= &(1, 5) {
+                context_attributes.push(ffi::egl::CONTEXT_OPENGL_DEBUG as i32);
+                context_attributes.push(ffi::egl::TRUE as i32);
+            }
+
+            // TODO: using this flag sometimes generates an error
+            //       there was a change in the specs that added this flag, so it may not be
+            //       supported everywhere ; however it is not possible to know whether it is
+            //       supported or not
+            //flags = flags | ffi::egl::CONTEXT_OPENGL_DEBUG_BIT_KHR as i32;
+        }
+
+        context_attributes.push(ffi::egl::CONTEXT_FLAGS_KHR as i32);
+        context_attributes.push(flags);
+
+    } else if egl_version >= &(1, 3) && api == Api::OpenGlEs {
+        // robustness is not supported
+        match gl_robustness {
+            Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
+                return Err(CreationError::RobustnessNotSupported);
+            },
+            _ => ()
+        }
+
+        context_attributes.push(ffi::egl::CONTEXT_CLIENT_VERSION as i32);
+        context_attributes.push(version.0 as i32);
+    }
+
+    context_attributes.push(ffi::egl::NONE as i32);
+
+    let context = egl::CreateContext(display, config_id, ptr::null(),
+                                    context_attributes.as_ptr());
+
+    if context.is_null() {
+        match egl::GetError() as u32 {
+            ffi::egl::BAD_ATTRIBUTE => return Err(CreationError::OpenGlVersionNotSupported),
+            e => panic!("eglCreateContext failed: 0x{:x}", e),
+        }
+    }
+
+    Ok(context)
+}
+

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -27,6 +27,8 @@ extern crate image;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+#[cfg(target_os = "windows")]
+extern crate mozangle;
 #[cfg(feature = "headless")]
 extern crate osmesa_sys;
 extern crate ron;
@@ -37,8 +39,10 @@ extern crate time;
 extern crate webrender;
 extern crate yaml_rust;
 
+mod angle;
 mod binary_frame_reader;
 mod blob;
+mod egl;
 mod json_frame_writer;
 mod parse_function;
 mod perf;
@@ -159,6 +163,7 @@ impl HeadlessContext {
 
 pub enum WindowWrapper {
     Window(glutin::GlWindow, Rc<gl::Gl>),
+    Angle(glutin::Window, angle::Context, Rc<gl::Gl>),
     Headless(HeadlessContext, Rc<gl::Gl>),
 }
 
@@ -168,21 +173,26 @@ impl WindowWrapper {
     fn swap_buffers(&self) {
         match *self {
             WindowWrapper::Window(ref window, _) => window.swap_buffers().unwrap(),
+            WindowWrapper::Angle(_, ref context, _) => context.swap_buffers().unwrap(),
             WindowWrapper::Headless(_, _) => {}
         }
     }
 
     fn get_inner_size(&self) -> DeviceUintSize {
+        //HACK: `winit` needs to figure out its hidpi story...
+        #[cfg(target_os = "macos")]
+        fn inner_size(window: &glutin::Window) -> (u32, u32) {
+            let (w, h) = window.get_inner_size().unwrap();
+            let factor = window.hidpi_factor();
+            ((w as f32 * factor) as _, (h as f32 * factor) as _)
+        }
+        #[cfg(not(target_os = "macos"))]
+        fn inner_size(window: &glutin::Window) -> (u32, u32) {
+            window.get_inner_size().unwrap()
+        }
         let (w, h) = match *self {
-            //HACK: `winit` needs to figure out its hidpi story...
-            #[cfg(target_os = "macos")]
-            WindowWrapper::Window(ref window, _) => {
-                let (w, h) = window.get_inner_size().unwrap();
-                let factor = window.hidpi_factor();
-                ((w as f32 * factor) as _, (h as f32 * factor) as _)
-            },
-            #[cfg(not(target_os = "macos"))]
-            WindowWrapper::Window(ref window, _) => window.get_inner_size().unwrap(),
+            WindowWrapper::Window(ref window, _) => inner_size(window.window()),
+            WindowWrapper::Angle(ref window, ..) => inner_size(window),
             WindowWrapper::Headless(ref context, _) => (context.width, context.height),
         };
         DeviceUintSize::new(w, h)
@@ -191,6 +201,7 @@ impl WindowWrapper {
     fn hidpi_factor(&self) -> f32 {
         match *self {
             WindowWrapper::Window(ref window, _) => window.hidpi_factor(),
+            WindowWrapper::Angle(ref window, ..) => window.hidpi_factor(),
             WindowWrapper::Headless(_, _) => 1.0,
         }
     }
@@ -198,6 +209,7 @@ impl WindowWrapper {
     fn resize(&mut self, size: DeviceUintSize) {
         match *self {
             WindowWrapper::Window(ref mut window, _) => window.set_inner_size(size.width, size.height),
+            WindowWrapper::Angle(ref mut window, ..) => window.set_inner_size(size.width, size.height),
             WindowWrapper::Headless(_, _) => unimplemented!(), // requites Glutin update
         }
     }
@@ -205,19 +217,24 @@ impl WindowWrapper {
     fn set_title(&mut self, title: &str) {
         match *self {
             WindowWrapper::Window(ref window, _) => window.set_title(title),
+            WindowWrapper::Angle(ref window, ..) => window.set_title(title),
             WindowWrapper::Headless(_, _) => (),
         }
     }
 
     pub fn gl(&self) -> &gl::Gl {
         match *self {
-            WindowWrapper::Window(_, ref gl) | WindowWrapper::Headless(_, ref gl) => &**gl,
+            WindowWrapper::Window(_, ref gl) |
+            WindowWrapper::Angle(_, _, ref gl) |
+            WindowWrapper::Headless(_, ref gl) => &**gl,
         }
     }
 
     pub fn clone_gl(&self) -> Rc<gl::Gl> {
         match *self {
-            WindowWrapper::Window(_, ref gl) | WindowWrapper::Headless(_, ref gl) => gl.clone(),
+            WindowWrapper::Window(_, ref gl) |
+            WindowWrapper::Angle(_, _, ref gl) |
+            WindowWrapper::Headless(_, ref gl) => gl.clone(),
         }
     }
 }
@@ -227,6 +244,7 @@ fn make_window(
     dp_ratio: Option<f32>,
     vsync: bool,
     events_loop: &Option<glutin::EventsLoop>,
+    angle: bool,
 ) -> WindowWrapper {
     let wrapper = match *events_loop {
         Some(ref events_loop) => {
@@ -240,25 +258,37 @@ fn make_window(
                 .with_title("WRech")
                 .with_multitouch()
                 .with_dimensions(size.width, size.height);
-            let window = glutin::GlWindow::new(window_builder, context_builder, events_loop)
-                .unwrap();
 
-            unsafe {
-                window
-                    .make_current()
-                    .expect("unable to make context current!");
-            }
+            let init = |context: &glutin::GlContext| {
+                unsafe {
+                    context
+                        .make_current()
+                        .expect("unable to make context current!");
+                }
 
-            let gl = match window.get_api() {
-                glutin::Api::OpenGl => unsafe {
-                    gl::GlFns::load_with(|symbol| window.get_proc_address(symbol) as *const _)
-                },
-                glutin::Api::OpenGlEs => unsafe {
-                    gl::GlesFns::load_with(|symbol| window.get_proc_address(symbol) as *const _)
-                },
-                glutin::Api::WebGl => unimplemented!(),
+                match context.get_api() {
+                    glutin::Api::OpenGl => unsafe {
+                        gl::GlFns::load_with(|symbol| context.get_proc_address(symbol) as *const _)
+                    },
+                    glutin::Api::OpenGlEs => unsafe {
+                        gl::GlesFns::load_with(|symbol| context.get_proc_address(symbol) as *const _)
+                    },
+                    glutin::Api::WebGl => unimplemented!(),
+                }
             };
-            WindowWrapper::Window(window, gl)
+
+            if angle {
+                let (window, context) = angle::Context::with_window(
+                    window_builder, context_builder, events_loop
+                ).unwrap();
+                let gl = init(&context);
+                WindowWrapper::Angle(window, context, gl)
+            } else {
+                let window = glutin::GlWindow::new(window_builder, context_builder, events_loop)
+                    .unwrap();
+                let gl = init(&window);
+                WindowWrapper::Window(window, gl)
+            }
         }
         None => {
             let gl = match gl::GlType::default() {
@@ -364,7 +394,9 @@ fn main() {
         Some(glutin::EventsLoop::new())
     };
 
-    let mut window = make_window(size, dp_ratio, args.is_present("vsync"), &events_loop);
+    let mut window = make_window(
+        size, dp_ratio, args.is_present("vsync"), &events_loop, args.is_present("angle"),
+    );
     let dp_ratio = dp_ratio.unwrap_or(window.hidpi_factor());
     let dim = window.get_inner_size();
 


### PR DESCRIPTION
The `--angle` command-line parameter enables it on Windows, when `--headless` is not also used. It panics on non-Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2529)
<!-- Reviewable:end -->
