### PR TITLE
Fix brush_blend on SandyBridge iGPU

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -11,8 +11,8 @@ varying vec3 vUv;
 
 flat varying float vAmount;
 flat varying int vOp;
-flat varying mat4 vColorMat;
-flat varying vec4 vColorOffset;
+flat varying mat3 vColorMat;
+flat varying vec3 vColorOffset;
 flat varying vec4 vUvClipBounds;
 
 #ifdef WR_VERTEX_SHADER
@@ -51,48 +51,52 @@ void brush_vs(
     switch (vOp) {
         case 2: {
             // Grayscale
-            vColorMat = mat4(vec4(lumR + oneMinusLumR * invAmount, lumR - lumR * invAmount, lumR - lumR * invAmount, 0.0),
-                             vec4(lumG - lumG * invAmount, lumG + oneMinusLumG * invAmount, lumG - lumG * invAmount, 0.0),
-                             vec4(lumB - lumB * invAmount, lumB - lumB * invAmount, lumB + oneMinusLumB * invAmount, 0.0),
-                             vec4(0.0, 0.0, 0.0, 1.0));
-            vColorOffset = vec4(0.0);
+            vColorMat = mat3(
+                vec3(lumR + oneMinusLumR * invAmount, lumR - lumR * invAmount, lumR - lumR * invAmount),
+                vec3(lumG - lumG * invAmount, lumG + oneMinusLumG * invAmount, lumG - lumG * invAmount),
+                vec3(lumB - lumB * invAmount, lumB - lumB * invAmount, lumB + oneMinusLumB * invAmount)
+            );
+            vColorOffset = vec3(0.0);
             break;
         }
         case 3: {
             // HueRotate
             float c = cos(amount);
             float s = sin(amount);
-            vColorMat = mat4(vec4(lumR + oneMinusLumR * c - lumR * s, lumR - lumR * c + 0.143 * s, lumR - lumR * c - oneMinusLumR * s, 0.0),
-                            vec4(lumG - lumG * c - lumG * s, lumG + oneMinusLumG * c + 0.140 * s, lumG - lumG * c + lumG * s, 0.0),
-                            vec4(lumB - lumB * c + oneMinusLumB * s, lumB - lumB * c - 0.283 * s, lumB + oneMinusLumB * c + lumB * s, 0.0),
-                            vec4(0.0, 0.0, 0.0, 1.0));
-            vColorOffset = vec4(0.0);
+            vColorMat = mat3(
+                vec3(lumR + oneMinusLumR * c - lumR * s, lumR - lumR * c + 0.143 * s, lumR - lumR * c - oneMinusLumR * s),
+                vec3(lumG - lumG * c - lumG * s, lumG + oneMinusLumG * c + 0.140 * s, lumG - lumG * c + lumG * s),
+                vec3(lumB - lumB * c + oneMinusLumB * s, lumB - lumB * c - 0.283 * s, lumB + oneMinusLumB * c + lumB * s)
+            );
+            vColorOffset = vec3(0.0);
             break;
         }
         case 5: {
             // Saturate
-            vColorMat = mat4(vec4(invAmount * lumR + amount, invAmount * lumR, invAmount * lumR, 0.0),
-                             vec4(invAmount * lumG, invAmount * lumG + amount, invAmount * lumG, 0.0),
-                             vec4(invAmount * lumB, invAmount * lumB, invAmount * lumB + amount, 0.0),
-                             vec4(0.0, 0.0, 0.0, 1.0));
-            vColorOffset = vec4(0.0);
+            vColorMat = mat3(
+                vec3(invAmount * lumR + amount, invAmount * lumR, invAmount * lumR),
+                vec3(invAmount * lumG, invAmount * lumG + amount, invAmount * lumG),
+                vec3(invAmount * lumB, invAmount * lumB, invAmount * lumB + amount)
+            );
+            vColorOffset = vec3(0.0);
             break;
         }
         case 6: {
             // Sepia
-            vColorMat = mat4(vec4(0.393 + 0.607 * invAmount, 0.349 - 0.349 * invAmount, 0.272 - 0.272 * invAmount, 0.0),
-                             vec4(0.769 - 0.769 * invAmount, 0.686 + 0.314 * invAmount, 0.534 - 0.534 * invAmount, 0.0),
-                             vec4(0.189 - 0.189 * invAmount, 0.168 - 0.168 * invAmount, 0.131 + 0.869 * invAmount, 0.0),
-                             vec4(0.0, 0.0, 0.0, 1.0));
-            vColorOffset = vec4(0.0);
+            vColorMat = mat3(
+                vec3(0.393 + 0.607 * invAmount, 0.349 - 0.349 * invAmount, 0.272 - 0.272 * invAmount),
+                vec3(0.769 - 0.769 * invAmount, 0.686 + 0.314 * invAmount, 0.534 - 0.534 * invAmount),
+                vec3(0.189 - 0.189 * invAmount, 0.168 - 0.168 * invAmount, 0.131 + 0.869 * invAmount)
+            );
+            vColorOffset = vec3(0.0);
             break;
         }
         case 10: {
             // Color Matrix
-            vec4 mat_data[4] = fetch_from_resource_cache_4(user_data.z);
+            vec4 mat_data[3] = fetch_from_resource_cache_3(user_data.z);
             vec4 offset_data = fetch_from_resource_cache_1(user_data.z + 4);
-            vColorMat = mat4(mat_data[0], mat_data[1], mat_data[2], mat_data[3]);
-            vColorOffset = offset_data;
+            vColorMat = mat3(mat_data[0].xyz, mat_data[1].xyz, mat_data[2].xyz);
+            vColorOffset = offset_data.rgb;
             break;
         }
         default: break;
@@ -101,60 +105,56 @@ void brush_vs(
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-vec4 Contrast(vec4 Cs, float amount) {
-    return vec4(Cs.rgb * amount - 0.5 * amount + 0.5, Cs.a);
+vec3 Contrast(vec3 Cs, float amount) {
+    return Cs.rgb * amount - 0.5 * amount + 0.5;
 }
 
-vec4 Invert(vec4 Cs, float amount) {
-    return vec4(mix(Cs.rgb, vec3(1.0) - Cs.rgb, amount), Cs.a);
+vec3 Invert(vec3 Cs, float amount) {
+    return mix(Cs.rgb, vec3(1.0) - Cs.rgb, amount);
 }
 
-vec4 Brightness(vec4 Cs, float amount) {
+vec3 Brightness(vec3 Cs, float amount) {
     // Apply the brightness factor.
     // Resulting color needs to be clamped to output range
     // since we are pre-multiplying alpha in the shader.
-    return vec4(clamp(Cs.rgb * amount, vec3(0.0), vec3(1.0)), Cs.a);
-}
-
-vec4 Opacity(vec4 Cs, float amount) {
-    return vec4(Cs.rgb, Cs.a * amount);
+    return clamp(Cs.rgb * amount, vec3(0.0), vec3(1.0));
 }
 
 vec4 brush_fs() {
     vec4 Cs = texture(sColor0, vUv);
 
-    // Un-premultiply the input.
-    Cs.rgb /= Cs.a;
+    if (Cs.a == 0.0) {
+        return vec4(0.0); // could also `discard`
+    }
 
-    vec4 color;
+    // Un-premultiply the input.
+    float alpha = Cs.a;
+    vec3 color = Cs.rgb / Cs.a;
 
     switch (vOp) {
         case 0:
-            color = Cs;
             break;
         case 1:
-            color = Contrast(Cs, vAmount);
+            color = Contrast(color, vAmount);
             break;
         case 4:
-            color = Invert(Cs, vAmount);
+            color = Invert(color, vAmount);
             break;
         case 7:
-            color = Brightness(Cs, vAmount);
+            color = Brightness(color, vAmount);
             break;
-        case 8:
-            color = Opacity(Cs, vAmount);
+        case 8: // Opacity
+            alpha *= vAmount;
             break;
         default:
-            color = vColorMat * Cs + vColorOffset;
+            color = vColorMat * color + vColorOffset;
     }
 
     // Fail-safe to ensure that we don't sample outside the rendered
     // portion of a blend source.
-    color.a *= point_inside_rect(vUv.xy, vUvClipBounds.xy, vUvClipBounds.zw);
+    alpha *= point_inside_rect(vUv.xy, vUvClipBounds.xy, vUvClipBounds.zw);
 
     // Pre-multiply the alpha into the output value.
-    color.rgb *= color.a;
-
-    return color;
+    return alpha * vec4(color, 1.0);
 }
 #endif

--- a/wrench/reftests/filters/filter-color-matrix-ref.yaml
+++ b/wrench/reftests/filters/filter-color-matrix-ref.yaml
@@ -16,6 +16,3 @@ root:
         - type: rect
           bounds: [60, 10, 50, 50]
           color: [255, 0, 0, 1]
-        - type: rect
-          bounds: [60, 60, 50, 50]
-          color: [128, 128, 128, 1]

--- a/wrench/reftests/filters/filter-color-matrix.yaml
+++ b/wrench/reftests/filters/filter-color-matrix.yaml
@@ -40,14 +40,3 @@ root:
             - type: rect
               bounds: [0, 0, 50, 50]
               color: [0, 0, 255, 1]
-        - type: stacking-context
-          bounds: [60, 60, 50, 50]
-          filters: color-matrix( 1, 0, 0, 0,
-                                 0, 1, 0, 0,
-                                 0, 0, 1, 0,
-                                 0, 0, 0, 0.5,
-                                 0, 0, 0, 0 )
-          items:
-            - type: rect
-              bounds: [0, 0, 50, 50]
-              color: [255, 255, 255, 1]


### PR DESCRIPTION
Dividing by zero is not a good idea in GLSL.
Also fixes #2088 since we are at it.
r? @jrmuizel

Edit: wiki entry - https://github.com/servo/webrender/wiki/Driver-issues#division-by-zero-on-sandybridge-in-the-fragment-shader

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2530)
<!-- Reviewable:end -->
