### PR TITLE
Remove the Angle flickering workaround (3)

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -931,22 +931,6 @@ impl Device {
         }
     }
 
-    //TODO: remove once the Angle workaround is no longer needed
-    pub fn reset_angle_sampler_metadata(&mut self, texture: &Texture) {
-        self.bind_texture(DEFAULT_TEXTURE, texture);
-        self.gl.tex_parameter_f(
-            texture.target,
-            gl::TEXTURE_BASE_LEVEL,
-            1.0 as _,
-        );
-        self.gl.draw_arrays(gl::TRIANGLES, 0, 1); // dummy draw
-        self.gl.tex_parameter_f(
-            texture.target,
-            gl::TEXTURE_BASE_LEVEL,
-            0.0 as _, // assumes 0.0 is the normal value for this texture
-        );
-    }
-
     pub fn create_texture(
         &mut self,
         target: TextureTarget,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2358,14 +2358,6 @@ impl Renderer {
         textures: &BatchTextures,
         stats: &mut RendererStats,
     ) {
-        // Work around Angle bug that forgets to update sampler metadata,
-        // by making the use of those samplers uniform across programs.
-        // https://github.com/servo/webrender/wiki/Driver-issues#texturesize-in-vertex-shaders
-        let work_around_angle_bug = cfg!(windows);
-        if work_around_angle_bug {
-            self.device.reset_angle_sampler_metadata(&self.texture_resolver.dummy_cache_texture);
-        }
-
         for i in 0 .. textures.colors.len() {
             self.texture_resolver.bind(
                 &textures.colors[i],


### PR DESCRIPTION
Reverts #2504
No longer needed as my upstream Angle patch has landed and propagated to Gecko: https://hg.mozilla.org/mozilla-central/rev/6be00f9f1cd8 
so long, flickering, and thanks for all... not sure what, that's been really annoying :)

r? anyone