### PR TITLE
evict items from GlyphCache when evicted from TextureCache

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -4,16 +4,16 @@
 
 #[cfg(test)]
 use api::{IdNamespace, LayoutPoint};
-use api::{ColorF, ColorU, DevicePoint, DeviceUintSize};
+use api::{ColorF, ColorU};
 use api::{FontInstanceFlags, FontInstancePlatformOptions};
 use api::{FontKey, FontRenderMode, FontTemplate, FontVariation};
 use api::{GlyphDimensions, GlyphKey, SubpixelDirection};
 use api::{ImageData, ImageDescriptor, ImageFormat, LayerToWorldTransform};
 use app_units::Au;
 use device::TextureFilter;
-use glyph_cache::{CachedGlyphInfo, GlyphCache};
+use glyph_cache::{GlyphCache, GlyphCacheEntry, CachedGlyphInfo};
 use gpu_cache::GpuCache;
-use internal_types::{FastHashSet, ResourceCacheError};
+use internal_types::ResourceCacheError;
 use platform::font::FontContext;
 use profiler::TextureCacheProfileCounters;
 use rayon::ThreadPool;
@@ -309,11 +309,11 @@ pub struct GlyphRasterizer {
     // because the glyph cache hash table is not updated
     // until the end of the frame when we wait for glyph requests
     // to be resolved.
-    pending_glyphs: FastHashSet<GlyphRequest>,
+    pending_glyphs: usize,
 
     // Receives the rendered glyphs.
-    glyph_rx: Receiver<Vec<GlyphRasterJob>>,
-    glyph_tx: Sender<Vec<GlyphRasterJob>>,
+    glyph_rx: Receiver<GlyphRasterJobs>,
+    glyph_tx: Sender<GlyphRasterJobs>,
 
     // We defer removing fonts to the end of the frame so that:
     // - this work is done outside of the critical path,
@@ -341,7 +341,7 @@ impl GlyphRasterizer {
                 shared_context: Mutex::new(shared_context),
                 workers: Arc::clone(&workers),
             }),
-            pending_glyphs: FastHashSet::default(),
+            pending_glyphs: 0,
             glyph_rx,
             glyph_tx,
             workers,
@@ -391,7 +391,7 @@ impl GlyphRasterizer {
                 .lock_shared_context()
                 .has_font(&font.font_key)
         );
-        let mut glyphs = Vec::new();
+        let mut new_glyphs = Vec::new();
 
         let glyph_key_cache = glyph_cache.get_glyph_key_cache_for_font_mut(font.clone());
 
@@ -399,58 +399,51 @@ impl GlyphRasterizer {
         for key in glyph_keys {
             match glyph_key_cache.entry(key.clone()) {
                 Entry::Occupied(mut entry) => {
-                    if let Ok(Some(ref mut glyph_info)) = *entry.get_mut() {
-                        if texture_cache.request(&mut glyph_info.texture_cache_handle, gpu_cache) {
-                            // This case gets hit when we have already rasterized
-                            // the glyph and stored it in CPU memory, but the glyph
-                            // has been evicted from the texture cache. In which case
-                            // we need to re-upload it to the GPU.
-                            texture_cache.update(
-                                &mut glyph_info.texture_cache_handle,
-                                ImageDescriptor {
-                                    width: glyph_info.size.width,
-                                    height: glyph_info.size.height,
-                                    stride: None,
-                                    format: ImageFormat::BGRA8,
-                                    is_opaque: false,
-                                    offset: 0,
-                                },
-                                TextureFilter::Linear,
-                                Some(ImageData::Raw(glyph_info.glyph_bytes.clone())),
-                                [glyph_info.offset.x, glyph_info.offset.y, glyph_info.scale],
-                                None,
-                                gpu_cache,
-                            );
+                    let value = entry.into_mut();
+                    match *value {
+                        GlyphCacheEntry::Cached(ref glyph) => {
+                            // Skip the glyph if it is already has a valid texture cache handle.
+                            if !texture_cache.request(&glyph.texture_cache_handle, gpu_cache) {
+                                continue;
+                            }
                         }
+                        // Otherwise, skip the entry if it is blank or pending.
+                        GlyphCacheEntry::Blank |
+                        GlyphCacheEntry::Pending => continue,
                     }
+                    // This case gets hit when we already rasterized the glyph, but the
+                    // glyph has been evicted from the texture cache. Just force it to
+                    // pending so it gets rematerialized.
+                    *value = GlyphCacheEntry::Pending;
                 }
-                Entry::Vacant(..) => {
-                    let request = GlyphRequest::new(&font, key);
-                    if self.pending_glyphs.insert(request.clone()) {
-                        glyphs.push(request);
-                    }
+                Entry::Vacant(entry) => {
+                    // This is the first time we've seen the glyph, so mark it as pending.
+                    entry.insert(GlyphCacheEntry::Pending);
                 }
             }
+
+            new_glyphs.push(key.clone());
         }
 
-        if glyphs.is_empty() {
+        if new_glyphs.is_empty() {
             return;
         }
 
+        self.pending_glyphs += 1;
         let font_contexts = Arc::clone(&self.font_contexts);
         let glyph_tx = self.glyph_tx.clone();
         // spawn an async task to get off of the render backend thread as early as
         // possible and in that task use rayon's fork join dispatch to rasterize the
         // glyphs in the thread pool.
         self.workers.spawn(move || {
-            let jobs = glyphs
+            let jobs = new_glyphs
                 .par_iter()
-                .map(|request: &GlyphRequest| {
+                .map(|key: &GlyphKey| {
                     profile_scope!("glyph-raster");
                     let mut context = font_contexts.lock_current_context();
                     let job = GlyphRasterJob {
-                        request: request.clone(),
-                        result: context.rasterize_glyph(&request.font, &request.key),
+                        key: key.clone(),
+                        result: context.rasterize_glyph(&font, key),
                     };
 
                     // Sanity check.
@@ -466,7 +459,7 @@ impl GlyphRasterizer {
                 })
                 .collect();
 
-            glyph_tx.send(jobs).unwrap();
+            glyph_tx.send(GlyphRasterJobs { font, jobs }).unwrap();
         });
     }
 
@@ -493,72 +486,60 @@ impl GlyphRasterizer {
         gpu_cache: &mut GpuCache,
         _texture_cache_profile: &mut TextureCacheProfileCounters,
     ) {
-        let mut rasterized_glyphs = Vec::with_capacity(self.pending_glyphs.len());
+        // Pull rasterized glyphs from the queue and Update the caches.
+        while self.pending_glyphs > 0 {
+            self.pending_glyphs -= 1;
 
-        // Pull rasterized glyphs from the queue.
-
-        while !self.pending_glyphs.is_empty() {
             // TODO: rather than blocking until all pending glyphs are available
             // we could try_recv and steal work from the thread pool to take advantage
             // of the fact that this thread is alive and we avoid the added latency
             // of blocking it.
-            let raster_jobs = self.glyph_rx
+            let GlyphRasterJobs { font, mut jobs } = self.glyph_rx
                 .recv()
                 .expect("BUG: Should be glyphs pending!");
-            for job in raster_jobs {
-                debug_assert!(self.pending_glyphs.contains(&job.request));
-                self.pending_glyphs.remove(&job.request);
 
-                rasterized_glyphs.push(job);
-            }
-        }
+            // Ensure that the glyphs are always processed in the same
+            // order for a given text run (since iterating a hash set doesn't
+            // guarantee order). This can show up as very small float inaccuacry
+            // differences in rasterizers due to the different coordinates
+            // that text runs get associated with by the texture cache allocator.
+            jobs.sort_by(|a, b| a.key.cmp(&b.key));
 
-        // Ensure that the glyphs are always processed in the same
-        // order for a given text run (since iterating a hash set doesn't
-        // guarantee order). This can show up as very small float inaccuacry
-        // differences in rasterizers due to the different coordinates
-        // that text runs get associated with by the texture cache allocator.
-        rasterized_glyphs.sort_by(|a, b| a.request.cmp(&b.request));
+            let glyph_key_cache = glyph_cache.get_glyph_key_cache_for_font_mut(font);
 
-        // Update the caches.
-        for job in rasterized_glyphs {
-            let glyph_info = job.result
-                .and_then(|glyph| if glyph.width > 0 && glyph.height > 0 {
-                    assert_eq!((glyph.left.fract(), glyph.top.fract()), (0.0, 0.0));
-                    let glyph_bytes = Arc::new(glyph.bytes);
-                    let mut texture_cache_handle = TextureCacheHandle::new();
-                    texture_cache.request(&mut texture_cache_handle, gpu_cache);
-                    texture_cache.update(
-                        &mut texture_cache_handle,
-                        ImageDescriptor {
-                            width: glyph.width,
-                            height: glyph.height,
-                            stride: None,
-                            format: ImageFormat::BGRA8,
-                            is_opaque: false,
-                            offset: 0,
-                        },
-                        TextureFilter::Linear,
-                        Some(ImageData::Raw(glyph_bytes.clone())),
-                        [glyph.left, -glyph.top, glyph.scale],
-                        None,
-                        gpu_cache,
-                    );
-                    Some(CachedGlyphInfo {
-                        texture_cache_handle,
-                        glyph_bytes,
-                        size: DeviceUintSize::new(glyph.width, glyph.height),
-                        offset: DevicePoint::new(glyph.left, -glyph.top),
-                        scale: glyph.scale,
-                        format: glyph.format,
-                    })
-                } else {
-                    None
+            for GlyphRasterJob { key, result } in jobs {
+                let glyph_info = result.map_or(GlyphCacheEntry::Blank, |glyph| {
+                    if glyph.width > 0 && glyph.height > 0 {
+                        assert_eq!((glyph.left.fract(), glyph.top.fract()), (0.0, 0.0));
+                        let mut texture_cache_handle = TextureCacheHandle::new();
+                        texture_cache.request(&mut texture_cache_handle, gpu_cache);
+                        texture_cache.update(
+                            &mut texture_cache_handle,
+                            ImageDescriptor {
+                                width: glyph.width,
+                                height: glyph.height,
+                                stride: None,
+                                format: ImageFormat::BGRA8,
+                                is_opaque: false,
+                                offset: 0,
+                            },
+                            TextureFilter::Linear,
+                            Some(ImageData::Raw(Arc::new(glyph.bytes))),
+                            [glyph.left, -glyph.top, glyph.scale],
+                            None,
+                            gpu_cache,
+                            Some(glyph_key_cache.eviction_notice()),
+                        );
+                        GlyphCacheEntry::Cached(CachedGlyphInfo {
+                            texture_cache_handle,
+                            format: glyph.format,
+                        })
+                    } else {
+                        GlyphCacheEntry::Blank
+                    }
                 });
-
-            let glyph_key_cache = glyph_cache.get_glyph_key_cache_for_font_mut(job.request.font);
-
-            glyph_key_cache.insert(job.request.key, Ok(glyph_info));
+                glyph_key_cache.insert(key, glyph_info);
+            }
         }
 
         // Now that we are done with the critical path (rendering the glyphs),
@@ -583,7 +564,7 @@ impl GlyphRasterizer {
     #[cfg(feature = "replay")]
     pub fn reset(&mut self) {
         //TODO: any signals need to be sent to the workers?
-        self.pending_glyphs.clear();
+        self.pending_glyphs = 0;
         self.fonts_to_remove.clear();
     }
 }
@@ -619,8 +600,13 @@ impl GlyphRequest {
 }
 
 struct GlyphRasterJob {
-    request: GlyphRequest,
+    key: GlyphKey,
     result: Option<RasterizedGlyph>,
+}
+
+struct GlyphRasterJobs {
+    font: FontInstance,
+    jobs: Vec<GlyphRasterJob>,
 }
 
 #[test]

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -933,6 +933,7 @@ impl RenderTaskCache {
                 [0.0; 3],
                 None,
                 gpu_cache,
+                None,
             );
 
             // Get the allocation details in the texture cache, and store

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -35,7 +35,7 @@ use device::{ProgramCache, ReadPixelsFormat};
 use euclid::{rect, Transform3D};
 use frame_builder::FrameBuilderConfig;
 use gleam::gl;
-use glyph_rasterizer::GlyphFormat;
+use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
 use gpu_types::PrimitiveInstance;
 use internal_types::{SourceTexture, ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE, ResourceCacheError};
@@ -1309,9 +1309,6 @@ impl Renderer {
 
         let shaders = Shaders::new(&mut device, gl_type, &options)?;
 
-        let texture_cache = TextureCache::new(max_device_size);
-        let max_texture_size = texture_cache.max_texture_size();
-
         let backend_profile_counters = BackendProfileCounters::new();
 
         let dither_matrix_texture = if options.enable_dithering {
@@ -1489,11 +1486,7 @@ impl Renderer {
         let thread_listener_for_scene_builder = thread_listener.clone();
         let rb_thread_name = format!("WRRenderBackend#{}", options.renderer_id.unwrap_or(0));
         let scene_thread_name = format!("WRSceneBuilder#{}", options.renderer_id.unwrap_or(0));
-        let resource_cache = ResourceCache::new(
-            texture_cache,
-            workers,
-            blob_image_renderer,
-        )?;
+        let glyph_rasterizer = GlyphRasterizer::new(workers)?;
 
         let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new(config, api_tx.clone());
         thread::Builder::new().name(scene_thread_name.clone()).spawn(move || {
@@ -1515,6 +1508,14 @@ impl Renderer {
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
                 thread_listener.thread_started(&rb_thread_name);
             }
+
+            let texture_cache = TextureCache::new(max_device_size);
+            let resource_cache = ResourceCache::new(
+                texture_cache,
+                glyph_rasterizer,
+                blob_image_renderer,
+            );
+
             let mut backend = RenderBackend::new(
                 api_rx,
                 payload_rx_for_backend,
@@ -1552,7 +1553,7 @@ impl Renderer {
             backend_profile_counters: BackendProfileCounters::new(),
             profile_counters: RendererProfileCounters::new(),
             profiler: Profiler::new(),
-            max_texture_size: max_texture_size,
+            max_texture_size: max_device_size,
             max_recorded_profiles: options.max_recorded_profiles,
             clear_color: options.clear_color,
             enable_clear_scissor: options.enable_clear_scissor,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -22,9 +22,8 @@ use device::TextureFilter;
 use glyph_cache::{GlyphCache, GlyphCacheEntry};
 use glyph_rasterizer::{FontInstance, GlyphFormat, GlyphRasterizer, GlyphRequest};
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle};
-use internal_types::{FastHashMap, FastHashSet, ResourceCacheError, SourceTexture, TextureUpdateList};
+use internal_types::{FastHashMap, FastHashSet, SourceTexture, TextureUpdateList};
 use profiler::{ResourceProfileCounters, TextureCacheProfileCounters};
-use rayon::ThreadPool;
 use render_backend::FrameId;
 use render_task::{RenderTaskCache, RenderTaskCacheKey, RenderTaskId, RenderTaskTree};
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
@@ -277,12 +276,10 @@ pub struct ResourceCache {
 impl ResourceCache {
     pub fn new(
         texture_cache: TextureCache,
-        workers: Arc<ThreadPool>,
+        glyph_rasterizer: GlyphRasterizer,
         blob_image_renderer: Option<Box<BlobImageRenderer>>,
-    ) -> Result<Self, ResourceCacheError> {
-        let glyph_rasterizer = GlyphRasterizer::new(workers)?;
-
-        Ok(ResourceCache {
+    ) -> Self {
+        ResourceCache {
             cached_glyphs: GlyphCache::new(),
             cached_images: ResourceClassCache::new(),
             cached_render_tasks: RenderTaskCache::new(),
@@ -294,7 +291,7 @@ impl ResourceCache {
             pending_image_requests: FastHashSet::default(),
             glyph_rasterizer,
             blob_image_renderer,
-        })
+        }
     }
 
     pub fn max_texture_size(&self) -> u32 {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -19,11 +19,7 @@ use capture::PlainExternalImage;
 #[cfg(any(feature = "replay", feature = "png"))]
 use capture::CaptureConfig;
 use device::TextureFilter;
-use glyph_cache::GlyphCache;
-#[cfg(feature = "capture")]
-use glyph_cache::{PlainGlyphCacheRef, PlainCachedGlyphInfo};
-#[cfg(feature = "replay")]
-use glyph_cache::{CachedGlyphInfo, PlainGlyphCacheOwn};
+use glyph_cache::{GlyphCache, GlyphCacheEntry};
 use glyph_rasterizer::{FontInstance, GlyphFormat, GlyphRasterizer, GlyphRequest};
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle};
 use internal_types::{FastHashMap, FastHashSet, ResourceCacheError, SourceTexture, TextureUpdateList};
@@ -143,46 +139,40 @@ struct CachedImageInfo {
     epoch: Epoch,
 }
 
-#[derive(Debug)]
-#[cfg_attr(feature = "capture", derive(Clone, Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub enum ResourceClassCacheError {
-    OverLimitSize,
-}
-
-pub type ResourceCacheResult<V> = Result<V, ResourceClassCacheError>;
-
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct ResourceClassCache<K: Hash + Eq, V> {
-    resources: FastHashMap<K, ResourceCacheResult<V>>,
+pub struct ResourceClassCache<K: Hash + Eq, V, U: Default> {
+    resources: FastHashMap<K, V>,
+    pub user_data: U,
 }
 
-impl<K, V> ResourceClassCache<K, V>
+impl<K, V, U> ResourceClassCache<K, V, U>
 where
     K: Clone + Hash + Eq + Debug,
+    U: Default,
 {
-    pub fn new() -> ResourceClassCache<K, V> {
+    pub fn new() -> ResourceClassCache<K, V, U> {
         ResourceClassCache {
             resources: FastHashMap::default(),
+            user_data: Default::default(),
         }
     }
 
-    fn get(&self, key: &K) -> &ResourceCacheResult<V> {
+    pub fn get(&self, key: &K) -> &V {
         self.resources.get(key)
             .expect("Didn't find a cached resource with that ID!")
     }
 
-    pub fn insert(&mut self, key: K, value: ResourceCacheResult<V>) {
+    pub fn insert(&mut self, key: K, value: V) {
         self.resources.insert(key, value);
     }
 
-    pub fn get_mut(&mut self, key: &K) -> &mut ResourceCacheResult<V> {
+    pub fn get_mut(&mut self, key: &K) -> &mut V {
         self.resources.get_mut(key)
             .expect("Didn't find a cached resource with that ID!")
     }
 
-    pub fn entry(&mut self, key: K) -> Entry<K, ResourceCacheResult<V>> {
+    pub fn entry(&mut self, key: K) -> Entry<K, V> {
         self.resources.entry(key)
     }
 
@@ -202,6 +192,13 @@ where
         for key in resources_to_destroy {
             let _ = self.resources.remove(&key).unwrap();
         }
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.resources.retain(f);
     }
 }
 
@@ -224,7 +221,14 @@ impl Into<BlobImageRequest> for ImageRequest {
     }
 }
 
-type ImageCache = ResourceClassCache<ImageRequest, CachedImageInfo>;
+#[derive(Debug)]
+#[cfg_attr(feature = "capture", derive(Clone, Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum ImageCacheError {
+    OverLimitSize,
+}
+
+type ImageCache = ResourceClassCache<ImageRequest, Result<CachedImageInfo, ImageCacheError>, ()>;
 pub type FontInstanceMap = Arc<RwLock<FastHashMap<FontInstanceKey, FontInstance>>>;
 
 #[derive(Default)]
@@ -566,7 +570,7 @@ impl ResourceCache {
             // The image or tiling size is too big for hardware texture size.
             warn!("Dropping image, image:(w:{},h:{}, tile:{}) is too big for hardware!",
                   template.descriptor.width, template.descriptor.height, template.tiling.unwrap_or(0));
-            self.cached_images.insert(request, Err(ResourceClassCacheError::OverLimitSize));
+            self.cached_images.insert(request, Err(ImageCacheError::OverLimitSize));
             return;
         }
 
@@ -682,7 +686,7 @@ impl ResourceCache {
         debug_assert!(fetch_buffer.is_empty());
 
         for (loop_index, key) in glyph_keys.iter().enumerate() {
-            if let Ok(Some(ref glyph)) = *glyph_key_cache.get(key) {
+            if let GlyphCacheEntry::Cached(ref glyph) = *glyph_key_cache.get(key) {
                 let cache_item = self.texture_cache.get(&glyph.texture_cache_handle);
                 if current_texture_id != cache_item.texture_id ||
                    current_glyph_format != glyph.format {
@@ -794,6 +798,7 @@ impl ResourceCache {
         debug_assert_eq!(self.state, State::Idle);
         self.state = State::AddResources;
         self.texture_cache.begin_frame(frame_id);
+        self.cached_glyphs.begin_frame(&mut self.texture_cache);
         self.cached_render_tasks.begin_frame(&mut self.texture_cache);
         self.current_frame_id = frame_id;
     }
@@ -928,6 +933,7 @@ impl ResourceCache {
                 [0.0; 3],
                 image_template.dirty_rect,
                 gpu_cache,
+                None,
             );
             image_template.dirty_rect = None;
         }
@@ -1035,7 +1041,7 @@ pub struct PlainResources {
 #[derive(Serialize)]
 pub struct PlainCacheRef<'a> {
     current_frame_id: FrameId,
-    glyphs: PlainGlyphCacheRef<'a>,
+    glyphs: &'a GlyphCache,
     glyph_dimensions: &'a GlyphDimensionsCache,
     images: &'a ImageCache,
     render_tasks: &'a RenderTaskCache,
@@ -1046,7 +1052,7 @@ pub struct PlainCacheRef<'a> {
 #[derive(Deserialize)]
 pub struct PlainCacheOwn {
     current_frame_id: FrameId,
-    glyphs: PlainGlyphCacheOwn,
+    glyphs: GlyphCache,
     glyph_dimensions: GlyphDimensionsCache,
     images: ImageCache,
     render_tasks: RenderTaskCache,
@@ -1228,64 +1234,10 @@ impl ResourceCache {
     }
 
     #[cfg(feature = "capture")]
-    pub fn save_caches(&self, root: &PathBuf) -> PlainCacheRef {
-        use std::io::Write;
-        use std::fs;
-
-        let path_glyphs = root.join("glyphs");
-        if !path_glyphs.is_dir() {
-            fs::create_dir(&path_glyphs).unwrap();
-        }
-
-        info!("\tcached glyphs");
-        let mut glyph_paths = FastHashMap::default();
-        for cache in self.cached_glyphs.glyph_key_caches.values() {
-            for result in cache.resources.values() {
-                let arc = match *result {
-                    Ok(Some(ref info)) => &info.glyph_bytes,
-                    Ok(None) | Err(_) => continue,
-                };
-                let glyph_id = glyph_paths.len() + 1;
-                let entry = match glyph_paths.entry(arc.as_ptr()) {
-                    Entry::Occupied(_) => continue,
-                    Entry::Vacant(e) => e,
-                };
-
-                let file_name = format!("{}.raw", glyph_id);
-                let short_path = format!("glyphs/{}", file_name);
-                fs::File::create(path_glyphs.join(&file_name))
-                    .expect(&format!("Unable to create {}", short_path))
-                    .write_all(&*arc)
-                    .unwrap();
-                entry.insert(short_path);
-            }
-        }
-
+    pub fn save_caches(&self, _root: &PathBuf) -> PlainCacheRef {
         PlainCacheRef {
             current_frame_id: self.current_frame_id,
-            glyphs: self.cached_glyphs.glyph_key_caches
-                .iter()
-                .map(|(font_instance, cache)| {
-                    let resources = cache.resources
-                        .iter()
-                        .map(|(key, result)| {
-                            (key.clone(), match *result {
-                                Ok(Some(ref info)) => Ok(Some(PlainCachedGlyphInfo {
-                                    texture_cache_handle: info.texture_cache_handle.clone(),
-                                    glyph_bytes: glyph_paths[&info.glyph_bytes.as_ptr()].clone(),
-                                    size: info.size,
-                                    offset: info.offset,
-                                    scale: info.scale,
-                                    format: info.format,
-                                })),
-                                Ok(None) => Ok(None),
-                                Err(ref e) => Err(e.clone()),
-                            })
-                        })
-                        .collect();
-                    (font_instance, ResourceClassCache { resources })
-                })
-                .collect(),
+            glyphs: &self.cached_glyphs,
             glyph_dimensions: &self.cached_glyph_dimensions,
             images: &self.cached_images,
             render_tasks: &self.cached_render_tasks,
@@ -1311,47 +1263,8 @@ impl ResourceCache {
 
         match caches {
             Some(cached) => {
-                let glyph_key_caches = cached.glyphs
-                    .into_iter()
-                    .map(|(font_instance, rcc)| {
-                        let resources = rcc.resources
-                            .into_iter()
-                            .map(|(key, result)| {
-                                (key, match result {
-                                    Ok(Some(info)) => {
-                                        let glyph_bytes = match raw_map.entry(info.glyph_bytes) {
-                                            Entry::Occupied(e) => {
-                                                e.get().clone()
-                                            }
-                                            Entry::Vacant(e) => {
-                                                let mut buffer = Vec::new();
-                                                File::open(root.join(e.key()))
-                                                    .expect(&format!("Unable to open {}", e.key()))
-                                                    .read_to_end(&mut buffer)
-                                                    .unwrap();
-                                                e.insert(Arc::new(buffer))
-                                                    .clone()
-                                            }
-                                        };
-                                        Ok(Some(CachedGlyphInfo {
-                                            texture_cache_handle: info.texture_cache_handle,
-                                            glyph_bytes,
-                                            size: info.size,
-                                            offset: info.offset,
-                                            scale: info.scale,
-                                            format: info.format,
-                                        }))
-                                    },
-                                    Ok(None) => Ok(None),
-                                    Err(e) => Err(e),
-                                })
-                            })
-                            .collect();
-                        (font_instance, ResourceClassCache { resources })
-                    })
-                    .collect();
                 self.current_frame_id = cached.current_frame_id;
-                self.cached_glyphs = GlyphCache { glyph_key_caches };
+                self.cached_glyphs = cached.glyphs;
                 self.cached_glyph_dimensions = cached.glyph_dimensions;
                 self.cached_images = cached.images;
                 self.cached_render_tasks = cached.render_tasks;

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -197,9 +197,6 @@ pub struct EvictionNotice {
     evicted: Rc<Cell<bool>>,
 }
 
-// Only checked and updated on the main thread.
-unsafe impl Send for EvictionNotice {}
-
 impl EvictionNotice {
     fn notify(&self) {
         self.evicted.set(true);

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -14,8 +14,10 @@ use internal_types::{RenderTargetInfo, SourceTexture, TextureUpdate, TextureUpda
 use profiler::{ResourceProfileCounter, TextureCacheProfileCounters};
 use render_backend::FrameId;
 use resource_cache::CacheItem;
+use std::cell::Cell;
 use std::cmp;
 use std::mem;
+use std::rc::Rc;
 
 // The fixed number of layers for the shared texture cache.
 // There is one array texture per image format, allocated lazily.
@@ -103,6 +105,8 @@ struct CacheEntry {
     filter: TextureFilter,
     // The actual device texture ID this is part of.
     texture_id: CacheTextureId,
+    // Optional notice when the entry is evicted from the cache.
+    eviction_notice: Option<EvictionNotice>,
 }
 
 impl CacheEntry {
@@ -124,6 +128,7 @@ impl CacheEntry {
             format,
             filter,
             uv_rect_handle: GpuCacheHandle::new(),
+            eviction_notice: None,
         }
     }
 
@@ -150,6 +155,12 @@ impl CacheEntry {
             image_source.write_gpu_blocks(&mut request);
         }
     }
+
+    fn evict(&self) {
+        if let Some(eviction_notice) = self.eviction_notice.as_ref() {
+            eviction_notice.notify();
+        }
+    }
 }
 
 type WeakCacheEntryHandle = WeakFreeListHandle<CacheEntry>;
@@ -170,6 +181,37 @@ pub struct TextureCacheHandle {
 impl TextureCacheHandle {
     pub fn new() -> Self {
         TextureCacheHandle { entry: None }
+    }
+}
+
+// An eviction notice is a shared condition useful for detecting
+// when a TextureCacheHandle gets evicted from the TextureCache.
+// It is optionally installed to the TextureCache when an update()
+// is scheduled. A single notice may be shared among any number of
+// TextureCacheHandle updates. The notice may then be subsequently
+// checked to see if any of the updates using it have been evicted.
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct EvictionNotice {
+    evicted: Rc<Cell<bool>>,
+}
+
+// Only checked and updated on the main thread.
+unsafe impl Send for EvictionNotice {}
+
+impl EvictionNotice {
+    fn notify(&self) {
+        self.evicted.set(true);
+    }
+
+    pub fn check(&self) -> bool {
+        if self.evicted.get() {
+            self.evicted.set(false);
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -301,6 +343,7 @@ impl TextureCache {
         user_data: [f32; 3],
         mut dirty_rect: Option<DeviceUintRect>,
         gpu_cache: &mut GpuCache,
+        eviction_notice: Option<&EvictionNotice>,
     ) {
         // Determine if we need to allocate texture cache memory
         // for this item. We need to reallocate if any of the following
@@ -338,6 +381,9 @@ impl TextureCache {
         let entry = self.entries
             .get_opt_mut(handle.entry.as_ref().unwrap())
             .expect("BUG: handle must be valid now");
+
+        // Install the new eviction notice for this update, if applicable.
+        entry.eviction_notice = eviction_notice.cloned();
 
         // Invalidate the contents of the resource rect in the GPU cache.
         // This ensures that the update_gpu_cache below will add
@@ -498,6 +544,7 @@ impl TextureCache {
         // Free the selected items
         for handle in eviction_candidates {
             let entry = self.entries.free(handle);
+            entry.evict();
             self.free(entry);
         }
 
@@ -552,6 +599,7 @@ impl TextureCache {
                 retained_entries.push(handle);
             } else {
                 let entry = self.entries.free(handle);
+                entry.evict();
                 if let Some(region) = self.free(entry) {
                     found_matching_slab |= region.slab_size == needed_slab_size;
                     freed_complete_page |= region.is_empty();
@@ -1069,6 +1117,7 @@ impl TextureArray {
                 format: self.format,
                 filter: self.filter,
                 texture_id: self.texture_id.unwrap(),
+                eviction_notice: None,
             }
         })
     }


### PR DESCRIPTION
This is a follow-up to #2516 to make the GlyphCache itself much leaner to further reduce the amount of memory leaking/bloat we're seeing in Gecko by limiting the size of the GlyphCache.

Per discussion with Glenn, since the TextureCache is itself limited in size, and GlyphCache entries are ultimately upload to it, it makes sense to just use that to effectively limit the GlyphCache by purging its entries when they are removed from the TextureCache. This has many nice downwind effects in that GlyphCache entries themselves are now much smaller.

To link them together, I needed to introduce the notion of an EvictionNotice which the TextureCache uses to signal that an entry has been evicted, so that the GlyphKeyCaches can know when to actually check for purge entries, and avoids the expense of regularly having to scan through all glyphs.

I also optimized the amount of FontInstances we need to copy around to plumb the GlyphCache, which will further reduce memory thrashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2543)
<!-- Reviewable:end -->
