### PR TITLE
Add a callback for RB thread creation.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1487,6 +1487,7 @@ impl Renderer {
         let blob_image_renderer = options.blob_image_renderer.take();
         let thread_listener_for_render_backend = thread_listener.clone();
         let thread_listener_for_scene_builder = thread_listener.clone();
+        let renderer_id_for_render_backend = options.renderer_id.clone();
         let rb_thread_name = format!("WRRenderBackend#{}", options.renderer_id.unwrap_or(0));
         let scene_thread_name = format!("WRSceneBuilder#{}", options.renderer_id.unwrap_or(0));
         let resource_cache = ResourceCache::new(
@@ -1513,6 +1514,7 @@ impl Renderer {
         thread::Builder::new().name(rb_thread_name.clone()).spawn(move || {
             register_thread_with_profiler(rb_thread_name.clone());
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
+                thread_listener.new_render_backend_thread(renderer_id_for_render_backend);
                 thread_listener.thread_started(&rb_thread_name);
             }
             let mut backend = RenderBackend::new(
@@ -3828,6 +3830,7 @@ pub trait OutputImageHandler {
 pub trait ThreadListener {
     fn thread_started(&self, thread_name: &str);
     fn thread_stopped(&self, thread_name: &str);
+    fn new_render_backend_thread(&self, renderer_id: Option<u64>);
 }
 
 pub struct RendererOptions {


### PR DESCRIPTION
We'll want this for APZ, because APZ will need to know which thread is
the render backend thread corresponding to a particular window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2550)
<!-- Reviewable:end -->
