### PR TITLE
Make automatic mipmap generation opt-in.

### DIFF
--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -202,7 +202,7 @@ impl Example for App {
         let image_mask_key = api.generate_image_key();
         resources.add_image(
             image_mask_key,
-            ImageDescriptor::new(2, 2, ImageFormat::R8, true),
+            ImageDescriptor::new(2, 2, ImageFormat::R8, true, false),
             ImageData::new(vec![0, 80, 180, 255]),
             None,
         );

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -232,7 +232,7 @@ impl Example for App {
         let blob_img1 = api.generate_image_key();
         resources.add_image(
             blob_img1,
-            api::ImageDescriptor::new(500, 500, api::ImageFormat::BGRA8, true),
+            api::ImageDescriptor::new(500, 500, api::ImageFormat::BGRA8, true, false),
             api::ImageData::new_blob_image(serialize_blob(api::ColorU::new(50, 50, 150, 255))),
             Some(128),
         );
@@ -240,7 +240,7 @@ impl Example for App {
         let blob_img2 = api.generate_image_key();
         resources.add_image(
             blob_img2,
-            api::ImageDescriptor::new(200, 200, api::ImageFormat::BGRA8, true),
+            api::ImageDescriptor::new(200, 200, api::ImageFormat::BGRA8, true, false),
             api::ImageData::new_blob_image(serialize_blob(api::ColorU::new(50, 150, 50, 255))),
             None,
         );

--- a/webrender/examples/common/image_helper.rs
+++ b/webrender/examples/common/image_helper.rs
@@ -12,5 +12,5 @@ pub fn make_checkerboard(width: u32, height: u32) -> (ImageDescriptor, ImageData
             image_data.extend_from_slice(&[lum, lum, lum, 0xff]);
         }
     }
-    (ImageDescriptor::new(width, height, ImageFormat::BGRA8, true), ImageData::new(image_data))
+    (ImageDescriptor::new(width, height, ImageFormat::BGRA8, true, false), ImageData::new(image_data))
 }

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -70,7 +70,7 @@ impl App {
         let mut resources = ResourceUpdates::new();
         resources.add_image(
             self.external_image_key.unwrap(),
-            ImageDescriptor::new(100, 100, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(100, 100, ImageFormat::BGRA8, true, false),
             ImageData::External(ExternalImageData {
                 id: ExternalImageId(0),
                 channel_index: 0,

--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -101,7 +101,7 @@ impl Example for App {
                 let mut updates = ResourceUpdates::new();
                 updates.update_image(
                     self.image_key,
-                    ImageDescriptor::new(64, 64, ImageFormat::BGRA8, true),
+                    ImageDescriptor::new(64, 64, ImageFormat::BGRA8, true, false),
                     ImageData::new(image_data),
                     None,
                 );

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -111,7 +111,7 @@ impl Example for App {
             self.image_generator.generate_image(128);
             resources.add_image(
                 key0,
-                ImageDescriptor::new(128, 128, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(128, 128, ImageFormat::BGRA8, true, false),
                 ImageData::new(self.image_generator.take()),
                 None,
             );
@@ -119,7 +119,7 @@ impl Example for App {
             self.image_generator.generate_image(128);
             resources.add_image(
                 key1,
-                ImageDescriptor::new(128, 128, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(128, 128, ImageFormat::BGRA8, true, false),
                 ImageData::new(self.image_generator.take()),
                 None,
             );
@@ -215,7 +215,7 @@ impl Example for App {
 
                                 updates.add_image(
                                     image_key,
-                                    ImageDescriptor::new(size, size, ImageFormat::BGRA8, true),
+                                    ImageDescriptor::new(size, size, ImageFormat::BGRA8, true, false),
                                     ImageData::new(self.image_generator.take()),
                                     None,
                                 );
@@ -233,7 +233,7 @@ impl Example for App {
 
                         updates.update_image(
                             image_key,
-                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true),
+                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true, false),
                             ImageData::new(self.image_generator.take()),
                             None,
                         );
@@ -254,7 +254,7 @@ impl Example for App {
 
                         updates.add_image(
                             image_key,
-                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true),
+                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true, false),
                             ImageData::External(image_data),
                             None,
                         );
@@ -272,7 +272,7 @@ impl Example for App {
 
                         updates.add_image(
                             image_key,
-                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true),
+                            ImageDescriptor::new(size, size, ImageFormat::BGRA8, true, false),
                             ImageData::new(self.image_generator.take()),
                             None,
                         );

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -101,7 +101,7 @@ impl Example for App {
         let yuv_chanel3 = api.generate_image_key();
         resources.add_image(
             yuv_chanel1,
-            ImageDescriptor::new(100, 100, ImageFormat::R8, true),
+            ImageDescriptor::new(100, 100, ImageFormat::R8, true, false),
             ImageData::External(ExternalImageData {
                 id: ExternalImageId(0),
                 channel_index: 0,
@@ -113,7 +113,7 @@ impl Example for App {
         );
         resources.add_image(
             yuv_chanel2,
-            ImageDescriptor::new(100, 100, ImageFormat::RG8, true),
+            ImageDescriptor::new(100, 100, ImageFormat::RG8, true, false),
             ImageData::External(ExternalImageData {
                 id: ExternalImageId(1),
                 channel_index: 0,
@@ -125,7 +125,7 @@ impl Example for App {
         );
         resources.add_image(
             yuv_chanel2_1,
-            ImageDescriptor::new(100, 100, ImageFormat::R8, true),
+            ImageDescriptor::new(100, 100, ImageFormat::R8, true, false),
             ImageData::External(ExternalImageData {
                 id: ExternalImageId(2),
                 channel_index: 0,
@@ -137,7 +137,7 @@ impl Example for App {
         );
         resources.add_image(
             yuv_chanel3,
-            ImageDescriptor::new(100, 100, ImageFormat::R8, true),
+            ImageDescriptor::new(100, 100, ImageFormat::R8, true, false),
             ImageData::External(ExternalImageData {
                 id: ExternalImageId(3),
                 channel_index: 0,

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -521,6 +521,7 @@ impl GlyphRasterizer {
                                 stride: None,
                                 format: ImageFormat::BGRA8,
                                 is_opaque: false,
+                                allow_mipmaps: false,
                                 offset: 0,
                             },
                             TextureFilter::Linear,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -921,6 +921,7 @@ impl RenderTaskCache {
                 size.height as u32,
                 image_format,
                 is_opaque,
+                false,
             );
 
             // Allocate space in the texture cache, but don't supply

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1725,7 +1725,7 @@ impl Renderer {
     fn get_screenshot_for_debugger(&mut self) -> String {
         use api::ImageDescriptor;
 
-        let desc = ImageDescriptor::new(1024, 768, ImageFormat::BGRA8, true);
+        let desc = ImageDescriptor::new(1024, 768, ImageFormat::BGRA8, true, false);
         let data = self.device.read_pixels(&desc);
         let screenshot = debug_server::Screenshot::new(desc.width, desc.height, data);
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -889,8 +889,7 @@ impl ResourceCache {
                     height: actual_height,
                     stride,
                     offset,
-                    format: image_descriptor.format,
-                    is_opaque: image_descriptor.is_opaque,
+                    ..*image_descriptor
                 }
             } else {
                 image_template.descriptor.clone()
@@ -908,7 +907,8 @@ impl ResourceCache {
                     // that is > 512 in either dimension, so it should cover
                     // the most important use cases. We may want to support
                     // mip-maps on shared cache items in the future.
-                    if descriptor.width > 512 &&
+                    if descriptor.allow_mipmaps &&
+                       descriptor.width > 512 &&
                        descriptor.height > 512 &&
                        !self.texture_cache.is_allowed_in_shared_cache(
                         TextureFilter::Linear,

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -76,10 +76,17 @@ pub struct ImageDescriptor {
     pub stride: Option<u32>,
     pub offset: u32,
     pub is_opaque: bool,
+    pub allow_mipmaps: bool,
 }
 
 impl ImageDescriptor {
-    pub fn new(width: u32, height: u32, format: ImageFormat, is_opaque: bool) -> Self {
+    pub fn new(
+        width: u32,
+        height: u32,
+        format: ImageFormat,
+        is_opaque: bool,
+        allow_mipmaps: bool,
+    ) -> Self {
         ImageDescriptor {
             width,
             height,
@@ -87,6 +94,7 @@ impl ImageDescriptor {
             stride: None,
             offset: 0,
             is_opaque,
+            allow_mipmaps,
         }
     }
 

--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -3,6 +3,6 @@
 == very-big-tile-size.yaml very-big-tile-size-ref.yaml
 == tile-with-spacing.yaml tile-with-spacing-ref.yaml
 fuzzy(1,250000) == tile-repeat-prim-or-decompose.yaml tile-repeat-prim-or-decompose-ref.yaml
-== downscale.yaml downscale.png
+options(allow-mipmaps) == downscale.yaml downscale.png
 == segments.yaml segments.png
 == yuv.yaml yuv.png

--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -88,7 +88,7 @@ impl<'a> RawtestHarness<'a> {
         let blob_img = self.wrench.api.generate_image_key();
         resources.add_image(
             blob_img,
-            ImageDescriptor::new(151, 56, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(151, 56, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
             Some(128),
         );
@@ -140,7 +140,7 @@ impl<'a> RawtestHarness<'a> {
             blob_img = api.generate_image_key();
             resources.add_image(
                 blob_img,
-                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
                 ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
                 None,
             );
@@ -220,14 +220,14 @@ impl<'a> RawtestHarness<'a> {
             blob_img = api.generate_image_key();
             resources.add_image(
                 blob_img,
-                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
                 ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
                 None,
             );
             blob_img2 = api.generate_image_key();
             resources.add_image(
                 blob_img2,
-                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
                 ImageData::new_blob_image(blob::serialize_blob(ColorU::new(80, 50, 150, 255))),
                 None,
             );
@@ -285,13 +285,13 @@ impl<'a> RawtestHarness<'a> {
         let mut resources = ResourceUpdates::new();
         resources.update_image(
             blob_img,
-            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
             Some(rect(100, 100, 100, 100)),
         );
         resources.update_image(
             blob_img2,
-            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(59, 50, 150, 255))),
             Some(rect(100, 100, 100, 100)),
         );
@@ -306,7 +306,7 @@ impl<'a> RawtestHarness<'a> {
         let mut resources = ResourceUpdates::new();
         resources.update_image(
             blob_img,
-            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 150, 150, 255))),
             Some(rect(200, 200, 100, 100)),
         );
@@ -339,7 +339,7 @@ impl<'a> RawtestHarness<'a> {
             let img = self.wrench.api.generate_image_key();
             resources.add_image(
                 img,
-                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+                ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
                 ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
                 None,
             );
@@ -368,7 +368,7 @@ impl<'a> RawtestHarness<'a> {
         let mut resources = ResourceUpdates::new();
         resources.update_image(
             blob_img,
-            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 50, 150, 255))),
             Some(rect(100, 100, 100, 100)),
         );
@@ -392,7 +392,7 @@ impl<'a> RawtestHarness<'a> {
         let mut resources = ResourceUpdates::new();
         resources.update_image(
             blob_img,
-            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(500, 500, ImageFormat::BGRA8, true, false),
             ImageData::new_blob_image(blob::serialize_blob(ColorU::new(50, 150, 150, 255))),
             Some(rect(200, 200, 100, 100)),
         );
@@ -507,7 +507,7 @@ impl<'a> RawtestHarness<'a> {
         let image = self.wrench.api.generate_image_key();
         resources.add_image(
             image,
-            ImageDescriptor::new(1, 1, ImageFormat::BGRA8, true),
+            ImageDescriptor::new(1, 1, ImageFormat::BGRA8, true, false),
             ImageData::new(vec![0xFF, 0, 0, 0xFF]),
             None,
         );

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -32,6 +32,7 @@ const PLATFORM: &str = "other";
 const OPTION_DISABLE_SUBPX: &str = "disable-subpixel";
 const OPTION_DISABLE_AA: &str = "disable-aa";
 const OPTION_DISABLE_DUAL_SOURCE_BLENDING: &str = "disable-dual-source-blending";
+const OPTION_ALLOW_MIPMAPS: &str = "allow-mipmaps";
 
 pub struct ReftestOptions {
     // These override values that are lower.
@@ -77,6 +78,7 @@ pub struct Reftest {
     expected_alpha_targets: Option<usize>,
     expected_color_targets: Option<usize>,
     disable_dual_source_blending: bool,
+    allow_mipmaps: bool,
     zoom_factor: f32,
 }
 
@@ -196,6 +198,7 @@ impl ReftestManifest {
             let mut expected_draw_calls = None;
             let mut disable_dual_source_blending = false;
             let mut zoom_factor = 1.0;
+            let mut allow_mipmaps = false;
 
             for (i, token) in tokens.iter().enumerate() {
                 match *token {
@@ -248,6 +251,9 @@ impl ReftestManifest {
                         if args.iter().any(|arg| arg == &OPTION_DISABLE_DUAL_SOURCE_BLENDING) {
                             disable_dual_source_blending = true;
                         }
+                        if args.iter().any(|arg| arg == &OPTION_ALLOW_MIPMAPS) {
+                            allow_mipmaps = true;
+                        }
                     }
                     "==" => {
                         op = ReftestOp::Equal;
@@ -267,6 +273,7 @@ impl ReftestManifest {
                             expected_alpha_targets,
                             expected_color_targets,
                             disable_dual_source_blending,
+                            allow_mipmaps,
                             zoom_factor,
                         });
 
@@ -351,6 +358,7 @@ impl<'a> ReftestHarness<'a> {
                     t.reference.as_path(),
                     window_size,
                     t.font_render_mode,
+                    t.allow_mipmaps,
                 );
                 reference
             }
@@ -366,6 +374,7 @@ impl<'a> ReftestHarness<'a> {
             t.test.as_path(),
             reference.size,
             t.font_render_mode,
+            t.allow_mipmaps,
         );
 
         if t.disable_dual_source_blending {
@@ -464,9 +473,11 @@ impl<'a> ReftestHarness<'a> {
         filename: &Path,
         size: DeviceUintSize,
         font_render_mode: Option<FontRenderMode>,
+        allow_mipmaps: bool,
     ) -> (ReftestImage, RendererStats) {
         let mut reader = YamlFrameReader::new(filename);
         reader.set_font_render_mode(font_render_mode);
+        reader.allow_mipmaps(allow_mipmaps);
         reader.do_frame(self.wrench);
 
         // wait for the frame

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -104,7 +104,7 @@ fn generate_checkerboard_image(
     }
 
     (
-        ImageDescriptor::new(width, height, ImageFormat::BGRA8, true),
+        ImageDescriptor::new(width, height, ImageFormat::BGRA8, true, false),
         ImageData::new(pixels),
     )
 }
@@ -122,7 +122,7 @@ fn generate_xy_gradient_image(w: u32, h: u32) -> (ImageDescriptor, ImageData) {
     }
 
     (
-        ImageDescriptor::new(w, h, ImageFormat::BGRA8, true),
+        ImageDescriptor::new(w, h, ImageFormat::BGRA8, true, false),
         ImageData::new(pixels),
     )
 }
@@ -152,7 +152,7 @@ fn generate_solid_color_image(
     }
 
     (
-        ImageDescriptor::new(w, h, ImageFormat::BGRA8, a == 255),
+        ImageDescriptor::new(w, h, ImageFormat::BGRA8, a == 255, false),
         ImageData::new(pixels),
     )
 }
@@ -200,6 +200,7 @@ pub struct YamlFrameReader {
     fonts: HashMap<FontDescriptor, FontKey>,
     font_instances: HashMap<(FontKey, Au, FontInstanceFlags), FontInstanceKey>,
     font_render_mode: Option<FontRenderMode>,
+    allow_mipmaps: bool,
 
     /// A HashMap that allows specifying a numeric id for clip and clip chains in YAML
     /// and having each of those ids correspond to a unique ClipId.
@@ -224,6 +225,7 @@ impl YamlFrameReader {
             font_render_mode: None,
             image_map: HashMap::new(),
             clip_id_map: HashMap::new(),
+            allow_mipmaps: false,
         }
     }
 
@@ -415,6 +417,7 @@ impl YamlFrameReader {
                     image_dims.1,
                     format,
                     is_image_opaque(format, &bytes[..]),
+                    self.allow_mipmaps,
                 );
                 let data = ImageData::new(bytes);
                 (descriptor, data)
@@ -514,6 +517,10 @@ impl YamlFrameReader {
                     stretch,
                 } => wrench.font_key_from_properties(family, weight, style, stretch),
             })
+    }
+
+    pub fn allow_mipmaps(&mut self, allow_mipmaps: bool) {
+        self.allow_mipmaps = allow_mipmaps;
     }
 
     pub fn set_font_render_mode(&mut self, render_mode: Option<FontRenderMode>) {


### PR DESCRIPTION
Gecko downscales images before passing them to WR, so typically
doesn't want automatic mipmap generation enabled, which can be
slow on some platforms / drivers.

Mipmaps can still be enabled on a per-image basis, by setting the
allow_mipmaps field in the ImageDescriptor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2555)
<!-- Reviewable:end -->
