### PR TITLE
Fix TEXTURE_RECT vUvClipBounds value

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -94,7 +94,11 @@ void brush_vs(
 
             // Set the clip bounds to a value that won't have any
             // effect for local space images.
+#ifdef WR_FEATURE_TEXTURE_RECT
+            vUvClipBounds = vec4(0.0, 0.0, vec2(textureSize(sColor0)));
+#else
             vUvClipBounds = vec4(0.0, 0.0, 1.0, 1.0);
+#endif
             break;
         }
     }


### PR DESCRIPTION
Address #2546.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2558)
<!-- Reviewable:end -->
