### PR TITLE
Add hit testing support in wrench

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -505,6 +505,7 @@ fn main() {
     let mut show_help = false;
     let mut do_loop = false;
     let mut cpu_profile_index = 0;
+    let mut cursor_position = WorldPoint::zero();
 
     let dim = window.get_inner_size();
     wrench.update(dim);
@@ -528,13 +529,14 @@ fn main() {
                 glutin::WindowEvent::Closed => {
                     return glutin::ControlFlow::Break;
                 }
-
                 glutin::WindowEvent::Refresh |
-                glutin::WindowEvent::Focused(..) |
-                glutin::WindowEvent::CursorMoved { .. } => {
+                glutin::WindowEvent::Focused(..) => {
                     do_render = true;
                 }
-
+                glutin::WindowEvent::CursorMoved { position: (x, y), .. } => {
+                    cursor_position = WorldPoint::new(x as f32, y as f32);
+                    do_render = true;
+                }
                 glutin::WindowEvent::KeyboardInput {
                     input: glutin::KeyboardInput {
                         state: glutin::ElementState::Pressed,
@@ -614,6 +616,20 @@ fn main() {
 
                         wrench.set_page_zoom(new_zoom_factor);
                         do_frame = true;
+                    }
+                    VirtualKeyCode::X => {
+                        let results = wrench.api.hit_test(
+                            wrench.document_id,
+                            None,
+                            cursor_position,
+                            HitTestFlags::FIND_ALL
+                        );
+
+                        println!("Hit test results:");
+                        for item in &results.items {
+                            println!("  • {:?}", item);
+                        }
+                        println!("");
                     }
                     _ => {}
                 }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -577,6 +577,7 @@ impl Wrench {
             "M - Trigger memory pressure event",
             "T - Save CPU profile to a file",
             "C - Save a capture to captures/wrench/",
+            "X - Do a hit test at the current cursor position",
         ];
 
         let color_and_offset = [(*BLACK_COLOR, 2.0), (*WHITE_COLOR, 0.0)];

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -371,6 +371,19 @@ impl YamlFrameReader {
         }
     }
 
+    fn to_hit_testing_tag(&self, item: &Yaml) -> Option<ItemTag> {
+        match *item {
+            Yaml::Array(ref array) if array.len() == 2 => {
+                match (array[0].as_i64(), array[1].as_i64()) {
+                    (Some(first), Some(second)) => Some((first as u64, second as u16)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+
+    }
+
     pub fn add_or_get_image(
             &mut self,
             file: &Path,
@@ -1283,6 +1296,8 @@ impl YamlFrameReader {
 
             let mut info = LayoutPrimitiveInfo::with_clip_rect(LayoutRect::zero(), clip_rect);
             info.is_backface_visible = item["backface-visible"].as_bool().unwrap_or(true);;
+            info.tag = self.to_hit_testing_tag(&item["hit-testing-tag"]);
+
             match item_type {
                 "rect" => self.handle_rect(dl, item, &mut info),
                 "clear-rect" => self.handle_clear_rect(dl, item, &mut info),

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -687,9 +687,17 @@ impl YamlFrameWriter {
             };
 
             let mut v = new_table();
-            rect_node(&mut v, "bounds", &base.rect());
+            let info = base.get_layer_primitive_info(&LayoutVector2D::zero());
+            rect_node(&mut v, "bounds", &info.rect);
+            rect_node(&mut v, "clip-rect", &info.clip_rect);
 
-            rect_node(&mut v, "clip-rect", base.clip_rect());
+            if let Some(tag) = info.tag {
+                yaml_node(
+                    &mut v,
+                    "hit-testing-tag",
+                     Yaml::Array(vec![Yaml::Integer(tag.0 as i64), Yaml::Integer(tag.1 as i64)])
+                );
+            }
 
             let clip_and_scroll_yaml = match clip_id_mapper.map_info(&base.clip_and_scroll()) {
                 (scroll_id, Some(clip_id)) => {


### PR DESCRIPTION
Process hit testing tags when writing and reading wrench YAML. Also, add
a keybinding which performs a hit test. This is useful for debugging hit
testing issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2559)
<!-- Reviewable:end -->
