### PR TITLE
Revert "Stop running taskcluster CI on the master branch."

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -49,8 +49,6 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
-        excludeBranches:
-          - master
     payload:
       maxRunTime: 3600
       image: 'staktrace/webrender-test:latest'
@@ -83,8 +81,6 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
-        excludeBranches:
-          - master
     payload:
       maxRunTime: 3600
       image: 'staktrace/webrender-test:latest'
@@ -130,8 +126,6 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
-        excludeBranches:
-          - master
     payload:
       maxRunTime: 3600
       command:
@@ -164,8 +158,6 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
-        excludeBranches:
-          - master
     payload:
       maxRunTime: 3600
       command:


### PR DESCRIPTION
This reverts commit 01d2b04bbfce4f97e00fa7c23606d282ca0e48c7, since
apparently there's a taskcluster-github bug that stops running CI on
pull requests as well. It is being fixed in taskcluster/taskcluster-github#234
but looks like there is some debate, so in the meantime we should back
out the exclusion.