### PR TITLE
Make DebugRenderer optional to save startup time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 9.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 [features]
 default = ["freetype-lib"]
 freetype-lib = ["freetype/servo-freetype-sys"]
-profiler = ["thread_profiler/thread_profiler"]
+profiler = ["thread_profiler/thread_profiler", "debug_renderer"]
 debugger = ["ws", "serde_json", "serde", "image", "base64", "debug_renderer"]
 capture = ["webrender_api/serialize", "ron", "serde"]
 replay = ["webrender_api/deserialize", "ron", "serde"]
@@ -39,6 +39,7 @@ serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 image = { optional = true, version = "0.18" }
 base64 = { optional = true, version = "0.6" }
 ron = { optional = true, version = "0.1.7" }
+cfg-if = "0.1.2"
 
 [dev-dependencies]
 mozangle = "0.1"

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -48,6 +48,8 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate thread_profiler;
+#[macro_use]
+extern crate cfg_if;
 #[cfg(any(feature = "debugger", feature = "capture", feature = "replay"))]
 #[macro_use]
 extern crate serde;
@@ -61,6 +63,7 @@ mod clip;
 mod clip_scroll_node;
 mod clip_scroll_tree;
 mod debug_colors;
+#[cfg(feature = "debug_renderer")]
 mod debug_font_data;
 #[cfg(feature = "debug_renderer")]
 mod debug_render;

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -2,22 +2,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ColorF, ColorU};
-#[cfg(feature = "debug_renderer")]
-use debug_render::DebugRenderer;
-use euclid::{Point2D, Rect, Size2D, vec2};
-use query::{GpuSampler, GpuTimer, NamedTag};
+use api::ColorF;
+use query::{GpuTimer, NamedTag};
 use std::collections::vec_deque::VecDeque;
-use internal_types::FastHashMap;
-use renderer::MAX_VERTEX_TEXTURE_WIDTH;
-use std::{f32, mem};
+use std::f32;
 use time::precise_time_ns;
 
-const GRAPH_WIDTH: f32 = 1024.0;
-const GRAPH_HEIGHT: f32 = 320.0;
-const GRAPH_PADDING: f32 = 8.0;
-const GRAPH_FRAME_HEIGHT: f32 = 16.0;
-const PROFILE_PADDING: f32 = 10.0;
+cfg_if! {
+    if #[cfg(feature = "debug_renderer")] {
+        use api::ColorU;
+        use debug_render::DebugRenderer;
+        use euclid::{Point2D, Rect, Size2D, vec2};
+        use query::GpuSampler;
+        use internal_types::FastHashMap;
+        use renderer::MAX_VERTEX_TEXTURE_WIDTH;
+        use std::mem;
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "debug_renderer")] {
+        const GRAPH_WIDTH: f32 = 1024.0;
+        const GRAPH_HEIGHT: f32 = 320.0;
+        const GRAPH_PADDING: f32 = 8.0;
+        const GRAPH_FRAME_HEIGHT: f32 = 16.0;
+        const PROFILE_PADDING: f32 = 10.0;
+    }
+}
 
 const ONE_SECOND_NS: u64 = 1000000000;
 
@@ -26,7 +37,7 @@ pub struct GpuProfileTag {
     pub label: &'static str,
     pub color: ColorF,
 }
-
+ 
 impl NamedTag for GpuProfileTag {
     fn get_label(&self) -> &str {
         self.label
@@ -86,11 +97,13 @@ impl ProfileCounter for IntProfileCounter {
     }
 }
 
+#[cfg(feature = "debug_renderer")]
 pub struct FloatProfileCounter {
     description: &'static str,
     value: f32,
 }
 
+#[cfg(feature = "debug_renderer")]
 impl ProfileCounter for FloatProfileCounter {
     fn description(&self) -> &'static str {
         self.description
@@ -490,6 +503,7 @@ struct GraphStats {
 }
 
 struct ProfileGraph {
+    #[cfg(feature = "debug_renderer")]
     max_samples: usize,
     values: VecDeque<f32>,
     short_description: &'static str,

--- a/webrender/src/query.rs
+++ b/webrender/src/query.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use gleam::gl;
+#[cfg(feature = "debug_renderer")]
 use std::mem;
 use std::rc::Rc;
 
@@ -54,6 +55,7 @@ impl<T> QuerySet<T> {
         })
     }
 
+    #[cfg(feature = "debug_renderer")]
     fn take<F: Fn(&mut T, gl::GLuint)>(&mut self, fun: F) -> Vec<T> {
         let mut data = mem::replace(&mut self.data, Vec::new());
         for (value, &query) in data.iter_mut().zip(self.set.iter()) {
@@ -157,6 +159,7 @@ impl<T: NamedTag> GpuFrameProfile<T> {
         GpuSampleQuery
     }
 
+    #[cfg(feature = "debug_renderer")]
     fn build_samples(&mut self) -> (FrameId, Vec<GpuTimer<T>>, Vec<GpuSampler<T>>) {
         debug_assert!(!self.inside_frame);
         let gl = &self.gl;
@@ -233,6 +236,7 @@ impl<T> GpuProfiler<T> {
 }
 
 impl<T: NamedTag> GpuProfiler<T> {
+    #[cfg(feature = "debug_renderer")]
     pub fn build_samples(&mut self) -> (FrameId, Vec<GpuTimer<T>>, Vec<GpuSampler<T>>) {
         self.frames[self.next_frame].build_samples()
     }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -563,7 +563,7 @@ impl Wrench {
         ];
 
         let color_and_offset = [(*BLACK_COLOR, 2.0), (*WHITE_COLOR, 0.0)];
-        let dr = self.renderer.debug_renderer().unwrap();
+        let dr = self.renderer.debug_renderer();
 
         for ref co in &color_and_offset {
             let x = self.device_pixel_ratio * (15.0 + co.1);

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -563,7 +563,7 @@ impl Wrench {
         ];
 
         let color_and_offset = [(*BLACK_COLOR, 2.0), (*WHITE_COLOR, 0.0)];
-        let dr = self.renderer.debug_renderer();
+        let dr = self.renderer.debug_renderer().unwrap();
 
         for ref co in &color_and_offset {
             let x = self.device_pixel_ratio * (15.0 + co.1);


### PR DESCRIPTION
This change makes the `DebugRenderer` optional, thereby saving the compilation time of two shaders ("debug_font" and "debug_color") and improving the startup time of webrender. If you don't need to debug webrender, there is no point in having a `DebugRenderer` and no point in compiling the shaders. 

The relevant feature is called `debug_renderer`. It is enabled by default for the features `debugger` and `profiler` (mostly because `wrench` needs them). Otherwise, this feature is not enabled by default, which also saves roughly 2.5 MB of RAM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2574)
<!-- Reviewable:end -->
