### PR TITLE
Remove PictureKind enum.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -16,7 +16,7 @@ use gpu_types::{BrushFlags, BrushInstance, ClipChainRectIndex, ZBufferId, ZBuffe
 use gpu_types::{ClipMaskInstance, ClipScrollNodeIndex, RasterizationSpace};
 use gpu_types::{CompositePrimitiveInstance, PrimitiveInstance, SimplePrimitiveInstance};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
-use picture::{PictureCompositeMode, PictureKind, PicturePrimitive};
+use picture::{PictureCompositeMode, PicturePrimitive};
 use plane_split::{BspSplitter, Polygon, Splitter};
 use prim_store::{CachedGradient, ImageSource, PrimitiveIndex, PrimitiveKind, PrimitiveMetadata, PrimitiveStore};
 use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PictureIndex, PrimitiveRun};
@@ -648,252 +648,39 @@ impl AlphaBatchBuilder {
                                 let cache_task_address = render_tasks.get_task_address(cache_task_id);
                                 let textures = BatchTextures::render_target_cache();
 
-                                match picture.kind {
-                                    PictureKind::Image {
-                                        composite_mode,
-                                        secondary_render_task_id,
-                                        is_in_3d_context,
-                                        reference_frame_index,
-                                        real_local_rect,
-                                        ref extra_gpu_data_handle,
-                                        ..
-                                    } => {
-                                        // If this picture is participating in a 3D rendering context,
-                                        // then don't add it to any batches here. Instead, create a polygon
-                                        // for it and add it to the current plane splitter.
-                                        if is_in_3d_context {
-                                            // Push into parent plane splitter.
+                                // If this picture is participating in a 3D rendering context,
+                                // then don't add it to any batches here. Instead, create a polygon
+                                // for it and add it to the current plane splitter.
+                                if picture.is_in_3d_context {
+                                    // Push into parent plane splitter.
 
-                                            let real_xf = &ctx.clip_scroll_tree
-                                                .nodes[reference_frame_index.0]
-                                                .world_content_transform
-                                                .into();
-                                            let polygon = make_polygon(
-                                                real_local_rect,
-                                                &real_xf,
-                                                prim_index.0,
-                                            );
+                                    let real_xf = &ctx.clip_scroll_tree
+                                        .nodes[picture.reference_frame_index.0]
+                                        .world_content_transform
+                                        .into();
+                                    let polygon = make_polygon(
+                                        picture.real_local_rect,
+                                        &real_xf,
+                                        prim_index.0,
+                                    );
 
-                                            splitter.add(polygon);
+                                    splitter.add(polygon);
 
-                                            return;
-                                        }
+                                    return;
+                                }
 
-                                        // Depending on the composite mode of the picture, we generate the
-                                        // old style Composite primitive instances. In the future, we'll
-                                        // remove these and pass them through the brush batching pipeline.
-                                        // This will allow us to unify some of the shaders, apply clip masks
-                                        // when compositing pictures, and also correctly apply pixel snapping
-                                        // to picture compositing operations.
-                                        let source_id = cache_task_id;
+                                // Depending on the composite mode of the picture, we generate the
+                                // old style Composite primitive instances. In the future, we'll
+                                // remove these and pass them through the brush batching pipeline.
+                                // This will allow us to unify some of the shaders, apply clip masks
+                                // when compositing pictures, and also correctly apply pixel snapping
+                                // to picture compositing operations.
+                                let source_id = cache_task_id;
 
-                                        match composite_mode.expect("bug: only composites here") {
-                                            PictureCompositeMode::Filter(filter) => {
-                                                match filter {
-                                                    FilterOp::Blur(..) => {
-                                                        let kind = BatchKind::Brush(
-                                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
-                                                        );
-                                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-
-                                                        let uv_rect_address = render_tasks[cache_task_id]
-                                                            .get_texture_handle()
-                                                            .as_int(gpu_cache);
-
-                                                        let instance = BrushInstance {
-                                                            picture_address: task_address,
-                                                            prim_address: prim_cache_address,
-                                                            clip_chain_rect_index,
-                                                            scroll_id,
-                                                            clip_task_address,
-                                                            z,
-                                                            segment_index: 0,
-                                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                                            brush_flags: BrushFlags::empty(),
-                                                            user_data: [
-                                                                uv_rect_address,
-                                                                BrushImageSourceKind::Color as i32,
-                                                                RasterizationSpace::Screen as i32,
-                                                            ],
-                                                        };
-                                                        batch.push(PrimitiveInstance::from(instance));
-                                                    }
-                                                    FilterOp::DropShadow(offset, _, _) => {
-                                                        let kind = BatchKind::Brush(
-                                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray),
-                                                        );
-                                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
-
-                                                        let uv_rect_address = render_tasks[cache_task_id]
-                                                            .get_texture_handle()
-                                                            .as_int(gpu_cache);
-
-                                                        let instance = BrushInstance {
-                                                            picture_address: task_address,
-                                                            prim_address: prim_cache_address,
-                                                            clip_chain_rect_index,
-                                                            scroll_id,
-                                                            clip_task_address,
-                                                            z,
-                                                            segment_index: 0,
-                                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                                            brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-                                                            user_data: [
-                                                                uv_rect_address,
-                                                                BrushImageSourceKind::ColorAlphaMask as i32,
-                                                                // TODO(gw): This is totally wrong, but the drop-shadow code itself
-                                                                //           is completely wrong, and doesn't work correctly with
-                                                                //           transformed Picture sources. I'm leaving this as is for
-                                                                //           now, and will fix drop-shadows properly, as a follow up.
-                                                                RasterizationSpace::Local as i32,
-                                                            ],
-                                                        };
-
-                                                        {
-                                                            let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                            batch.push(PrimitiveInstance::from(instance));
-                                                        }
-
-                                                        let secondary_id = secondary_render_task_id.expect("no secondary!?");
-                                                        let saved_index = render_tasks[secondary_id].saved_index.expect("no saved index!?");
-                                                        debug_assert_ne!(saved_index, SavedTargetIndex::PENDING);
-                                                        let secondary_task_address = render_tasks.get_task_address(secondary_id);
-                                                        let secondary_textures = BatchTextures {
-                                                            colors: [
-                                                                SourceTexture::RenderTaskCache(saved_index),
-                                                                SourceTexture::Invalid,
-                                                                SourceTexture::Invalid,
-                                                            ],
-                                                        };
-                                                        let key = BatchKey::new(
-                                                            BatchKind::HardwareComposite,
-                                                            BlendMode::PremultipliedAlpha,
-                                                            secondary_textures,
-                                                        );
-                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                        let content_rect = prim_metadata.local_rect.translate(&-offset);
-                                                        let rect =
-                                                            (content_rect * LayerToWorldScale::new(1.0) * ctx.device_pixel_scale).round()
-                                                                                                                                 .to_i32();
-
-                                                        let instance = CompositePrimitiveInstance::new(
-                                                            task_address,
-                                                            secondary_task_address,
-                                                            RenderTaskAddress(0),
-                                                            rect.origin.x,
-                                                            rect.origin.y,
-                                                            z,
-                                                            rect.size.width,
-                                                            rect.size.height,
-                                                        );
-
-                                                        batch.push(PrimitiveInstance::from(instance));
-                                                    }
-                                                    _ => {
-                                                        let key = BatchKey::new(
-                                                            BatchKind::Brush(BrushBatchKind::Blend),
-                                                            BlendMode::PremultipliedAlpha,
-                                                            BatchTextures::render_target_cache(),
-                                                        );
-
-                                                        let filter_mode = match filter {
-                                                            FilterOp::Blur(..) => 0,
-                                                            FilterOp::Contrast(..) => 1,
-                                                            FilterOp::Grayscale(..) => 2,
-                                                            FilterOp::HueRotate(..) => 3,
-                                                            FilterOp::Invert(..) => 4,
-                                                            FilterOp::Saturate(..) => 5,
-                                                            FilterOp::Sepia(..) => 6,
-                                                            FilterOp::Brightness(..) => 7,
-                                                            FilterOp::Opacity(..) => 8,
-                                                            FilterOp::DropShadow(..) => 9,
-                                                            FilterOp::ColorMatrix(..) => 10,
-                                                        };
-
-                                                        let user_data = match filter {
-                                                            FilterOp::Contrast(amount) |
-                                                            FilterOp::Grayscale(amount) |
-                                                            FilterOp::Invert(amount) |
-                                                            FilterOp::Saturate(amount) |
-                                                            FilterOp::Sepia(amount) |
-                                                            FilterOp::Brightness(amount) |
-                                                            FilterOp::Opacity(_, amount) => {
-                                                                (amount * 65536.0) as i32
-                                                            }
-                                                            FilterOp::HueRotate(angle) => {
-                                                                (0.01745329251 * angle * 65536.0) as i32
-                                                            }
-                                                            // Go through different paths
-                                                            FilterOp::Blur(..) |
-                                                            FilterOp::DropShadow(..) => {
-                                                                unreachable!();
-                                                            }
-                                                            FilterOp::ColorMatrix(_) => {
-                                                                extra_gpu_data_handle.as_int(gpu_cache)
-                                                            }
-                                                        };
-
-                                                        let instance = BrushInstance {
-                                                            picture_address: task_address,
-                                                            prim_address: prim_cache_address,
-                                                            clip_chain_rect_index,
-                                                            scroll_id,
-                                                            clip_task_address,
-                                                            z,
-                                                            segment_index: 0,
-                                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                                            brush_flags: BrushFlags::empty(),
-                                                            user_data: [
-                                                                cache_task_address.0 as i32,
-                                                                filter_mode,
-                                                                user_data,
-                                                            ],
-                                                        };
-
-                                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                        batch.push(PrimitiveInstance::from(instance));
-                                                    }
-                                                }
-                                            }
-                                            PictureCompositeMode::MixBlend(mode) => {
-                                                let backdrop_id = secondary_render_task_id.expect("no backdrop!?");
-
-                                                let key = BatchKey::new(
-                                                    BatchKind::Brush(
-                                                        BrushBatchKind::MixBlend {
-                                                            task_id,
-                                                            source_id,
-                                                            backdrop_id,
-                                                        },
-                                                    ),
-                                                    BlendMode::PremultipliedAlpha,
-                                                    BatchTextures::no_texture(),
-                                                );
-                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
-                                                let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
-                                                let source_task_address = render_tasks.get_task_address(source_id);
-
-                                                let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
-                                                    clip_task_address,
-                                                    z,
-                                                    segment_index: 0,
-                                                    edge_flags: EdgeAaSegmentMask::empty(),
-                                                    brush_flags: BrushFlags::empty(),
-                                                    user_data: [
-                                                        mode as u32 as i32,
-                                                        backdrop_task_address.0 as i32,
-                                                        source_task_address.0 as i32,
-                                                    ],
-                                                };
-
-                                                batch.push(PrimitiveInstance::from(instance));
-                                            }
-                                            PictureCompositeMode::Blit => {
+                                match picture.composite_mode.expect("bug: only composites here") {
+                                    PictureCompositeMode::Filter(filter) => {
+                                        match filter {
+                                            FilterOp::Blur(..) => {
                                                 let kind = BatchKind::Brush(
                                                     BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
                                                 );
@@ -922,7 +709,208 @@ impl AlphaBatchBuilder {
                                                 };
                                                 batch.push(PrimitiveInstance::from(instance));
                                             }
+                                            FilterOp::DropShadow(offset, _, _) => {
+                                                let kind = BatchKind::Brush(
+                                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray),
+                                                );
+                                                let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+
+                                                let uv_rect_address = render_tasks[cache_task_id]
+                                                    .get_texture_handle()
+                                                    .as_int(gpu_cache);
+
+                                                let instance = BrushInstance {
+                                                    picture_address: task_address,
+                                                    prim_address: prim_cache_address,
+                                                    clip_chain_rect_index,
+                                                    scroll_id,
+                                                    clip_task_address,
+                                                    z,
+                                                    segment_index: 0,
+                                                    edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
+                                                    user_data: [
+                                                        uv_rect_address,
+                                                        BrushImageSourceKind::ColorAlphaMask as i32,
+                                                        // TODO(gw): This is totally wrong, but the drop-shadow code itself
+                                                        //           is completely wrong, and doesn't work correctly with
+                                                        //           transformed Picture sources. I'm leaving this as is for
+                                                        //           now, and will fix drop-shadows properly, as a follow up.
+                                                        RasterizationSpace::Local as i32,
+                                                    ],
+                                                };
+
+                                                {
+                                                    let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                    batch.push(PrimitiveInstance::from(instance));
+                                                }
+
+                                                let secondary_id = picture.secondary_render_task_id.expect("no secondary!?");
+                                                let saved_index = render_tasks[secondary_id].saved_index.expect("no saved index!?");
+                                                debug_assert_ne!(saved_index, SavedTargetIndex::PENDING);
+                                                let secondary_task_address = render_tasks.get_task_address(secondary_id);
+                                                let secondary_textures = BatchTextures {
+                                                    colors: [
+                                                        SourceTexture::RenderTaskCache(saved_index),
+                                                        SourceTexture::Invalid,
+                                                        SourceTexture::Invalid,
+                                                    ],
+                                                };
+                                                let key = BatchKey::new(
+                                                    BatchKind::HardwareComposite,
+                                                    BlendMode::PremultipliedAlpha,
+                                                    secondary_textures,
+                                                );
+                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                let content_rect = prim_metadata.local_rect.translate(&-offset);
+                                                let rect =
+                                                    (content_rect * LayerToWorldScale::new(1.0) * ctx.device_pixel_scale).round()
+                                                                                                                         .to_i32();
+
+                                                let instance = CompositePrimitiveInstance::new(
+                                                    task_address,
+                                                    secondary_task_address,
+                                                    RenderTaskAddress(0),
+                                                    rect.origin.x,
+                                                    rect.origin.y,
+                                                    z,
+                                                    rect.size.width,
+                                                    rect.size.height,
+                                                );
+
+                                                batch.push(PrimitiveInstance::from(instance));
+                                            }
+                                            _ => {
+                                                let key = BatchKey::new(
+                                                    BatchKind::Brush(BrushBatchKind::Blend),
+                                                    BlendMode::PremultipliedAlpha,
+                                                    BatchTextures::render_target_cache(),
+                                                );
+
+                                                let filter_mode = match filter {
+                                                    FilterOp::Blur(..) => 0,
+                                                    FilterOp::Contrast(..) => 1,
+                                                    FilterOp::Grayscale(..) => 2,
+                                                    FilterOp::HueRotate(..) => 3,
+                                                    FilterOp::Invert(..) => 4,
+                                                    FilterOp::Saturate(..) => 5,
+                                                    FilterOp::Sepia(..) => 6,
+                                                    FilterOp::Brightness(..) => 7,
+                                                    FilterOp::Opacity(..) => 8,
+                                                    FilterOp::DropShadow(..) => 9,
+                                                    FilterOp::ColorMatrix(..) => 10,
+                                                };
+
+                                                let user_data = match filter {
+                                                    FilterOp::Contrast(amount) |
+                                                    FilterOp::Grayscale(amount) |
+                                                    FilterOp::Invert(amount) |
+                                                    FilterOp::Saturate(amount) |
+                                                    FilterOp::Sepia(amount) |
+                                                    FilterOp::Brightness(amount) |
+                                                    FilterOp::Opacity(_, amount) => {
+                                                        (amount * 65536.0) as i32
+                                                    }
+                                                    FilterOp::HueRotate(angle) => {
+                                                        (0.01745329251 * angle * 65536.0) as i32
+                                                    }
+                                                    // Go through different paths
+                                                    FilterOp::Blur(..) |
+                                                    FilterOp::DropShadow(..) => {
+                                                        unreachable!();
+                                                    }
+                                                    FilterOp::ColorMatrix(_) => {
+                                                        picture.extra_gpu_data_handle.as_int(gpu_cache)
+                                                    }
+                                                };
+
+                                                let instance = BrushInstance {
+                                                    picture_address: task_address,
+                                                    prim_address: prim_cache_address,
+                                                    clip_chain_rect_index,
+                                                    scroll_id,
+                                                    clip_task_address,
+                                                    z,
+                                                    segment_index: 0,
+                                                    edge_flags: EdgeAaSegmentMask::empty(),
+                                                    brush_flags: BrushFlags::empty(),
+                                                    user_data: [
+                                                        cache_task_address.0 as i32,
+                                                        filter_mode,
+                                                        user_data,
+                                                    ],
+                                                };
+
+                                                let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                batch.push(PrimitiveInstance::from(instance));
+                                            }
                                         }
+                                    }
+                                    PictureCompositeMode::MixBlend(mode) => {
+                                        let backdrop_id = picture.secondary_render_task_id.expect("no backdrop!?");
+
+                                        let key = BatchKey::new(
+                                            BatchKind::Brush(
+                                                BrushBatchKind::MixBlend {
+                                                    task_id,
+                                                    source_id,
+                                                    backdrop_id,
+                                                },
+                                            ),
+                                            BlendMode::PremultipliedAlpha,
+                                            BatchTextures::no_texture(),
+                                        );
+                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                        let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
+                                        let source_task_address = render_tasks.get_task_address(source_id);
+
+                                        let instance = BrushInstance {
+                                            picture_address: task_address,
+                                            prim_address: prim_cache_address,
+                                            clip_chain_rect_index,
+                                            scroll_id,
+                                            clip_task_address,
+                                            z,
+                                            segment_index: 0,
+                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                            brush_flags: BrushFlags::empty(),
+                                            user_data: [
+                                                mode as u32 as i32,
+                                                backdrop_task_address.0 as i32,
+                                                source_task_address.0 as i32,
+                                            ],
+                                        };
+
+                                        batch.push(PrimitiveInstance::from(instance));
+                                    }
+                                    PictureCompositeMode::Blit => {
+                                        let kind = BatchKind::Brush(
+                                            BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
+                                        );
+                                        let key = BatchKey::new(kind, non_segmented_blend_mode, textures);
+                                        let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+
+                                        let uv_rect_address = render_tasks[cache_task_id]
+                                            .get_texture_handle()
+                                            .as_int(gpu_cache);
+
+                                        let instance = BrushInstance {
+                                            picture_address: task_address,
+                                            prim_address: prim_cache_address,
+                                            clip_chain_rect_index,
+                                            scroll_id,
+                                            clip_task_address,
+                                            z,
+                                            segment_index: 0,
+                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                            brush_flags: BrushFlags::empty(),
+                                            user_data: [
+                                                uv_rect_address,
+                                                BrushImageSourceKind::Color as i32,
+                                                RasterizationSpace::Screen as i32,
+                                            ],
+                                        };
+                                        batch.push(PrimitiveInstance::from(instance));
                                     }
                                 }
                             }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -24,7 +24,7 @@ use glyph_rasterizer::FontInstance;
 use hit_test::{HitTestingItem, HitTestingRun};
 use image::{decompose_image, TiledImageInfo};
 use internal_types::{FastHashMap, FastHashSet};
-use picture::{PictureCompositeMode, PictureKind};
+use picture::PictureCompositeMode;
 use prim_store::{BrushKind, BrushPrimitive, BrushSegmentDescriptor, CachedGradient};
 use prim_store::{CachedGradientIndex, ImageCacheKey, ImagePrimitiveCpu, ImageSource};
 use prim_store::{PictureIndex, PrimitiveContainer, PrimitiveIndex, PrimitiveStore};
@@ -1010,14 +1010,10 @@ impl<'a> DisplayListFlattener<'a> {
             let parent_pic_index = self.picture_stack.last().unwrap();
             let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
 
-            match parent_pic.kind {
-                PictureKind::Image { ref mut composite_mode, .. } => {
-                    // If not already isolated for some other reason,
-                    // make this picture as isolated.
-                    if composite_mode.is_none() {
-                        *composite_mode = Some(PictureCompositeMode::Blit);
-                    }
-                }
+            // If not already isolated for some other reason,
+            // make this picture as isolated.
+            if parent_pic.composite_mode.is_none() {
+                parent_pic.composite_mode = Some(PictureCompositeMode::Blit);
             }
         }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -39,44 +39,10 @@ pub enum PictureCompositeMode {
 }
 
 #[derive(Debug)]
-pub enum PictureKind {
-    Image {
-        // If a mix-blend-mode, contains the render task for
-        // the readback of the framebuffer that we use to sample
-        // from in the mix-blend-mode shader.
-        // For drop-shadow filter, this will store the original
-        // picture task which would be rendered on screen after
-        // blur pass.
-        secondary_render_task_id: Option<RenderTaskId>,
-        /// How this picture should be composited.
-        /// If None, don't composite - just draw directly on parent surface.
-        composite_mode: Option<PictureCompositeMode>,
-        // If true, this picture is part of a 3D context.
-        is_in_3d_context: bool,
-        // If requested as a frame output (for rendering
-        // pages to a texture), this is the pipeline this
-        // picture is the root of.
-        frame_output_pipeline_id: Option<PipelineId>,
-        // The original reference frame ID for this picture.
-        // It is only different if this is part of a 3D
-        // rendering context.
-        reference_frame_index: ClipScrollNodeIndex,
-        real_local_rect: LayerRect,
-        // An optional cache handle for storing extra data
-        // in the GPU cache, depending on the type of
-        // picture.
-        extra_gpu_data_handle: GpuCacheHandle,
-    },
-}
-
-#[derive(Debug)]
 pub struct PicturePrimitive {
     // If this picture is drawn to an intermediate surface,
     // the associated target information.
     pub surface: Option<RenderTaskId>,
-
-    // Details specific to this type of picture.
-    pub kind: PictureKind,
 
     // List of primitive runs that make up this picture.
     pub runs: Vec<PrimitiveRun>,
@@ -91,26 +57,48 @@ pub struct PicturePrimitive {
     // The current screen-space rect of the rendered
     // portion of this picture.
     task_rect: DeviceIntRect,
+
+    // If a mix-blend-mode, contains the render task for
+    // the readback of the framebuffer that we use to sample
+    // from in the mix-blend-mode shader.
+    // For drop-shadow filter, this will store the original
+    // picture task which would be rendered on screen after
+    // blur pass.
+    pub secondary_render_task_id: Option<RenderTaskId>,
+    /// How this picture should be composited.
+    /// If None, don't composite - just draw directly on parent surface.
+    pub composite_mode: Option<PictureCompositeMode>,
+    // If true, this picture is part of a 3D context.
+    pub is_in_3d_context: bool,
+    // If requested as a frame output (for rendering
+    // pages to a texture), this is the pipeline this
+    // picture is the root of.
+    pub frame_output_pipeline_id: Option<PipelineId>,
+    // The original reference frame ID for this picture.
+    // It is only different if this is part of a 3D
+    // rendering context.
+    pub reference_frame_index: ClipScrollNodeIndex,
+    pub real_local_rect: LayerRect,
+    // An optional cache handle for storing extra data
+    // in the GPU cache, depending on the type of
+    // picture.
+    pub extra_gpu_data_handle: GpuCacheHandle,
 }
 
 impl PicturePrimitive {
     pub fn resolve_scene_properties(&mut self, properties: &SceneProperties) -> bool {
-        match self.kind {
-            PictureKind::Image { ref mut composite_mode, .. } => {
-                match composite_mode {
-                    &mut Some(PictureCompositeMode::Filter(ref mut filter)) => {
-                        match filter {
-                            &mut FilterOp::Opacity(ref binding, ref mut value) => {
-                                *value = properties.resolve_float(binding, *value);
-                            }
-                            _ => {}
-                        }
-
-                        filter.is_visible()
+        match self.composite_mode {
+            Some(PictureCompositeMode::Filter(ref mut filter)) => {
+                match filter {
+                    &mut FilterOp::Opacity(ref binding, ref mut value) => {
+                        *value = properties.resolve_float(binding, *value);
                     }
-                    _ => true,
+                    _ => {}
                 }
+
+                filter.is_visible()
             }
+            _ => true,
         }
     }
 
@@ -125,15 +113,13 @@ impl PicturePrimitive {
         PicturePrimitive {
             runs: Vec::new(),
             surface: None,
-            kind: PictureKind::Image {
-                secondary_render_task_id: None,
-                composite_mode,
-                is_in_3d_context,
-                frame_output_pipeline_id,
-                reference_frame_index,
-                real_local_rect: LayerRect::zero(),
-                extra_gpu_data_handle: GpuCacheHandle::new(),
-            },
+            secondary_render_task_id: None,
+            composite_mode,
+            is_in_3d_context,
+            frame_output_pipeline_id,
+            reference_frame_index,
+            real_local_rect: LayerRect::zero(),
+            extra_gpu_data_handle: GpuCacheHandle::new(),
             apply_local_clip_rect,
             pipeline_id,
             task_rect: DeviceIntRect::zero(),
@@ -166,24 +152,20 @@ impl PicturePrimitive {
     ) -> LayerRect {
         let local_content_rect = prim_run_rect.local_rect_in_actual_parent_space;
 
-        match self.kind {
-            PictureKind::Image { composite_mode, ref mut real_local_rect, .. } => {
-                *real_local_rect = prim_run_rect.local_rect_in_original_parent_space;
+        self.real_local_rect = prim_run_rect.local_rect_in_original_parent_space;
 
-                match composite_mode {
-                    Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {
-                        let inflate_size = (blur_radius * BLUR_SAMPLE_SCALE).ceil();
-                        local_content_rect.inflate(inflate_size, inflate_size)
-                    }
-                    Some(PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, _))) => {
-                        let inflate_size = blur_radius * BLUR_SAMPLE_SCALE;
-                        local_content_rect.inflate(inflate_size, inflate_size)
-                                          .translate(&offset)
-                    }
-                    _ => {
-                        local_content_rect
-                    }
-                }
+        match self.composite_mode {
+            Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {
+                let inflate_size = (blur_radius * BLUR_SAMPLE_SCALE).ceil();
+                local_content_rect.inflate(inflate_size, inflate_size)
+            }
+            Some(PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, _))) => {
+                let inflate_size = blur_radius * BLUR_SAMPLE_SCALE;
+                local_content_rect.inflate(inflate_size, inflate_size)
+                                  .translate(&offset)
+            }
+            _ => {
+                local_content_rect
             }
         }
     }
@@ -202,189 +184,178 @@ impl PicturePrimitive {
                                 .screen_rect
                                 .as_ref()
                                 .expect("bug: trying to draw an off-screen picture!?");
-        let device_rect;
+        let device_rect = match self.composite_mode {
+            Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {
+                // If blur radius is 0, we can skip drawing this an an
+                // intermediate surface.
+                if blur_radius == 0.0 {
+                    pic_state.tasks.extend(pic_state_for_children.tasks);
+                    self.surface = None;
 
-        match self.kind {
-            PictureKind::Image {
-                ref mut secondary_render_task_id,
-                ref mut extra_gpu_data_handle,
-                composite_mode,
-                ..
-            } => {
-                device_rect = match composite_mode {
-                    Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {
-                        // If blur radius is 0, we can skip drawing this an an
-                        // intermediate surface.
-                        if blur_radius == 0.0 {
-                            pic_state.tasks.extend(pic_state_for_children.tasks);
-                            self.surface = None;
+                    DeviceIntRect::zero()
+                } else {
+                    let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
+                    let blur_range = (blur_std_deviation * BLUR_SAMPLE_SCALE).ceil() as i32;
 
-                            DeviceIntRect::zero()
-                        } else {
-                            let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
-                            let blur_range = (blur_std_deviation * BLUR_SAMPLE_SCALE).ceil() as i32;
+                    // The clipped field is the part of the picture that is visible
+                    // on screen. The unclipped field is the screen-space rect of
+                    // the complete picture, if no screen / clip-chain was applied
+                    // (this includes the extra space for blur region). To ensure
+                    // that we draw a large enough part of the picture to get correct
+                    // blur results, inflate that clipped area by the blur range, and
+                    // then intersect with the total screen rect, to minimize the
+                    // allocation size.
+                    let device_rect = prim_screen_rect
+                        .clipped
+                        .inflate(blur_range, blur_range)
+                        .intersection(&prim_screen_rect.unclipped)
+                        .unwrap();
 
-                            // The clipped field is the part of the picture that is visible
-                            // on screen. The unclipped field is the screen-space rect of
-                            // the complete picture, if no screen / clip-chain was applied
-                            // (this includes the extra space for blur region). To ensure
-                            // that we draw a large enough part of the picture to get correct
-                            // blur results, inflate that clipped area by the blur range, and
-                            // then intersect with the total screen rect, to minimize the
-                            // allocation size.
-                            let device_rect = prim_screen_rect
-                                .clipped
-                                .inflate(blur_range, blur_range)
-                                .intersection(&prim_screen_rect.unclipped)
-                                .unwrap();
+                    let picture_task = RenderTask::new_picture(
+                        RenderTaskLocation::Dynamic(None, device_rect.size),
+                        prim_index,
+                        RenderTargetKind::Color,
+                        device_rect.origin,
+                        PremultipliedColorF::TRANSPARENT,
+                        ClearMode::Transparent,
+                        pic_state_for_children.tasks,
+                    );
 
-                            let picture_task = RenderTask::new_picture(
-                                RenderTaskLocation::Dynamic(None, device_rect.size),
-                                prim_index,
-                                RenderTargetKind::Color,
-                                device_rect.origin,
-                                PremultipliedColorF::TRANSPARENT,
-                                ClearMode::Transparent,
-                                pic_state_for_children.tasks,
-                            );
+                    let picture_task_id = frame_state.render_tasks.add(picture_task);
 
-                            let picture_task_id = frame_state.render_tasks.add(picture_task);
+                    let blur_render_task = RenderTask::new_blur(
+                        blur_std_deviation,
+                        picture_task_id,
+                        frame_state.render_tasks,
+                        RenderTargetKind::Color,
+                        ClearMode::Transparent,
+                    );
 
-                            let blur_render_task = RenderTask::new_blur(
-                                blur_std_deviation,
-                                picture_task_id,
-                                frame_state.render_tasks,
-                                RenderTargetKind::Color,
-                                ClearMode::Transparent,
-                            );
+                    let render_task_id = frame_state.render_tasks.add(blur_render_task);
+                    pic_state.tasks.push(render_task_id);
+                    self.surface = Some(render_task_id);
 
-                            let render_task_id = frame_state.render_tasks.add(blur_render_task);
-                            pic_state.tasks.push(render_task_id);
-                            self.surface = Some(render_task_id);
-
-                            device_rect
-                        }
-                    }
-                    Some(PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, _))) => {
-                        // TODO(gw): This is totally wrong and can never work with
-                        //           transformed drop-shadow elements. Fix me!
-                        let rect = (prim_metadata.local_rect.translate(&-offset) * content_scale).round().to_i32();
-                        let mut picture_task = RenderTask::new_picture(
-                            RenderTaskLocation::Dynamic(None, rect.size),
-                            prim_index,
-                            RenderTargetKind::Color,
-                            rect.origin,
-                            PremultipliedColorF::TRANSPARENT,
-                            ClearMode::Transparent,
-                            pic_state_for_children.tasks,
-                        );
-                        picture_task.mark_for_saving();
-
-                        let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
-                        let picture_task_id = frame_state.render_tasks.add(picture_task);
-
-                        let blur_render_task = RenderTask::new_blur(
-                            blur_std_deviation.round(),
-                            picture_task_id,
-                            frame_state.render_tasks,
-                            RenderTargetKind::Color,
-                            ClearMode::Transparent,
-                        );
-
-                        *secondary_render_task_id = Some(picture_task_id);
-
-                        let render_task_id = frame_state.render_tasks.add(blur_render_task);
-                        pic_state.tasks.push(render_task_id);
-                        self.surface = Some(render_task_id);
-
-                        rect
-                    }
-                    Some(PictureCompositeMode::MixBlend(..)) => {
-                        let picture_task = RenderTask::new_picture(
-                            RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
-                            prim_index,
-                            RenderTargetKind::Color,
-                            prim_screen_rect.clipped.origin,
-                            PremultipliedColorF::TRANSPARENT,
-                            ClearMode::Transparent,
-                            pic_state_for_children.tasks,
-                        );
-
-                        let readback_task_id = frame_state.render_tasks.add(
-                            RenderTask::new_readback(prim_screen_rect.clipped)
-                        );
-
-                        *secondary_render_task_id = Some(readback_task_id);
-                        pic_state.tasks.push(readback_task_id);
-
-                        let render_task_id = frame_state.render_tasks.add(picture_task);
-                        pic_state.tasks.push(render_task_id);
-                        self.surface = Some(render_task_id);
-
-                        prim_screen_rect.clipped
-                    }
-                    Some(PictureCompositeMode::Filter(filter)) => {
-                        // If this filter is not currently going to affect
-                        // the picture, just collapse this picture into the
-                        // current render task. This most commonly occurs
-                        // when opacity == 1.0, but can also occur on other
-                        // filters and be a significant performance win.
-                        if filter.is_noop() {
-                            pic_state.tasks.extend(pic_state_for_children.tasks);
-                            self.surface = None;
-                        } else {
-
-                            if let FilterOp::ColorMatrix(m) = filter {
-                                if let Some(mut request) = frame_state.gpu_cache.request(extra_gpu_data_handle) {
-                                    for i in 0..5 {
-                                        request.push([m[i*4], m[i*4+1], m[i*4+2], m[i*4+3]]);
-                                    }
-                                }
-                            }
-
-                            let picture_task = RenderTask::new_picture(
-                                RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
-                                prim_index,
-                                RenderTargetKind::Color,
-                                prim_screen_rect.clipped.origin,
-                                PremultipliedColorF::TRANSPARENT,
-                                ClearMode::Transparent,
-                                pic_state_for_children.tasks,
-                            );
-
-                            let render_task_id = frame_state.render_tasks.add(picture_task);
-                            pic_state.tasks.push(render_task_id);
-                            self.surface = Some(render_task_id);
-                        }
-
-                        prim_screen_rect.clipped
-                    }
-                    Some(PictureCompositeMode::Blit) => {
-                        let picture_task = RenderTask::new_picture(
-                            RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
-                            prim_index,
-                            RenderTargetKind::Color,
-                            prim_screen_rect.clipped.origin,
-                            PremultipliedColorF::TRANSPARENT,
-                            ClearMode::Transparent,
-                            pic_state_for_children.tasks,
-                        );
-
-                        let render_task_id = frame_state.render_tasks.add(picture_task);
-                        pic_state.tasks.push(render_task_id);
-                        self.surface = Some(render_task_id);
-
-                        prim_screen_rect.clipped
-                    }
-                    None => {
-                        pic_state.tasks.extend(pic_state_for_children.tasks);
-                        self.surface = None;
-
-                        DeviceIntRect::zero()
-                    }
-                };
+                    device_rect
+                }
             }
-        }
+            Some(PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, _))) => {
+                // TODO(gw): This is totally wrong and can never work with
+                //           transformed drop-shadow elements. Fix me!
+                let rect = (prim_metadata.local_rect.translate(&-offset) * content_scale).round().to_i32();
+                let mut picture_task = RenderTask::new_picture(
+                    RenderTaskLocation::Dynamic(None, rect.size),
+                    prim_index,
+                    RenderTargetKind::Color,
+                    rect.origin,
+                    PremultipliedColorF::TRANSPARENT,
+                    ClearMode::Transparent,
+                    pic_state_for_children.tasks,
+                );
+                picture_task.mark_for_saving();
+
+                let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
+                let picture_task_id = frame_state.render_tasks.add(picture_task);
+
+                let blur_render_task = RenderTask::new_blur(
+                    blur_std_deviation.round(),
+                    picture_task_id,
+                    frame_state.render_tasks,
+                    RenderTargetKind::Color,
+                    ClearMode::Transparent,
+                );
+
+                self.secondary_render_task_id = Some(picture_task_id);
+
+                let render_task_id = frame_state.render_tasks.add(blur_render_task);
+                pic_state.tasks.push(render_task_id);
+                self.surface = Some(render_task_id);
+
+                rect
+            }
+            Some(PictureCompositeMode::MixBlend(..)) => {
+                let picture_task = RenderTask::new_picture(
+                    RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                    prim_index,
+                    RenderTargetKind::Color,
+                    prim_screen_rect.clipped.origin,
+                    PremultipliedColorF::TRANSPARENT,
+                    ClearMode::Transparent,
+                    pic_state_for_children.tasks,
+                );
+
+                let readback_task_id = frame_state.render_tasks.add(
+                    RenderTask::new_readback(prim_screen_rect.clipped)
+                );
+
+                self.secondary_render_task_id = Some(readback_task_id);
+                pic_state.tasks.push(readback_task_id);
+
+                let render_task_id = frame_state.render_tasks.add(picture_task);
+                pic_state.tasks.push(render_task_id);
+                self.surface = Some(render_task_id);
+
+                prim_screen_rect.clipped
+            }
+            Some(PictureCompositeMode::Filter(filter)) => {
+                // If this filter is not currently going to affect
+                // the picture, just collapse this picture into the
+                // current render task. This most commonly occurs
+                // when opacity == 1.0, but can also occur on other
+                // filters and be a significant performance win.
+                if filter.is_noop() {
+                    pic_state.tasks.extend(pic_state_for_children.tasks);
+                    self.surface = None;
+                } else {
+
+                    if let FilterOp::ColorMatrix(m) = filter {
+                        if let Some(mut request) = frame_state.gpu_cache.request(&mut self.extra_gpu_data_handle) {
+                            for i in 0..5 {
+                                request.push([m[i*4], m[i*4+1], m[i*4+2], m[i*4+3]]);
+                            }
+                        }
+                    }
+
+                    let picture_task = RenderTask::new_picture(
+                        RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                        prim_index,
+                        RenderTargetKind::Color,
+                        prim_screen_rect.clipped.origin,
+                        PremultipliedColorF::TRANSPARENT,
+                        ClearMode::Transparent,
+                        pic_state_for_children.tasks,
+                    );
+
+                    let render_task_id = frame_state.render_tasks.add(picture_task);
+                    pic_state.tasks.push(render_task_id);
+                    self.surface = Some(render_task_id);
+                }
+
+                prim_screen_rect.clipped
+            }
+            Some(PictureCompositeMode::Blit) => {
+                let picture_task = RenderTask::new_picture(
+                    RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                    prim_index,
+                    RenderTargetKind::Color,
+                    prim_screen_rect.clipped.origin,
+                    PremultipliedColorF::TRANSPARENT,
+                    ClearMode::Transparent,
+                    pic_state_for_children.tasks,
+                );
+
+                let render_task_id = frame_state.render_tasks.add(picture_task);
+                pic_state.tasks.push(render_task_id);
+                self.surface = Some(render_task_id);
+
+                prim_screen_rect.clipped
+            }
+            None => {
+                pic_state.tasks.extend(pic_state_for_children.tasks);
+                self.surface = None;
+
+                DeviceIntRect::zero()
+            }
+        };
 
         // If scrolling or property animation has resulted in the task
         // rect being different than last time, invalidate the GPU
@@ -399,19 +370,15 @@ impl PicturePrimitive {
     pub fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
         request.push(self.task_rect.to_f32());
 
-        match self.kind {
-            PictureKind::Image { composite_mode, .. } => {
-                let color = match composite_mode {
-                    Some(PictureCompositeMode::Filter(FilterOp::DropShadow(_, _, color))) => {
-                        color.premultiplied()
-                    }
-                    _ => {
-                        PremultipliedColorF::WHITE
-                    }
-                };
-
-                request.push(color);
+        let color = match self.composite_mode {
+            Some(PictureCompositeMode::Filter(FilterOp::DropShadow(_, _, color))) => {
+                color.premultiplied()
             }
-        }
+            _ => {
+                PremultipliedColorF::WHITE
+            }
+        };
+
+        request.push(color);
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -13,7 +13,6 @@ use gpu_cache::{GpuCache};
 use gpu_types::{BlurDirection, BlurInstance};
 use gpu_types::{ClipScrollNodeData, ZBufferIdGenerator};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
-use picture::PictureKind;
 use prim_store::{CachedGradient, PrimitiveIndex, PrimitiveKind, PrimitiveStore};
 use prim_store::{BrushKind, DeferredResolve};
 use profiler::FrameProfileCounters;
@@ -399,7 +398,7 @@ impl RenderTarget for ColorRenderTarget {
 
                         // If this pipeline is registered as a frame output
                         // store the information necessary to do the copy.
-                        if let PictureKind::Image { frame_output_pipeline_id: Some(pipeline_id), .. } = pic.kind {
+                        if let Some(pipeline_id) = pic.frame_output_pipeline_id {
                             self.outputs.push(FrameOutput {
                                 pipeline_id,
                                 task_id,


### PR DESCRIPTION
Previously, we had separate Picture kinds for box shadows and
text shadows.

Now, box-shadows are drawn as clip sources, and text shadows are
drawn as a regular picture with a blur filter set as the picture
composite mode.

This PR should not contain any functional changes - it's just
re-arranging the code to no longer use PictureKind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2575)
<!-- Reviewable:end -->
