### PR TITLE
Capture: include the external data type info for the resource cache

### DIFF
--- a/webrender/src/capture.rs
+++ b/webrender/src/capture.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use api::{CaptureBits, ExternalImageData, ExternalImageId, ImageDescriptor, TexelRect};
+use api::{CaptureBits, ExternalImageData, ImageDescriptor, TexelRect};
 #[cfg(feature = "png")]
 use device::ReadPixelsFormat;
 use ron;
@@ -123,10 +123,8 @@ pub struct ExternalCaptureImage {
 pub struct PlainExternalImage {
     /// Path to the RON file describing the texel data.
     pub data: String,
-    /// Public ID of the external image.
-    pub id: ExternalImageId,
-    /// Channel index of an external image.
-    pub channel_index: u8,
+    /// External image data source.
+    pub external: ExternalImageData,
     /// UV sub-rectangle of the image.
     pub uv: TexelRect,
 }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2324,7 +2324,9 @@ impl Renderer {
                                         let dummy_data: Vec<u8> = vec![255; total_size as usize];
                                         uploader.upload(rect, layer_index, stride, &dummy_data);
                                     }
-                                    _ => panic!("No external buffer found"),
+                                    ExternalImageSource::NativeTexture(eid) => {
+                                        panic!("Unexpected external texture {:?} for the texture cache update of {:?}", eid, id);
+                                    }
                                 };
                                 handler.unlock(id, channel_index);
                             }
@@ -4103,8 +4105,7 @@ impl Renderer {
                 }
                 let plain = PlainExternalImage {
                     data: short_path,
-                    id: def.external.id,
-                    channel_index: def.external.channel_index,
+                    external: def.external,
                     uv: ext_image.uv,
                 };
                 config.serialize(&plain, &def.short_path);
@@ -4178,9 +4179,9 @@ impl Renderer {
                     e.insert(Arc::new(buffer)).clone()
                 }
             };
-            let key = (plain_ext.id, plain_ext.channel_index);
+            let ext = plain_ext.external;
             let value = (CapturedExternalImageData::Buffer(data), plain_ext.uv);
-            image_handler.data.insert(key, value);
+            image_handler.data.insert((ext.id, ext.channel_index), value);
         }
 
         if let Some(renderer) = CaptureConfig::deserialize::<PlainRenderer, _>(&root, "renderer") {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1322,11 +1322,7 @@ impl ResourceCache {
         for (key, template) in resources.image_templates {
             let data = match CaptureConfig::deserialize::<PlainExternalImage, _>(root, &template.data) {
                 Some(plain) => {
-                    let ext_data = ExternalImageData {
-                        id: plain.id,
-                        channel_index: plain.channel_index,
-                        image_type: ExternalImageType::Buffer,
-                    };
+                    let ext_data = plain.external;
                     external_images.push(plain);
                     ImageData::External(ext_data)
                 }


### PR DESCRIPTION
This fixes the use case of re-building the scene after a capture gets loaded that contains external texture types (e.g. saved from Firefox).
r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2582)
<!-- Reviewable:end -->
