### PR TITLE
Add reftest for clipping fast-shadows

### DIFF
--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -53,4 +53,5 @@ platform(linux) == writing-modes.yaml writing-modes-ref.yaml
 platform(linux) == blurred-shadow-local-clip-rect.yaml blurred-shadow-local-clip-rect-ref.png
 platform(linux) == two-shadows.yaml two-shadows.png
 == shadow-clip.yaml shadow-clip-ref.yaml
+== shadow-fast-clip.yaml shadow-fast-clip-ref.yaml
 fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png

--- a/wrench/reftests/text/shadow-fast-clip-ref.yaml
+++ b/wrench/reftests/text/shadow-fast-clip-ref.yaml
@@ -1,0 +1,21 @@
+# Test that fast shadows actually apply clips
+---
+root:
+  items:
+    - type: clip
+      bounds: [28, 28, 80, 80]
+      items:
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [9, 101]
+          size: 12
+          color: [0, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [8, 100]
+          size: 12
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"

--- a/wrench/reftests/text/shadow-fast-clip.yaml
+++ b/wrench/reftests/text/shadow-fast-clip.yaml
@@ -1,0 +1,22 @@
+# Test that fast shadows actually apply clips
+---
+root:
+  items:
+    - type: clip
+      bounds: [28, 28, 80, 80]
+      items:
+        -
+          type: "shadow"
+          bounds: [0, 0, 200, 200]
+          blur-radius: 0
+          offset: [1, 1]
+          color: [0, 0, 0, 1]
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [8, 100]
+          size: 12
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-all-shadows"


### PR DESCRIPTION
I believe glenn's shadow unification patch regressed this (looking into the fix now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2592)
<!-- Reviewable:end -->
