### PR TITLE
Make the debug_renderer feature more granular (fix for #2574)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -98,6 +98,7 @@ tasks:
           servo-tidy &&
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
+          (cd webrender && cargo build --verbose --no-default-features --features capture) &&
           (cd webrender && cargo build --verbose --features capture,profiler) &&
           (cd webrender && cargo build --verbose --features replay) &&
           (cd wrench && cargo build --verbose --features env_logger) &&
@@ -175,6 +176,7 @@ tasks:
           export RUSTC_WRAPPER=sccache &&
           (cd webrender_api && cargo test --verbose --features "ipc") &&
           (cd webrender && cargo build --verbose --no-default-features) &&
+          (cd webrender && cargo build --verbose --no-default-features --features capture) &&
           (cd webrender && cargo build --verbose --features capture,profiler) &&
           (cd webrender && cargo build --verbose --features replay) &&
           (cd wrench && cargo build --verbose --features env_logger) &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
   - servo-tidy
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender_api && cargo test --verbose --features "ipc"); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features); fi
+  - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --no-default-features --features capture); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features profiler,capture); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd webrender && cargo build --verbose --features replay); fi
   - if [ $BUILD_KIND = DEBUG ]; then (cd wrench && cargo build --verbose --features env_logger); fi

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -6,7 +6,7 @@ use super::shader_source;
 use api::{ColorF, ImageFormat};
 use api::{DeviceIntPoint, DeviceIntRect, DeviceUintRect, DeviceUintSize};
 use api::TextureTarget;
-#[cfg(feature = "debug_renderer")]
+#[cfg(any(feature = "debug_renderer", feature="capture"))]
 use api::ImageDescriptor;
 use euclid::Transform3D;
 use gleam::gl;
@@ -463,12 +463,12 @@ impl Texture {
         self.format
     }
 
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature = "capture"))]
     pub fn get_filter(&self) -> TextureFilter {
         self.filter
     }
 
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature = "capture"))]
     pub fn get_render_target(&self) -> Option<RenderTargetInfo> {
         self.render_target.clone()
     }
@@ -1530,7 +1530,7 @@ impl Device {
         }
     }
 
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature = "capture"))]
     pub fn read_pixels(&mut self, img_desc: &ImageDescriptor) -> Vec<u8> {
         let desc = gl_describe_format(self.gl(), img_desc.format);
         self.gl.read_pixels(
@@ -1596,7 +1596,7 @@ impl Device {
     }
 
     /// Attaches the provided texture to the current Read FBO binding.
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature="capture"))]
     fn attach_read_texture_raw(
         &mut self, texture_id: gl::GLuint, target: gl::GLuint, layer_id: i32
     ) {
@@ -1623,14 +1623,14 @@ impl Device {
         }
     }
 
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature="capture"))]
     pub fn attach_read_texture_external(
         &mut self, texture_id: gl::GLuint, target: TextureTarget, layer_id: i32
     ) {
         self.attach_read_texture_raw(texture_id, get_gl_target(target), layer_id)
     }
 
-    #[cfg(feature = "debug_renderer")]
+    #[cfg(any(feature = "debug_renderer", feature="capture"))]
     pub fn attach_read_texture(&mut self, texture: &Texture, layer_id: i32) {
         self.attach_read_texture_raw(texture.id, texture.target, layer_id)
     }


### PR DESCRIPTION
Should resolve Gecko issues. The feature `capture` doesn't need access to all the struct necessary for the feature `debug_renderer`, just some functions from `device.rs` were disabled.

This PR includes #2591, not sure how they could be merged together.

/r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2593)
<!-- Reviewable:end -->
