### PR TITLE
Added DPI to GlyphOptions to indicate the DPI for glyph rasterization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "freetype"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -908,7 +908,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
  "dwrote 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1539,7 +1539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum font-loader 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fbd86bafc9e14ab7076e084d31eed4633120f910d0c42a017e5382aac89937f"
 "checksum foreign-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ebc04f19019fff1f2d627b5581574ead502f80c48c88900575a46e0840fe5d0"
-"checksum freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "398b8a11884898184d55aca9806f002b3cf68f0e860e0cbb4586f834ee39b0e7"
+"checksum freetype 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b659e75b7a7338fe75afd7f909fc2b71937845cffb6ebe54ba2e50f13d8e903d"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -689,6 +689,7 @@ impl<'a> DisplayListFlattener<'a> {
                     item.glyphs(),
                     item.display_list().get(item.glyphs()).count(),
                     text_info.glyph_options,
+                    text_info.glyph_options.and_then(|options| options.dpi),
                 );
             }
             SpecificDisplayItem::Rectangle(ref info) => {
@@ -2010,6 +2011,7 @@ impl<'a> DisplayListFlattener<'a> {
         glyph_range: ItemRange<GlyphInstance>,
         glyph_count: usize,
         glyph_options: Option<GlyphOptions>,
+        dpi: Option<u32>,
     ) {
         let prim = {
             let instance_map = self.font_instances.read().unwrap();
@@ -2074,6 +2076,7 @@ impl<'a> DisplayListFlattener<'a> {
                 flags,
                 font_instance.platform_options,
                 font_instance.variations.clone(),
+                dpi,
             );
             TextRunPrimitiveCpu {
                 font: prim_font,

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -147,6 +147,9 @@ pub struct FontInstance {
     //           or something similar to that.
     pub size: Au,
     pub color: ColorU,
+    /// DPI of the monitor that this font will be rendered with. 
+    /// Used by `FT_Set_Char_Size`. If set to `None`, will be 72 DPI
+    pub dpi: Option<u32>,
     pub bg_color: ColorU,
     pub render_mode: FontRenderMode,
     pub subpx_dir: SubpixelDirection,
@@ -167,11 +170,13 @@ impl FontInstance {
         flags: FontInstanceFlags,
         platform_options: Option<FontInstancePlatformOptions>,
         variations: Vec<FontVariation>,
+        dpi: Option<u32>,
     ) -> Self {
         FontInstance {
             font_key,
             size,
             color: color.into(),
+            dpi,
             bg_color,
             render_mode,
             subpx_dir,

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -305,14 +305,15 @@ impl FontContext {
                 yx: (shape.skew_y * -65536.0) as FT_Fixed,
                 yy: (shape.scale_y * 65536.0) as FT_Fixed,
             };
+            let dpi = font.dpi.unwrap_or(72);
             unsafe {
                 FT_Set_Transform(face.face, &mut ft_shape, ptr::null_mut());
                 FT_Set_Char_Size(
                     face.face,
                     (req_size * x_scale * 64.0 + 0.5) as FT_F26Dot6,
                     (req_size * y_scale * 64.0 + 0.5) as FT_F26Dot6,
-                    0,
-                    0,
+                    dpi,
+                    dpi,
                 )
             }
         };

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1525,6 +1525,7 @@ impl Renderer {
             }
         })?;
 
+        let dpi = options.dpi;
         thread::Builder::new().name(rb_thread_name.clone()).spawn(move || {
             register_thread_with_profiler(rb_thread_name.clone());
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
@@ -1537,6 +1538,7 @@ impl Renderer {
                 texture_cache,
                 glyph_rasterizer,
                 blob_image_renderer,
+                dpi,
             );
 
             let mut backend = RenderBackend::new(
@@ -3854,6 +3856,8 @@ pub trait ThreadListener {
 
 pub struct RendererOptions {
     pub device_pixel_ratio: f32,
+    /// DPI of the monitor
+    pub dpi: Option<u32>,
     pub resource_override_path: Option<PathBuf>,
     pub enable_aa: bool,
     pub enable_dithering: bool,
@@ -3882,6 +3886,7 @@ impl Default for RendererOptions {
     fn default() -> Self {
         RendererOptions {
             device_pixel_ratio: 1.0,
+            dpi: None,
             resource_override_path: None,
             enable_aa: true,
             enable_dithering: true,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -254,7 +254,7 @@ pub struct ResourceCache {
     cached_glyphs: GlyphCache,
     cached_images: ImageCache,
     cached_render_tasks: RenderTaskCache,
-
+    dpi: Option<u32>,
     resources: Resources,
     state: State,
     current_frame_id: FrameId,
@@ -278,6 +278,7 @@ impl ResourceCache {
         texture_cache: TextureCache,
         glyph_rasterizer: GlyphRasterizer,
         blob_image_renderer: Option<Box<BlobImageRenderer>>,
+        dpi: Option<u32>,
     ) -> Self {
         ResourceCache {
             cached_glyphs: GlyphCache::new(),
@@ -291,6 +292,7 @@ impl ResourceCache {
             pending_image_requests: FastHashSet::default(),
             glyph_rasterizer,
             blob_image_renderer,
+            dpi,
         }
     }
 
@@ -426,6 +428,7 @@ impl ResourceCache {
             flags,
             platform_options,
             variations,
+            self.dpi,
         );
         self.resources.font_instances
             .write()

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -199,6 +199,8 @@ impl Hash for FontVariation {
 pub struct GlyphOptions {
     pub render_mode: FontRenderMode,
     pub flags: FontInstanceFlags,
+    /// The DPI used for rasterizing this font
+    pub dpi: Option<u32>,
 }
 
 impl Default for GlyphOptions {
@@ -206,6 +208,7 @@ impl Default for GlyphOptions {
         GlyphOptions {
             render_mode: FontRenderMode::Subpixel,
             flags: FontInstanceFlags::empty(),
+            dpi: None,
         }
     }
 }


### PR DESCRIPTION
Fixes #2596 - the PR is a bit all over the place, not sure if the DPI is needed in all structs. Also not sure if Windows or Mac have the same problems. The DPI still has to be set by the user, but at least there is an option to set it, instead of having none.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2597)
<!-- Reviewable:end -->
