### PR TITLE
Fix fast shadow clip

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1410,6 +1410,12 @@ impl<'a> DisplayListFlattener<'a> {
         // Gaussian blur with a standard deviation equal to half the blur radius."
         let std_deviation = shadow.blur_radius * 0.5;
 
+        // If the shadow has no blur, any elements will get directly rendered
+        // into the parent picture surface, instead of allocating and drawing
+        // into an intermediate surface. In this case, we will need to apply
+        // the local clip rect to primitives.
+        let apply_local_clip_rect = shadow.blur_radius == 0.0;
+
         // Create a picture that the shadow primitives will be added to. If the
         // blur radius is 0, the code in Picture::prepare_for_render will
         // detect this and mark the picture to be drawn directly into the
@@ -1420,7 +1426,7 @@ impl<'a> DisplayListFlattener<'a> {
             pipeline_id,
             current_reference_frame_index,
             None,
-            false,
+            apply_local_clip_rect,
         );
 
         // Create the primitive to draw the shadow picture into the scene.

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -53,4 +53,5 @@ platform(linux) == writing-modes.yaml writing-modes-ref.yaml
 platform(linux) == blurred-shadow-local-clip-rect.yaml blurred-shadow-local-clip-rect-ref.png
 platform(linux) == two-shadows.yaml two-shadows.png
 == shadow-clip.yaml shadow-clip-ref.yaml
+== shadow-fast-clip.yaml shadow-fast-clip-ref.yaml
 fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png

--- a/wrench/reftests/text/shadow-fast-clip-ref.yaml
+++ b/wrench/reftests/text/shadow-fast-clip-ref.yaml
@@ -1,0 +1,21 @@
+# Test that fast shadows actually apply clips
+---
+root:
+  items:
+    - type: clip
+      bounds: [28, 28, 80, 80]
+      items:
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [9, 101]
+          size: 12
+          color: [0, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [8, 100]
+          size: 12
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"

--- a/wrench/reftests/text/shadow-fast-clip.yaml
+++ b/wrench/reftests/text/shadow-fast-clip.yaml
@@ -1,0 +1,22 @@
+# Test that fast shadows actually apply clips
+---
+root:
+  items:
+    - type: clip
+      bounds: [28, 28, 80, 80]
+      items:
+        -
+          type: "shadow"
+          bounds: [0, 0, 200, 200]
+          blur-radius: 0
+          offset: [1, 1]
+          color: [0, 0, 0, 1]
+        -
+          bounds: [6, 6, 132, 133]
+          text: "overflow text"          
+          origin: [8, 100]
+          size: 12
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-all-shadows"


### PR DESCRIPTION
We need to ensure that we only disable local clip rects on shadow
pictures that will allocate an intermediate surface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2601)
<!-- Reviewable:end -->
