### PR TITLE
Disable segment path for Pictures, we don't support it yet.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -237,11 +237,14 @@ impl BrushKind {
     fn supports_segments(&self) -> bool {
         match *self {
             BrushKind::Solid { .. } |
-            BrushKind::Picture { .. } |
             BrushKind::Image { .. } |
             BrushKind::YuvImage { .. } |
             BrushKind::RadialGradient { .. } |
             BrushKind::LinearGradient { .. } => true,
+
+            // TODO(gw): Allow batch.rs to add segment instances
+            //           for Picture primitives.
+            BrushKind::Picture { .. } => false,
 
             BrushKind::Clear => false,
         }

--- a/wrench/reftests/filters/filter-segments-ref.yaml
+++ b/wrench/reftests/filters/filter-segments-ref.yaml
@@ -1,0 +1,18 @@
+---
+root:
+  items:
+    - type: clip
+      bounds: [10, 10, 256, 256]
+      complex:
+        - rect: [10, 10, 256, 256]
+          radius: 16
+      items:
+        - type: rect
+          color: [54, 54, 54]
+          bounds: [10, 10, 512, 512]
+    - type: rect
+      color: red
+      bounds: [0, 0, 300, 32]
+    - type: rect
+      color: red
+      bounds: [0, 250, 300, 32]

--- a/wrench/reftests/filters/filter-segments.yaml
+++ b/wrench/reftests/filters/filter-segments.yaml
@@ -1,0 +1,24 @@
+# Ensure that picture / filter primitives draw the entire primitive
+# when they are eligible to be segmented. The red rects are used to
+# mask out the corners, since the AA varies between the tests.
+---
+root:
+  items:
+    - type: clip
+      bounds: [10, 10, 256, 256]
+      complex:
+        - rect: [10, 10, 256, 256]
+          radius: 16
+      items:
+        - type: stacking-context
+          filters: grayscale(1)
+          items:
+            - type: rect
+              color: red
+              bounds: [10, 10, 512, 512]
+    - type: rect
+      color: red
+      bounds: [0, 0, 300, 32]
+    - type: rect
+      color: red
+      bounds: [0, 250, 300, 32]

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -33,4 +33,4 @@
 == filter-drop-shadow.yaml filter-drop-shadow.png
 == filter-drop-shadow-on-viewport-edge.yaml filter-drop-shadow-on-viewport-edge.png
 == blend-clipped.yaml blend-clipped.png
-
+== filter-segments.yaml filter-segments-ref.yaml


### PR DESCRIPTION
We need a bit of extra work in batch.rs before pictures will be
correctly added when they have a valid segmentation. For now,
just disable segment building for pictures until we do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2602)
<!-- Reviewable:end -->
