### PR TITLE
Add reftest for partial glyph shadows

### DIFF
--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -54,4 +54,5 @@ platform(linux) == blurred-shadow-local-clip-rect.yaml blurred-shadow-local-clip
 platform(linux) == two-shadows.yaml two-shadows.png
 == shadow-clip.yaml shadow-clip-ref.yaml
 == shadow-fast-clip.yaml shadow-fast-clip-ref.yaml
+== shadow-partial-glyph.yaml shadow-partial-glyph-ref.yaml
 fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png

--- a/wrench/reftests/text/shadow-partial-glyph-ref.yaml
+++ b/wrench/reftests/text/shadow-partial-glyph-ref.yaml
@@ -1,0 +1,50 @@
+--- # taking the shadow of multiple copies of a glyph with different clips should look the same as the unclipped glyph
+root:
+  items:
+        -
+          type: "shadow"
+          blur-radius: 2
+          bounds: [14, 18, 205, 35]
+          offset: [40, 0]
+          color: black
+        -
+          bounds: [14, 18, 205, 35]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 0, 0]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-all-shadows"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [16, 18, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [30, 18, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 255, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [16, 32, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 255, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [30, 32, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [255, 0, 255, 1]
+          font: "VeraBd.ttf"

--- a/wrench/reftests/text/shadow-partial-glyph.yaml
+++ b/wrench/reftests/text/shadow-partial-glyph.yaml
@@ -1,0 +1,43 @@
+--- # taking the shadow of multiple copies of a glyph with different clips should look the same as the unclipped glyph
+root:
+  items:
+        -
+          type: "shadow"
+          blur-radius: 2
+          bounds: [14, 18, 205, 35]
+          offset: [40, 0]
+          color: black
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [16, 18, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [255, 0, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [30, 18, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 255, 0, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [16, 32, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [0, 0, 255, 1]
+          font: "VeraBd.ttf"
+        -
+          bounds: [14, 18, 205, 35]
+          clip-rect: [30, 32, 14, 14]
+          glyphs: [58]
+          offsets: [16, 43]
+          size: 18
+          color: [255, 0, 255, 1]
+          font: "VeraBd.ttf"
+        -
+          type: "pop-all-shadows"


### PR DESCRIPTION
This was probably fixed by glenn' s shadow unification patch.

Closes #2549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2603)
<!-- Reviewable:end -->
