### PR TITLE
Fix AA on ellipse clip code under some edge cases.

### DIFF
--- a/webrender/res/ellipse.glsl
+++ b/webrender/res/ellipse.glsl
@@ -58,7 +58,7 @@ float rounded_rect(vec2 pos,
     // Start with a negative value (means "inside") for all fragments that are not
     // in a corner. If the fragment is in a corner, one of the clip_against_ellipse_if_needed
     // calls below will update it.
-    float current_distance = -1.0;
+    float current_distance = -aa_range;
 
     // Clip against each ellipse.
     current_distance = clip_against_ellipse_if_needed(pos,

--- a/wrench/reftests/aa/aa-dist-bug-ref.yaml
+++ b/wrench/reftests/aa/aa-dist-bug-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+    - type: rect
+      color: red
+      bounds: [340, 184, 50, 20]

--- a/wrench/reftests/aa/aa-dist-bug.yaml
+++ b/wrench/reftests/aa/aa-dist-bug.yaml
@@ -1,0 +1,43 @@
+# Test that when the AA range is > 1, the AA is correctly applied to
+# an ellipse clip. This is a regression test for issue #2576.
+# The rectangles below mask out most of the box shadow and rounded
+# corners, which are not relevant to what is being tested here.
+---
+root:
+  items:
+    - type: stacking-context
+      transform: rotate-z(45) rotate-x(60)
+      transform-origin: 300 300
+      items:
+        - type: box-shadow
+          bounds: [0, 0, 150, 150]
+          color: black
+          offset: [150, 50]
+          border-radius: 8
+
+        - type: clip
+          bounds: [90, 0, 150, 150]
+          complex:
+            - rect: [90, 0, 150, 150]
+              radius: 8
+          items:
+          - type: rect
+            color: red
+            border-radius: 8
+            bounds: [90, 0, 150, 150]
+
+    - type: rect
+      color: white
+      bounds: [250, 100, 240, 84]
+
+    - type: rect
+      color: white
+      bounds: [250, 204, 240, 70]
+
+    - type: rect
+      color: white
+      bounds: [240, 100, 100, 150]
+
+    - type: rect
+      color: white
+      bounds: [390, 100, 100, 150]

--- a/wrench/reftests/aa/reftest.list
+++ b/wrench/reftests/aa/reftest.list
@@ -1,1 +1,2 @@
 == rounded-rects.yaml rounded-rects-ref.png
+== aa-dist-bug.yaml aa-dist-bug-ref.yaml


### PR DESCRIPTION
If the AA range is > 1.0, due to a specific transform, the inner
pixels of a primitive that are not affected by the elliptical
radii in a clip mask may end up with a signed distance of 1.0,
which causes blending artifacts.

Instead, initialize the default value for signed distance to
the calculated AA range, which ensures we get a blend factor
of 1.0 in such cases.

Fixes #2576.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2604)
<!-- Reviewable:end -->
