### PR TITLE
Stop running taskcluster CI on the master branch.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -49,6 +49,8 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
+        excludeBranches:
+          - master
     payload:
       maxRunTime: 3600
       image: 'staktrace/webrender-test:latest'
@@ -81,6 +83,8 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
+        excludeBranches:
+          - master
     payload:
       maxRunTime: 3600
       image: 'staktrace/webrender-test:latest'
@@ -127,6 +131,8 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
+        excludeBranches:
+          - master
     payload:
       maxRunTime: 3600
       command:
@@ -159,6 +165,8 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - push
+        excludeBranches:
+          - master
     payload:
       maxRunTime: 3600
       command:


### PR DESCRIPTION
Now that https://bugzilla.mozilla.org/show_bug.cgi?id=1433506 has
merged, we have the ability to exclude taskcluster CI from running on
specific branches. Running it on the master branch is useless and gets
triggered by bors as it merges stuff back and forth. We can disable
running CI on master to free up some machine time.

(Take 2, now that the excludeBranches stuff should be working properly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2610)
<!-- Reviewable:end -->
