### PR TITLE
Ensure scene-only transactions still go through the scene builder thread

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -929,7 +929,7 @@ impl RenderBackend {
             );
         }
 
-        if transaction_msg.use_scene_builder_thread && !transaction_msg.is_empty() {
+        if transaction_msg.use_scene_builder_thread {
             let doc = self.documents.get_mut(&document_id).unwrap();
             doc.forward_transaction_to_scene_builder(
                 transaction_msg,


### PR DESCRIPTION
If WR gets a transaction which only contains scene messages, and has the
flag to use the scene builder thread, it will not actually use the scene
builder thread, because the update_document function first drains all
the scene messages, and then checks to see if the transaction is empty.
In this scenario the transaction is empty (because all the scene
messages got drained) but the op.build flag is set to true. So instead
of delegating the scene build to the builder thread, the build is done
on the RB thread.

This patch modifies the condition so that all transactions that are
intended to be handled by the scene builder thread get handled there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2611)
<!-- Reviewable:end -->
