### PR TITLE
Remove force_intermediate_surface.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1009,7 +1009,6 @@ impl<'a> DisplayListFlattener<'a> {
                 current_reference_frame_index,
                 None,
                 true,
-                false,
             );
 
             self.picture_stack.push(pic_index);
@@ -1066,7 +1065,6 @@ impl<'a> DisplayListFlattener<'a> {
                 current_reference_frame_index,
                 None,
                 true,
-                false,
             );
 
             let prim = BrushPrimitive::new_picture(
@@ -1121,7 +1119,6 @@ impl<'a> DisplayListFlattener<'a> {
                 current_reference_frame_index,
                 None,
                 true,
-                false,
             );
 
             // For drop shadows, add an extra brush::picture primitive
@@ -1185,7 +1182,6 @@ impl<'a> DisplayListFlattener<'a> {
                 current_reference_frame_index,
                 None,
                 true,
-                false,
             );
 
             let src_prim = BrushPrimitive::new_picture(
@@ -1222,7 +1218,11 @@ impl<'a> DisplayListFlattener<'a> {
             frame_output_pipeline_id = Some(pipeline_id);
         }
 
-        if participating_in_3d_context {
+        // Force an intermediate surface if the stacking context
+        // has a clip node. In the future, we may decide during
+        // prepare step to skip the intermediate surface if the
+        // clip node doesn't affect the stacking context rect.
+        if participating_in_3d_context || clipping_node.is_some() {
             // TODO(gw): For now, as soon as this picture is in
             //           a 3D context, we draw it to an intermediate
             //           surface and apply plane splitting. However,
@@ -1241,7 +1241,6 @@ impl<'a> DisplayListFlattener<'a> {
             current_reference_frame_index,
             frame_output_pipeline_id,
             true,
-            clipping_node.is_some(),
         );
 
         // Create a brush primitive that draws this picture.
@@ -1481,7 +1480,6 @@ impl<'a> DisplayListFlattener<'a> {
             current_reference_frame_index,
             None,
             apply_local_clip_rect,
-            false,
         );
 
         // Create the primitive to draw the shadow picture into the scene.

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1050,7 +1050,6 @@ impl PrimitiveStore {
         reference_frame_index: ClipScrollNodeIndex,
         frame_output_pipeline_id: Option<PipelineId>,
         apply_local_clip_rect: bool,
-        force_intermediate_surface: bool,
     ) -> PictureIndex {
         let picture = PicturePrimitive::new_image(
             composite_mode,
@@ -1059,7 +1058,6 @@ impl PrimitiveStore {
             reference_frame_index,
             frame_output_pipeline_id,
             apply_local_clip_rect,
-            force_intermediate_surface,
         );
 
         let picture_index = PictureIndex(self.pictures.len());
@@ -1845,7 +1843,7 @@ impl PrimitiveStore {
                         return None;
                     }
 
-                    may_need_clip_mask = pic.composite_mode.is_some() || pic.force_intermediate_surface;
+                    may_need_clip_mask = pic.composite_mode.is_some();
 
                     let inflation_factor = match pic.composite_mode {
                         Some(PictureCompositeMode::Filter(FilterOp::Blur(blur_radius))) => {


### PR DESCRIPTION
We can slightly simplify the picture code by forcing the composite
mode to Blit when there is a clip node for stacking contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2616)
<!-- Reviewable:end -->
