### PR TITLE
Support sampling from the render task cache in brush images.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1258,13 +1258,21 @@ impl BrushPrimitive {
         cached_gradients: &[CachedGradient],
     ) -> Option<(BrushBatchKind, BatchTextures, [i32; 3])> {
         match self.kind {
-            BrushKind::Image { request, .. } => {
-                let cache_item = resolve_image(
-                    request,
-                    resource_cache,
-                    gpu_cache,
-                    deferred_resolves,
-                );
+            BrushKind::Image { request, ref source, .. } => {
+
+                let cache_item = match *source {
+                    ImageSource::Default => {
+                        resolve_image(
+                            request,
+                            resource_cache,
+                            gpu_cache,
+                            deferred_resolves,
+                        )
+                    }
+                    ImageSource::Cache { ref item, .. } => {
+                        item.clone()
+                    }
+                };
 
                 if cache_item.texture_id == SourceTexture::Invalid {
                     None

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -2183,17 +2183,33 @@ impl<'a> DisplayListFlattener<'a> {
             tile: tile_offset,
         };
 
+        let sub_rect = sub_rect.map(|texel_rect| {
+            DeviceIntRect::new(
+                DeviceIntPoint::new(
+                    texel_rect.uv0.x as i32,
+                    texel_rect.uv0.y as i32,
+                ),
+                DeviceIntSize::new(
+                    (texel_rect.uv1.x - texel_rect.uv0.x) as i32,
+                    (texel_rect.uv1.y - texel_rect.uv0.y) as i32,
+                ),
+            )
+        });
+
         // See if conditions are met to run through the new
         // image brush shader, which supports segments.
         if tile_spacing == LayerSize::zero() &&
            stretch_size == info.rect.size &&
-           sub_rect.is_none() &&
            tile_offset.is_none() {
             let prim = BrushPrimitive::new(
                 BrushKind::Image {
                     request,
                     current_epoch: Epoch::invalid(),
                     alpha_type,
+                    stretch_size,
+                    tile_spacing,
+                    source: ImageSource::Default,
+                    sub_rect,
                 },
                 None,
             );
@@ -2213,18 +2229,7 @@ impl<'a> DisplayListFlattener<'a> {
                 source: ImageSource::Default,
                 key: ImageCacheKey {
                     request,
-                    texel_rect: sub_rect.map(|texel_rect| {
-                        DeviceIntRect::new(
-                            DeviceIntPoint::new(
-                                texel_rect.uv0.x as i32,
-                                texel_rect.uv0.y as i32,
-                            ),
-                            DeviceIntSize::new(
-                                (texel_rect.uv1.x - texel_rect.uv0.x) as i32,
-                                (texel_rect.uv1.y - texel_rect.uv0.y) as i32,
-                            ),
-                        )
-                    }),
+                    texel_rect: sub_rect,
                 },
             };
 


### PR DESCRIPTION
This PR adds support for sampling the render task cache in brush images, and test it out adds support for image sub rects in brush_image.

The sub rects implementation is duplicated between the brush and non-brush primitives, but I think it's fine to live with this temporarily because if things go well the non-brush code path will go away soon and the way I am planning to support pre-rendering tile spacing will make the two code paths diverge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2619)
<!-- Reviewable:end -->
