### PR TITLE
Ensure that every scene swap provides epoch information to APZ

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -264,6 +264,7 @@ impl Document {
             frame_ops: transaction_msg.frame_ops,
             render: transaction_msg.generate_frame,
             document_id,
+            current_epochs: self.current.scene.pipeline_epochs.clone(),
         }).unwrap();
     }
 


### PR DESCRIPTION
In cases where there is a transaction with no scene request, we still
need to send the active pipelines and epochs to APZ. I had previously
thought that any pipelines no longer built would end up in
removed_pipelines, which would have made this unnecessary, but that was
a misunderstanding of what removed_pipelines holds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2620)
<!-- Reviewable:end -->
