### PR TITLE
Readable shader error messages

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -53,7 +53,6 @@ const SHADER_VERSION_GLES: &str = "#version 300 es\n";
 const SHADER_KIND_VERTEX: &str = "#define WR_VERTEX_SHADER\n";
 const SHADER_KIND_FRAGMENT: &str = "#define WR_FRAGMENT_SHADER\n";
 const SHADER_IMPORT: &str = "#include ";
-const SHADER_LINE_MARKER: &str = "#line 1\n";
 
 pub struct TextureSlot(pub usize);
 
@@ -170,9 +169,7 @@ fn get_shader_source(shader_name: &str, base_path: &Option<PathBuf>) -> Option<S
 // Parse a shader string for imports. Imports are recursively processed, and
 // prepended to the list of outputs.
 fn parse_shader_source(source: String, base_path: &Option<PathBuf>, output: &mut String) {
-    output.push_str(SHADER_LINE_MARKER);
-
-    for (line_num, line) in source.lines().enumerate() {
+    for line in source.lines() {
         if line.starts_with(SHADER_IMPORT) {
             let imports = line[SHADER_IMPORT.len() ..].split(",");
 
@@ -182,8 +179,6 @@ fn parse_shader_source(source: String, base_path: &Option<PathBuf>, output: &mut
                     parse_shader_source(include, base_path, output);
                 }
             }
-
-            output.push_str(&format!("#line {}\n", line_num+1));
         } else {
             output.push_str(line);
             output.push_str("\n");
@@ -777,6 +772,25 @@ impl Device {
         self.bound_draw_fbo = FBOId(0);
     }
 
+    #[cfg(debug_assertions)]
+    fn print_shader_errors(source: &str, log: &str) {
+        // hacky way to extract the offending lines
+        if !log.starts_with("0:") {
+            return;
+        }
+        let end_pos = match log[2..].chars().position(|c| !c.is_digit(10)) {
+            Some(pos) => 2 + pos,
+            None => return,
+        };
+        let base_line_number = match log[2 .. end_pos].parse::<usize>() {
+            Ok(number) if number >= 2 => number - 2,
+            _ => return,
+        };
+        for (line, prefix) in source.lines().skip(base_line_number).zip(&["|",">","|"]) {
+            println!("{}\t{}", prefix, line);
+        }
+    }
+
     pub fn compile_shader(
         gl: &gl::Gl,
         name: &str,
@@ -790,6 +804,8 @@ impl Device {
         let log = gl.get_shader_info_log(id);
         if gl.get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
             println!("Failed to compile shader: {}\n{}", name, log);
+            #[cfg(debug_assertions)]
+            Self::print_shader_errors(source, &log);
             Err(ShaderError::Compilation(name.to_string(), log))
         } else {
             if !log.is_empty() {


### PR DESCRIPTION
Working with shaders, I find `#line` navigation experience to be rather poor:
  1. first, I take an `apitrace` capture
  2. load the capture, go to the last `glShaderSource`
  3. copy out the input into a new file
  4. for each `#line` directive, try to match the reported error number ...

This PR removes line overrides. Instead, it prints the relevant piece to the console, e.g.:
```
Loading shaders...
Failed to compile shader: cs_clip_image
0:1152(17): error: syntax error, unexpected NEW_IDENTIFIER, expecting ',' or ';'

|	    ClipScrollNode scroll_node = fetch_clip_scroll_node(cmi.scroll_node_id);
>	    DImageMaskData mask = fetch_mask_data(cmi.clip_data_address);
|	    RectWithSize local_rect = mask.local_rect;
```

This information instantly gives me an idea of what's wrong (note: unlike the original driver message), and makes all the listed steps unnecessary for 99% of cases. And when the steps are necessary, we don't have to check for each `#line` occurrence since the driver-reported line number is no longer ambiguous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2622)
<!-- Reviewable:end -->
