### PR TITLE
Use a freelist to store render task cache entries, make cache entry public.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "osmesa-src"
 version = "17.4.0-devel"
-source = "git+https://github.com/servo/osmesa-src#1cf8c2f21c7e9047c3bd5a2f1accbc08e5636cf7"
+source = "git+https://github.com/jrmuizel/osmesa-src?branch=serialize#0f81d082b4cca16ea4d344bf6758b5a2f8d98277"
 
 [[package]]
 name = "osmesa-sys"
@@ -1476,7 +1476,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)",
+ "osmesa-src 17.4.0-devel (git+https://github.com/jrmuizel/osmesa-src?branch=serialize)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1639,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a225d1e2717567599c24f88e49f00856c6e825a12125181ee42c4257e3688d39"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
-"checksum osmesa-src 17.4.0-devel (git+https://github.com/servo/osmesa-src)" = "<none>"
+"checksum osmesa-src 17.4.0-devel (git+https://github.com/jrmuizel/osmesa-src?branch=serialize)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum pathfinder_font_renderer 0.3.0 (git+https://github.com/pcwalton/pathfinder)" = "<none>"
 "checksum pathfinder_gfx_utils 0.1.0 (git+https://github.com/pcwalton/pathfinder)" = "<none>"

--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -90,6 +90,12 @@ impl<T> FreeList<T> {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.slots.clear();
+        self.free_list_head = None;
+        self.active_count = 0;
+    }
+
     #[allow(dead_code)]
     pub fn get(&self, id: &FreeListHandle<T>) -> &T {
         self.slots[id.index as usize].value.as_ref().unwrap()


### PR DESCRIPTION
This is a small patch in preparation for upcoming changes that are
related to caching render tasks. Storing these as a freelist allows
handing out weak handles, rather than always fetching by hash key.

We can provide these to the caller of request_render_task() to allow
fetching the CacheItem during batching, without another hash map
lookup. This is more in line with how the PathFinder integration
works, and also useful for some upcoming patches which will cache
other render task kinds. Specifically, in addition to the CacheItem
for a cached render task, the batching code will be able to retrieve
other details about a cached render task, such as required blend mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2641)
<!-- Reviewable:end -->
