### PR TITLE
add reftest for mask clips on stacking contexts, closes #1957

### DIFF
--- a/wrench/reftests/mask/mask-atomicity-ref.yaml
+++ b/wrench/reftests/mask/mask-atomicity-ref.yaml
@@ -1,0 +1,17 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: [25, 25, 100, 100]
+      color: red
+    - type: stacking-context
+      bounds: [0, 0, 200, 200]
+      filters:
+        - "opacity(0.5)"
+      items:
+      - type: rect
+        bounds: [0, 0, 100, 100]
+        color: blue
+      - type: rect
+        bounds: [50, 50, 100, 100]
+        color: green

--- a/wrench/reftests/mask/mask-atomicity.yaml
+++ b/wrench/reftests/mask/mask-atomicity.yaml
@@ -1,0 +1,24 @@
+---
+root:
+  items:
+    - type: rect
+      bounds: [25, 25, 100, 100]
+      color: red
+    - type: clip
+      bounds: [0, 0, 200, 200]
+      id: 1
+      image-mask:
+          # premultiplied 0.5 alpha white(??)
+          image: solid-color(127,127,127,127,200,200)
+          rect: [0, 0, 200, 200]
+          repeat: false
+    - type: stacking-context
+      bounds: [0, 0, 200, 200]
+      clip-node: 1
+      items:
+      - type: rect
+        bounds: [0, 0, 100, 100]
+        color: blue
+      - type: rect
+        bounds: [50, 50, 100, 100]
+        color: green

--- a/wrench/reftests/mask/reftest.list
+++ b/wrench/reftests/mask/reftest.list
@@ -5,3 +5,4 @@
 == mask-transformed-to-empty-rect.yaml mask-transformed-to-empty-rect-ref.yaml
 == rounded-corners.yaml rounded-corners.png
 != mask.yaml out-of-bounds.yaml
+fuzzy(1,8750) == mask-atomicity.yaml mask-atomicity-ref.yaml


### PR DESCRIPTION
This was made possible by #2600. I had to make the test a bit fuzzy
since the reference uses floating point color, while the test uses integer color.
They're visually indistinguishable, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2646)
<!-- Reviewable:end -->
