### PR TITLE
Error on missed pipeline DL

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -570,7 +570,11 @@ impl<'a> DisplayListFlattener<'a> {
         let iframe_pipeline_id = info.pipeline_id;
         let pipeline = match self.scene.pipelines.get(&iframe_pipeline_id) {
             Some(pipeline) => pipeline,
-            None => return,
+            None => {
+                //TODO: assert/debug_assert?
+                error!("Unknown pipeline used for iframe {:?}", info);
+                return
+            },
         };
 
         self.id_to_index_mapper.initialize_for_pipeline(pipeline);


### PR DESCRIPTION
We hit this in Gecko workloads. It would be ideal to cry out louder (if not panic at all), but until the Gecko side is resolved, we should at least indicate that stuff is going off the rails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2647)
<!-- Reviewable:end -->
