### PR TITLE
stop using bare println

### DIFF
--- a/webrender/src/debug_server.rs
+++ b/webrender/src/debug_server.rs
@@ -63,7 +63,7 @@ impl ws::Handler for Server {
                     "fetch_clip_scroll_tree" => DebugCommand::FetchClipScrollTree,
                     "fetch_render_tasks" => DebugCommand::FetchRenderTasks,
                     msg => {
-                        println!("unknown msg {}", msg);
+                        error!("unknown msg {}", msg);
                         return Ok(());
                     }
                 };
@@ -105,9 +105,9 @@ impl DebugServer {
 
         let join_handle = Some(thread::spawn(move || {
             let address = "127.0.0.1:3583";
-            println!("WebRender debug server started: {}", address);
+            debug!("WebRender debug server started: {}", address);
             if let Err(..) = socket.listen(address) {
-                println!("ERROR: Unable to bind debugger websocket (port may be in use).");
+                error!("ERROR: Unable to bind debugger websocket (port may be in use).");
             }
         }));
 

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -787,7 +787,7 @@ impl Device {
             _ => return,
         };
         for (line, prefix) in source.lines().skip(base_line_number).zip(&["|",">","|"]) {
-            println!("{}\t{}", prefix, line);
+            error!("{}\t{}", prefix, line);
         }
     }
 
@@ -803,13 +803,13 @@ impl Device {
         gl.compile_shader(id);
         let log = gl.get_shader_info_log(id);
         if gl.get_shader_iv(id, gl::COMPILE_STATUS) == (0 as gl::GLint) {
-            println!("Failed to compile shader: {}\n{}", name, log);
+            error!("Failed to compile shader: {}\n{}", name, log);
             #[cfg(debug_assertions)]
             Self::print_shader_errors(source, &log);
             Err(ShaderError::Compilation(name.to_string(), log))
         } else {
             if !log.is_empty() {
-                println!("Warnings detected on shader: {}\n{}", name, log);
+                warn!("Warnings detected on shader: {}\n{}", name, log);
             }
             Ok(id)
         }
@@ -1380,7 +1380,7 @@ impl Device {
 
                 if self.gl.get_program_iv(pid, gl::LINK_STATUS) == (0 as gl::GLint) {
                     let error_log = self.gl.get_program_info_log(pid);
-                    println!(
+                    error!(
                       "Failed to load a program object with a program binary: {} renderer {}\n{}",
                       base_filename,
                       self.renderer_name,
@@ -1442,7 +1442,7 @@ impl Device {
 
             if self.gl.get_program_iv(pid, gl::LINK_STATUS) == (0 as gl::GLint) {
                 let error_log = self.gl.get_program_info_log(pid);
-                println!(
+                error!(
                     "Failed to link shader program: {}\n{}",
                     base_filename,
                     error_log

--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -455,7 +455,7 @@ impl GlyphRasterizer {
     #[cfg(feature = "pathfinder")]
     fn add_font_to_pathfinder(&mut self, font_key: &FontKey, template: &FontTemplate) {
         let font_contexts = Arc::clone(&self.font_contexts);
-        eprintln!("add_font_to_pathfinder({:?})", font_key);
+        debug!("add_font_to_pathfinder({:?})", font_key);
         font_contexts.lock_pathfinder_context().add_font(&font_key, &template);
     }
 

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -196,7 +196,7 @@ impl FontContext {
                     },
                 );
             } else {
-                println!("WARN: webrender failed to load font");
+                warn!("WARN: webrender failed to load font");
                 debug!("font={:?}", font_key);
             }
         }
@@ -223,7 +223,7 @@ impl FontContext {
                     },
                 );
             } else {
-                println!("WARN: webrender failed to load font");
+                warn!("WARN: webrender failed to load font");
                 debug!("font={:?}, path={:?}", font_key, pathname);
             }
         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1416,7 +1416,7 @@ impl Renderer {
         // gracefully fail now than panic as soon as a texture is allocated.
         let min_texture_size = 512;
         if device_max_size < min_texture_size {
-            println!(
+            error!(
                 "Device reporting insufficient max texture size ({})",
                 device_max_size
             );


### PR DESCRIPTION
println writes to stdout unconditionally, which can cause release builds of
firefox to crash (panic) if stdout becomes unavailable. We should feed all
prints (that aren't explicitly for print-debugging) through our logging
framework so that stdout disappearing can be correctly handled by our
logging crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2648)
<!-- Reviewable:end -->
