### PR TITLE
Add a sampler mechanism

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -182,8 +182,8 @@ pub extern crate webrender_api;
 
 #[doc(hidden)]
 pub use device::{build_shader_strings, ProgramCache, ReadPixelsFormat, UploadMethod, VertexUsageHint};
-pub use renderer::{CpuProfile, DebugFlags, GpuProfile, OutputImageHandler, RendererKind};
-pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource};
+pub use renderer::{AsyncPropertySampler, CpuProfile, DebugFlags, OutputImageHandler, RendererKind};
+pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource, GpuProfile};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, PipelineInfo, Renderer, RendererOptions};
 pub use renderer::{RendererStats, SceneBuilderHooks, ThreadListener};
 pub use renderer::MAX_VERTEX_TEXTURE_WIDTH;

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -338,6 +338,11 @@ impl Transaction {
         self.frame_ops.push(FrameMsg::EnableFrameOutput(pipeline_id, enable));
     }
 
+    /// Consumes this object and just returns the frame ops.
+    pub fn get_frame_ops(self) -> Vec<FrameMsg> {
+        self.frame_ops
+    }
+
     fn finalize(self) -> (TransactionMsg, Vec<Payload>) {
         (
             TransactionMsg {


### PR DESCRIPTION
These changes are needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1451469

r? @nical 

I wasn't totally sure what the best place was to hook in the sample() method in the first patch. Part of me was thinking it would be better to do it inside the `if op.render {...}` block but I think what I have is equivalent, at least for the gecko case, because all the transactions that have messages that produce `DocumentOps::render` will also have their `generate_frame` flag set. But let me know if you think that can be improved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2654)
<!-- Reviewable:end -->
