### PR TITLE
Change drop-shadows to be drawn via a single primitive.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -14,7 +14,6 @@ use api::{RepeatMode, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity, S
 use api::{SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect, TileOffset};
 use api::{TransformStyle, YuvColorSpace, YuvData};
 use app_units::Au;
-use batch::BrushImageSourceKind;
 use border::ImageBorderSegment;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, StickyFrameInfo};
@@ -1070,11 +1069,7 @@ impl<'a> DisplayListFlattener<'a> {
                 true,
             );
 
-            let prim = BrushPrimitive::new_picture(
-                container_index,
-                BrushImageSourceKind::Color,
-                LayerVector2D::zero(),
-            );
+            let prim = BrushPrimitive::new_picture(container_index);
 
             let prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
@@ -1124,34 +1119,7 @@ impl<'a> DisplayListFlattener<'a> {
                 true,
             );
 
-            // For drop shadows, add an extra brush::picture primitive
-            // that will draw the picture as an alpha mask.
-            let shadow_prim_index = match *filter {
-                FilterOp::DropShadow(offset, ..) => {
-                    let shadow_prim = BrushPrimitive::new_picture(
-                        src_pic_index,
-                        BrushImageSourceKind::ColorAlphaMask,
-                        offset,
-                    );
-                    Some(self.prim_store.add_primitive(
-                        &LayerRect::zero(),
-                        &max_clip,
-                        is_backface_visible,
-                        None,
-                        None,
-                        PrimitiveContainer::Brush(shadow_prim),
-                    ))
-                }
-                _ => {
-                    None
-                }
-            };
-
-            let src_prim = BrushPrimitive::new_picture(
-                src_pic_index,
-                BrushImageSourceKind::Color,
-                LayoutVector2D::zero(),
-            );
+            let src_prim = BrushPrimitive::new_picture(src_pic_index);
             let src_prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
                 &max_clip,
@@ -1163,13 +1131,6 @@ impl<'a> DisplayListFlattener<'a> {
 
             let parent_pic = &mut self.prim_store.pictures[parent_pic_index.0];
             parent_pic_index = src_pic_index;
-
-            if let Some(shadow_prim_index) = shadow_prim_index {
-                parent_pic.add_primitive(
-                    shadow_prim_index,
-                    clip_and_scroll,
-                );
-            }
 
             parent_pic.add_primitive(src_prim_index, clip_and_scroll);
 
@@ -1187,11 +1148,7 @@ impl<'a> DisplayListFlattener<'a> {
                 true,
             );
 
-            let src_prim = BrushPrimitive::new_picture(
-                src_pic_index,
-                BrushImageSourceKind::Color,
-                LayoutVector2D::zero(),
-            );
+            let src_prim = BrushPrimitive::new_picture(src_pic_index);
 
             let src_prim_index = self.prim_store.add_primitive(
                 &LayerRect::zero(),
@@ -1247,11 +1204,7 @@ impl<'a> DisplayListFlattener<'a> {
         );
 
         // Create a brush primitive that draws this picture.
-        let sc_prim = BrushPrimitive::new_picture(
-            pic_index,
-            BrushImageSourceKind::Color,
-            LayoutVector2D::zero(),
-        );
+        let sc_prim = BrushPrimitive::new_picture(pic_index);
 
         // Add the brush to the parent picture.
         let sc_prim_index = self.prim_store.add_primitive(
@@ -1486,11 +1439,7 @@ impl<'a> DisplayListFlattener<'a> {
         );
 
         // Create the primitive to draw the shadow picture into the scene.
-        let shadow_prim = BrushPrimitive::new_picture(
-            shadow_pic_index,
-            BrushImageSourceKind::Color,
-            LayoutVector2D::zero(),
-        );
+        let shadow_prim = BrushPrimitive::new_picture(shadow_pic_index);
         let shadow_prim_index = self.prim_store.add_primitive(
             &LayerRect::zero(),
             &max_clip,

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -151,6 +151,13 @@ impl GpuCacheAddress {
             v: u16::MAX,
         }
     }
+
+    pub fn offset(&self, offset: usize) -> Self {
+        GpuCacheAddress {
+            u: self.u + offset as u16,
+            v: self.v
+        }
+    }
 }
 
 impl Add<usize> for GpuCacheAddress {


### PR DESCRIPTION
Previously, drop-shadows were a Picture, with two brush image
primitives, each referencing the picture (one for the content,
one for the shadow with an offset).

Although conceptually reasonable, this exposes some problems
with the way the current prim_store visibility pass works.
Specifically, we can end up processing the picture more than
once. In general this is an inefficiency but doesn't affect
correctness, but it breaks some assumptions once the content
of the drop-shadow element is an item in the render task cache.

In the future, this problem should disappear as we refactor
how the visibility pass operates, but for now the simplest solution
is to draw the drop-shadow with a single primitive. To make this
work, there are a couple of hacks in this patch, which
push an extra brush image primitive into the GPU cache data.

The drop shadows still have an issue with the shadow disappearing
if the content of the drop shadow is off-screen, however this is
no worse than the existing code. Doing it this way actually makes
it easier to fix this is the future too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2656)
<!-- Reviewable:end -->
