### PR TITLE
hotfix for #2657, prevent subpixel in masks

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1225,7 +1225,8 @@ impl<'a> DisplayListFlattener<'a> {
         // TODO(gw): This is super conservative. We can expand on this a lot
         //           once all the picture code is in place and landed.
         let allow_subpixel_aa = composite_ops.count() == 0 &&
-                                transform_style == TransformStyle::Flat;
+                                transform_style == TransformStyle::Flat &&
+                                composite_mode.is_none();
 
         // Push the SC onto the stack, so we know how to handle things in
         // pop_stacking_context.


### PR DESCRIPTION
people are noticing this a lot, so let's just do this now and figure out the more robust solutions later.

#2657 still needs a proper regression test, which I'll try to knock out tomorrow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2662)
<!-- Reviewable:end -->
