### PR TITLE
Various render task refactors to help with upcoming caching changes.

### DIFF
--- a/webrender/src/box_shadow.rs
+++ b/webrender/src/box_shadow.rs
@@ -10,7 +10,7 @@ use gpu_cache::GpuCacheHandle;
 use gpu_types::BoxShadowStretchMode;
 use prim_store::{BrushKind, BrushPrimitive, PrimitiveContainer};
 use prim_store::ScrollNodeAndClipChain;
-use resource_cache::CacheItem;
+use render_task::RenderTaskCacheEntryHandle;
 use util::RectHelpers;
 
 #[derive(Debug)]
@@ -25,7 +25,7 @@ pub struct BoxShadowClipSource {
     // The current cache key (in device-pixels), and handles
     // to the cached clip region and blurred texture.
     pub cache_key: Option<(DeviceIntSize, BoxShadowCacheKey)>,
-    pub cache_item: CacheItem,
+    pub cache_handle: Option<RenderTaskCacheEntryHandle>,
     pub clip_data_handle: GpuCacheHandle,
 
     // Local-space size of the required render task size.

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -14,14 +14,17 @@ use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use gpu_types::{BoxShadowStretchMode, ClipScrollNodeIndex};
 use prim_store::{ClipData, ImageMaskData};
 use render_task::to_cache_size;
-use resource_cache::{CacheItem, ImageRequest, ResourceCache};
+use resource_cache::{ImageRequest, ResourceCache};
 use util::{LayerToWorldFastTransform, MaxRect, calculate_screen_bounding_rect};
 use util::{extract_inner_rect_safe, pack_as_float};
 use std::sync::Arc;
 
-pub type ClipStore = FreeList<ClipSources>;
-pub type ClipSourcesHandle = FreeListHandle<ClipSources>;
-pub type ClipSourcesWeakHandle = WeakFreeListHandle<ClipSources>;
+#[derive(Debug)]
+pub enum ClipStoreMarker {}
+
+pub type ClipStore = FreeList<ClipSources, ClipStoreMarker>;
+pub type ClipSourcesHandle = FreeListHandle<ClipStoreMarker>;
+pub type ClipSourcesWeakHandle = WeakFreeListHandle<ClipStoreMarker>;
 
 #[derive(Debug)]
 pub struct LineDecorationClipSource {
@@ -237,7 +240,7 @@ impl ClipSource {
             clip_mode,
             stretch_mode_x,
             stretch_mode_y,
-            cache_item: CacheItem::invalid(),
+            cache_handle: None,
             cache_key: None,
             clip_data_handle: GpuCacheHandle::new(),
             minimal_shadow_rect,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -392,7 +392,7 @@ impl FrameBuilder {
 
         let gpu_cache_frame_id = gpu_cache.end_frame(gpu_cache_profile);
 
-        render_tasks.build();
+        render_tasks.write_task_data();
 
         resource_cache.end_frame();
 

--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -17,14 +17,14 @@ struct Epoch(u32);
 #[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct FreeListHandle<T> {
+pub struct FreeListHandle<M> {
     index: u32,
     epoch: Epoch,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<M>,
 }
 
-impl<T> FreeListHandle<T> {
-    pub fn weak(&self) -> WeakFreeListHandle<T> {
+impl<M> FreeListHandle<M> {
+    pub fn weak(&self) -> WeakFreeListHandle<M> {
         WeakFreeListHandle {
             index: self.index,
             epoch: self.epoch,
@@ -33,7 +33,7 @@ impl<T> FreeListHandle<T> {
     }
 }
 
-impl<T> Clone for WeakFreeListHandle<T> {
+impl<M> Clone for WeakFreeListHandle<M> {
     fn clone(&self) -> Self {
         WeakFreeListHandle {
             index: self.index,
@@ -46,10 +46,10 @@ impl<T> Clone for WeakFreeListHandle<T> {
 #[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct WeakFreeListHandle<T> {
+pub struct WeakFreeListHandle<M> {
     index: u32,
     epoch: Epoch,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<M>,
 }
 
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -62,31 +62,34 @@ struct Slot<T> {
 
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct FreeList<T> {
+pub struct FreeList<T, M> {
     slots: Vec<Slot<T>>,
     free_list_head: Option<u32>,
     active_count: usize,
+    _marker: PhantomData<M>,
 }
 
-pub enum UpsertResult<T> {
+pub enum UpsertResult<T, M> {
     Updated(T),
-    Inserted(FreeListHandle<T>),
+    Inserted(FreeListHandle<M>),
 }
 
-impl<T> FreeList<T> {
+impl<T, M> FreeList<T, M> {
     pub fn new() -> Self {
         FreeList {
             slots: Vec::new(),
             free_list_head: None,
             active_count: 0,
+            _marker: PhantomData,
         }
     }
 
-    pub fn recycle(self) -> FreeList<T> {
+    pub fn recycle(self) -> FreeList<T, M> {
         FreeList {
             slots: recycle_vec(self.slots),
             free_list_head: None,
             active_count: 0,
+            _marker: PhantomData,
         }
     }
 
@@ -97,16 +100,16 @@ impl<T> FreeList<T> {
     }
 
     #[allow(dead_code)]
-    pub fn get(&self, id: &FreeListHandle<T>) -> &T {
+    pub fn get(&self, id: &FreeListHandle<M>) -> &T {
         self.slots[id.index as usize].value.as_ref().unwrap()
     }
 
     #[allow(dead_code)]
-    pub fn get_mut(&mut self, id: &FreeListHandle<T>) -> &mut T {
+    pub fn get_mut(&mut self, id: &FreeListHandle<M>) -> &mut T {
         self.slots[id.index as usize].value.as_mut().unwrap()
     }
 
-    pub fn get_opt(&self, id: &WeakFreeListHandle<T>) -> Option<&T> {
+    pub fn get_opt(&self, id: &WeakFreeListHandle<M>) -> Option<&T> {
         let slot = &self.slots[id.index as usize];
         if slot.epoch == id.epoch {
             slot.value.as_ref()
@@ -115,7 +118,7 @@ impl<T> FreeList<T> {
         }
     }
 
-    pub fn get_opt_mut(&mut self, id: &WeakFreeListHandle<T>) -> Option<&mut T> {
+    pub fn get_opt_mut(&mut self, id: &WeakFreeListHandle<M>) -> Option<&mut T> {
         let slot = &mut self.slots[id.index as usize];
         if slot.epoch == id.epoch {
             slot.value.as_mut()
@@ -128,7 +131,7 @@ impl<T> FreeList<T> {
     // handle is a valid entry, update the value and return the
     // previous data. If the provided handle is invalid, then
     // insert the data into a new slot and return the new handle.
-    pub fn upsert(&mut self, id: &WeakFreeListHandle<T>, data: T) -> UpsertResult<T> {
+    pub fn upsert(&mut self, id: &WeakFreeListHandle<M>, data: T) -> UpsertResult<T, M> {
         if self.slots[id.index as usize].epoch == id.epoch {
             let slot = &mut self.slots[id.index as usize];
             let result = UpsertResult::Updated(slot.value.take().unwrap());
@@ -139,7 +142,7 @@ impl<T> FreeList<T> {
         }
     }
 
-    pub fn insert(&mut self, item: T) -> FreeListHandle<T> {
+    pub fn insert(&mut self, item: T) -> FreeListHandle<M> {
         self.active_count += 1;
 
         match self.free_list_head {
@@ -176,7 +179,7 @@ impl<T> FreeList<T> {
         }
     }
 
-    pub fn free(&mut self, id: FreeListHandle<T>) -> T {
+    pub fn free(&mut self, id: FreeListHandle<M>) -> T {
         self.active_count -= 1;
         let slot = &mut self.slots[id.index as usize];
         slot.next = self.free_list_head;

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -11,7 +11,7 @@ use clip_scroll_tree::CoordinateSystemId;
 use device::TextureFilter;
 #[cfg(feature = "pathfinder")]
 use euclid::{TypedPoint2D, TypedVector2D};
-use freelist::{FreeList, FreeListHandle};
+use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use glyph_rasterizer::GpuGlyphCacheKey;
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle};
 use gpu_types::{ImageSource, RasterizationSpace};
@@ -120,12 +120,18 @@ impl RenderTaskTree {
         pass.add_render_task(id, task.get_dynamic_size(), task.target_kind());
     }
 
+    pub fn prepare_for_render(&mut self) {
+        for task in &mut self.tasks {
+            task.prepare_for_render();
+        }
+    }
+
     pub fn get_task_address(&self, id: RenderTaskId) -> RenderTaskAddress {
         debug_assert_eq!(self.frame_id, id.1);
         RenderTaskAddress(id.0)
     }
 
-    pub fn build(&mut self) {
+    pub fn write_task_data(&mut self) {
         for task in &self.tasks {
             self.task_data.push(task.write_task_data());
         }
@@ -158,7 +164,7 @@ impl ops::IndexMut<RenderTaskId> for RenderTaskTree {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum RenderTaskLocation {
     Fixed(DeviceIntRect),
-    Dynamic(Option<(DeviceIntPoint, RenderTargetIndex)>, DeviceIntSize),
+    Dynamic(Option<(DeviceIntPoint, RenderTargetIndex)>, Option<DeviceIntSize>),
     TextureCache(SourceTexture, i32, DeviceIntRect),
 }
 
@@ -312,7 +318,7 @@ impl RenderTask {
     pub fn new_readback(screen_rect: DeviceIntRect) -> Self {
         RenderTask {
             children: Vec::new(),
-            location: RenderTaskLocation::Dynamic(None, screen_rect.size),
+            location: RenderTaskLocation::Dynamic(None, Some(screen_rect.size)),
             kind: RenderTaskKind::Readback(screen_rect),
             clear_mode: ClearMode::Transparent,
             saved_index: None,
@@ -336,7 +342,7 @@ impl RenderTask {
 
         RenderTask {
             children,
-            location: RenderTaskLocation::Dynamic(None, size),
+            location: RenderTaskLocation::Dynamic(None, Some(size)),
             kind: RenderTaskKind::Blit(BlitTask {
                 source,
             }),
@@ -379,7 +385,7 @@ impl RenderTask {
 
                         // Request a cacheable render task with a blurred, minimal
                         // sized box-shadow rect.
-                        info.cache_item = resource_cache.request_render_task(
+                        info.cache_handle = Some(resource_cache.request_render_task(
                             RenderTaskCacheKey {
                                 size: cache_size,
                                 kind: RenderTaskCacheKeyKind::BoxShadow(cache_key),
@@ -387,6 +393,7 @@ impl RenderTask {
                             gpu_cache,
                             render_tasks,
                             None,
+                            false,
                             |render_tasks| {
                                 // Draw the rounded rect.
                                 let mask_task = RenderTask::new_rounded_rect_mask(
@@ -408,9 +415,9 @@ impl RenderTask {
                                 let root_task_id = render_tasks.add(blur_render_task);
                                 children.push(root_task_id);
 
-                                (root_task_id, false)
+                                root_task_id
                             }
-                        );
+                        ));
                     }
                     ClipSource::Rectangle(..) |
                     ClipSource::RoundedRectangle(..) |
@@ -423,7 +430,7 @@ impl RenderTask {
 
         RenderTask {
             children,
-            location: RenderTaskLocation::Dynamic(None, outer_rect.size),
+            location: RenderTaskLocation::Dynamic(None, Some(outer_rect.size)),
             kind: RenderTaskKind::CacheMask(CacheMaskTask {
                 actual_rect: outer_rect,
                 clips,
@@ -440,7 +447,7 @@ impl RenderTask {
     ) -> Self {
         RenderTask {
             children: Vec::new(),
-            location: RenderTaskLocation::Dynamic(None, size),
+            location: RenderTaskLocation::Dynamic(None, Some(size)),
             kind: RenderTaskKind::ClipRegion(ClipRegionTask {
                 clip_data_address,
             }),
@@ -498,7 +505,7 @@ impl RenderTask {
 
         let blur_task_v = RenderTask {
             children: vec![downscaling_src_task_id],
-            location: RenderTaskLocation::Dynamic(None, adjusted_blur_target_size),
+            location: RenderTaskLocation::Dynamic(None, Some(adjusted_blur_target_size)),
             kind: RenderTaskKind::VerticalBlur(BlurTask {
                 blur_std_deviation: adjusted_blur_std_deviation,
                 target_kind,
@@ -512,7 +519,7 @@ impl RenderTask {
 
         RenderTask {
             children: vec![blur_task_v_id],
-            location: RenderTaskLocation::Dynamic(None, adjusted_blur_target_size),
+            location: RenderTaskLocation::Dynamic(None, Some(adjusted_blur_target_size)),
             kind: RenderTaskKind::HorizontalBlur(BlurTask {
                 blur_std_deviation: adjusted_blur_std_deviation,
                 target_kind,
@@ -530,7 +537,7 @@ impl RenderTask {
     ) -> Self {
         RenderTask {
             children: vec![src_task_id],
-            location: RenderTaskLocation::Dynamic(None, target_size),
+            location: RenderTaskLocation::Dynamic(None, Some(target_size)),
             kind: RenderTaskKind::Scaling(target_kind),
             clear_mode: match target_kind {
                 RenderTargetKind::Color => ClearMode::Transparent,
@@ -632,14 +639,14 @@ impl RenderTask {
         }
     }
 
-    pub fn get_texture_handle(&self) -> &GpuCacheHandle {
+    pub fn get_texture_address(&self, gpu_cache: &GpuCache) -> GpuCacheAddress {
         match self.kind {
             RenderTaskKind::Picture(ref info) => {
-                &info.uv_rect_handle
+                gpu_cache.get_address(&info.uv_rect_handle)
             }
             RenderTaskKind::VerticalBlur(ref info) |
             RenderTaskKind::HorizontalBlur(ref info) => {
-                &info.uv_rect_handle
+                gpu_cache.get_address(&info.uv_rect_handle)
             }
             RenderTaskKind::ClipRegion(..) |
             RenderTaskKind::Readback(..) |
@@ -655,7 +662,10 @@ impl RenderTask {
     pub fn get_dynamic_size(&self) -> DeviceIntSize {
         match self.location {
             RenderTaskLocation::Fixed(..) => DeviceIntSize::zero(),
-            RenderTaskLocation::Dynamic(_, size) => size,
+            RenderTaskLocation::Dynamic(_, Some(size)) => size,
+            RenderTaskLocation::Dynamic(_, None) => {
+                panic!("bug: render task must have assigned size by now");
+            }
             RenderTaskLocation::TextureCache(_, _, rect) => rect.size,
         }
     }
@@ -680,6 +690,7 @@ impl RenderTask {
             //           to mark a task as unused explicitly. This
             //           would allow us to restore this debug check.
             RenderTaskLocation::Dynamic(Some((origin, target_index)), size) => {
+                let size = size.expect("bug: must be assigned a size by now");
                 (DeviceIntRect::new(origin, size), target_index)
             }
             RenderTaskLocation::Dynamic(None, _) => {
@@ -749,7 +760,14 @@ impl RenderTask {
         }
     }
 
-    pub fn prepare_for_render(
+    // Optionally, prepare the render task for drawing. This is executed
+    // after all resource cache items (textures and glyphs) have been
+    // resolved and can be queried. It also allows certain render tasks
+    // to defer calculating an exact size until now, if desired.
+    pub fn prepare_for_render(&mut self) {
+    }
+
+    pub fn write_gpu_blocks(
         &mut self,
         gpu_cache: &mut GpuCache,
     ) {
@@ -867,20 +885,29 @@ pub struct RenderTaskCacheKey {
     pub kind: RenderTaskCacheKeyKind,
 }
 
+#[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct RenderTaskCacheEntry {
+    pending_render_task_id: Option<RenderTaskId>,
+    user_data: Option<[f32; 3]>,
+    is_opaque: bool,
     pub handle: TextureCacheHandle,
 }
+
+#[derive(Debug)]
+pub enum RenderTaskCacheMarker {}
 
 // A cache of render tasks that are stored in the texture
 // cache for usage across frames.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct RenderTaskCache {
-    map: FastHashMap<RenderTaskCacheKey, FreeListHandle<RenderTaskCacheEntry>>,
-    cache_entries: FreeList<RenderTaskCacheEntry>,
+    map: FastHashMap<RenderTaskCacheKey, FreeListHandle<RenderTaskCacheMarker>>,
+    cache_entries: FreeList<RenderTaskCacheEntry, RenderTaskCacheMarker>,
 }
+
+pub type RenderTaskCacheEntryHandle = WeakFreeListHandle<RenderTaskCacheMarker>;
 
 impl RenderTaskCache {
     pub fn new() -> Self {
@@ -927,6 +954,77 @@ impl RenderTaskCache {
         }
     }
 
+    pub fn update(
+        &mut self,
+        gpu_cache: &mut GpuCache,
+        texture_cache: &mut TextureCache,
+        render_tasks: &mut RenderTaskTree,
+    ) {
+        // Iterate the list of render task cache entries,
+        // and allocate / update the texture cache location
+        // if the entry has been evicted or not yet allocated.
+        for (_, handle) in &self.map {
+            let entry = self.cache_entries.get_mut(handle);
+
+            if let Some(pending_render_task_id) = entry.pending_render_task_id.take() {
+                let render_task = &mut render_tasks[pending_render_task_id];
+                let target_kind = render_task.target_kind();
+
+                // Find out what size to alloc in the texture cache.
+                let size = match render_task.location {
+                    RenderTaskLocation::Fixed(..) |
+                    RenderTaskLocation::TextureCache(..) => {
+                        panic!("BUG: dynamic task was expected");
+                    }
+                    RenderTaskLocation::Dynamic(_, None) => {
+                        panic!("BUG: must have assigned size by now");
+                    }
+                    RenderTaskLocation::Dynamic(_, Some(size)) => size,
+                };
+
+                // Select the right texture page to allocate from.
+                let image_format = match target_kind {
+                    RenderTargetKind::Color => ImageFormat::BGRA8,
+                    RenderTargetKind::Alpha => ImageFormat::R8,
+                };
+
+                let descriptor = ImageDescriptor::new(
+                    size.width as u32,
+                    size.height as u32,
+                    image_format,
+                    entry.is_opaque,
+                    false,
+                );
+
+                // Allocate space in the texture cache, but don't supply
+                // and CPU-side data to be uploaded.
+                texture_cache.update(
+                    &mut entry.handle,
+                    descriptor,
+                    TextureFilter::Linear,
+                    None,
+                    entry.user_data.unwrap_or([0.0; 3]),
+                    None,
+                    gpu_cache,
+                    None,
+                );
+
+                // Get the allocation details in the texture cache, and store
+                // this in the render task. The renderer will draw this
+                // task into the appropriate layer and rect of the texture
+                // cache on this frame.
+                let (texture_id, texture_layer, uv_rect) =
+                    texture_cache.get_cache_location(&entry.handle);
+
+                render_task.location = RenderTaskLocation::TextureCache(
+                    texture_id,
+                    texture_layer,
+                    uv_rect.to_i32()
+                );
+            }
+        }
+    }
+
     pub fn request_render_task<F>(
         &mut self,
         key: RenderTaskCacheKey,
@@ -934,9 +1032,10 @@ impl RenderTaskCache {
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
         user_data: Option<[f32; 3]>,
+        is_opaque: bool,
         mut f: F,
-    ) -> Result<CacheItem, ()>
-         where F: FnMut(&mut RenderTaskTree) -> Result<(RenderTaskId, bool), ()> {
+    ) -> Result<RenderTaskCacheEntryHandle, ()>
+         where F: FnMut(&mut RenderTaskTree) -> Result<RenderTaskId, ()> {
         // Get the texture cache handle for this cache key,
         // or create one.
         let cache_entries = &mut self.cache_entries;
@@ -945,74 +1044,37 @@ impl RenderTaskCache {
                                .or_insert_with(|| {
                                     let entry = RenderTaskCacheEntry {
                                         handle: TextureCacheHandle::new(),
+                                        pending_render_task_id: None,
+                                        user_data,
+                                        is_opaque,
                                     };
                                     cache_entries.insert(entry)
                                 });
         let cache_entry = cache_entries.get_mut(entry_handle);
 
-        // Check if this texture cache handle is valid.
-        if texture_cache.request(&cache_entry.handle, gpu_cache) {
-            // Invoke user closure to get render task chain
-            // to draw this into the texture cache.
-            let (render_task_id, is_opaque) = try!(f(render_tasks));
-            let render_task = &mut render_tasks[render_task_id];
+        if cache_entry.pending_render_task_id.is_none() {
+            // Check if this texture cache handle is valid.
+            if texture_cache.request(&cache_entry.handle, gpu_cache) {
+                // Invoke user closure to get render task chain
+                // to draw this into the texture cache.
+                let render_task_id = try!(f(render_tasks));
 
-            // Select the right texture page to allocate from.
-            let image_format = match render_task.target_kind() {
-                RenderTargetKind::Color => ImageFormat::BGRA8,
-                RenderTargetKind::Alpha => ImageFormat::R8,
-            };
-
-            // Find out what size to alloc in the texture cache.
-            let size = match render_task.location {
-                RenderTaskLocation::Fixed(..) |
-                RenderTaskLocation::TextureCache(..) => {
-                    panic!("BUG: dynamic task was expected");
-                }
-                RenderTaskLocation::Dynamic(_, size) => size,
-            };
-
-            // TODO(gw): Support color tasks in the texture cache,
-            //           and perhaps consider if we can determine
-            //           if some tasks are opaque as an optimization.
-            let descriptor = ImageDescriptor::new(
-                size.width as u32,
-                size.height as u32,
-                image_format,
-                is_opaque,
-                false,
-            );
-
-            // Allocate space in the texture cache, but don't supply
-            // and CPU-side data to be uploaded.
-            texture_cache.update(
-                &mut cache_entry.handle,
-                descriptor,
-                TextureFilter::Linear,
-                None,
-                user_data.unwrap_or([0.0; 3]),
-                None,
-                gpu_cache,
-                None,
-            );
-
-            // Get the allocation details in the texture cache, and store
-            // this in the render task. The renderer will draw this
-            // task into the appropriate layer and rect of the texture
-            // cache on this frame.
-            let (texture_id, texture_layer, uv_rect) =
-                texture_cache.get_cache_location(&cache_entry.handle);
-
-            render_task.location = RenderTaskLocation::TextureCache(
-                texture_id,
-                texture_layer,
-                uv_rect.to_i32()
-            );
+                cache_entry.pending_render_task_id = Some(render_task_id);
+                cache_entry.user_data = user_data;
+                cache_entry.is_opaque = is_opaque;
+            }
         }
 
-        // Finally, return the texture cache handle that we know
-        // is now up to date.
-        Ok(texture_cache.get(&cache_entry.handle))
+        Ok(entry_handle.weak())
+    }
+
+    pub fn get_cache_entry(
+        &self,
+        handle: &RenderTaskCacheEntryHandle,
+    ) -> &RenderTaskCacheEntry {
+        self.cache_entries
+            .get_opt(handle)
+            .expect("bug: invalid render task cache handle")
     }
 
     #[allow(dead_code)]

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -83,6 +83,9 @@ enum EntryKind {
     },
 }
 
+#[derive(Debug)]
+pub enum CacheEntryMarker {}
+
 // Stores information related to a single entry in the texture
 // cache. This is stored for each item whether it's in the shared
 // cache or a standalone texture.
@@ -163,7 +166,7 @@ impl CacheEntry {
     }
 }
 
-type WeakCacheEntryHandle = WeakFreeListHandle<CacheEntry>;
+type WeakCacheEntryHandle = WeakFreeListHandle<CacheEntryMarker>;
 
 // A texture cache handle is a weak reference to a cache entry.
 // If the handle has not been inserted into the cache yet, the
@@ -240,17 +243,17 @@ pub struct TextureCache {
 
     // Maintains the list of all current items in
     // the texture cache.
-    entries: FreeList<CacheEntry>,
+    entries: FreeList<CacheEntry, CacheEntryMarker>,
 
     // A list of the strong handles of items that were
     // allocated in the standalone texture pool. Used
     // for evicting old standalone textures.
-    standalone_entry_handles: Vec<FreeListHandle<CacheEntry>>,
+    standalone_entry_handles: Vec<FreeListHandle<CacheEntryMarker>>,
 
     // A list of the strong handles of items that were
     // allocated in the shared texture cache. Used
     // for evicting old cache items.
-    shared_entry_handles: Vec<FreeListHandle<CacheEntry>>,
+    shared_entry_handles: Vec<FreeListHandle<CacheEntryMarker>>,
 }
 
 impl TextureCache {

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -833,6 +833,7 @@ impl RenderPass {
                                 None
                             }
                             RenderTaskLocation::Dynamic(ref mut origin, size) => {
+                                let size = size.expect("bug: size must be assigned by now");
                                 let alloc_size = DeviceUintSize::new(size.width as u32, size.height as u32);
                                 let (alloc_origin, target_index) =  match target_kind {
                                     RenderTargetKind::Color => color.allocate(alloc_size),
@@ -854,7 +855,7 @@ impl RenderPass {
 
                         // Give the render task an opportunity to add any
                         // information to the GPU cache, if appropriate.
-                        task.prepare_for_render(gpu_cache);
+                        task.write_gpu_blocks(gpu_cache);
 
                         (target_kind, texture_target)
                     };


### PR DESCRIPTION
* request_render_task() now returns a handle to a render task
  cache entry, rather than an allocated texture cache item. This
  is more in line with how normal texture cache request work.

* Allows the allocation to happen later in the frame (for example
  if the exact render task size is not yet known).

* Allows storing more information about a cached render task
  than what a texture cache item stores (for example, a specific
  blend mode that is required).

* Allows batching code to cheaply look up a cached render task
  entry by using a freelist instead of a hashmap. This will become
  more important as we start to cache render tasks that have
  larger / more complex cache keys.

* Add an extra type parameter to freelist.rs to allow using a custom
  marker type. This avoids rustc errors related to Send or Sync
  not being implemented on free list handles with !Send or !Sync
  phantom data types.

* Allow the size of a render task to be set to None initially, if
  it is not known.

* Add a new render task call (prepare_for_render) which can be used
  by render tasks to prepare tasks that rely on glyphs and/or images
  in the resource cache to be resolved first. This can also be used
  to set the size of a render task before render target allocation,
  if the render task size is not known during initial visibility pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2663)
<!-- Reviewable:end -->
