### PR TITLE
Fix filtered elements being clipped during property animation.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1958,7 +1958,13 @@ impl PrimitiveStore {
                 pic.runs = pic_context_for_children.prim_runs;
 
                 let metadata = &mut self.cpu_metadata[prim_index.0];
-                metadata.local_rect = pic.update_local_rect(result);
+
+                let new_local_rect = pic.update_local_rect(result);
+
+                if new_local_rect != metadata.local_rect {
+                    metadata.local_rect = new_local_rect;
+                    frame_state.gpu_cache.invalidate(&mut metadata.gpu_location);
+                }
             }
         }
 


### PR DESCRIPTION
When the local rect of a picture primitive changes (due to a
child primitive or picture being attached to an animating
scroll node), we need to invalidate the GPU cache entry for
this picture. This ensures that the correct local rect is
uploaded to the GPU shaders.

Fixes #2668.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2669)
<!-- Reviewable:end -->
