### PR TITLE
GPU cache invalidation fix and extra checks

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -24,6 +24,7 @@ use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind, RenderTaskTre
 use renderer::{BlendMode, ImageBufferKind};
 use renderer::BLOCKS_PER_UV_RECT;
 use resource_cache::{CacheItem, GlyphFetchResult, ImageRequest, ResourceCache};
+use scene::FilterOpHelpers;
 use std::{usize, f32, i32};
 use tiling::{RenderTargetContext};
 use util::{MatrixHelpers, TransformedRectKind};
@@ -673,6 +674,7 @@ impl AlphaBatchBuilder {
 
                         let add_to_parent_pic = match picture.composite_mode {
                             Some(PictureCompositeMode::Filter(filter)) => {
+                                assert!(filter.is_visible());
                                 match filter {
                                     FilterOp::Blur(..) => {
                                         match picture.surface {

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -598,6 +598,9 @@ impl AlphaBatchBuilder {
     ) {
         let z = z_generator.next();
         let prim_metadata = ctx.prim_store.get_metadata(prim_index);
+        #[cfg(debug_assertions)] //TODO: why is this needed?
+        debug_assert_eq!(prim_metadata.prepared_frame_id, render_tasks.frame_id());
+
         let scroll_node = &ctx.node_data[scroll_id.0 as usize];
         // TODO(gw): Calculating this for every primitive is a bit
         //           wasteful. We should probably cache this in

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -558,7 +558,10 @@ impl GpuCache {
     pub fn invalidate(&mut self, handle: &GpuCacheHandle) {
         if let Some(ref location) = handle.location {
             let block = &mut self.texture.blocks[location.block_index.0];
-            block.epoch.next();
+            // don't invalidate blocks that are already re-assigned
+            if block.epoch == location.epoch {
+                block.epoch.next();
+            }
         }
     }
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -142,6 +142,11 @@ impl RenderTaskTree {
         self.next_saved.0 += 1;
         id
     }
+
+    #[cfg(debug_assertions)]
+    pub fn frame_id(&self) -> FrameId {
+        self.frame_id
+    }
 }
 
 impl ops::Index<RenderTaskId> for RenderTaskTree {


### PR DESCRIPTION
Fixes #2667

This PR is a bag of small things:
  - 420dd5b adds debug-only checks to make sure all the batches being rendered have been prepared correctly. It didn't fire for my limited testing, but I find it useful anyway for the peace of mind.
  - 78ca661 brings more symmetry to the prepare/add duopoly, checking for the filter to be visible on the other side
  - f280d47 fixes the GPU cache invalidation. If the epoch has already been updated, means the cache entry belongs to a different primitive, and we have no rights to access it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2671)
<!-- Reviewable:end -->
