### PR TITLE
Various small changes related to caching text runs with brushes.

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 0
+#define VECS_PER_SPECIFIC_BRUSH 2
 #define FORCE_NO_PERSPECTIVE
 
 #include shared,prim_shared,brush

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -174,14 +174,12 @@ void brush_vs(
             vMaskSwizzle = vec2(0.0, 1.0);
             vColor = image_data.color;
             break;
-        case COLOR_MODE_SUBPX_PASS1:
         case COLOR_MODE_SUBPX_BG_PASS2:
         case COLOR_MODE_SUBPX_DUAL_SOURCE:
             vMaskSwizzle = vec2(1.0, 0.0);
             vColor = image_data.color;
             break;
         case COLOR_MODE_SUBPX_CONST_COLOR:
-        case COLOR_MODE_SUBPX_PASS0:
         case COLOR_MODE_SUBPX_BG_PASS0:
         case COLOR_MODE_COLOR_BITMAP:
             vMaskSwizzle = vec2(1.0, 0.0);

--- a/webrender/res/brush_mix_blend.glsl
+++ b/webrender/res/brush_mix_blend.glsl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#define VECS_PER_SPECIFIC_BRUSH 0
+#define VECS_PER_SPECIFIC_BRUSH 2
 
 #include shared,prim_shared,brush
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -45,14 +45,12 @@ varying vec3 vClipMaskUv;
 
 #define COLOR_MODE_ALPHA              1
 #define COLOR_MODE_SUBPX_CONST_COLOR  2
-#define COLOR_MODE_SUBPX_PASS0        3
-#define COLOR_MODE_SUBPX_PASS1        4
-#define COLOR_MODE_SUBPX_BG_PASS0     5
-#define COLOR_MODE_SUBPX_BG_PASS1     6
-#define COLOR_MODE_SUBPX_BG_PASS2     7
-#define COLOR_MODE_SUBPX_DUAL_SOURCE  8
-#define COLOR_MODE_BITMAP             9
-#define COLOR_MODE_COLOR_BITMAP       10
+#define COLOR_MODE_SUBPX_BG_PASS0     3
+#define COLOR_MODE_SUBPX_BG_PASS1     4
+#define COLOR_MODE_SUBPX_BG_PASS2     5
+#define COLOR_MODE_SUBPX_DUAL_SOURCE  6
+#define COLOR_MODE_BITMAP             7
+#define COLOR_MODE_COLOR_BITMAP       8
 
 uniform HIGHP_SAMPLER_FLOAT sampler2D sLocalClipRects;
 

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -43,6 +43,17 @@ varying vec3 vClipMaskUv;
 #define VECS_PER_TEXT_RUN           3
 #define VECS_PER_GRADIENT_STOP      2
 
+#define COLOR_MODE_ALPHA              1
+#define COLOR_MODE_SUBPX_CONST_COLOR  2
+#define COLOR_MODE_SUBPX_PASS0        3
+#define COLOR_MODE_SUBPX_PASS1        4
+#define COLOR_MODE_SUBPX_BG_PASS0     5
+#define COLOR_MODE_SUBPX_BG_PASS1     6
+#define COLOR_MODE_SUBPX_BG_PASS2     7
+#define COLOR_MODE_SUBPX_DUAL_SOURCE  8
+#define COLOR_MODE_BITMAP             9
+#define COLOR_MODE_COLOR_BITMAP       10
+
 uniform HIGHP_SAMPLER_FLOAT sampler2D sLocalClipRects;
 
 // Instanced attributes

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -15,17 +15,6 @@ varying vec4 vUvClip;
 
 #ifdef WR_VERTEX_SHADER
 
-#define MODE_ALPHA              0
-#define MODE_SUBPX_CONST_COLOR  1
-#define MODE_SUBPX_PASS0        2
-#define MODE_SUBPX_PASS1        3
-#define MODE_SUBPX_BG_PASS0     4
-#define MODE_SUBPX_BG_PASS1     5
-#define MODE_SUBPX_BG_PASS2     6
-#define MODE_SUBPX_DUAL_SOURCE  7
-#define MODE_BITMAP             8
-#define MODE_COLOR_BITMAP       9
-
 VertexInfo write_text_vertex(vec2 clamped_local_pos,
                              RectWithSize local_clip_rect,
                              float z,
@@ -135,25 +124,25 @@ void main(void) {
     write_clip(vi.screen_pos, prim.clip_area);
 
     switch (uMode) {
-        case MODE_ALPHA:
-        case MODE_BITMAP:
+        case COLOR_MODE_ALPHA:
+        case COLOR_MODE_BITMAP:
             vMaskSwizzle = vec2(0.0, 1.0);
             vColor = text.color;
             break;
-        case MODE_SUBPX_PASS1:
-        case MODE_SUBPX_BG_PASS2:
-        case MODE_SUBPX_DUAL_SOURCE:
+        case COLOR_MODE_SUBPX_PASS1:
+        case COLOR_MODE_SUBPX_BG_PASS2:
+        case COLOR_MODE_SUBPX_DUAL_SOURCE:
             vMaskSwizzle = vec2(1.0, 0.0);
             vColor = text.color;
             break;
-        case MODE_SUBPX_CONST_COLOR:
-        case MODE_SUBPX_PASS0:
-        case MODE_SUBPX_BG_PASS0:
-        case MODE_COLOR_BITMAP:
+        case COLOR_MODE_SUBPX_CONST_COLOR:
+        case COLOR_MODE_SUBPX_PASS0:
+        case COLOR_MODE_SUBPX_BG_PASS0:
+        case COLOR_MODE_COLOR_BITMAP:
             vMaskSwizzle = vec2(1.0, 0.0);
             vColor = vec4(text.color.a);
             break;
-        case MODE_SUBPX_BG_PASS1:
+        case COLOR_MODE_SUBPX_BG_PASS1:
             vMaskSwizzle = vec2(-1.0, 1.0);
             vColor = vec4(text.color.a) * text.bg_color;
             break;

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -129,14 +129,12 @@ void main(void) {
             vMaskSwizzle = vec2(0.0, 1.0);
             vColor = text.color;
             break;
-        case COLOR_MODE_SUBPX_PASS1:
         case COLOR_MODE_SUBPX_BG_PASS2:
         case COLOR_MODE_SUBPX_DUAL_SOURCE:
             vMaskSwizzle = vec2(1.0, 0.0);
             vColor = text.color;
             break;
         case COLOR_MODE_SUBPX_CONST_COLOR:
-        case COLOR_MODE_SUBPX_PASS0:
         case COLOR_MODE_SUBPX_BG_PASS0:
         case COLOR_MODE_COLOR_BITMAP:
             vMaskSwizzle = vec2(1.0, 0.0);

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -22,7 +22,7 @@ use prim_store::{CachedGradient, ImageSource, PrimitiveIndex, PrimitiveKind, Pri
 use prim_store::{BrushPrimitive, BrushKind, DeferredResolve, EdgeAaSegmentMask, PictureIndex, PrimitiveRun};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskKind, RenderTaskTree};
 use renderer::{BlendMode, ImageBufferKind};
-use renderer::BLOCKS_PER_UV_RECT;
+use renderer::{BLOCKS_PER_UV_RECT, ShaderColorMode};
 use resource_cache::{CacheItem, GlyphFetchResult, ImageRequest, ResourceCache};
 use scene::FilterOpHelpers;
 use std::{usize, f32, i32};
@@ -41,15 +41,6 @@ pub enum TransformBatchKind {
     Image(ImageBufferKind),
     BorderCorner,
     BorderEdge,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub enum BrushImageSourceKind {
-    Color = 0,
-    //Alpha = 1,            // Unused for now, but left here as shaders need to match.
-    ColorAlphaMask = 2,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -707,7 +698,7 @@ impl AlphaBatchBuilder {
                                                     brush_flags: BrushFlags::empty(),
                                                     user_data: [
                                                         uv_rect_address.as_int(),
-                                                        (BrushImageSourceKind::Color as i32) << 16 |
+                                                        (ShaderColorMode::ColorBitmap as i32) << 16 |
                                                         RasterizationSpace::Screen as i32,
                                                         picture.extra_gpu_data_handle.as_int(gpu_cache),
                                                     ],
@@ -775,7 +766,7 @@ impl AlphaBatchBuilder {
                                                 brush_flags: BrushFlags::empty(),
                                                 user_data: [
                                                     shadow_uv_rect_address,
-                                                    (BrushImageSourceKind::ColorAlphaMask as i32) << 16 |
+                                                    (ShaderColorMode::Alpha as i32) << 16 |
                                                     RasterizationSpace::Screen as i32,
                                                     shadow_data_address.as_int(),
                                                 ],
@@ -785,7 +776,7 @@ impl AlphaBatchBuilder {
                                                 prim_address: prim_cache_address,
                                                 user_data: [
                                                     content_uv_rect_address,
-                                                    (BrushImageSourceKind::Color as i32) << 16 |
+                                                    (ShaderColorMode::ColorBitmap as i32) << 16 |
                                                     RasterizationSpace::Screen as i32,
                                                     extra_data_address.as_int(),
                                                 ],
@@ -958,7 +949,7 @@ impl AlphaBatchBuilder {
                                     brush_flags: BrushFlags::empty(),
                                     user_data: [
                                         uv_rect_address,
-                                        (BrushImageSourceKind::Color as i32) << 16 |
+                                        (ShaderColorMode::ColorBitmap as i32) << 16 |
                                         RasterizationSpace::Screen as i32,
                                         picture.extra_gpu_data_handle.as_int(gpu_cache),
                                     ],
@@ -1341,7 +1332,7 @@ impl BrushPrimitive {
                         textures,
                         [
                             cache_item.uv_rect_handle.as_int(gpu_cache),
-                            (BrushImageSourceKind::Color as i32) << 16|
+                            (ShaderColorMode::ColorBitmap as i32) << 16|
                              RasterizationSpace::Local as i32,
                             0,
                         ],

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -760,8 +760,8 @@ impl AlphaBatchBuilder {
 
                                             // Get the GPU cache address of the extra data handle.
                                             let extra_data_address = gpu_cache.get_address(&picture.extra_gpu_data_handle);
-                                            let shadow_prim_address = extra_data_address.offset(3);
-                                            let shadow_data_address = extra_data_address.offset(7);
+                                            let shadow_prim_address = extra_data_address.offset(2);
+                                            let shadow_data_address = extra_data_address.offset(8);
 
                                             let shadow_instance = BrushInstance {
                                                 picture_address: task_address,

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -162,16 +162,16 @@ impl AlphaBatchList {
     ) -> &mut Vec<PrimitiveInstance> {
         let mut selected_batch_index = None;
 
-        match (key.kind, key.blend_mode) {
-            (BatchKind::Transformable(_, TransformBatchKind::TextRun(_)), BlendMode::SubpixelWithBgColor) |
-            (BatchKind::Transformable(_, TransformBatchKind::TextRun(_)), BlendMode::SubpixelVariableTextColor) => {
-                'outer_text: for (batch_index, batch) in self.batches.iter().enumerate().rev().take(10) {
-                    // Subpixel text is drawn in two passes. Because of this, we need
+        match key.blend_mode {
+            BlendMode::SubpixelWithBgColor |
+            BlendMode::SubpixelVariableTextColor => {
+                'outer_multipass: for (batch_index, batch) in self.batches.iter().enumerate().rev().take(10) {
+                    // Some subpixel batches is drawn in two passes. Because of this, we need
                     // to check for overlaps with every batch (which is a bit different
                     // than the normal batching below).
                     for item_rect in &self.item_rects[batch_index] {
                         if item_rect.intersects(task_relative_bounding_rect) {
-                            break 'outer_text;
+                            break 'outer_multipass;
                         }
                     }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -27,6 +27,9 @@ use tiling::RenderTargetKind;
    this picture (e.g. in screen space or local space).
  */
 
+pub const IMAGE_BRUSH_EXTRA_BLOCKS: usize = 2;
+pub const IMAGE_BRUSH_BLOCKS: usize = 6;
+
 /// Specifies how this Picture should be composited
 /// onto the target it belongs to.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -561,6 +564,9 @@ impl PicturePrimitive {
                     //           rect for the shadow. To tidy this up in future,
                     //           we could consider abstracting the code in prim_store.rs
                     //           that writes a brush primitive header.
+
+                    // NOTE: If any of the layout below changes, the IMAGE_BRUSH_EXTRA_BLOCKS and
+                    //       IMAGE_BRUSH_BLOCKS fields above *must* be updated.
 
                     // Basic brush primitive header is (see end of prepare_prim_for_render_inner in prim_store.rs)
                     //  local_rect

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -547,10 +547,9 @@ impl PicturePrimitive {
             }
 
             if let Some(mut request) = frame_state.gpu_cache.request(&mut self.extra_gpu_data_handle) {
-                // [GLSL ImageBrush: task_rect, offset, color]
+                // [GLSL ImageBrushExtraData: task_rect, offset]
                 request.push(self.task_rect.to_f32());
                 request.push([0.0; 4]);
-                request.push(PremultipliedColorF::WHITE);
 
                 // TODO(gw): It would make the shaders a bit simpler if the offset
                 //           was provided as part of the brush::picture instance,
@@ -566,19 +565,26 @@ impl PicturePrimitive {
                     // Basic brush primitive header is (see end of prepare_prim_for_render_inner in prim_store.rs)
                     //  local_rect
                     //  clip_rect
+                    //  [brush specific data]
                     //  [segment_rect, (repetitions.xy, 0.0, 0.0)]
                     let shadow_rect = prim_metadata.local_rect.translate(&offset);
                     let shadow_clip_rect = prim_metadata.local_clip_rect.translate(&offset);
 
+                    // local_rect, clip_rect
                     request.push(shadow_rect);
                     request.push(shadow_clip_rect);
+
+                    // ImageBrush colors
+                    request.push(color.premultiplied());
+                    request.push(PremultipliedColorF::WHITE);
+
+                    // segment rect / repetitions
                     request.push(shadow_rect);
                     request.push([1.0, 1.0, 0.0, 0.0]);
 
                     // Now write another GLSL ImageBrush struct, for the shadow to reference.
                     request.push(self.task_rect.to_f32());
                     request.push([offset.x, offset.y, 0.0, 0.0]);
-                    request.push(color.premultiplied());
                 }
             }
         }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -346,9 +346,14 @@ impl BrushPrimitive {
     ) {
         // has to match VECS_PER_SPECIFIC_BRUSH
         match self.kind {
+            BrushKind::YuvImage { .. } => {}
+
             BrushKind::Picture { .. } |
-            BrushKind::YuvImage { .. } |
-            BrushKind::Image { .. } => {}
+            BrushKind::Image { .. } => {
+                request.push(PremultipliedColorF::WHITE);
+                request.push(PremultipliedColorF::WHITE);
+            }
+
             BrushKind::Solid { color } => {
                 request.push(color.premultiplied());
             }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -268,7 +268,7 @@ fn flag_changed(before: DebugFlags, after: DebugFlags, select: DebugFlags) -> Op
 }
 
 #[repr(C)]
-enum ShaderColorMode {
+pub enum ShaderColorMode {
     Alpha = 1,
     SubpixelConstantTextColor = 2,
     SubpixelPass0 = 3,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -268,28 +268,28 @@ fn flag_changed(before: DebugFlags, after: DebugFlags, select: DebugFlags) -> Op
 }
 
 #[repr(C)]
-enum TextShaderMode {
-    Alpha = 0,
-    SubpixelConstantTextColor = 1,
-    SubpixelPass0 = 2,
-    SubpixelPass1 = 3,
-    SubpixelWithBgColorPass0 = 4,
-    SubpixelWithBgColorPass1 = 5,
-    SubpixelWithBgColorPass2 = 6,
-    SubpixelDualSource = 7,
-    Bitmap = 8,
-    ColorBitmap = 9,
+enum ShaderColorMode {
+    Alpha = 1,
+    SubpixelConstantTextColor = 2,
+    SubpixelPass0 = 3,
+    SubpixelPass1 = 4,
+    SubpixelWithBgColorPass0 = 5,
+    SubpixelWithBgColorPass1 = 6,
+    SubpixelWithBgColorPass2 = 7,
+    SubpixelDualSource = 8,
+    Bitmap = 9,
+    ColorBitmap = 10,
 }
 
-impl From<GlyphFormat> for TextShaderMode {
-    fn from(format: GlyphFormat) -> TextShaderMode {
+impl From<GlyphFormat> for ShaderColorMode {
+    fn from(format: GlyphFormat) -> ShaderColorMode {
         match format {
-            GlyphFormat::Alpha | GlyphFormat::TransformedAlpha => TextShaderMode::Alpha,
+            GlyphFormat::Alpha | GlyphFormat::TransformedAlpha => ShaderColorMode::Alpha,
             GlyphFormat::Subpixel | GlyphFormat::TransformedSubpixel => {
                 panic!("Subpixel glyph formats must be handled separately.");
             }
-            GlyphFormat::Bitmap => TextShaderMode::Bitmap,
-            GlyphFormat::ColorBitmap => TextShaderMode::ColorBitmap,
+            GlyphFormat::Bitmap => ShaderColorMode::Bitmap,
+            GlyphFormat::ColorBitmap => ShaderColorMode::ColorBitmap,
         }
     }
 }
@@ -2912,7 +2912,7 @@ impl Renderer {
                             BlendMode::Alpha => panic!("Attempt to composite non-premultiplied text primitives."),
                             BlendMode::PremultipliedAlpha => {
                                 self.device.set_blend_mode_premultiplied_alpha();
-                                self.device.switch_mode(TextShaderMode::from(glyph_format) as _);
+                                self.device.switch_mode(ShaderColorMode::from(glyph_format) as _);
 
                                 self.draw_instanced_batch(
                                     &batch.instances,
@@ -2923,7 +2923,7 @@ impl Renderer {
                             }
                             BlendMode::SubpixelDualSource => {
                                 self.device.set_blend_mode_subpixel_dual_source();
-                                self.device.switch_mode(TextShaderMode::SubpixelDualSource as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelDualSource as _);
 
                                 self.draw_instanced_batch(
                                     &batch.instances,
@@ -2934,7 +2934,7 @@ impl Renderer {
                             }
                             BlendMode::SubpixelConstantTextColor(color) => {
                                 self.device.set_blend_mode_subpixel_constant_text_color(color);
-                                self.device.switch_mode(TextShaderMode::SubpixelConstantTextColor as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelConstantTextColor as _);
 
                                 self.draw_instanced_batch(
                                     &batch.instances,
@@ -2949,7 +2949,7 @@ impl Renderer {
                                 // http://anholt.livejournal.com/32058.html
                                 //
                                 self.device.set_blend_mode_subpixel_pass0();
-                                self.device.switch_mode(TextShaderMode::SubpixelPass0 as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelPass0 as _);
 
                                 self.draw_instanced_batch(
                                     &batch.instances,
@@ -2959,7 +2959,7 @@ impl Renderer {
                                 );
 
                                 self.device.set_blend_mode_subpixel_pass1();
-                                self.device.switch_mode(TextShaderMode::SubpixelPass1 as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelPass1 as _);
 
                                 // When drawing the 2nd pass, we know that the VAO, textures etc
                                 // are all set up from the previous draw_instanced_batch call,
@@ -2975,7 +2975,7 @@ impl Renderer {
                                 // /webrender/doc/text-rendering.md
                                 //
                                 self.device.set_blend_mode_subpixel_with_bg_color_pass0();
-                                self.device.switch_mode(TextShaderMode::SubpixelWithBgColorPass0 as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass0 as _);
 
                                 self.draw_instanced_batch(
                                     &batch.instances,
@@ -2985,7 +2985,7 @@ impl Renderer {
                                 );
 
                                 self.device.set_blend_mode_subpixel_with_bg_color_pass1();
-                                self.device.switch_mode(TextShaderMode::SubpixelWithBgColorPass1 as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass1 as _);
 
                                 // When drawing the 2nd and 3rd passes, we know that the VAO, textures etc
                                 // are all set up from the previous draw_instanced_batch call,
@@ -2995,7 +2995,7 @@ impl Renderer {
                                     .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
 
                                 self.device.set_blend_mode_subpixel_with_bg_color_pass2();
-                                self.device.switch_mode(TextShaderMode::SubpixelWithBgColorPass2 as _);
+                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass2 as _);
 
                                 self.device
                                     .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -220,7 +220,6 @@ impl BrushShader {
             BlendMode::PremultipliedDestOut |
             BlendMode::SubpixelDualSource |
             BlendMode::SubpixelConstantTextColor(..) |
-            BlendMode::SubpixelVariableTextColor |
             BlendMode::SubpixelWithBgColor => &mut self.alpha,
         }
     }


### PR DESCRIPTION
* Remove unused subpixel blend mode (can retrieve via git if we need later).
* Switch brush_image shader to do mask swizzling the same way as text shader.
  * This allows handling the various subpx modes in brush_image for later.
  * It's more flexible, a superset of existing brush_image swizzle modes.
* Remove BrushImageSourceKind.
* Store two colors inline with the brush primitive data for images / pictures.
  * These are always fetched in the brush_image VS.
  * Extra data is only fetched when drawing drop-shadows / screen-space images.
* Rename TextShaderMode -> ShaderColorMode, move to prim_shared.
* Allow batching code to correctly handle multi-pass mode for any batch kind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2674)
<!-- Reviewable:end -->
