### PR TITLE
add clear_namespace hook to BlobImageRenderer trait

### DIFF
--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -215,6 +215,7 @@ impl api::BlobImageRenderer for CheckerboardRenderer {
     }
     fn delete_font(&mut self, _font: api::FontKey) {}
     fn delete_font_instance(&mut self, _instance: api::FontInstanceKey) {}
+    fn clear_namespace(&mut self, _namespace: api::IdNamespace) {}
 }
 
 struct App {}

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1105,6 +1105,10 @@ impl ResourceCache {
             .retain(|key, _| key.0 != namespace);
         self.cached_glyphs
             .clear_fonts(|font| font.font_key.0 == namespace);
+
+        if let Some(ref mut r) = self.blob_image_renderer {
+            r.clear_namespace(namespace);
+        }
     }
 }
 

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -191,6 +191,8 @@ pub trait BlobImageRenderer: Send {
     fn delete_font(&mut self, key: FontKey);
 
     fn delete_font_instance(&mut self, key: FontInstanceKey);
+
+    fn clear_namespace(&mut self, namespace: IdNamespace);
 }
 
 pub type BlobImageData = Vec<u8>;

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -164,4 +164,6 @@ impl BlobImageRenderer for CheckerboardRenderer {
     fn delete_font(&mut self, _key: FontKey) {}
 
     fn delete_font_instance(&mut self, _key: FontInstanceKey) {}
+
+    fn clear_namespace(&mut self, _namespace: IdNamespace) {}
 }


### PR DESCRIPTION
To deal with Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1448703, we need to be able to tell the BlobImageRenderer at a well-defined time when the namespace actually gets cleared, so that it can thus clear its resources at said time. This requires adding a new hook to the trait, since we only really know what time this actually happens when clear_namespace() is called on the resource cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2676)
<!-- Reviewable:end -->
