### PR TITLE
Some more preparatory work for text run caching.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -157,36 +157,31 @@ void main(void) {
 
 #ifdef WR_FRAGMENT_SHADER
 
-#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
-vec4 brush_fs(out vec4);
-#else
-vec4 brush_fs();
-#endif
-
-void main(void) {
+struct Fragment {
     vec4 color;
-
-    // Run the specific brush FS code to output the color.
 #ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
     vec4 blend;
-    color = brush_fs(blend);
-#else
-    color = brush_fs();
 #endif
+};
+
+Fragment brush_fs();
+
+void main(void) {
+    // Run the specific brush FS code to output the color.
+    Fragment frag = brush_fs();
 
 #ifdef WR_FEATURE_ALPHA_PASS
     // Apply the clip mask
     float clip_alpha = do_clip();
 
-    color *= clip_alpha;
+    frag.color *= clip_alpha;
 
     #ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
-        blend *= clip_alpha;
-        oFragBlend = blend;
+        oFragBlend = frag.blend * clip_alpha;
     #endif
 #endif
 
     // TODO(gw): Handle pre-multiply common code here as required.
-    oFragColor = color;
+    oFragColor = frag.color;
 }
 #endif

--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -157,15 +157,33 @@ void main(void) {
 
 #ifdef WR_FRAGMENT_SHADER
 
+#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+vec4 brush_fs(out vec4);
+#else
 vec4 brush_fs();
+#endif
 
 void main(void) {
+    vec4 color;
+
     // Run the specific brush FS code to output the color.
-    vec4 color = brush_fs();
+#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+    vec4 blend;
+    color = brush_fs(blend);
+#else
+    color = brush_fs();
+#endif
 
 #ifdef WR_FEATURE_ALPHA_PASS
     // Apply the clip mask
-    color *= do_clip();
+    float clip_alpha = do_clip();
+
+    color *= clip_alpha;
+
+    #ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
+        blend *= clip_alpha;
+        oFragBlend = blend;
+    #endif
 #endif
 
     // TODO(gw): Handle pre-multiply common code here as required.

--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -122,11 +122,11 @@ vec3 Brightness(vec3 Cs, float amount) {
     return clamp(Cs.rgb * amount, vec3(0.0), vec3(1.0));
 }
 
-vec4 brush_fs() {
+Fragment brush_fs() {
     vec4 Cs = texture(sColor0, vUv);
 
     if (Cs.a == 0.0) {
-        return vec4(0.0); // could also `discard`
+        return Fragment(vec4(0.0)); // could also `discard`
     }
 
     // Un-premultiply the input.
@@ -157,6 +157,6 @@ vec4 brush_fs() {
     alpha *= point_inside_rect(vUv.xy, vUvClipBounds.xy, vUvClipBounds.zw);
 
     // Pre-multiply the alpha into the output value.
-    return alpha * vec4(color, 1.0);
+    return Fragment(alpha * vec4(color, 1.0));
 }
 #endif

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -112,6 +112,10 @@ void brush_vs(
     int raster_space = user_data.y & 0xffff;
     ImageBrushData image_data = fetch_image_data(prim_address);
 
+    if (color_mode == COLOR_MODE_FROM_PASS) {
+        color_mode = uMode;
+    }
+
     // Derive the texture coordinates for this image, based on
     // whether the source image is a local-space or screen-space
     // image.

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -205,12 +205,7 @@ void brush_vs(
 
 #ifdef WR_FRAGMENT_SHADER
 
-vec4 brush_fs(
-#ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
-    out vec4 blend
-#endif
-) {
-
+Fragment brush_fs() {
     vec2 uv_size = vUvBounds.zw - vUvBounds.xy;
 
 #ifdef WR_FEATURE_ALPHA_PASS
@@ -240,23 +235,23 @@ vec4 brush_fs(
     vec2 uv = clamp(repeated_uv, vUvSampleBounds.xy, vUvSampleBounds.zw);
 
     vec4 texel = TEX_SAMPLE(sColor0, vec3(uv, vUv.z));
-    vec4 color;
+
+    Fragment frag;
 
 #ifdef WR_FEATURE_ALPHA_PASS
     float alpha = init_transform_fs(vLocalPos);
     texel.rgb = texel.rgb * vMaskSwizzle.x + texel.aaa * vMaskSwizzle.y;
 
+    vec4 alpha_mask = texel * alpha;
+    frag.color = vColor * alpha_mask;
+
     #ifdef WR_FEATURE_DUAL_SOURCE_BLENDING
-        vec4 alpha_mask = texel * alpha;
-        color = vColor * alpha_mask;
-        blend = alpha_mask * vColor.a;
-    #else
-        color = vColor * texel * alpha;
+        frag.blend = alpha_mask * vColor.a;
     #endif
 #else
-    color = texel;
+    frag.color = texel;
 #endif
 
-    return color;
+    return frag;
 }
 #endif

--- a/webrender/res/brush_linear_gradient.glsl
+++ b/webrender/res/brush_linear_gradient.glsl
@@ -70,7 +70,7 @@ void brush_vs(
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-vec4 brush_fs() {
+Fragment brush_fs() {
 
 #ifdef WR_FEATURE_ALPHA_PASS
     // Handle top and left inflated edges (see brush_image).
@@ -102,6 +102,6 @@ vec4 brush_fs() {
     color *= init_transform_fs(vLocalPos);
 #endif
 
-    return color;
+    return Fragment(color);
 }
 #endif

--- a/webrender/res/brush_mix_blend.glsl
+++ b/webrender/res/brush_mix_blend.glsl
@@ -196,15 +196,15 @@ const int MixBlendMode_Saturation  = 13;
 const int MixBlendMode_Color       = 14;
 const int MixBlendMode_Luminosity  = 15;
 
-vec4 brush_fs() {
+Fragment brush_fs() {
     vec4 Cb = textureLod(sCacheRGBA8, vBackdropUv, 0.0);
     vec4 Cs = textureLod(sCacheRGBA8, vSrcUv, 0.0);
 
     if (Cb.a == 0.0) {
-        return Cs;
+        return Fragment(Cs);
     }
     if (Cs.a == 0.0) {
-        return vec4(0.0);
+        return Fragment(vec4(0.0));
     }
 
     // The mix-blend-mode functions assume no premultiplied alpha
@@ -275,6 +275,6 @@ vec4 brush_fs() {
 
     result.rgb *= result.a;
 
-    return result;
+    return Fragment(result);
 }
 #endif

--- a/webrender/res/brush_radial_gradient.glsl
+++ b/webrender/res/brush_radial_gradient.glsl
@@ -73,7 +73,7 @@ void brush_vs(
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-vec4 brush_fs() {
+Fragment brush_fs() {
 
 #ifdef WR_FEATURE_ALPHA_PASS
     // Handle top and left inflated edges (see brush_image).
@@ -141,6 +141,6 @@ vec4 brush_fs() {
     color *= init_transform_fs(vLocalPos);
 #endif
 
-    return color;
+    return Fragment(color);
 }
 #endif

--- a/webrender/res/brush_solid.glsl
+++ b/webrender/res/brush_solid.glsl
@@ -42,11 +42,11 @@ void brush_vs(
 #endif
 
 #ifdef WR_FRAGMENT_SHADER
-vec4 brush_fs() {
+Fragment brush_fs() {
     vec4 color = vColor;
 #ifdef WR_FEATURE_ALPHA_PASS
     color *= init_transform_fs(vLocalPos);
 #endif
-    return color;
+    return Fragment(color);
 }
 #endif

--- a/webrender/res/brush_yuv_image.glsl
+++ b/webrender/res/brush_yuv_image.glsl
@@ -135,7 +135,7 @@ const mat3 YuvColorMatrix = mat3(
 );
 #endif
 
-vec4 brush_fs() {
+Fragment brush_fs() {
     vec3 yuv_value;
 
 #if defined (WR_FEATURE_YUV_PLANAR)
@@ -169,6 +169,6 @@ vec4 brush_fs() {
     color *= init_transform_fs(vLocalPos);
 #endif
 
-    return color;
+    return Fragment(color);
 }
 #endif

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -43,6 +43,7 @@ varying vec3 vClipMaskUv;
 #define VECS_PER_TEXT_RUN           3
 #define VECS_PER_GRADIENT_STOP      2
 
+#define COLOR_MODE_FROM_PASS          0
 #define COLOR_MODE_ALPHA              1
 #define COLOR_MODE_SUBPX_CONST_COLOR  2
 #define COLOR_MODE_SUBPX_BG_PASS0     3

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -64,7 +64,12 @@ void main(void) {
 
     int glyph_index = prim.user_data0;
     int resource_address = prim.user_data1;
-    int subpx_dir = prim.user_data2;
+    int subpx_dir = prim.user_data2 >> 16;
+    int color_mode = prim.user_data2 & 0xffff;
+
+    if (color_mode == COLOR_MODE_FROM_PASS) {
+        color_mode = uMode;
+    }
 
     Glyph glyph = fetch_glyph(prim.specific_prim_address,
                               glyph_index,
@@ -123,7 +128,7 @@ void main(void) {
 
     write_clip(vi.screen_pos, prim.clip_area);
 
-    switch (uMode) {
+    switch (color_mode) {
         case COLOR_MODE_ALPHA:
         case COLOR_MODE_BITMAP:
             vMaskSwizzle = vec2(0.0, 1.0);

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -16,7 +16,7 @@ use api::{RenderApiSender, RenderNotifier, TexelRect, TextureTarget};
 use api::{channel};
 use api::DebugCommand;
 use api::channel::PayloadReceiverHelperMethods;
-use batch::{BatchKey, BatchKind, BatchTextures, BrushBatchKind, TransformBatchKind};
+use batch::{BatchKind, BatchTextures, BrushBatchKind, TransformBatchKind};
 #[cfg(any(feature = "capture", feature = "replay"))]
 use capture::{CaptureConfig, ExternalCaptureImage, PlainExternalImage};
 use debug_colors;
@@ -32,7 +32,6 @@ use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
 #[cfg(feature = "pathfinder")]
 use gpu_glyph_renderer::GpuGlyphRenderer;
-use gpu_types::PrimitiveInstance;
 use internal_types::{SourceTexture, ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE, ResourceCacheError};
 use internal_types::{CacheTextureId, DebugOutput, FastHashMap, RenderedDocument, ResultMsg};
 use internal_types::{TextureUpdateList, TextureUpdateOp, TextureUpdateSource};
@@ -268,7 +267,10 @@ fn flag_changed(before: DebugFlags, after: DebugFlags, select: DebugFlags) -> Op
 }
 
 #[repr(C)]
+#[derive(Copy, Clone, Debug)]
 pub enum ShaderColorMode {
+    FromRenderPassMode = 0,
+
     Alpha = 1,
     SubpixelConstantTextColor = 2,
     SubpixelWithBgColorPass0 = 3,
@@ -2611,48 +2613,6 @@ impl Renderer {
         }
     }
 
-    fn submit_batch(
-        &mut self,
-        key: &BatchKey,
-        instances: &[PrimitiveInstance],
-        projection: &Transform3D<f32>,
-        render_tasks: &RenderTaskTree,
-        render_target: Option<(&Texture, i32)>,
-        framebuffer_size: DeviceUintSize,
-        stats: &mut RendererStats,
-        scissor_rect: Option<DeviceIntRect>,
-    ) {
-        self.shaders
-            .get(key)
-            .bind(
-                &mut self.device, projection,
-                &mut self.renderer_errors,
-            );
-
-        // Handle special case readback for composites.
-        if let BatchKind::Brush(BrushBatchKind::MixBlend { task_id, source_id, backdrop_id }) = key.kind {
-            // composites can't be grouped together because
-            // they may overlap and affect each other.
-            debug_assert_eq!(instances.len(), 1);
-            self.handle_readback_composite(
-                render_target,
-                framebuffer_size,
-                scissor_rect,
-                &render_tasks[source_id],
-                &render_tasks[task_id],
-                &render_tasks[backdrop_id],
-            );
-        }
-
-        let _timer = self.gpu_profile.start_timer(key.kind.sampler_tag());
-        self.draw_instanced_batch(
-            instances,
-            VertexArrayKind::Primitive,
-            &key.textures,
-            stats
-        );
-    }
-
     fn handle_blits(
         &mut self,
         blits: &[BlitJob],
@@ -2847,15 +2807,19 @@ impl Renderer {
                     .iter()
                     .rev()
                 {
-                    self.submit_batch(
-                        &batch.key,
+                    self.shaders
+                        .get(&batch.key)
+                        .bind(
+                            &mut self.device, projection,
+                            &mut self.renderer_errors,
+                        );
+
+                    let _timer = self.gpu_profile.start_timer(batch.key.kind.sampler_tag());
+                    self.draw_instanced_batch(
                         &batch.instances,
-                        projection,
-                        render_tasks,
-                        render_target,
-                        target_size,
-                        stats,
-                        alpha_batch_container.target_rect,
+                        VertexArrayKind::Primitive,
+                        &batch.key.textures,
+                        stats
                     );
                 }
 
@@ -2880,138 +2844,87 @@ impl Renderer {
             }
 
             for batch in &alpha_batch_container.alpha_batches {
-                match batch.key.kind {
-                    BatchKind::Transformable(transform_kind, TransformBatchKind::TextRun(glyph_format)) => {
-                        // Text run batches are handled by this special case branch.
-                        // In the case of subpixel text, we draw it as a two pass
-                        // effect, to ensure we can apply clip masks correctly.
-                        // In the future, there are several optimizations available:
-                        // 1) Use dual source blending where available (almost all recent hardware).
-                        // 2) Use frame buffer fetch where available (most modern hardware).
-                        // 3) Consider the old constant color blend method where no clip is applied.
-                        let _timer = self.gpu_profile.start_timer(GPU_TAG_PRIM_TEXT_RUN);
-
-                        // bind the proper shader first
-                        match batch.key.blend_mode {
-                            BlendMode::SubpixelDualSource => &mut self.shaders.ps_text_run_dual_source,
-                            _ => &mut self.shaders.ps_text_run,
+                if batch.key.blend_mode != prev_blend_mode {
+                    match batch.key.blend_mode {
+                        BlendMode::None => {
+                            unreachable!("bug: opaque blend in alpha pass");
                         }
-                            .get(glyph_format, transform_kind)
-                            .bind(
-                                &mut self.device,
-                                projection,
-                                &mut self.renderer_errors,
-                            );
-
-                        match batch.key.blend_mode {
-                            BlendMode::Alpha => panic!("Attempt to composite non-premultiplied text primitives."),
-                            BlendMode::PremultipliedAlpha => {
-                                self.device.set_blend_mode_premultiplied_alpha();
-                                self.device.switch_mode(ShaderColorMode::from(glyph_format) as _);
-
-                                self.draw_instanced_batch(
-                                    &batch.instances,
-                                    VertexArrayKind::Primitive,
-                                    &batch.key.textures,
-                                    stats,
-                                );
-                            }
-                            BlendMode::SubpixelDualSource => {
-                                self.device.set_blend_mode_subpixel_dual_source();
-                                self.device.switch_mode(ShaderColorMode::SubpixelDualSource as _);
-
-                                self.draw_instanced_batch(
-                                    &batch.instances,
-                                    VertexArrayKind::Primitive,
-                                    &batch.key.textures,
-                                    stats,
-                                );
-                            }
-                            BlendMode::SubpixelConstantTextColor(color) => {
-                                self.device.set_blend_mode_subpixel_constant_text_color(color);
-                                self.device.switch_mode(ShaderColorMode::SubpixelConstantTextColor as _);
-
-                                self.draw_instanced_batch(
-                                    &batch.instances,
-                                    VertexArrayKind::Primitive,
-                                    &batch.key.textures,
-                                    stats,
-                                );
-                            }
-                            BlendMode::SubpixelWithBgColor => {
-                                // Using the three pass "component alpha with font smoothing
-                                // background color" rendering technique:
-                                //
-                                // /webrender/doc/text-rendering.md
-                                //
-                                self.device.set_blend_mode_subpixel_with_bg_color_pass0();
-                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass0 as _);
-
-                                self.draw_instanced_batch(
-                                    &batch.instances,
-                                    VertexArrayKind::Primitive,
-                                    &batch.key.textures,
-                                    stats,
-                                );
-
-                                self.device.set_blend_mode_subpixel_with_bg_color_pass1();
-                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass1 as _);
-
-                                // When drawing the 2nd and 3rd passes, we know that the VAO, textures etc
-                                // are all set up from the previous draw_instanced_batch call,
-                                // so just issue a draw call here to avoid re-uploading the
-                                // instances and re-binding textures etc.
-                                self.device
-                                    .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
-
-                                self.device.set_blend_mode_subpixel_with_bg_color_pass2();
-                                self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass2 as _);
-
-                                self.device
-                                    .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
-                            }
-                            BlendMode::PremultipliedDestOut | BlendMode::None => {
-                                unreachable!("bug: bad blend mode for text");
-                            }
+                        BlendMode::Alpha => {
+                            self.device.set_blend_mode_alpha();
                         }
-
-                        prev_blend_mode = BlendMode::None;
+                        BlendMode::PremultipliedAlpha => {
+                            self.device.set_blend_mode_premultiplied_alpha();
+                        }
+                        BlendMode::PremultipliedDestOut => {
+                            self.device.set_blend_mode_premultiplied_dest_out();
+                        }
+                        BlendMode::SubpixelDualSource => {
+                            self.device.set_blend_mode_subpixel_dual_source();
+                        }
+                        BlendMode::SubpixelConstantTextColor(color) => {
+                            self.device.set_blend_mode_subpixel_constant_text_color(color);
+                        }
+                        BlendMode::SubpixelWithBgColor => {
+                            // Using the three pass "component alpha with font smoothing
+                            // background color" rendering technique:
+                            //
+                            // /webrender/doc/text-rendering.md
+                            //
+                            self.device.set_blend_mode_subpixel_with_bg_color_pass0();
+                            self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass0 as _);
+                        }
                     }
-                    _ => {
-                        if batch.key.blend_mode != prev_blend_mode {
-                            match batch.key.blend_mode {
-                                BlendMode::None => {
-                                    unreachable!("bug: opaque blend in alpha pass");
-                                }
-                                BlendMode::Alpha => {
-                                    self.device.set_blend_mode_alpha();
-                                }
-                                BlendMode::PremultipliedAlpha => {
-                                    self.device.set_blend_mode_premultiplied_alpha();
-                                }
-                                BlendMode::PremultipliedDestOut => {
-                                    self.device.set_blend_mode_premultiplied_dest_out();
-                                }
-                                BlendMode::SubpixelConstantTextColor(..) |
-                                BlendMode::SubpixelWithBgColor |
-                                BlendMode::SubpixelDualSource => {
-                                    unreachable!("bug: subpx text handled earlier");
-                                }
-                            }
-                            prev_blend_mode = batch.key.blend_mode;
-                        }
+                    prev_blend_mode = batch.key.blend_mode;
+                }
 
-                        self.submit_batch(
-                            &batch.key,
-                            &batch.instances,
-                            projection,
-                            render_tasks,
-                            render_target,
-                            target_size,
-                            stats,
-                            alpha_batch_container.target_rect,
-                        );
-                    }
+                self.shaders
+                    .get(&batch.key)
+                    .bind(
+                        &mut self.device, projection,
+                        &mut self.renderer_errors,
+                    );
+
+                // Handle special case readback for composites.
+                if let BatchKind::Brush(BrushBatchKind::MixBlend { task_id, source_id, backdrop_id }) = batch.key.kind {
+                    // composites can't be grouped together because
+                    // they may overlap and affect each other.
+                    debug_assert_eq!(batch.instances.len(), 1);
+                    self.handle_readback_composite(
+                        render_target,
+                        target_size,
+                        alpha_batch_container.target_rect,
+                        &render_tasks[source_id],
+                        &render_tasks[task_id],
+                        &render_tasks[backdrop_id],
+                    );
+                }
+
+                let _timer = self.gpu_profile.start_timer(batch.key.kind.sampler_tag());
+                self.draw_instanced_batch(
+                    &batch.instances,
+                    VertexArrayKind::Primitive,
+                    &batch.key.textures,
+                    stats
+                );
+
+                if batch.key.blend_mode == BlendMode::SubpixelWithBgColor {
+                    self.device.set_blend_mode_subpixel_with_bg_color_pass1();
+                    self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass1 as _);
+
+                    // When drawing the 2nd and 3rd passes, we know that the VAO, textures etc
+                    // are all set up from the previous draw_instanced_batch call,
+                    // so just issue a draw call here to avoid re-uploading the
+                    // instances and re-binding textures etc.
+                    self.device
+                        .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
+
+                    self.device.set_blend_mode_subpixel_with_bg_color_pass2();
+                    self.device.switch_mode(ShaderColorMode::SubpixelWithBgColorPass2 as _);
+
+                    self.device
+                        .draw_indexed_triangles_instanced_u16(6, batch.instances.len() as i32);
+
+                    prev_blend_mode = BlendMode::None;
                 }
             }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2870,7 +2870,7 @@ impl Renderer {
 
         let _gl = self.gpu_profile.start_marker("alpha batches");
         let transparent_sampler = self.gpu_profile.start_sampler(GPU_SAMPLER_TAG_TRANSPARENT);
-        self.device.set_blend(false);
+        self.device.set_blend(true);
         let mut prev_blend_mode = BlendMode::None;
 
         for alpha_batch_container in &target.alpha_batch_containers {
@@ -2891,7 +2891,6 @@ impl Renderer {
                         // 3) Consider the old constant color blend method where no clip is applied.
                         let _timer = self.gpu_profile.start_timer(GPU_TAG_PRIM_TEXT_RUN);
 
-                        self.device.set_blend(true);
                         // bind the proper shader first
                         match batch.key.blend_mode {
                             BlendMode::SubpixelDualSource => &mut self.shaders.ps_text_run_dual_source,
@@ -2977,24 +2976,20 @@ impl Renderer {
                         }
 
                         prev_blend_mode = BlendMode::None;
-                        self.device.set_blend(false);
                     }
                     _ => {
                         if batch.key.blend_mode != prev_blend_mode {
                             match batch.key.blend_mode {
                                 BlendMode::None => {
-                                    self.device.set_blend(false);
+                                    unreachable!("bug: opaque blend in alpha pass");
                                 }
                                 BlendMode::Alpha => {
-                                    self.device.set_blend(true);
                                     self.device.set_blend_mode_alpha();
                                 }
                                 BlendMode::PremultipliedAlpha => {
-                                    self.device.set_blend(true);
                                     self.device.set_blend_mode_premultiplied_alpha();
                                 }
                                 BlendMode::PremultipliedDestOut => {
-                                    self.device.set_blend(true);
                                     self.device.set_blend_mode_premultiplied_dest_out();
                                 }
                                 BlendMode::SubpixelConstantTextColor(..) |

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -803,8 +803,16 @@ impl Shaders {
             }
             BatchKind::Transformable(transform_kind, batch_kind) => {
                 let prim_shader = match batch_kind {
-                    TransformBatchKind::TextRun(..) => {
-                        unreachable!("bug: text batches are special cased");
+                    TransformBatchKind::TextRun(glyph_format) => {
+                        let text_shader = match key.blend_mode {
+                            BlendMode::SubpixelDualSource => {
+                                &mut self.ps_text_run_dual_source
+                            }
+                            _ => {
+                                &mut self.ps_text_run
+                            }
+                        };
+                        return text_shader.get(glyph_format, transform_kind);
                     }
                     TransformBatchKind::Image(image_buffer_kind) => {
                         self.ps_image[image_buffer_kind as usize]


### PR DESCRIPTION
* Support dual-source blending in brush shaders (optionally).
* Optimize how blend enable state is set in alpha batches. 
* Refactor and simplify how submit_batch works for subpixel modes.
  * In most cases, pass the shader color mode via instances.
  * The instance can have a value that says to take the color mode from uMode instead. This is used for multi-pass renderings.
  * Simplify the submit_batch code in a way that text runs are not special cased. This allows any primitive kind to work with any of the subpixel blend modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2677)
<!-- Reviewable:end -->
