### PR TITLE
Robustify shutdown for the scene builder thread

### DIFF
--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -38,6 +38,7 @@ pub enum SceneBuilderResult {
         render: bool,
         result_tx: Sender<SceneSwapResult>,
     },
+    Stopped,
 }
 
 // Message from render backend to scene builder to indicate the
@@ -170,7 +171,12 @@ impl SceneBuilder {
                     hooks.post_scene_swap(pipeline_info);
                 }
             }
-            SceneBuilderRequest::Stop => { return false; }
+            SceneBuilderRequest::Stop => {
+                self.tx.send(SceneBuilderResult::Stopped).unwrap();
+                // We don't need to send a WakeUp to api_tx because we only
+                // get the Stop when the RenderBackend loop is exiting.
+                return false;
+            }
         }
 
         true


### PR DESCRIPTION
Currently the scene builder thread can be processing a scene when the RB
thread shuts down. In this case, the scene builder thread may end up
trying to unwrap() the send result from the
SceneBuilderResult::Transaction, but that would fail and panic. Although one
alternative is to simply remove that unwrap() call, it seems better to
have a proper shutdown sequence and assert that things are happening as
we expect them to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2681)
<!-- Reviewable:end -->
