### PR TITLE
Clip dots/dashes to task rect

### DIFF
--- a/webrender/res/cs_clip_border.glsl
+++ b/webrender/res/cs_clip_border.glsl
@@ -134,9 +134,16 @@ void main(void) {
     vec2 device_pos = world_pos.xy * uDevicePixelRatio;
 
     // Position vertex within the render task area.
-    vec2 final_pos = device_pos -
-                     area.screen_origin +
-                     area.common_data.task_rect.p0;
+    vec2 task_rect_origin = area.common_data.task_rect.p0;
+    vec2 final_pos = device_pos - area.screen_origin + task_rect_origin;
+
+    // Clamp the mask rectangle to the render task area.
+    final_pos = clamp(final_pos,
+                      task_rect_origin,
+                      task_rect_origin + area.common_data.task_rect.size);
+
+    // Now move the clamped rectangle back to world space and use it for world_pos.
+    world_pos.xy = (final_pos - task_rect_origin + area.screen_origin) / uDevicePixelRatio;
 
     // Calculate the local space position for this vertex.
     vec4 node_pos = get_node_pos(world_pos.xy, scroll_node);


### PR DESCRIPTION
This ensures that when rendering dots and dashes that are clipped, they
don't render outside of the task rectangle. This should increase
performance (since dots and dashes outside the task rectangle produce
degenerate triangles) and avoid corrupting nearby areas of the
RenderTarget texture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2683)
<!-- Reviewable:end -->
