### PR TITLE
Make the ready callback more consistent

### DIFF
--- a/direct-composition/src/main_windows.rs
+++ b/direct-composition/src/main_windows.rs
@@ -186,7 +186,7 @@ impl api::RenderNotifier for Notifier {
         let _ = self.events_proxy.wakeup();
     }
 
-    fn new_document_ready(&self, _: api::DocumentId, _: bool, _: bool) {
+    fn new_frame_ready(&self, _: api::DocumentId, _: bool, _: bool) {
         self.wake_up();
     }
 }

--- a/webrender/examples/common/boilerplate.rs
+++ b/webrender/examples/common/boilerplate.rs
@@ -34,7 +34,7 @@ impl RenderNotifier for Notifier {
         let _ = self.events_proxy.wakeup();
     }
 
-    fn new_document_ready(&self, _: DocumentId, _scrolled: bool, _composite_needed: bool) {
+    fn new_frame_ready(&self, _: DocumentId, _scrolled: bool, _composite_needed: bool) {
         self.wake_up();
     }
 }

--- a/webrender/examples/multiwindow.rs
+++ b/webrender/examples/multiwindow.rs
@@ -37,7 +37,7 @@ impl RenderNotifier for Notifier {
         let _ = self.events_proxy.wakeup();
     }
 
-    fn new_document_ready(&self, _: DocumentId, _scrolled: bool, _composite_needed: bool) {
+    fn new_frame_ready(&self, _: DocumentId, _scrolled: bool, _composite_needed: bool) {
         self.wake_up();
     }
 }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1046,8 +1046,8 @@ impl RenderBackend {
             doc.render_on_hittest = false;
         }
 
-        if op.render || op.scroll {
-            self.notifier.new_document_ready(document_id, op.scroll, op.composite);
+        if transaction_msg.generate_frame {
+            self.notifier.new_frame_ready(document_id, op.scroll, op.composite);
         }
     }
 
@@ -1340,7 +1340,7 @@ impl RenderBackend {
             self.result_tx.send(msg_publish).unwrap();
             profile_counters.reset();
 
-            self.notifier.new_document_ready(id, false, true);
+            self.notifier.new_frame_ready(id, false, true);
             self.documents.insert(id, doc);
         }
     }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -219,8 +219,6 @@ impl Transaction {
     /// Supplies a new frame to WebRender.
     ///
     /// Non-blocking, it notifies a worker process which processes the display list.
-    /// When it's done and a RenderNotifier has been set in `webrender::Renderer`,
-    /// [new_frame_ready()][notifier] gets called.
     ///
     /// Note: Scrolling doesn't require an own Frame.
     ///
@@ -236,8 +234,6 @@ impl Transaction {
     /// * `preserve_frame_state`: If a previous frame exists which matches this pipeline
     ///                           id, this setting determines if frame state (such as scrolling
     ///                           position) should be preserved for this new display list.
-    ///
-    /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
     pub fn set_display_list(
         &mut self,
         epoch: Epoch,
@@ -313,7 +309,13 @@ impl Transaction {
         self.frame_ops.push(FrameMsg::SetPan(pan));
     }
 
-    /// Generate a new frame.
+    /// Generate a new frame. When it's done and a RenderNotifier has been set
+    /// in `webrender::Renderer`, [new_frame_ready()][notifier] gets called.
+    /// Note that the notifier is called even if the frame generation was a
+    /// no-op; the arguments passed to `new_frame_ready` will provide information
+    /// as to what happened.
+    ///
+    /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
     pub fn generate_frame(&mut self) {
         self.generate_frame = true;
     }
@@ -1107,7 +1109,7 @@ pub struct DynamicProperties {
 pub trait RenderNotifier: Send {
     fn clone(&self) -> Box<RenderNotifier>;
     fn wake_up(&self);
-    fn new_document_ready(&self, DocumentId, scrolled: bool, composite_needed: bool);
+    fn new_frame_ready(&self, DocumentId, scrolled: bool, composite_needed: bool);
     fn external_event(&self, _evt: ExternalEvent) {
         unimplemented!()
     }

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -349,7 +349,7 @@ impl RenderNotifier for Notifier {
         self.tx.send(NotifierEvent::ShutDown).unwrap();
     }
 
-    fn new_document_ready(&self, _: DocumentId, _scrolled: bool, composite_needed: bool) {
+    fn new_frame_ready(&self, _: DocumentId, _scrolled: bool, composite_needed: bool) {
         if composite_needed {
             self.wake_up();
         }

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -109,7 +109,7 @@ impl RenderNotifier for Notifier {
         self.update(false);
     }
 
-    fn new_document_ready(&self, _: DocumentId, scrolled: bool, _composite_needed: bool) {
+    fn new_frame_ready(&self, _: DocumentId, scrolled: bool, _composite_needed: bool) {
         self.update(!scrolled);
     }
 }


### PR DESCRIPTION
For gecko we need to ensure that we get a callback for every single
transaction that has a generate_frame flag set, because Gecko uses this
callback as part of a mechanism to throttle frame requests. If the
callback never arrives, it gets stuck thinking there are still inflight
frame requests, and doesn't request more.

This patch slightly modifies the semantics of the callback to ensure it
meets Gecko's needs. The main semantic change is that it may now get
called with both the `scrolled` and `composite` arguments as false,
whereas before at least one of these was always true.

This patch also renames the callback to better match the new semantics.
The new name is actually the original name of the callback, as can be
seen from the out-of-date documentation, which I'm also fixing in this
patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2691)
<!-- Reviewable:end -->
