### PR TITLE
Ensure subpixel AA is disabled for intermediate surfaces

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -77,6 +77,7 @@ pub struct PictureContext<'a> {
     pub inv_world_transform: Option<WorldToLayoutFastTransform>,
     pub apply_local_clip_rect: bool,
     pub inflation_factor: f32,
+    pub allow_subpixel_aa: bool,
 }
 
 pub struct PictureState {
@@ -211,6 +212,7 @@ impl FrameBuilder {
             inv_world_transform: None,
             apply_local_clip_rect: true,
             inflation_factor: 0.0,
+            allow_subpixel_aa: true,
         };
 
         let mut pic_state = PictureState::new();

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -272,6 +272,11 @@ impl PicturePrimitive {
         }
     }
 
+    // Disallow subpixel AA if an intermediate surface is needed.
+    pub fn allow_subpixel_aa(&self) -> bool {
+        self.can_draw_directly_to_parent_surface()
+    }
+
     pub fn prepare_for_render_inner(
         &mut self,
         prim_index: PrimitiveIndex,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -722,9 +722,14 @@ impl TextRunPrimitiveCpu {
         &mut self,
         device_pixel_scale: DevicePixelScale,
         transform: Option<LayoutToWorldTransform>,
+        allow_subpixel_aa: bool,
         display_list: &BuiltDisplayList,
         frame_building_state: &mut FrameBuildingState,
     ) {
+        if !allow_subpixel_aa {
+            self.font.render_mode = self.font.render_mode.limit_by(FontRenderMode::Alpha);
+        }
+
         let font = self.get_font(device_pixel_scale, transform);
 
         // Cache the glyph positions, if not in the cache already.
@@ -1368,6 +1373,7 @@ impl PrimitiveStore {
                 text.prepare_for_render(
                     frame_context.device_pixel_scale,
                     transform,
+                    pic_context.allow_subpixel_aa,
                     pic_context.display_list,
                     frame_state,
                 );
@@ -2151,6 +2157,8 @@ impl PrimitiveStore {
                         inv_world_transform,
                         apply_local_clip_rect: pic.apply_local_clip_rect,
                         inflation_factor,
+                        // TODO(lsalzman): allow overriding parent if intermediate surface is opaque
+                        allow_subpixel_aa: pic_context.allow_subpixel_aa && pic.allow_subpixel_aa(),
                     }
                 };
 

--- a/wrench/reftests/text/allow-subpixel-ref.yaml
+++ b/wrench/reftests/text/allow-subpixel-ref.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - text: "This should not be subpixel text"
+      origin: 20 120
+      size: 18
+      color: black
+      font: "VeraBd.ttf"

--- a/wrench/reftests/text/allow-subpixel.yaml
+++ b/wrench/reftests/text/allow-subpixel.yaml
@@ -1,0 +1,18 @@
+--- # Verify that subpixel AA is disabled if the text's enclosing stacking context requires an intermediate surface
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 500, 200]
+      items:
+        - text: "This should not be subpixel text"
+          origin: 20 120
+          size: 18
+          color: black
+          font: "VeraBd.ttf"
+        - type: stacking-context
+          bounds: [0, 0, 100, 100]
+          mix-blend-mode: multiply
+          items:
+            - type: rect
+              bounds: [0, 0, 100, 100]
+              color: white

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -57,3 +57,4 @@ platform(linux) == two-shadows.yaml two-shadows.png
 == shadow-partial-glyph.yaml shadow-partial-glyph-ref.yaml
 fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png
 fuzzy(1,71) platform(linux) == raster-space.yaml raster-space.png
+!= allow-subpixel.yaml allow-subpixel-ref.yaml


### PR DESCRIPTION
This is to address Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1452563

Mix-blend-mode causes the parent picture's composite_mode to be altered well after we've already built the text runs/fonts contained therein, which mucks up the allow_subpixel_aa determination and anything that was constructed based on it.

So Glenn and I decided it makes more sense to remove the allow_subpixel_aa flag from FlattenedStackingContext and put it instead of PictureContext, which then gets queried much later when the primitive is prepared and the font modified accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2693)
<!-- Reviewable:end -->
