### PR TITLE
Panic more verbosely if we don't find the descriptor

### DIFF
--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -131,7 +131,10 @@ impl FontContext {
         }
 
         let system_fc = dwrote::FontCollection::system();
-        let font = system_fc.get_font_from_descriptor(&font_handle).unwrap();
+        let font = match system_fc.get_font_from_descriptor(&font_handle) {
+            Some(font) => font,
+            None => { panic!("missing descriptor {:?}", font_handle) }
+        };
         let face = font.create_font_face();
         self.fonts.insert(*font_key, face);
     }


### PR DESCRIPTION
We're running into a panic on unwrap() in
https://bugzilla.mozilla.org/show_bug.cgi?id=1455848
This should help us find out more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2699)
<!-- Reviewable:end -->
