### PR TITLE
Allow subpixel with specified background color in offscreen targets.

### DIFF
--- a/webrender/src/glyph_rasterizer.rs
+++ b/webrender/src/glyph_rasterizer.rs
@@ -224,6 +224,10 @@ impl FontInstance {
         platform_options: Option<FontInstancePlatformOptions>,
         variations: Vec<FontVariation>,
     ) -> Self {
+        // If a background color is enabled, it only makes sense
+        // for it to be completely opaque.
+        debug_assert!(bg_color.a == 0 || bg_color.a == 255);
+
         FontInstance {
             font_key,
             size,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -728,7 +728,7 @@ impl TextRunPrimitiveCpu {
         display_list: &BuiltDisplayList,
         frame_building_state: &mut FrameBuildingState,
     ) {
-        if !allow_subpixel_aa {
+        if !allow_subpixel_aa && self.font.bg_color.a == 0 {
             self.font.render_mode = self.font.render_mode.limit_by(FontRenderMode::Alpha);
         }
 

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2891,6 +2891,13 @@ impl Renderer {
             }
 
             for batch in &alpha_batch_container.alpha_batches {
+                self.shaders
+                    .get(&batch.key)
+                    .bind(
+                        &mut self.device, projection,
+                        &mut self.renderer_errors,
+                    );
+
                 if batch.key.blend_mode != prev_blend_mode {
                     match batch.key.blend_mode {
                         BlendMode::None => {
@@ -2923,13 +2930,6 @@ impl Renderer {
                     }
                     prev_blend_mode = batch.key.blend_mode;
                 }
-
-                self.shaders
-                    .get(&batch.key)
-                    .bind(
-                        &mut self.device, projection,
-                        &mut self.renderer_errors,
-                    );
 
                 // Handle special case readback for composites.
                 if let BatchKind::Brush(BrushBatchKind::MixBlend { task_id, source_id, backdrop_id }) = batch.key.kind {

--- a/wrench/reftests/text/bg-color-ref.yaml
+++ b/wrench/reftests/text/bg-color-ref.yaml
@@ -1,0 +1,8 @@
+---
+root:
+  items:
+    - text: "A"
+      origin: 30 220
+      size: 200
+      color: black
+      font: "FreeSans.ttf"

--- a/wrench/reftests/text/bg-color.yaml
+++ b/wrench/reftests/text/bg-color.yaml
@@ -1,0 +1,15 @@
+# verify that drawing a text run on an off-screen surface with a
+# specified background color gives the same result as drawing a
+# subpixel text run directly on the background.
+---
+root:
+  items:
+    - type: stacking-context
+      transform-style: preserve-3d
+      items:
+      - text: "A"
+        origin: 30 220
+        size: 200
+        color: black
+        font: "FreeSans.ttf"
+        bg-color: white

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -58,3 +58,4 @@ platform(linux) == two-shadows.yaml two-shadows.png
 fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png
 fuzzy(1,71) platform(linux) == raster-space.yaml raster-space.png
 != allow-subpixel.yaml allow-subpixel-ref.yaml
+== bg-color.yaml bg-color-ref.yaml

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -467,6 +467,7 @@ impl Wrench {
         size: Au,
         flags: FontInstanceFlags,
         render_mode: Option<FontRenderMode>,
+        bg_color: Option<ColorU>,
     ) -> FontInstanceKey {
         let key = self.api.generate_font_instance_key();
         let mut update = ResourceUpdates::new();
@@ -474,6 +475,9 @@ impl Wrench {
         options.flags |= flags;
         if let Some(render_mode) = render_mode {
             options.render_mode = render_mode;
+        }
+        if let Some(bg_color) = bg_color {
+            options.bg_color = bg_color;
         }
         update.add_font_instance(key, font_key, size, Some(options), None, Vec::new());
         self.api.update_resources(update);


### PR DESCRIPTION
When a subpixel text run has a specified background color, we can
safely draw it into an off-screen surface.

Fix a bug in the renderer where the shader color mode was being
set before the shader was bound.

Add support in wrench for specifying the background color of
a text run.

Add a reftest that checks offscreen surface + bg color subpixel
text is the same as subpixel text on a normal background.

Fixes #2670.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2701)
<!-- Reviewable:end -->
