### PR TITLE
work around a rustc bug

### DIFF
--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -89,7 +89,7 @@ impl LayoutPrimitiveInfo {
 
 pub type LayoutPrimitiveInfo = PrimitiveInfo<LayoutPixel>;
 
-#[repr(u8)]
+#[repr(u64)]
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum SpecificDisplayItem {
     Clip(ClipDisplayItem),
@@ -472,7 +472,7 @@ pub enum TransformStyle {
 //           within a stacking context, rather than just the glyphs. If
 //           this change occurs, we'll update the naming of this.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-#[repr(C, u8)]
+#[repr(u32)]
 pub enum GlyphRasterSpace {
     // Rasterize glyphs in local-space, applying supplied scale to glyph sizes.
     // Best performance, but lower quality.


### PR DESCRIPTION
rustc tries to expand enum tags to fill padding even if
the requested size is smaller. This causes any code
manipulating the enum's raw repr to produce buggy results,
as it will write garbage into the padding, corrupting
what rustc thinks is the tag. This is being fixed upstream,
but for now just work around it by making the tags the same
size rustc expects.

See https://github.com/rust-lang/rust/issues/50098

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2708)
<!-- Reviewable:end -->
