### PR TITLE
Basic chasing infrastructure

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -17,7 +17,7 @@ use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, StickyFrameInfo};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
 use euclid::{SideOffsets2D, vec2};
-use frame_builder::{FrameBuilder, FrameBuilderConfig};
+use frame_builder::{ChasePrimitive, FrameBuilder, FrameBuilderConfig};
 use glyph_rasterizer::FontInstance;
 use gpu_cache::GpuCacheHandle;
 use gpu_types::BrushFlags;
@@ -875,6 +875,10 @@ impl<'a> DisplayListFlattener<'a> {
 
         if container.is_visible() {
             let prim_index = self.create_primitive(info, clip_sources, container);
+            if cfg!(debug_assertions) && ChasePrimitive::LocalRect(info.rect) == self.config.chase_primitive {
+                println!("Chasing {:?}", prim_index);
+                self.prim_store.chase_id = Some(prim_index);
+            }
             self.add_primitive_to_hit_testing_list(info, clip_and_scroll);
             self.add_primitive_to_draw_list(prim_index, clip_and_scroll);
         }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -26,6 +26,21 @@ use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext};
 use tiling::{ScrollbarPrimitive, SpecialRenderPasses};
 use util::{self, WorldToLayoutFastTransform};
 
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum ChasePrimitive {
+    Nothing,
+    LocalRect(LayoutRect),
+}
+
+impl Default for ChasePrimitive {
+    fn default() -> Self {
+        ChasePrimitive::Nothing
+    }
+}
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -34,6 +49,7 @@ pub struct FrameBuilderConfig {
     pub default_font_render_mode: FontRenderMode,
     pub dual_source_blending_is_supported: bool,
     pub dual_source_blending_is_enabled: bool,
+    pub chase_primitive: ChasePrimitive,
 }
 
 /// A builder structure for `tiling::Frame`
@@ -132,6 +148,7 @@ impl FrameBuilder {
                 default_font_render_mode: FontRenderMode::Mono,
                 dual_source_blending_is_enabled: true,
                 dual_source_blending_is_supported: false,
+                chase_primitive: ChasePrimitive::Nothing,
             },
         }
     }

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -182,6 +182,7 @@ pub extern crate webrender_api;
 #[doc(hidden)]
 pub use device::{build_shader_strings, ReadPixelsFormat, UploadMethod, VertexUsageHint};
 pub use device::{ProgramBinary, ProgramCache, ProgramCacheObserver, ProgramSources};
+pub use frame_builder::ChasePrimitive;
 pub use renderer::{AsyncPropertySampler, CpuProfile, DebugFlags, OutputImageHandler, RendererKind};
 pub use renderer::{ExternalImage, ExternalImageHandler, ExternalImageSource, GpuProfile};
 pub use renderer::{GraphicsApi, GraphicsApiInfo, PipelineInfo, Renderer, RendererOptions};

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -26,7 +26,7 @@ use device::{FileWatcherHandler, ShaderError, TextureFilter,
              VertexUsageHint, VAO, VBO, CustomVAO};
 use device::{ProgramCache, ReadPixelsFormat};
 use euclid::{rect, Transform3D};
-use frame_builder::FrameBuilderConfig;
+use frame_builder::{ChasePrimitive, FrameBuilderConfig};
 use gleam::gl;
 use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
@@ -1658,6 +1658,7 @@ impl Renderer {
             default_font_render_mode,
             dual_source_blending_is_enabled: true,
             dual_source_blending_is_supported: ext_dual_source_blending,
+            chase_primitive: options.chase_primitive,
         };
 
         let device_pixel_ratio = options.device_pixel_ratio;
@@ -4094,6 +4095,7 @@ pub struct RendererOptions {
     pub disable_dual_source_blending: bool,
     pub scene_builder_hooks: Option<Box<SceneBuilderHooks + Send>>,
     pub sampler: Option<Box<AsyncPropertySampler + Send>>,
+    pub chase_primitive: ChasePrimitive,
 }
 
 impl Default for RendererOptions {
@@ -4127,6 +4129,7 @@ impl Default for RendererOptions {
             disable_dual_source_blending: false,
             scene_builder_hooks: None,
             sampler: None,
+            chase_primitive: ChasePrimitive::Nothing,
         }
     }
 }

--- a/webrender_api/src/color.rs
+++ b/webrender_api/src/color.rs
@@ -115,7 +115,7 @@ pub struct ColorU {
 
 impl ColorU {
     /// Constructs a new additive `ColorU` from its components.
-    pub fn new(r: u8, g: u8, b: u8, a: u8) -> ColorU {
+    pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
         ColorU { r, g, b, a }
     }
 }

--- a/wrench/src/args.yaml
+++ b/wrench/src/args.yaml
@@ -67,6 +67,10 @@ args:
   - no_batch:
       long: no-batch
       help: Disable batching of instanced draw calls
+  - chase:
+      long: chase
+      help: Chase a particular primitive matching the local rect
+      takes_value: true
 
 subcommands:
     - png:

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -424,6 +424,20 @@ fn main() {
         })
         .unwrap_or(DeviceUintSize::new(1920, 1080));
     let zoom_factor = args.value_of("zoom").map(|z| z.parse::<f32>().unwrap());
+    let chase_primitive = match args.value_of("chase") {
+        Some(s) => {
+            let mut items = s
+                .split(',')
+                .map(|s| s.parse::<f32>().unwrap())
+                .collect::<Vec<_>>();
+            let rect = LayoutRect::new(
+                LayoutPoint::new(items[0], items[1]),
+                LayoutSize::new(items[2], items[3]),
+            );
+            webrender::ChasePrimitive::LocalRect(rect)
+        },
+        None => webrender::ChasePrimitive::Nothing,
+    };
 
     let mut events_loop = if args.is_present("headless") {
         None
@@ -462,6 +476,7 @@ fn main() {
         args.is_present("precache"),
         args.is_present("slow_subpixel"),
         zoom_factor.unwrap_or(1.0),
+        chase_primitive,
         notifier,
     );
 

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -180,6 +180,7 @@ impl Wrench {
         precache_shaders: bool,
         disable_dual_source_blending: bool,
         zoom_factor: f32,
+        chase_primitive: webrender::ChasePrimitive,
         notifier: Option<Box<RenderNotifier>>,
     ) -> Self {
         println!("Shader override path: {:?}", shader_override_path);
@@ -212,6 +213,7 @@ impl Wrench {
             precache_shaders,
             blob_image_renderer: Some(Box::new(blob::CheckerboardRenderer::new(callbacks.clone()))),
             disable_dual_source_blending,
+            chase_primitive,
             ..Default::default()
         };
 


### PR DESCRIPTION
While the capturing infrastructure allows users to inspect the scene and frame level state of the render pipeline, it's not able to answer the question of how does an item make it's way from one way to another. Or, often, where and why does it get culled. This is what the chasing is for: given a property of an item (currently, the local rectangle is supported), it tracks it through the pipeline and prints out all the paths taken, e.g.;
```
Chasing PrimitiveIndex(298)
	preparing a run of length 1 in pipeline PipelineId(1, 1)
	updating clip task with screen rect TypedRect(1712×32 at (0,29))
	base combined outer rect Some(TypedRect(1712×32 at (0,29)))
	need no task: no clips are left
	considered visible and ready with local rect TypedRect(1712.0×32.0 at (0.0,29.0))
```

This is something I've been needing for a few cases already, and I suspect will need more in the future.
Let me know if you have any ideas on how to make it better, or how to accomplish the task without this code at all ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2710)
<!-- Reviewable:end -->
