### PR TITLE
Final compile fixes for pathfinder

### DIFF
--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -52,6 +52,7 @@ pub struct WeakFreeListHandle<M> {
     _marker: PhantomData<M>,
 }
 
+#[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 struct Slot<T> {
@@ -60,6 +61,7 @@ struct Slot<T> {
     value: Option<T>,
 }
 
+#[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct FreeList<T, M> {

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -453,6 +453,6 @@ impl<'a> From<NativeFontHandleWrapper<'a>> for PathfinderComPtr<IDWriteFontFace>
             None => panic!("missing descriptor {:?}", font_handle.0),
         };
         let face = font.create_font_face();
-        PathfinderComPtr::new(face.as_ptr())
+        unsafe { PathfinderComPtr::new(face.as_ptr()) }
     }
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -217,8 +217,8 @@ impl BlurTask {
     }
 }
 
-#[cfg(feature = "pathfinder")]
 #[derive(Debug)]
+#[cfg(feature = "pathfinder")]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct GlyphTask {
@@ -943,6 +943,7 @@ pub enum RenderTaskCacheMarker {}
 
 // A cache of render tasks that are stored in the texture
 // cache for usage across frames.
+#[derive(Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct RenderTaskCache {


### PR DESCRIPTION
Closes #2645. 

Note: On Windows, pathfinder won't yet run properly, partly due to https://github.com/pcwalton/pathfinder/pull/82 and partly due to some `RenderTask`-related bugs (currently it crashes with "unexpected render task: glyph task") in ` webrender::render_task::RenderTask::uv_rect_kind`.

However, pathfinder now at least compiles on Windows, Linux and Mac. Also added various `#[derive(Debug)]` necessary for debugging the pathfinder crashes.