### PR TITLE
Make border image API more general

### DIFF
--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -268,26 +268,6 @@ pub enum RepeatMode {
     Space,
 }
 
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct NinePatchDescriptor {
-    pub width: u32,
-    pub height: u32,
-    pub slice: SideOffsets2D<u32>,
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ImageBorder {
-    pub image_key: ImageKey,
-    pub patch: NinePatchDescriptor,
-    /// Controls whether the center of the 9 patch image is
-    /// rendered or ignored.
-    pub fill: bool,
-    pub outset: SideOffsets2D<f32>,
-    pub repeat_horizontal: RepeatMode,
-    pub repeat_vertical: RepeatMode,
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GradientBorder {
     pub gradient: Gradient,
@@ -301,9 +281,54 @@ pub struct RadialGradientBorder {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+/// TODO(mrobinson): Currently only images are supported, but we will
+/// eventually add support for Gradient and RadialGradient.
+pub enum NinePatchBorderSource {
+    Image(ImageKey),
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct NinePatchBorder {
+    /// Describes what to use as the 9-patch source image. If this is an image,
+    /// it will be stretched to fill the size given by width x height.
+    pub source: NinePatchBorderSource,
+
+    /// The width of the 9-part image.
+    pub width: u32,
+
+    /// The height of the 9-part image.
+    pub height: u32,
+
+    /// Distances from each edge where the image should be sliced up. These
+    /// values are in 9-part-image space (the same space as width and height),
+    /// and the resulting image parts will be used to fill the corresponding
+    /// parts of the border as given by the border widths. This can lead to
+    /// stretching.
+    /// Slices can be overlapping. In that case, the same pixels from the
+    /// 9-part image will show up in multiple parts of the resulting border.
+    pub slice: SideOffsets2D<u32>,
+
+    /// Controls whether the center of the 9 patch image is rendered or
+    /// ignored. The center is never rendered if the slices are overlapping.
+    pub fill: bool,
+
+    /// Determines what happens if the horizontal side parts of the 9-part
+    /// image have a different size than the horizontal parts of the border.
+    pub repeat_horizontal: RepeatMode,
+
+    /// Determines what happens if the vertical side parts of the 9-part
+    /// image have a different size than the vertical parts of the border.
+    pub repeat_vertical: RepeatMode,
+
+    /// The outset for the border.
+    /// TODO(mrobinson): This should be removed and handled by the client.
+    pub outset: SideOffsets2D<f32>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum BorderDetails {
     Normal(NormalBorder),
-    Image(ImageBorder),
+    NinePatch(NinePatchBorder),
     Gradient(GradientBorder),
     RadialGradient(RadialGradientBorder),
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -901,17 +901,15 @@ impl YamlFrameReader {
                         "space" => RepeatMode::Space,
                         s => panic!("Unknown box border image repeat mode {}", s),
                     };
-                    Some(BorderDetails::Image(ImageBorder {
-                        image_key,
-                        patch: NinePatchDescriptor {
-                            width: image_width as u32,
-                            height: image_height as u32,
-                            slice: SideOffsets2D::new(slice[0], slice[1], slice[2], slice[3]),
-                        },
+                    Some(BorderDetails::NinePatch(NinePatchBorder {
+                        source: NinePatchBorderSource::Image(image_key),
+                        width: image_width as u32,
+                        height: image_height as u32,
+                        slice: SideOffsets2D::new(slice[0], slice[1], slice[2], slice[3]),
                         fill,
-                        outset: SideOffsets2D::new(outset[0], outset[1], outset[2], outset[3]),
                         repeat_horizontal,
                         repeat_vertical,
+                        outset: SideOffsets2D::new(outset[0], outset[1], outset[2], outset[3]),
                     }))
                 }
                 "gradient" => {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -865,7 +865,7 @@ impl YamlFrameWriter {
                                 yaml_node(&mut v, "radius", radius_node);
                             }
                         }
-                        BorderDetails::Image(ref details) => {
+                        BorderDetails::NinePatch(ref details) => {
                             let widths: Vec<f32> = vec![
                                 item.widths.top,
                                 item.widths.right,
@@ -880,16 +880,22 @@ impl YamlFrameWriter {
                             ];
                             yaml_node(&mut v, "width", f32_vec_yaml(&widths, true));
                             str_node(&mut v, "border-type", "image");
-                            if let Some(path) = self.path_for_image(details.image_key) {
-                                path_node(&mut v, "image", &path);
+
+                            match details.source {
+                                NinePatchBorderSource::Image(image_key) => {
+                                    if let Some(path) = self.path_for_image(image_key) {
+                                        path_node(&mut v, "image", &path);
+                                    }
+                                }
                             }
-                            u32_node(&mut v, "image-width", details.patch.width);
-                            u32_node(&mut v, "image-height", details.patch.height);
+
+                            u32_node(&mut v, "image-width", details.width);
+                            u32_node(&mut v, "image-height", details.height);
                             let slice: Vec<u32> = vec![
-                                details.patch.slice.top,
-                                details.patch.slice.right,
-                                details.patch.slice.bottom,
-                                details.patch.slice.left,
+                                details.slice.top,
+                                details.slice.right,
+                                details.slice.bottom,
+                                details.slice.left,
                             ];
                             yaml_node(&mut v, "slice", u32_vec_yaml(&slice, true));
                             yaml_node(&mut v, "outset", f32_vec_yaml(&outset, true));


### PR DESCRIPTION
This is a preparatory patch to add support for nine-patch like
functionality to border gradients. The new API is based on mstage's
proposed API from #1875.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2724)
<!-- Reviewable:end -->
