### PR TITLE
Reduce aColorTexCoord size

### DIFF
--- a/webrender/res/debug_font.glsl
+++ b/webrender/res/debug_font.glsl
@@ -9,11 +9,11 @@ varying vec4 vColor;
 
 #ifdef WR_VERTEX_SHADER
 in vec4 aColor;
-in vec4 aColorTexCoord;
+in vec2 aColorTexCoord;
 
 void main(void) {
     vColor = aColor;
-    vColorTexCoord = aColorTexCoord.xy;
+    vColorTexCoord = aColorTexCoord;
     vec4 pos = vec4(aPosition, 1.0);
     pos.xy = floor(pos.xy * uDevicePixelRatio + 0.5) / uDevicePixelRatio;
     gl_Position = uTransform * pos;


### PR DESCRIPTION
Rust side is providing 2 elements, and shader side expects 2, so no need to declare it as `vec4`
r? anyone (trivial)