### PR TITLE
Don't intersect the dirty rect with the tile rect.

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -188,3 +188,4 @@ pub use renderer::{GraphicsApi, GraphicsApiInfo, PipelineInfo, Renderer, Rendere
 pub use renderer::{RendererStats, SceneBuilderHooks, ThreadListener};
 pub use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 pub use webrender_api as api;
+pub use resource_cache::intersect_for_tile;

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use webrender::api::*;
+use webrender::intersect_for_tile;
 
 // Serialize/deserialize the blob.
 
@@ -29,7 +30,7 @@ fn deserialize_blob(blob: &[u8]) -> Result<ColorU, ()> {
 fn render_blob(
     color: ColorU,
     descriptor: &BlobImageDescriptor,
-    tile: Option<TileOffset>,
+    tile: Option<(TileSize, TileOffset)>,
     dirty_rect: Option<DeviceUintRect>,
 ) -> BlobImageResult {
     // Allocate storage for the result. Right now the resource cache expects the
@@ -39,13 +40,20 @@ fn render_blob(
     // Generate a per-tile pattern to see it in the demo. For a real use case it would not
     // make sense for the rendered content to depend on its tile.
     let tile_checker = match tile {
-        Some(tile) => (tile.x % 2 == 0) != (tile.y % 2 == 0),
+        Some((_, tile)) => (tile.x % 2 == 0) != (tile.y % 2 == 0),
         None => true,
     };
 
-    let dirty_rect = dirty_rect.unwrap_or(DeviceUintRect::new(
+    let mut dirty_rect = dirty_rect.unwrap_or(DeviceUintRect::new(
         DeviceUintPoint::new(0, 0),
         DeviceUintSize::new(descriptor.width, descriptor.height)));
+
+    if let Some((tile_size, tile)) = tile {
+        dirty_rect = intersect_for_tile(dirty_rect, tile_size as u32, tile_size as u32,
+                                        tile_size, tile)
+            .expect("empty rects should be culled by webrender");
+    }
+
 
     for y in dirty_rect.min_y() .. dirty_rect.max_y() {
         for x in dirty_rect.min_x() .. dirty_rect.max_x() {
@@ -101,7 +109,7 @@ impl BlobCallbacks {
 }
 
 pub struct CheckerboardRenderer {
-    image_cmds: HashMap<ImageKey, ColorU>,
+    image_cmds: HashMap<ImageKey, (ColorU, Option<TileSize>)>,
     callbacks: Arc<Mutex<BlobCallbacks>>,
 
     // The images rendered in the current frame (not kept here between frames).
@@ -119,16 +127,15 @@ impl CheckerboardRenderer {
 }
 
 impl BlobImageRenderer for CheckerboardRenderer {
-    fn add(&mut self, key: ImageKey, cmds: BlobImageData, _: Option<TileSize>) {
+    fn add(&mut self, key: ImageKey, cmds: BlobImageData, tile_size: Option<TileSize>) {
         self.image_cmds
-            .insert(key, deserialize_blob(&cmds[..]).unwrap());
+            .insert(key, (deserialize_blob(&cmds[..]).unwrap(), tile_size));
     }
 
     fn update(&mut self, key: ImageKey, cmds: BlobImageData, _dirty_rect: Option<DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
-        self.image_cmds
-            .insert(key, deserialize_blob(&cmds[..]).unwrap());
+        self.image_cmds.get_mut(&key).unwrap().0 = deserialize_blob(&cmds[..]).unwrap();
     }
 
     fn delete(&mut self, key: ImageKey) {
@@ -149,9 +156,11 @@ impl BlobImageRenderer for CheckerboardRenderer {
         // In this example we will use the thread pool to render individual tiles.
 
         // Gather the input data to send to a worker thread.
-        let cmds = self.image_cmds.get(&request.key).unwrap();
+        let &(color, tile_size) = self.image_cmds.get(&request.key).unwrap();
 
-        let result = render_blob(*cmds, descriptor, request.tile, dirty_rect);
+        let tile = request.tile.map(|tile| (tile_size.unwrap(), tile));
+
+        let result = render_blob(color, descriptor, tile, dirty_rect);
 
         self.rendered_images.insert(request, result);
     }


### PR DESCRIPTION
Gecko's blob renderer assumes that the dirty rect is in image
space and not in tile space. To avoid having to translate back
to image space in Gecko we can just not clip to the tile in WebRender.

This also fixes the wrench's blob renderer to store the tile size
and clip to the tile rect before rendering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2735)
<!-- Reviewable:end -->
