### PR TITLE
Fix short-circuit logic in HitTester

### DIFF
--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -251,7 +251,7 @@ impl HitTester {
                 }
 
                 let clip_chain_index = clip_and_scroll.clip_chain_index;
-                clipped_in |=
+                clipped_in = clipped_in ||
                     self.is_point_clipped_in_for_clip_chain(point, clip_chain_index, &mut test);
                 if !clipped_in {
                     break;


### PR DESCRIPTION
|= (the bitwise or-assignement operator) does not do short-circuiting.
It isn't an error to call is_point_clipped_in_for_clip_chain again in
this case, but it has the potential to do a lot of extra work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2739)
<!-- Reviewable:end -->
