### PR TITLE
Eliminate ClipScrollNode::local_viewport_rect

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -18,6 +18,7 @@ use util::{TransformedRectKind};
 
 #[derive(Debug)]
 pub struct StickyFrameInfo {
+    pub frame_rect: LayoutRect,
     pub margins: SideOffsets2D<Option<f32>>,
     pub vertical_offset_bounds: StickyOffsetBounds,
     pub horizontal_offset_bounds: StickyOffsetBounds,
@@ -27,12 +28,14 @@ pub struct StickyFrameInfo {
 
 impl StickyFrameInfo {
     pub fn new(
+        frame_rect: LayoutRect,
         margins: SideOffsets2D<Option<f32>>,
         vertical_offset_bounds: StickyOffsetBounds,
         horizontal_offset_bounds: StickyOffsetBounds,
         previously_applied_offset: LayoutVector2D
     ) -> StickyFrameInfo {
         StickyFrameInfo {
+            frame_rect,
             margins,
             vertical_offset_bounds,
             horizontal_offset_bounds,
@@ -86,14 +89,10 @@ impl NodeType {
 /// Contains information common among all types of ClipScrollTree nodes.
 #[derive(Debug)]
 pub struct ClipScrollNode {
-    /// Viewing rectangle in the coordinate system of the parent reference frame.
-    pub local_viewport_rect: LayoutRect,
-
     /// The transformation for this viewport in world coordinates is the transformation for
     /// our parent reference frame, plus any accumulated scrolling offsets from nodes
     /// between our reference frame and this node. For reference frames, we also include
-    /// whatever local transformation this reference frame provides. This can be combined
-    /// with the local_viewport_rect to get its position in world space.
+    /// whatever local transformation this reference frame provides.
     pub world_viewport_transform: LayoutToWorldFastTransform,
 
     /// World transform for content transformed by this node.
@@ -136,11 +135,9 @@ impl ClipScrollNode {
     pub fn new(
         pipeline_id: PipelineId,
         parent_index: Option<ClipScrollNodeIndex>,
-        rect: &LayoutRect,
         node_type: NodeType
     ) -> Self {
         ClipScrollNode {
-            local_viewport_rect: *rect,
             world_viewport_transform: LayoutToWorldFastTransform::identity(),
             world_content_transform: LayoutToWorldFastTransform::identity(),
             transform_kind: TransformedRectKind::AxisAligned,
@@ -156,7 +153,7 @@ impl ClipScrollNode {
     }
 
     pub fn empty() -> ClipScrollNode {
-        ClipScrollNode::new(PipelineId::dummy(), None, &LayoutRect::zero(), NodeType::Empty)
+        Self::new(PipelineId::dummy(), None, NodeType::Empty)
     }
 
     pub fn new_scroll_frame(
@@ -168,6 +165,7 @@ impl ClipScrollNode {
         scroll_sensitivity: ScrollSensitivity,
     ) -> Self {
         let node_type = NodeType::ScrollFrame(ScrollFrameInfo::new(
+            *frame_rect,
             scroll_sensitivity,
             LayoutSize::new(
                 (content_size.width - frame_rect.size.width).max(0.0),
@@ -176,12 +174,11 @@ impl ClipScrollNode {
             external_id,
         ));
 
-        Self::new(pipeline_id, Some(parent_index), frame_rect, node_type)
+        Self::new(pipeline_id, Some(parent_index), node_type)
     }
 
     pub fn new_reference_frame(
         parent_index: Option<ClipScrollNodeIndex>,
-        frame_rect: &LayoutRect,
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
@@ -197,17 +194,16 @@ impl ClipScrollNode {
             origin_in_parent_reference_frame,
             invertible: true,
         };
-        Self::new(pipeline_id, parent_index, frame_rect, NodeType::ReferenceFrame(info))
+        Self::new(pipeline_id, parent_index, NodeType::ReferenceFrame(info))
     }
 
     pub fn new_sticky_frame(
         parent_index: ClipScrollNodeIndex,
-        frame_rect: LayoutRect,
         sticky_frame_info: StickyFrameInfo,
         pipeline_id: PipelineId,
     ) -> Self {
         let node_type = NodeType::StickyFrame(sticky_frame_info);
-        Self::new(pipeline_id, Some(parent_index), &frame_rect, node_type)
+        Self::new(pipeline_id, Some(parent_index), node_type)
     }
 
 
@@ -475,8 +471,7 @@ impl ClipScrollNode {
         // The transformation for this viewport in world coordinates is the transformation for
         // our parent reference frame, plus any accumulated scrolling offsets from nodes
         // between our reference frame and this node. Finally, we also include
-        // whatever local transformation this reference frame provides. This can be combined
-        // with the local_viewport_rect to get its position in world space.
+        // whatever local transformation this reference frame provides.
         let relative_transform = info.resolved_transform
             .post_translate(state.parent_accumulated_scroll_offset)
             .to_transform()
@@ -524,7 +519,7 @@ impl ClipScrollNode {
         // between the scrolled content and unscrolled viewport we adjust the viewport's
         // position by the scroll offset in order to work with their relative positions on the
         // page.
-        let sticky_rect = self.local_viewport_rect.translate(viewport_scroll_offset);
+        let sticky_rect = info.frame_rect.translate(viewport_scroll_offset);
 
         let mut sticky_offset = LayoutVector2D::zero();
         if let Some(margin) = info.margins.top {
@@ -639,7 +634,7 @@ impl ClipScrollNode {
                 state.parent_accumulated_scroll_offset =
                     scrolling.offset + state.parent_accumulated_scroll_offset;
                 state.nearest_scrolling_ancestor_offset = scrolling.offset;
-                state.nearest_scrolling_ancestor_viewport = self.local_viewport_rect;
+                state.nearest_scrolling_ancestor_viewport = scrolling.viewport_rect;
             }
             NodeType::StickyFrame(ref info) => {
                 // We don't translate the combined rect by the sticky offset, because sticky
@@ -727,6 +722,10 @@ impl ClipScrollNode {
 
 #[derive(Copy, Clone, Debug)]
 pub struct ScrollFrameInfo {
+    /// The rectangle of the viewport of this scroll frame. This is important for
+    /// positioning of items inside child StickyFrames.
+    pub viewport_rect: LayoutRect,
+
     pub offset: LayoutVector2D,
     pub scroll_sensitivity: ScrollSensitivity,
 
@@ -743,11 +742,13 @@ pub struct ScrollFrameInfo {
 /// Manages scrolling offset.
 impl ScrollFrameInfo {
     pub fn new(
+        viewport_rect: LayoutRect,
         scroll_sensitivity: ScrollSensitivity,
         scrollable_size: LayoutSize,
         external_id: Option<ExternalScrollId>,
     ) -> ScrollFrameInfo {
         ScrollFrameInfo {
+            viewport_rect,
             offset: LayoutVector2D::zero(),
             scroll_sensitivity,
             scrollable_size,

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -365,12 +365,11 @@ impl ClipScrollTree {
         index: ClipScrollNodeIndex,
         parent_index: ClipScrollNodeIndex,
         handle: ClipSourcesHandle,
-        clip_rect: LayoutRect,
         pipeline_id: PipelineId,
     )  -> ClipChainIndex {
         let clip_chain_index = self.allocate_clip_chain();
         let node_type = NodeType::Clip { handle, clip_chain_index, clip_chain_node: None };
-        let node = ClipScrollNode::new(pipeline_id, Some(parent_index), &clip_rect, node_type);
+        let node = ClipScrollNode::new(pipeline_id, Some(parent_index), node_type);
         self.add_node(node, index);
         clip_chain_index
     }
@@ -379,16 +378,10 @@ impl ClipScrollTree {
         &mut self,
         index: ClipScrollNodeIndex,
         parent_index: ClipScrollNodeIndex,
-        frame_rect: LayoutRect,
         sticky_frame_info: StickyFrameInfo,
         pipeline_id: PipelineId,
     ) {
-        let node = ClipScrollNode::new_sticky_frame(
-            parent_index,
-            frame_rect,
-            sticky_frame_info,
-            pipeline_id,
-        );
+        let node = ClipScrollNode::new_sticky_frame(parent_index, sticky_frame_info, pipeline_id);
         self.add_node(node, index);
     }
 
@@ -461,8 +454,9 @@ impl ClipScrollTree {
             NodeType::ScrollFrame(scrolling_info) => {
                 pt.new_level(format!("ScrollFrame"));
                 pt.add_item(format!("index: {:?}", index));
+                pt.add_item(format!("viewport: {:?}", scrolling_info.viewport_rect));
                 pt.add_item(format!("scrollable_size: {:?}", scrolling_info.scrollable_size));
-                pt.add_item(format!("scroll.offset: {:?}", scrolling_info.offset));
+                pt.add_item(format!("scroll offset: {:?}", scrolling_info.offset));
             }
             NodeType::StickyFrame(ref sticky_frame_info) => {
                 pt.new_level(format!("StickyFrame"));
@@ -472,7 +466,6 @@ impl ClipScrollTree {
             NodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
         }
 
-        pt.add_item(format!("local_viewport_rect: {:?}", node.local_viewport_rect));
         pt.add_item(format!("world_viewport_transform: {:?}", node.world_viewport_transform));
         pt.add_item(format!("world_content_transform: {:?}", node.world_content_transform));
         pt.add_item(format!("coordinate_system_id: {:?}", node.coordinate_system_id));

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -27,9 +27,6 @@ pub struct HitTestClipScrollNode {
 
     /// World viewport transform for content transformed by this node.
     world_viewport_transform: LayoutToWorldFastTransform,
-
-    /// Origin of the viewport of the node, used to calculate node-relative positions.
-    node_origin: LayoutPoint,
 }
 
 /// A description of a clip chain in the HitTester. This is used to describe
@@ -141,7 +138,6 @@ impl HitTester {
                 regions: get_regions_for_clip_scroll_node(node, clip_store),
                 world_content_transform: node.world_content_transform,
                 world_viewport_transform: node.world_viewport_transform,
-                node_origin: node.local_viewport_rect.origin,
             });
 
             if let NodeType::Clip { clip_chain_index, .. } = node.node_type {
@@ -166,7 +162,7 @@ impl HitTester {
         test: &mut HitTest
     ) -> bool {
         if let Some(result) = test.get_from_clip_chain_cache(clip_chain_index) {
-            return result;
+            return result == ClippedIn::ClippedIn;
         }
 
         let descriptor = &self.clip_chains[clip_chain_index.0];
@@ -176,18 +172,18 @@ impl HitTester {
         };
 
         if !parent_clipped_in {
-            test.set_in_clip_chain_cache(clip_chain_index, false);
+            test.set_in_clip_chain_cache(clip_chain_index, ClippedIn::NotClippedIn);
             return false;
         }
 
         for clip_node_index in &descriptor.clips {
             if !self.is_point_clipped_in_for_node(point, *clip_node_index, test) {
-                test.set_in_clip_chain_cache(clip_chain_index, false);
+                test.set_in_clip_chain_cache(clip_chain_index, ClippedIn::NotClippedIn);
                 return false;
             }
         }
 
-        test.set_in_clip_chain_cache(clip_chain_index, true);
+        test.set_in_clip_chain_cache(clip_chain_index, ClippedIn::ClippedIn);
         true
     }
 
@@ -197,8 +193,8 @@ impl HitTester {
         node_index: ClipScrollNodeIndex,
         test: &mut HitTest
     ) -> bool {
-        if let Some(point) = test.node_cache.get(&node_index) {
-            return point.is_some();
+        if let Some(clipped_in) = test.node_cache.get(&node_index) {
+            return *clipped_in == ClippedIn::ClippedIn;
         }
 
         let node = &self.nodes[node_index.0];
@@ -206,20 +202,19 @@ impl HitTester {
         let transformed_point = match transform.inverse() {
             Some(inverted) => inverted.transform_point2d(&point),
             None => {
-                test.node_cache.insert(node_index, None);
+                test.node_cache.insert(node_index, ClippedIn::NotClippedIn);
                 return false;
             }
         };
 
-        let point_in_layer = transformed_point - node.node_origin.to_vector();
         for region in &node.regions {
             if !region.contains(&transformed_point) {
-                test.node_cache.insert(node_index, None);
+                test.node_cache.insert(node_index, ClippedIn::NotClippedIn);
                 return false;
             }
         }
 
-        test.node_cache.insert(node_index, Some(point_in_layer));
+        test.node_cache.insert(node_index, ClippedIn::ClippedIn);
         true
     }
 
@@ -290,26 +285,22 @@ impl HitTester {
                     break;
                 }
 
-                // We need to trigger a lookup against the root reference frame here, because
-                // items that are clipped by clip chains won't test against that part of the
-                // hierarchy. If we don't have a valid point for this test, we are likely
-                // in a situation where the reference frame has an univertible transform, but the
-                // item's clip does not.
-                let root_node_index = self.pipeline_root_nodes[&pipeline_id];
-                if !self.is_point_clipped_in_for_node(point, root_node_index, &mut test) {
-                    continue;
-                }
-                let point_in_viewport = match test.node_cache[&root_node_index] {
-                    Some(point) => point,
-                    None => continue,
-                };
-
                 // Don't hit items with backface-visibility:hidden if they are facing the back.
                 if !item.is_backface_visible {
                     if *facing_backwards.get_or_insert_with(|| transform.is_backface_visible()) {
                         continue;
                     }
                 }
+
+                // We need to calculate the position of the test point relative to the origin of
+                // the pipeline of the hit item. If we cannot get a transformed point, we are
+                // in a situation with an uninvertible transformation so we should just skip this
+                // result.
+                let root_node = &self.nodes[self.pipeline_root_nodes[&pipeline_id].0];
+                let point_in_viewport = match root_node.world_viewport_transform.inverse() {
+                    Some(inverted) => inverted.transform_point2d(&point),
+                    None => continue,
+                };
 
                 result.items.push(HitTestItem {
                     pipeline: pipeline_id,
@@ -356,12 +347,18 @@ fn get_regions_for_clip_scroll_node(
     }).collect()
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum ClippedIn {
+    ClippedIn,
+    NotClippedIn,
+}
+
 pub struct HitTest {
     pipeline_id: Option<PipelineId>,
     point: WorldPoint,
     flags: HitTestFlags,
-    node_cache: FastHashMap<ClipScrollNodeIndex, Option<LayoutPoint>>,
-    clip_chain_cache: Vec<Option<bool>>,
+    node_cache: FastHashMap<ClipScrollNodeIndex, ClippedIn>,
+    clip_chain_cache: Vec<Option<ClippedIn>>,
 }
 
 impl HitTest {
@@ -379,7 +376,7 @@ impl HitTest {
         }
     }
 
-    pub fn get_from_clip_chain_cache(&mut self, index: ClipChainIndex) -> Option<bool> {
+    fn get_from_clip_chain_cache(&mut self, index: ClipChainIndex) -> Option<ClippedIn> {
         if index.0 >= self.clip_chain_cache.len() {
             None
         } else {
@@ -387,14 +384,14 @@ impl HitTest {
         }
     }
 
-    pub fn set_in_clip_chain_cache(&mut self, index: ClipChainIndex, value: bool) {
+    fn set_in_clip_chain_cache(&mut self, index: ClipChainIndex, value: ClippedIn) {
         if index.0 >= self.clip_chain_cache.len() {
             self.clip_chain_cache.resize(index.0 + 1, None);
         }
         self.clip_chain_cache[index.0] = Some(value);
     }
 
-    pub fn get_absolute_point(&self, hit_tester: &HitTester) -> WorldPoint {
+    fn get_absolute_point(&self, hit_tester: &HitTester) -> WorldPoint {
         if !self.flags.contains(HitTestFlags::POINT_RELATIVE_TO_PIPELINE_VIEWPORT) {
             return self.point;
         }


### PR DESCRIPTION
It never really made sense for all types of ClipScrollNodes to have
bounding rectangles. For instance, for quite some time ReferenceFrames
always had bounding rectangles that started at zero and with unused
dimensions. With some recent refactoring we can eliminate this property
and have only those node types that need a bounding rectangle keep it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2743)
<!-- Reviewable:end -->
