### PR TITLE
Remove StackingContext::scroll_policy

### DIFF
--- a/webrender/examples/alpha_perf.rs
+++ b/webrender/examples/alpha_perf.rs
@@ -34,7 +34,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -50,7 +50,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             Some(PropertyBinding::Binding(self.property_key)),
             TransformStyle::Flat,
             None,

--- a/webrender/examples/basic.rs
+++ b/webrender/examples/basic.rs
@@ -192,7 +192,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -251,7 +251,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            api::ScrollPolicy::Scrollable,
             None,
             api::TransformStyle::Flat,
             None,

--- a/webrender/examples/document.rs
+++ b/webrender/examples/document.rs
@@ -113,7 +113,6 @@ impl Example for App {
             builder.push_stacking_context(
                 &LayoutPrimitiveInfo::new(doc.content_rect),
                 None,
-                ScrollPolicy::Fixed,
                 None,
                 TransformStyle::Flat,
                 None,

--- a/webrender/examples/frame_output.rs
+++ b/webrender/examples/frame_output.rs
@@ -101,7 +101,6 @@ impl App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,
@@ -150,7 +149,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/iframe.rs
+++ b/webrender/examples/iframe.rs
@@ -39,7 +39,6 @@ impl Example for App {
         sub_builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,
@@ -66,7 +65,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             Some(PropertyBinding::Binding(PropertyBindingKey::new(42))),
             TransformStyle::Flat,
             None,

--- a/webrender/examples/image_resize.rs
+++ b/webrender/examples/image_resize.rs
@@ -41,7 +41,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/multiwindow.rs
+++ b/webrender/examples/multiwindow.rs
@@ -181,7 +181,6 @@ impl Window {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/scrolling.rs
+++ b/webrender/examples/scrolling.rs
@@ -34,7 +34,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,
@@ -50,7 +49,6 @@ impl Example for App {
             builder.push_stacking_context(
                 &LayoutPrimitiveInfo::new((10, 10).by(0, 0)),
                 None,
-                ScrollPolicy::Scrollable,
                 None,
                 TransformStyle::Flat,
                 None,

--- a/webrender/examples/texture_cache_stress.rs
+++ b/webrender/examples/texture_cache_stress.rs
@@ -93,7 +93,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/examples/yuv.rs
+++ b/webrender/examples/yuv.rs
@@ -88,7 +88,6 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            ScrollPolicy::Scrollable,
             None,
             TransformStyle::Flat,
             None,

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -10,9 +10,9 @@ use api::{FilterOp, FontInstanceKey, GlyphInstance, GlyphOptions, GlyphRasterSpa
 use api::{IframeDisplayItem, ImageKey, ImageRendering, ItemRange, LayoutPoint};
 use api::{LayoutPrimitiveInfo, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
 use api::{LineOrientation, LineStyle, LocalClip, NinePatchBorderSource, PipelineId};
-use api::{PropertyBinding, RepeatMode, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity};
-use api::{Shadow, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect};
-use api::{TileOffset, TransformStyle, YuvColorSpace, YuvData};
+use api::{PropertyBinding, RepeatMode, ScrollFrameDisplayItem, ScrollSensitivity, Shadow};
+use api::{SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect, TileOffset};
+use api::{TransformStyle, YuvColorSpace, YuvData};
 use app_units::Au;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, StickyFrameInfo};
@@ -474,7 +474,7 @@ impl<'a> DisplayListFlattener<'a> {
         item: &DisplayItemRef,
         stacking_context: &StackingContext,
         unreplaced_scroll_id: ClipId,
-        mut scroll_node_id: ClipId,
+        scroll_node_id: ClipId,
         mut reference_frame_relative_offset: LayoutVector2D,
         is_backface_visible: bool,
     ) {
@@ -497,11 +497,6 @@ impl<'a> DisplayListFlattener<'a> {
                 stacking_context.mix_blend_mode_for_compositing(),
             )
         };
-
-        if stacking_context.scroll_policy == ScrollPolicy::Fixed {
-            scroll_node_id = self.current_reference_frame_id();
-            self.replacements.push((unreplaced_scroll_id, scroll_node_id));
-        }
 
         let bounds = item.rect();
         reference_frame_relative_offset += bounds.origin.to_vector();
@@ -546,10 +541,6 @@ impl<'a> DisplayListFlattener<'a> {
             pipeline_id,
             reference_frame_relative_offset,
         );
-
-        if stacking_context.scroll_policy == ScrollPolicy::Fixed {
-            self.replacements.pop();
-        }
 
         if stacking_context.reference_frame_id.is_some() {
             self.replacements.pop();
@@ -1301,10 +1292,6 @@ impl<'a> DisplayListFlattener<'a> {
 
     pub fn current_reference_frame_index(&self) -> ClipScrollNodeIndex {
         self.reference_frame_stack.last().unwrap().1
-    }
-
-    pub fn current_reference_frame_id(&self) -> ClipId{
-        self.reference_frame_stack.last().unwrap().0
     }
 
     pub fn setup_viewport_offset(

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -469,7 +469,6 @@ pub struct PushStackingContextDisplayItem {
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct StackingContext {
-    pub scroll_policy: ScrollPolicy,
     pub transform: Option<PropertyBinding<LayoutTransform>>,
     pub transform_style: TransformStyle,
     pub perspective: Option<LayoutTransform>,
@@ -479,12 +478,6 @@ pub struct StackingContext {
     pub glyph_raster_space: GlyphRasterSpace,
 } // IMPLICIT: filters: Vec<FilterOp>
 
-#[repr(u32)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum ScrollPolicy {
-    Scrollable = 0,
-    Fixed = 1,
-}
 
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -831,6 +824,13 @@ impl ClipId {
     }
 
     pub fn is_root_scroll_node(&self) -> bool {
+        match *self {
+            ClipId::Clip(1, _) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_root_reference_frame(&self) -> bool {
         match *self {
             ClipId::Clip(1, _) => true,
             _ => false,

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -16,14 +16,14 @@ use time::precise_time_ns;
 use {AlphaType, BorderDetails, BorderDisplayItem, BorderRadius, BorderWidths, BoxShadowClipMode};
 use {BoxShadowDisplayItem, ClipAndScrollInfo, ClipChainId, ClipChainItem, ClipDisplayItem, ClipId};
 use {ColorF, ComplexClipRegion, DisplayItem, ExtendMode, ExternalScrollId, FilterOp};
-use {FontInstanceKey, GlyphInstance, GlyphOptions, GlyphRasterSpace, Gradient, GradientDisplayItem, GradientStop};
-use {IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask, ImageRendering};
-use {LayoutPoint, LayoutPrimitiveInfo, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D};
-use {LineDisplayItem, LineOrientation, LineStyle, MixBlendMode, PipelineId, PropertyBinding};
-use {PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
-use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollPolicy, ScrollSensitivity, Shadow};
-use {SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, StickyOffsetBounds};
-use {TextDisplayItem, TransformStyle, YuvColorSpace, YuvData, YuvImageDisplayItem};
+use {FontInstanceKey, GlyphInstance, GlyphOptions, GlyphRasterSpace, Gradient};
+use {GradientDisplayItem, GradientStop, IframeDisplayItem, ImageDisplayItem, ImageKey, ImageMask};
+use {ImageRendering, LayoutPoint, LayoutPrimitiveInfo, LayoutRect, LayoutSize, LayoutTransform};
+use {LayoutVector2D, LineDisplayItem, LineOrientation, LineStyle, MixBlendMode, PipelineId};
+use {PropertyBinding, PushStackingContextDisplayItem, RadialGradient, RadialGradientDisplayItem};
+use {RectangleDisplayItem, ScrollFrameDisplayItem, ScrollSensitivity, Shadow, SpecificDisplayItem};
+use {StackingContext, StickyFrameDisplayItem, StickyOffsetBounds, TextDisplayItem, TransformStyle};
+use {YuvColorSpace, YuvData, YuvImageDisplayItem};
 
 // We don't want to push a long text-run. If a text-run is too long, split it into several parts.
 // This needs to be set to (renderer::MAX_VERTEX_TEXTURE_WIDTH - VECS_PER_PRIM_HEADER - VECS_PER_TEXT_RUN) * 2
@@ -1281,7 +1281,6 @@ impl DisplayListBuilder {
         &mut self,
         info: &LayoutPrimitiveInfo,
         clip_node_id: Option<ClipId>,
-        scroll_policy: ScrollPolicy,
         transform: Option<PropertyBinding<LayoutTransform>>,
         transform_style: TransformStyle,
         perspective: Option<LayoutTransform>,
@@ -1297,7 +1296,6 @@ impl DisplayListBuilder {
 
         let item = SpecificDisplayItem::PushStackingContext(PushStackingContextDisplayItem {
             stacking_context: StackingContext {
-                scroll_policy,
                 transform,
                 transform_style,
                 perspective,

--- a/wrench/reftests/border/degenerate-curve.yaml
+++ b/wrench/reftests/border/degenerate-curve.yaml
@@ -3,7 +3,6 @@ root:
   items: 
     - 
       bounds: [0, 0, 1024, 740]
-      "clip-and-scroll": 0
       type: "stacking-context"
       "scroll-policy": scrollable
       "transform-style": flat
@@ -48,7 +47,6 @@ root:
             color: 255 0 0 1.0000
         - 
           bounds: [28, 160, 144, 122]
-          "clip-and-scroll": 0
           type: border
           width: [18, 0, 18, 0]
           "border-type": normal
@@ -74,7 +72,6 @@ root:
             color: 255 0 0 1.0000
         - type: border
           bounds: [28, 302, 154, 122]
-          "clip-and-scroll": 0
           width: [18, 0, 18, 10]
           "border-type": normal
           color: 
@@ -107,7 +104,6 @@ root:
               color: 255 0 0 1.0000
         - type: border
           bounds: [202, 18, 144.03334, 122]
-          "clip-and-scroll": 0
           width: [18, 0.016666668, 18, 0.016666668]
           "border-type": normal
           color: 
@@ -132,7 +128,6 @@ root:
               color: 255 0 0 1.0000
         - type: border
           bounds: [202, 160, 144, 122]
-          "clip-and-scroll": 0
           width: [18, 0, 18, 0]
           "border-type": normal
           color: 
@@ -157,7 +152,6 @@ root:
             color: 255 0 0 1.0000
         - 
           bounds: [202, 302, 154, 122]
-          "clip-and-scroll": 0
           type: border
           width: [18, 0, 18, 10]
           "border-type": normal
@@ -187,7 +181,6 @@ root:
             color: 255 0 0 1.0000
         - 
           bounds: [376, 18, 144, 122]
-          "clip-and-scroll": 0
           type: border
           width: [18, 0, 18, 0]
           "border-type": normal
@@ -214,7 +207,6 @@ root:
         - 
           bounds: [376, 160, 144, 122]
           clip: [-17895698, -17895698, 35791396, 35791396]
-          "clip-and-scroll": 0
           type: border
           width: [18, 0, 18, 0]
           "border-type": normal
@@ -244,7 +236,6 @@ root:
             color: 255 0 0 1.0000
         - 
           bounds: [376, 302, 144, 122]
-          "clip-and-scroll": 0
           type: border
           width: [18, 0, 18, 0]
           "border-type": normal

--- a/wrench/reftests/border/dotted-corner-small-radius.yaml
+++ b/wrench/reftests/border/dotted-corner-small-radius.yaml
@@ -3,7 +3,6 @@ root:
   items: 
     - bounds: [5, 5, 490, 490]
       "clip-rect": [5, 5, 490, 490]
-      "clip-and-scroll": 0
       "backface-visible": true
       type: border
       width: 25

--- a/wrench/reftests/clip/clip-3d-transform.yaml
+++ b/wrench/reftests/clip/clip-3d-transform.yaml
@@ -19,12 +19,12 @@ root:
           "clip-rect": [0, 0, 800, 400]
           "backface-visible": true
           type: clip
-          id: 1
+          id: 2
           "content-size": [800, 400]
         -
           bounds: [0, 0, 400, 200]
           "clip-rect": [0, 0, 400, 200]
           "backface-visible": true
           type: rect
-          "clip-and-scroll": 1
+          clip-and-scroll: 2
           color: green

--- a/wrench/reftests/clip/clip-45-degree-rotation.yaml
+++ b/wrench/reftests/clip/clip-45-degree-rotation.yaml
@@ -5,26 +5,23 @@ root:
     -
       bounds: [0, 0, 0, 0]
       "clip-rect": [0, 0, 0, 0]
-      "clip-and-scroll": 0
       type: "stacking-context"
       transform: rotate(45) translate(200, 0)
       items:
         -
           bounds: [0, 0, 300, 300]
           "clip-rect": [0, 0, 300, 300]
-          "clip-and-scroll": 0
           type: rect
           color: red
         -
           bounds: [0, 0, 300, 300]
           "clip-rect": [0, 0, 300, 300]
-          "clip-and-scroll": 0
           type: clip
           id: 5
         -
           bounds: [0, 0, 0, 0]
           "clip-rect": [0, 0, 0, 0]
-          "clip-and-scroll": 5
+          clip-and-scroll: 5
           type: "stacking-context"
           transform: rotate(-45) translate(-300, 0)
           items:

--- a/wrench/reftests/clip/custom-clip-chain-node-ancestors.yaml
+++ b/wrench/reftests/clip/custom-clip-chain-node-ancestors.yaml
@@ -9,7 +9,6 @@ root:
     -
       bounds: [25, 25, 50, 50]
       "clip-rect": [25, 25, 50, 50]
-      "clip-and-scroll": 0
       type: clip
       id: 2
     -
@@ -28,6 +27,6 @@ root:
     -
       bounds: [0, 0, 200, 200]
       clip-rect: [0, 0, 200, 200]
-      clip-and-scroll: [0, 10]
+      clip-and-scroll: [root-scroll-node, 10]
       type: rect
       color: 0 255 0 1

--- a/wrench/reftests/clip/custom-clip-chains-ref.yaml
+++ b/wrench/reftests/clip/custom-clip-chains-ref.yaml
@@ -1,7 +1,7 @@
 root:
   items:
        - type: clip
-         id: 1
+         id: 2
          bounds: [0, 0, 200, 200]
          complex:
            - rect: [0, 0, 200, 200]

--- a/wrench/reftests/clip/custom-clip-chains.yaml
+++ b/wrench/reftests/clip/custom-clip-chains.yaml
@@ -12,7 +12,7 @@ root:
       transform: rotate(180)
       items:
        - type: clip
-         id: 1
+         id: 10
          bounds: [0, 0, 200, 200]
          complex:
            - rect: [0, 0, 200, 200]
@@ -51,7 +51,7 @@ root:
 
     - type: clip-chain
       id: 5
-      clips: [1, 2]
+      clips: [10, 2]
     - type: clip-chain
       id: 6
       parent: 5
@@ -59,4 +59,4 @@ root:
     - type: rect
       bounds: [0, 0, 200, 200]
       color: green
-      clip-and-scroll: [0, 6]
+      clip-and-scroll: [root-scroll-node, 6]

--- a/wrench/reftests/clip/fixed-position-clipping.yaml
+++ b/wrench/reftests/clip/fixed-position-clipping.yaml
@@ -8,43 +8,42 @@ root:
     -
       clip-rect: [15, 15, 30, 30]
       type: scroll-frame
-      id: 1
       content-size: [60, 60]
       bounds: [15, 15, 30, 30]
-    -
-      bounds: [10, 10, 100, 100]
-      clip-rect: [10, 10, 100, 100]
-      clip-and-scroll: 1
-      type: stacking-context
-      scroll-policy: fixed
       items:
-        -
-          bounds: [0, 0, 100, 100]
-          clip-rect: [0, 0, 100, 100]
-          clip-and-scroll: 1
-          type: rect
-          color: 0 256 0 1.0
+      -
+        bounds: [10, 10, 100, 100]
+        clip-rect: [10, 10, 100, 100]
+        clip-and-scroll: root-reference-frame
+        type: stacking-context
+        items:
+          -
+            bounds: [0, 0, 100, 100]
+            clip-rect: [0, 0, 100, 100]
+            clip-and-scroll: root-reference-frame
+            type: rect
+            color: 0 256 0 1.0
     # The same test as above, except this time the stacking context also starts its
     # own reference frame.
     -
       clip-rect: [115, 15, 30, 30]
       type: scroll-frame
-      id: 2
       content-size: [60, 60]
       bounds: [115, 15, 30, 30]
-    -
-      bounds: [110, 10, 100, 100]
-      clip-rect: [110, 10, 100, 100]
-      clip-and-scroll: 2
-      type: stacking-context
-      scroll-policy: fixed
-      transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
       items:
-        -
-          bounds: [0, 0, 100, 100]
-          clip-rect: [0, 0, 100, 100]
-          clip-and-scroll: 2
-          type: rect
-          color: 0 256 0 1.0
+      -
+        bounds: [110, 10, 100, 100]
+        clip-rect: [110, 10, 100, 100]
+        clip-and-scroll: root-reference-frame
+        reference-frame-id: 4
+        type: stacking-context
+        transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+        items:
+          -
+            bounds: [0, 0, 100, 100]
+            clip-rect: [0, 0, 100, 100]
+            clip-and-scroll: 4
+            type: rect
+            color: 0 256 0 1.0
   id: [0, 1]
 pipelines: []

--- a/wrench/reftests/clip/stacking-context-clip-ref.yaml
+++ b/wrench/reftests/clip/stacking-context-clip-ref.yaml
@@ -2,7 +2,7 @@
 root:
   items:
   - type: clip
-    id: 1
+    id: 2
     bounds: [0, 0, 100, 100]
     complex:
       - rect: [0, 0, 100, 100]
@@ -18,9 +18,9 @@ root:
       - type: rect
         bounds: [ 0, 0, 100, 100 ]
         color: [0, 255, 0]
-        clip-and-scroll: 1
+        clip-and-scroll: 2
   - type: clip
-    id: 2
+    id: 3
     bounds: [120, 0, 50, 50]
   - type: stacking-context
     bounds: [100, 0, 100, 100]
@@ -29,4 +29,4 @@ root:
       - type: rect
         bounds: [ 0, 0, 100, 100 ]
         color: [0, 255, 0]
-        clip-and-scroll: 2
+        clip-and-scroll: 3

--- a/wrench/reftests/clip/stacking-context-clip.yaml
+++ b/wrench/reftests/clip/stacking-context-clip.yaml
@@ -2,7 +2,7 @@
 root:
   items:
   - type: clip
-    id: 1
+    id: 2
     bounds: [0, 0, 100, 100]
     complex:
       - rect: [0, 0, 100, 100]
@@ -14,7 +14,7 @@ root:
         }
   - type: stacking-context
     bounds: [0, 0, 100, 100]
-    clip-node: 1
+    clip-node: 2
     items:
       - type: rect
         bounds: [ 0, 0, 100, 100 ]
@@ -24,12 +24,12 @@ root:
   # use a rounded clip here because we want to avoid subpixel differences and avoid
   # relying on a PNG reference image.
   - type: clip
-    id: 2
+    id: 3
     bounds: [120, 0, 50, 50]
   - type: stacking-context
     bounds: [100, 0, 100, 100]
     filters: hue-rotate(90)
-    clip-node: 2
+    clip-node: 3
     items:
       - type: rect
         bounds: [ 0, 0, 100, 100 ]

--- a/wrench/reftests/filters/blend-clipped.yaml
+++ b/wrench/reftests/filters/blend-clipped.yaml
@@ -7,23 +7,21 @@ root:
         -
           bounds: [0, 0, 1887, 2081]
           "clip-rect": [0, 0, 1887, 2081]
-          "clip-and-scroll": 0
           "backface-visible": true
           type: clip
-          id: 1
+          id: 2
           "content-size": [1887, 2081]
         -
           bounds: [0, 111, 1887, 1970]
           "clip-rect": [0, 111, 1887, 1970]
-          "clip-and-scroll": 0
           "backface-visible": true
           type: clip
-          id: 2
+          id: 3
           "content-size": [1887, 1970]
         -
           bounds: [0, 111, 1887, 1971]
           "clip-rect": [0, 111, 1887, 1971]
-          "clip-and-scroll": 2
+          "clip-and-scroll": 3
           "backface-visible": true
           type: iframe
           id: [1, 3]
@@ -38,13 +36,12 @@ pipelines:
           -
             bounds: [0, 0, 1887, 1971]
             "clip-rect": [0, 0, 1887, 1971]
-            "clip-and-scroll": 0
             type: clip
-            id: 1
+            id: 10
             "content-size": [1887, 1971]
           -
             "clip-rect": [0, 0, 1887, 1971]
-            "clip-and-scroll": 1
+            "clip-and-scroll": 10
             type: "scroll-frame"
             id: 2
             "content-size": [1887, 1971]

--- a/wrench/reftests/mask/mask-atomicity.yaml
+++ b/wrench/reftests/mask/mask-atomicity.yaml
@@ -6,7 +6,7 @@ root:
       color: red
     - type: clip
       bounds: [0, 0, 200, 200]
-      id: 1
+      id: 2
       image-mask:
           # premultiplied 0.5 alpha white(??)
           image: solid-color(127,127,127,127,200,200)
@@ -14,7 +14,7 @@ root:
           repeat: false
     - type: stacking-context
       bounds: [0, 0, 200, 200]
-      clip-node: 1
+      clip-node: 2
       items:
       - type: rect
         bounds: [0, 0, 100, 100]

--- a/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
+++ b/wrench/reftests/mask/mask-transformed-to-empty-rect.yaml
@@ -16,7 +16,7 @@ root:
             image: "tiny-check-mask.png"
             rect: [0, 0, 300, 300]
             repeat: false
-          id: 1
+          id: 2
           items:
             - type: rect
               bounds: [0, 0, 300, 300]

--- a/wrench/reftests/scrolling/clip-and-scroll-property.yaml
+++ b/wrench/reftests/scrolling/clip-and-scroll-property.yaml
@@ -3,21 +3,19 @@ root:
   items:
     -
       bounds: [0, 0, 200, 200]
-      "clip-and-scroll": 0
       type: "stacking-context"
       "scroll-policy": scrollable
       items:
         -
           bounds: [0, 0, 200, 200]
-          "clip-and-scroll": 0
           type: clip
-          id: 1
+          id: 2
         # Here we are testing that the clip-and-scroll property applies to
         # both stacking contexts and items.
         -
           bounds: [0, 0, 0, 0]
           content-size: [200, 200]
-          "clip-and-scroll": 1
+          clip-and-scroll: 2
           type: "stacking-context"
           "scroll-policy": scrollable
           transform: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, 0, 0, 1]
@@ -26,7 +24,7 @@ root:
             -
               bounds: [100, 0, 200, 200]
               clip: [-8947849, -8947849, 17895698, 17895698]
-              "clip-and-scroll": 1
+              clip-and-scroll: 2
               type: rect
               color: green
   id: [0, 0]

--- a/wrench/reftests/scrolling/fixed-position-ref.yaml
+++ b/wrench/reftests/scrolling/fixed-position-ref.yaml
@@ -12,6 +12,3 @@ root:
     - type: rect
       bounds: [180, 0, 50, 50]
       color: green
-    - type: rect
-      bounds: [240, 0, 50, 50]
-      color: green

--- a/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
+++ b/wrench/reftests/scrolling/fixed-position-scrolling-clip.yaml
@@ -7,22 +7,22 @@ root:
       scroll-offset: [0, 50]
       items:
       # The rectangles below should stay in place even when the parent scroll area scrolls,
-      # because they are in a fixed position stacking context. On the other hand, the clip
-      # item here will scroll with its parent scroll area. Normally fixed position items
-      # would only be clipped by their reference frame (in this case the root), but since
-      # these items specify an auxiliary clip, they will be clipped by their sibling clip (42).
+      # because they are use the root reference frame as their scroll node (fixed position).
+      # On the other hand, the clip item here will scroll with its parent scroll area. Normally
+      # fixed position items  would only be clipped by their reference frame (in this case the
+      # root), but ince  these items specify an auxiliary clip, they will be clipped by their
+      # sibling clip (42).
       - type: clip
         bounds: [10, 60, 50, 50]
         id: 42
       - type: stacking-context
         bounds: [10, 10, 100, 100]
-        scroll-policy: fixed
         items:
           - type: rect
             bounds: [0, 0, 100, 50]
             color: green
-            clip-and-scroll: [41, 42]
+            clip-and-scroll: [root-reference-frame, 42]
           - type: rect
             bounds: [0, 50, 100, 50]
             color: red
-            clip-and-scroll: [41, 42]
+            clip-and-scroll: [root-reference-frame, 42]

--- a/wrench/reftests/scrolling/fixed-position.yaml
+++ b/wrench/reftests/scrolling/fixed-position.yaml
@@ -5,11 +5,11 @@ root:
     # This stacking context should not scroll out of view because it is fixed position.
     - type: stacking-context
       bounds: [0, 0, 50, 50]
-      scroll-policy: fixed
       items:
         - type: rect
           bounds: [0, 0, 50, 50]
           color: green
+          clip-and-scroll: root-reference-frame
     # Even though there is a fixed position stacking context, it should scroll,
     # because it is fixed relative to its reference frame. The reference frame
     # of this stacking context is the stacking context parent because it has
@@ -17,49 +17,39 @@ root:
     - type: stacking-context
       bounds: [0, 0, 50, 50]
       transform: translate(60, 100)
+      reference-frame-id: 100
       items:
         - type: stacking-context
           bounds: [0, 0, 50, 50]
-          scroll-policy: fixed
           items:
             - type: rect
               bounds: [0, 0, 50, 50]
               color: green
+              clip-and-scroll: 100
     # This is similar to the previous case, but ensures that this still works
     # even with an identity transform.
     - type: stacking-context
       bounds: [120, 0, 50, 200]
       transform: translate(0, 0)
+      reference-frame-id: 101
       items:
         - type: stacking-context
           bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
           items:
             - type: rect
               bounds: [0, 100, 50, 50]
               color: green
+              clip-and-scroll: 101
     # This is similar to the previous case, but for perspective.
     - type: stacking-context
       bounds: [180, 0, 50, 200]
       perspective: 1
+      reference-frame-id: 102
       items:
         - type: stacking-context
           bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
           items:
             - type: rect
               bounds: [0, 100, 50, 50]
               color: green
-    # This is similar to the previous case, but since the perspective is
-    # 0 (equivalent to none), it shouldn't scroll.
-    - type: stacking-context
-      bounds: [240, 0, 50, 200]
-      perspective: 0
-      items:
-        - type: stacking-context
-          bounds: [0, 0, 50, 200]
-          scroll-policy: fixed
-          items:
-            - type: rect
-              bounds: [0, 0, 50, 50]
-              color: green
+              clip-and-scroll: 102

--- a/wrench/reftests/scrolling/sibling-hidden-clip.yaml
+++ b/wrench/reftests/scrolling/sibling-hidden-clip.yaml
@@ -3,20 +3,18 @@ root:
   items:
     -
       bounds: [0, 0, 200, 200]
-      "clip-and-scroll": 0
       type: "stacking-context"
       "scroll-policy": scrollable
       filters: [opacity(0.0)]
       items:
         -
           bounds: [0, 0, 50, 80]
-          "clip-and-scroll": 0
           type: clip
-          id: 1
+          id: 2
     - type: rect
       bounds: [10, 10, 100, 100]
       color: red
-      "clip-and-scroll": 1
+      clip-and-scroll: 2
 
   id: [0, 0]
 pipelines: []

--- a/wrench/reftests/scrolling/translate-nested-ref.yaml
+++ b/wrench/reftests/scrolling/translate-nested-ref.yaml
@@ -4,7 +4,6 @@ root:
     - 
       bounds: [8, 8, 500, 500]
       clip: [0, 0, 0, 0]
-      "clip-and-scroll": 0
       type: "stacking-context"
       items: 
         - 

--- a/wrench/reftests/scrolling/translate-nested.yaml
+++ b/wrench/reftests/scrolling/translate-nested.yaml
@@ -3,24 +3,23 @@ root:
   items: 
     - 
       bounds: [8, 8, 500, 500]
-      "clip-and-scroll": 0
       type: "stacking-context"
       items: 
         - 
           bounds: [0, 0, 200, 200]
           type: clip
-          id: 1
+          id: 2
           items:
           -
             bounds: [0, 0, 200, 200]
             type: rect
             color: red
-          - 
+          -
             bounds: [0, 0, 200, 200]
             type: "stacking-context"
             transform: translate(100, 0)
             items:
-              - 
+              -
                 bounds: [-100, 0, 200, 200]
                 clip-rect: [-300, -300, 900, 900]
                 type: rect

--- a/wrench/reftests/text/ahem.yaml
+++ b/wrench/reftests/text/ahem.yaml
@@ -4,26 +4,23 @@ root:
     -
       bounds: [0, 0, 0, 0]
       "clip-rect": [0, 0, 0, 0]
-      "clip-and-scroll": 0
       "backface-visible": true
     -
       bounds: [0, 0, 2560, 1294]
       "clip-rect": [0, 0, 2560, 1294]
-      "clip-and-scroll": 0
       "backface-visible": true
       type: rect
       color: white
     -
       bounds: [0, 0, 2560, 1294]
       "clip-rect": [0, 0, 2560, 1294]
-      "clip-and-scroll": 0
       "backface-visible": true
       type: clip
-      id: 1
+      id: 10
       "content-size": [2560, 1294]
     -
       "clip-rect": [0, 0, 2560, 1294]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 10
       "backface-visible": true
       type: "scroll-frame"
       id: 2
@@ -242,5 +239,5 @@ root:
     -
       bounds: [0, 0, 0, 0]
       "clip-rect": [0, 0, 0, 0]
-      "clip-and-scroll": 0
+      "clip-and-scroll": root-scroll-node
       "backface-visible": true

--- a/wrench/reftests/text/text-masking.yaml
+++ b/wrench/reftests/text/text-masking.yaml
@@ -3,13 +3,12 @@ root:
   items:
     - bounds: [0, 0, 750, 100]
       "clip-rect": [0, 0, 750, 100]
-      "clip-and-scroll": 0
       type: rect
       color: [180, 180, 180]
     - bounds: [0, 0, 750, 100]
       "clip-rect": [0, 0, 750, 100]
       type: clip
-      id: 1
+      id: 2
       "content-size": [750, 100]
       "image-mask":
         image: "text-masking-mask.png"
@@ -18,11 +17,11 @@ root:
     - text: "Cats making all the muffins knock over christmas tree"
       origin: 40 40
       size: 20
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       font: "FreeSans.ttf"
     - text: "Cats making all the muffins knock over christmas tree"
       origin: 40 80
       size: 20
       color: white
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       font: "FreeSans.ttf"

--- a/wrench/reftests/transforms/coord-system.yaml
+++ b/wrench/reftests/transforms/coord-system.yaml
@@ -7,19 +7,19 @@ root:
       items:
         -
           type: "scroll-frame"
-          id: 1
+          id: 2
           "content-size": [1024, 740]
           bounds: [0, 0, 1024, 740]
         -
           bounds: [0, 0, 1024, 200]
           "clip-rect": [0, 0, 1024, 200]
-          "clip-and-scroll": 1
+          "clip-and-scroll": 2
           type: "stacking-context"
           transform: [0.70710677, 0, -0.70710677, 0, 0, 1, 0, 0, 0.70710677, 0, 0.70710677, 0, 149.96133, 0, -937.9613, 1]
           items:
             -
               bounds: [0, 0, 1024, 200]
               "clip-rect": [0, 0, 1024, 200]
-              "clip-and-scroll": 1
+              "clip-and-scroll": 2
               type: rect
               color: 0 128 0 1.0000

--- a/wrench/reftests/transforms/image-rotated-clip.yaml
+++ b/wrench/reftests/transforms/image-rotated-clip.yaml
@@ -5,16 +5,16 @@ root:
       bounds: [18, 18, 400, 400]
       "clip-rect": [18, 18, 400, 400]
       type: clip
-      id: 1
+      id: 2
       "content-size": [400, 400]
     -
       bounds: [0, 0, 0, 0]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       type: "stacking-context"
       transform: [0.70710677, 0.70710677, 0, 0, -0.70710677, 0.70710677, 0, 0, 0, 0, 1, 0, 218, -64.84271, 0, 1]
       items:
         -
           bounds: [0, 0, 400, 400]
           "clip-rect": [0, 0, 400, 400]
-          "clip-and-scroll": 1
+          "clip-and-scroll": 2
           image: solid-color(255, 0, 0, 255, 400, 400)

--- a/wrench/reftests/transforms/nested-preserve-3d.yaml
+++ b/wrench/reftests/transforms/nested-preserve-3d.yaml
@@ -24,6 +24,5 @@ root:
             -
               bounds: [0, 0, 150, 150]
               "clip-rect": [0, 0, 150, 150]
-              "clip-and-scroll": 0
               type: rect
               color: 255 255 0 0.4000

--- a/wrench/reftests/transforms/nested-rotate-x.yaml
+++ b/wrench/reftests/transforms/nested-rotate-x.yaml
@@ -22,6 +22,5 @@ root:
             -
               bounds: [0, 0, 150, 150]
               "clip-rect": [0, 0, 150, 150]
-              "clip-and-scroll": 0
               type: rect
               color: 255 255 0 0.4000

--- a/wrench/reftests/transforms/rotated-image.yaml
+++ b/wrench/reftests/transforms/rotated-image.yaml
@@ -4,21 +4,19 @@ root:
     - 
       bounds: [0, 0, 2880, 1482]
       "clip-rect": [0, 0, 2880, 1482]
-      "clip-and-scroll": 0
       "backface-visible": true
       type: rect
       color: white
     - 
       bounds: [0, 0, 2880, 1482]
       "clip-rect": [0, 0, 2880, 1482]
-      "clip-and-scroll": 0
       "backface-visible": true
       type: clip
-      id: 1
+      id: 10
       "content-size": [2880, 1482]
     - 
       "clip-rect": [0, 0, 2880, 1482]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 10
       "backface-visible": true
       type: "scroll-frame"
       id: 2

--- a/wrench/reftests/transforms/segments-bug-ref.yaml
+++ b/wrench/reftests/transforms/segments-bug-ref.yaml
@@ -14,11 +14,11 @@ root:
               radius: 20
               "clip-mode": clip
         -
-          "clip-and-scroll": 4
+          clip-and-scroll: 4
           type: "stacking-context"
           items:
             -
               bounds: [12, 12, 130, 130]
-              "clip-and-scroll": 4
+              clip-and-scroll: 4
               type: rect
               color: 0 128 0 1.0000

--- a/wrench/reftests/transforms/singular-ref.yaml
+++ b/wrench/reftests/transforms/singular-ref.yaml
@@ -5,24 +5,24 @@ root:
       bounds: [0, 0, 200, 200]
       "clip-rect": [0, 0, 200, 200]
       type: clip
-      id: 1
+      id: 2
       "content-size": [200, 200]
     -
       bounds: [0, 100, 100, 100]
       "clip-rect": [0, 100, 100, 100]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       type: rect
       color: blue
     -
       bounds: [100, 0, 100, 100]
       "clip-rect": [100, 0, 100, 100]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       type: rect
       color: green
     -
       bounds: [100, 100, 100, 100]
       "clip-rect": [100, 100, 100, 100]
-      "clip-and-scroll": 1
+      "clip-and-scroll": 2
       type: rect
       color: red
 

--- a/wrench/reftests/transforms/singular.yaml
+++ b/wrench/reftests/transforms/singular.yaml
@@ -5,36 +5,36 @@ root:
       bounds: [0, 0, 200, 200]
       "clip-rect": [0, 0, 200, 200]
       type: clip
-      id: 1
+      id: 2
       "content-size": [200, 200]
     -
       bounds: [10, 10, 80, 80]
-      "clip-and-scroll": 1
+      clip-and-scroll: 2
       type: "stacking-context"
       transform: [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
       items:
         -
           bounds: [0, 0, 80, 80]
           "clip-rect": [0, 0, 80, 80]
-          "clip-and-scroll": 1
+          clip-and-scroll: 2
           type: rect
           color: black
     -
       bounds: [0, 100, 100, 100]
       "clip-rect": [0, 100, 100, 100]
-      "clip-and-scroll": 1
+      clip-and-scroll: 2
       type: rect
       color: blue
     -
       bounds: [100, 0, 100, 100]
       "clip-rect": [100, 0, 100, 100]
-      "clip-and-scroll": 1
+      clip-and-scroll: 2
       type: rect
       color: green
     -
       bounds: [100, 100, 100, 100]
       "clip-rect": [100, 100, 100, 100]
-      "clip-and-scroll": 1
+      clip-and-scroll: 2
       type: rect
       color: red
 

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -342,11 +342,30 @@ impl YamlFrameReader {
         }
     }
 
-    pub fn to_clip_id(&self, id: u64, pipeline_id: PipelineId) -> ClipId {
-        if id == 0 {
-            return ClipId::root_scroll_node(pipeline_id);
+    pub fn u64_to_clip_id(&self, number: u64, pipeline_id: PipelineId) -> ClipId {
+        match number {
+            0 => ClipId::root_reference_frame(pipeline_id),
+            1 => ClipId::root_scroll_node(pipeline_id),
+            _ => self.clip_id_map[&number],
         }
-        self.clip_id_map[&id]
+
+    }
+
+    pub fn to_clip_id(&self, item: &Yaml, pipeline_id: PipelineId) -> Option<ClipId> {
+        match *item {
+            Yaml::Integer(value) => Some(self.u64_to_clip_id(value as u64, pipeline_id)),
+            Yaml::String(ref id_string) if id_string == "root-reference-frame" =>
+                Some(ClipId::root_reference_frame(pipeline_id)),
+            Yaml::String(ref id_string) if id_string == "root-scroll-node" =>
+                Some(ClipId::root_scroll_node(pipeline_id)),
+            _ => None,
+        }
+    }
+
+    pub fn add_clip_id_mapping(&mut self, numeric_id: u64, real_id: ClipId) {
+        assert!(numeric_id != 0, "id=0 is reserved for the root reference frame");
+        assert!(numeric_id != 1, "id=1 is reserved for the root scroll node");
+        self.clip_id_map.insert(numeric_id, real_id);
     }
 
     fn to_clip_and_scroll_info(
@@ -355,21 +374,18 @@ impl YamlFrameReader {
         pipeline_id: PipelineId
     ) -> Option<ClipAndScrollInfo> {
         match *item {
-            Yaml::Integer(value) => {
-                Some(ClipAndScrollInfo::simple(self.to_clip_id(value as u64, pipeline_id)))
-            }
             Yaml::Array(ref array) if array.len() == 2 => {
-                let id_ints = (array[0].as_i64(), array[1].as_i64());
-                if let (Some(scroll_node_numeric_id), Some(clip_node_numeric_id)) = id_ints {
-                    Some(ClipAndScrollInfo::new(
-                        self.to_clip_id(scroll_node_numeric_id as u64, pipeline_id),
-                        self.to_clip_id(clip_node_numeric_id as u64, pipeline_id)
-                    ))
-                } else {
-                    None
-                }
+                let scroll_id = match self.to_clip_id(&array[0], pipeline_id) {
+                    Some(id) => id,
+                    None => return None,
+                };
+                let clip_id = match self.to_clip_id(&array[1], pipeline_id) {
+                    Some(id) => id,
+                    None => return None,
+                };
+                Some(ClipAndScrollInfo::new(scroll_id, clip_id))
             }
-            _ => None,
+            _ => self.to_clip_id(item, pipeline_id).map(|id| ClipAndScrollInfo::simple(id)),
         }
     }
 
@@ -1376,7 +1392,7 @@ impl YamlFrameReader {
             ScrollSensitivity::Script,
         );
         if let Some(numeric_id) = numeric_id {
-            self.clip_id_map.insert(numeric_id, real_id);
+            self.add_clip_id_mapping(numeric_id, real_id);
         }
 
         if !yaml["items"].is_badvalue() {
@@ -1409,7 +1425,7 @@ impl YamlFrameReader {
         );
 
         if let Some(numeric_id) = numeric_id {
-            self.clip_id_map.insert(numeric_id, real_id);
+            self.add_clip_id_mapping(numeric_id, real_id);
         }
 
         if !yaml["items"].is_badvalue() {
@@ -1448,12 +1464,10 @@ impl YamlFrameReader {
         let clip_ids: Vec<ClipId> = yaml["clips"]
             .as_vec_u64()
             .unwrap_or_else(Vec::new)
-            .iter().map(|id| self.to_clip_id(*id, builder.pipeline_id))
+            .iter().map(|id| self.u64_to_clip_id(*id, builder.pipeline_id))
             .collect();
 
-        let parent = yaml["parent"].as_i64().map(|id|
-            self.to_clip_id(id as u64, builder.pipeline_id)
-        );
+        let parent = self.to_clip_id(&yaml["parent"], builder.pipeline_id);
         let parent = match parent {
             Some(ClipId::ClipChain(clip_chain_id)) => Some(clip_chain_id),
             Some(_) => panic!("Tried to create a ClipChain with a non-ClipChain parent"),
@@ -1461,7 +1475,7 @@ impl YamlFrameReader {
         };
 
         let real_id = builder.define_clip_chain(parent, clip_ids);
-        self.clip_id_map.insert(numeric_id as u64, ClipId::ClipChain(real_id));
+        self.add_clip_id_mapping(numeric_id as u64, ClipId::ClipChain(real_id));
     }
 
     pub fn handle_clip(&mut self, dl: &mut DisplayListBuilder, wrench: &mut Wrench, yaml: &Yaml) {
@@ -1472,7 +1486,7 @@ impl YamlFrameReader {
 
         let real_id = dl.define_clip(clip_rect, complex_clips, image_mask);
         if let Some(numeric_id) = numeric_id {
-            self.clip_id_map.insert(numeric_id as u64, real_id);
+            self.add_clip_id_mapping(numeric_id as u64, real_id);
         }
 
         if !yaml["items"].is_badvalue() {
@@ -1517,8 +1531,7 @@ impl YamlFrameReader {
             .as_transform(&transform_origin)
             .map(|transform| transform.into());
 
-        let clip_node_id =
-            yaml["clip-node"].as_i64().map(|id| self.to_clip_id(id as u64, dl.pipeline_id));
+        let clip_node_id = self.to_clip_id(&yaml["clip-node"], dl.pipeline_id);
 
         let perspective = match yaml["perspective"].as_f32() {
             Some(value) if value != 0.0 => {
@@ -1534,9 +1547,6 @@ impl YamlFrameReader {
         let mix_blend_mode = yaml["mix-blend-mode"]
             .as_mix_blend_mode()
             .unwrap_or(MixBlendMode::Normal);
-        let scroll_policy = yaml["scroll-policy"]
-            .as_scroll_policy()
-            .unwrap_or(ScrollPolicy::Scrollable);
         let glyph_raster_space = yaml["glyph-raster-space"]
             .as_glyph_raster_space()
             .unwrap_or(GlyphRasterSpace::Screen);
@@ -1552,10 +1562,9 @@ impl YamlFrameReader {
         info.rect = bounds;
         info.clip_rect = bounds;
 
-        dl.push_stacking_context(
+        let reference_frame_id = dl.push_stacking_context(
             &info,
             clip_node_id,
-            scroll_policy,
             transform.into(),
             transform_style,
             perspective,
@@ -1563,6 +1572,14 @@ impl YamlFrameReader {
             filters,
             glyph_raster_space,
         );
+
+        let numeric_id = yaml["reference-frame-id"].as_i64();
+        match (numeric_id, reference_frame_id) {
+            (Some(numeric_id), Some(reference_frame_id)) => {
+                self.add_clip_id_mapping(numeric_id as u64, reference_frame_id);
+            }
+            _ => {},
+        }
 
         if !yaml["items"].is_badvalue() {
             self.add_display_list_items_from_yaml(dl, wrench, &yaml["items"]);

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -185,8 +185,6 @@ fn write_stacking_context(
     filter_iter: AuxIter<FilterOp>,
     clip_id_mapper: &ClipIdMapper,
 ) {
-    enum_node(parent, "scroll-policy", sc.scroll_policy);
-
     matrix4d_node(parent, "transform", &properties.resolve_layout_transform(&sc.transform));
 
     enum_node(parent, "transform-style", sc.transform_style);
@@ -202,7 +200,7 @@ fn write_stacking_context(
     str_node(parent, "glyph-raster-space", &glyph_raster_space);
 
     if let Some(clip_node_id) = sc.clip_node_id {
-        yaml_node(parent, "clip-node", Yaml::Integer(clip_id_mapper.map_id(&clip_node_id) as i64));
+        yaml_node(parent, "clip-node", clip_id_mapper.map_id(&clip_node_id));
     }
 
     if let Some(perspective) = sc.perspective {
@@ -719,13 +717,7 @@ impl YamlFrameWriter {
                 );
             }
 
-            let clip_and_scroll_yaml = match clip_id_mapper.map_info(&base.clip_and_scroll()) {
-                (scroll_id, Some(clip_id)) => {
-                    Yaml::Array(vec![Yaml::Integer(scroll_id), Yaml::Integer(clip_id)])
-                }
-                (scroll_id, None) => Yaml::Integer(scroll_id),
-            };
-            yaml_node(&mut v, "clip-and-scroll", clip_and_scroll_yaml);
+            yaml_node(&mut v, "clip-and-scroll", clip_id_mapper.map_info(&base.clip_and_scroll()));
             bool_node(&mut v, "backface-visible", base.is_backface_visible());
 
             match *base.item() {
@@ -1060,14 +1052,14 @@ impl YamlFrameWriter {
                     let id = ClipId::ClipChain(item.id);
                     u32_node(&mut v, "id", clip_id_mapper.add_id(id) as u32);
 
-                    let clip_ids: Vec<u32> = display_list.get(base.clip_chain_items()).map(|clip_id| {
-                        clip_id_mapper.map_id(&clip_id) as u32
+                    let clip_ids = display_list.get(base.clip_chain_items()).map(|clip_id| {
+                        clip_id_mapper.map_id(&clip_id)
                     }).collect();
-                    u32_vec_node(&mut v, "clips", &clip_ids);
+                    yaml_node(&mut v, "clips", Yaml::Array(clip_ids));
 
                     if let Some(parent) = item.parent {
                         let parent = ClipId::ClipChain(parent);
-                        u32_node(&mut v, "parent", clip_id_mapper.map_id(&parent) as u32);
+                        yaml_node(&mut v, "parent", clip_id_mapper.map_id(&parent));
                     }
                 }
                 ScrollFrame(item) => {
@@ -1227,7 +1219,7 @@ impl ClipIdMapper {
     fn new() -> ClipIdMapper {
         ClipIdMapper {
             hash_map: HashMap::new(),
-            current_clip_id: 1,
+            current_clip_id: 2,
         }
     }
 
@@ -1237,17 +1229,24 @@ impl ClipIdMapper {
         self.current_clip_id - 1
     }
 
-    fn map_id(&self, id: &ClipId) -> usize {
-        if id.is_root_scroll_node() {
-            return 0;
+    fn map_id(&self, id: &ClipId) -> Yaml {
+        if id.is_root_reference_frame() {
+            Yaml::String("root-reference-frame".to_owned())
+        } else if id.is_root_scroll_node() {
+            Yaml::String("root-scroll-node".to_owned())
+        } else {
+            Yaml::Integer(*self.hash_map.get(id).unwrap() as i64)
         }
-        *self.hash_map.get(id).unwrap()
     }
 
-    fn map_info(&self, info: &ClipAndScrollInfo) -> (i64, Option<i64>) {
-        (
-            self.map_id(&info.scroll_node_id) as i64,
-            info.clip_node_id.map(|ref id| self.map_id(id) as i64),
-        )
+    fn map_info(&self, info: &ClipAndScrollInfo) -> Yaml {
+        let scroll_node_yaml = self.map_id(&info.scroll_node_id);
+        match info.clip_node_id {
+            Some(ref clip_node_id) => Yaml::Array(vec![
+                scroll_node_yaml,
+                self.map_id(&clip_node_id)
+            ]),
+            None => scroll_node_yaml,
+        }
     }
 }

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -34,7 +34,6 @@ pub trait YamlHelper {
     fn as_glyph_raster_space(&self) -> Option<GlyphRasterSpace>;
     fn as_clip_mode(&self) -> Option<ClipMode>;
     fn as_mix_blend_mode(&self) -> Option<MixBlendMode>;
-    fn as_scroll_policy(&self) -> Option<ScrollPolicy>;
     fn as_filter_op(&self) -> Option<FilterOp>;
     fn as_vec_filter_op(&self) -> Option<Vec<FilterOp>>;
 }
@@ -121,8 +120,6 @@ define_string_enum!(
         Luminosity = "luminosity"
     ]
 );
-
-define_string_enum!(ScrollPolicy, [Scrollable = "scrollable", Fixed = "fixed"]);
 
 define_string_enum!(
     LineOrientation,
@@ -537,10 +534,6 @@ impl YamlHelper for Yaml {
     }
 
     fn as_mix_blend_mode(&self) -> Option<MixBlendMode> {
-        self.as_str().and_then(|x| StringEnum::from_str(x))
-    }
-
-    fn as_scroll_policy(&self) -> Option<ScrollPolicy> {
         self.as_str().and_then(|x| StringEnum::from_str(x))
     }
 


### PR DESCRIPTION
This can be handled in clients now that they have access to reference
frame ciip ids. Removing fixed positioning support from WebRender
simplifies the code greatly and also opens the way to explicit creation
of reference frames in the API. It will also allow us to get rid of the
hacky replacements code during display list flattening.

This also requires exposing the root reference frame to Wrench tests in
order to enable them retain the fixed positioning feature. This change
exposes new aliases to wrench "root-scroll-node" and
"root-reference-frame" in order to make this clearer. These nodes
correspond to the ids 1 and 0 respectively and Wrench will halt if it
encounters these used for other nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2747)
<!-- Reviewable:end -->
