### PR TITLE
Use non-animated (static) value if the animation is in delay phase

### DIFF
--- a/webrender/examples/animation.rs
+++ b/webrender/examples/animation.rs
@@ -43,14 +43,14 @@ impl Example for App {
         let bounds = (0, 0).to(200, 200);
 
         let filters = vec![
-            FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key), self.opacity),
+            FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key, self.opacity), self.opacity),
         ];
 
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
             None,
-            Some(PropertyBinding::Binding(self.property_key)),
+            Some(PropertyBinding::Binding(self.property_key, LayoutTransform::identity())),
             TransformStyle::Flat,
             None,
             MixBlendMode::Normal,

--- a/webrender/examples/iframe.rs
+++ b/webrender/examples/iframe.rs
@@ -65,7 +65,7 @@ impl Example for App {
         builder.push_stacking_context(
             &info,
             None,
-            Some(PropertyBinding::Binding(PropertyBindingKey::new(42))),
+            Some(PropertyBinding::Binding(PropertyBindingKey::new(42), LayoutTransform::identity())),
             TransformStyle::Flat,
             None,
             MixBlendMode::Normal,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -163,7 +163,7 @@ impl PicturePrimitive {
             Some(PictureCompositeMode::Filter(ref mut filter)) => {
                 match *filter {
                     FilterOp::Opacity(ref binding, ref mut value) => {
-                        *value = properties.resolve_float(binding, *value);
+                        *value = properties.resolve_float(binding);
                     }
                     _ => {}
                 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -231,7 +231,7 @@ impl OpacityBinding {
         let mut new_opacity = 1.0;
 
         for binding in &self.bindings {
-            let opacity = scene_properties.resolve_float(binding, 1.0);
+            let opacity = scene_properties.resolve_float(binding);
             new_opacity = new_opacity * opacity;
         }
 

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -54,15 +54,11 @@ impl SceneProperties {
     ) -> LayoutTransform {
         match *property {
             PropertyBinding::Value(value) => value,
-            PropertyBinding::Binding(ref key) => {
+            PropertyBinding::Binding(ref key, v) => {
                 self.transform_properties
                     .get(&key.id)
                     .cloned()
-                    .unwrap_or_else(|| {
-                        warn!("Property binding has an invalid value.");
-                        debug!("key={:?}", key);
-                        LayoutTransform::identity()
-                    })
+                    .unwrap_or(v)
             }
         }
     }
@@ -70,20 +66,15 @@ impl SceneProperties {
     /// Get the current value for a float property.
     pub fn resolve_float(
         &self,
-        property: &PropertyBinding<f32>,
-        default_value: f32
+        property: &PropertyBinding<f32>
     ) -> f32 {
         match *property {
             PropertyBinding::Value(value) => value,
-            PropertyBinding::Binding(ref key) => {
+            PropertyBinding::Binding(ref key, v) => {
                 self.float_properties
                     .get(&key.id)
                     .cloned()
-                    .unwrap_or_else(|| {
-                        warn!("Property binding has an invalid value.");
-                        debug!("key={:?}", key);
-                        default_value
-                    })
+                    .unwrap_or(v)
             }
         }
     }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1078,10 +1078,13 @@ impl<T> PropertyBindingKey<T> {
 /// A binding property can either be a specific value
 /// (the normal, non-animated case) or point to a binding location
 /// to fetch the current value from.
+/// Note that Binding has also a non-animated value, the value is
+/// used for the case where the animation is still in-delay phase
+/// (i.e. the animation doesn't produce any animation values).
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum PropertyBinding<T> {
     Value(T),
-    Binding(PropertyBindingKey<T>),
+    Binding(PropertyBindingKey<T>, T),
 }
 
 impl<T> From<T> for PropertyBinding<T> {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1090,12 +1090,6 @@ impl<T> From<T> for PropertyBinding<T> {
     }
 }
 
-impl<T> From<PropertyBindingKey<T>> for PropertyBinding<T> {
-    fn from(key: PropertyBindingKey<T>) -> PropertyBinding<T> {
-        PropertyBinding::Binding(key)
-    }
-}
-
 /// The current value of an animated property. This is
 /// supplied by the calling code.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/wrench/src/scene.rs
+++ b/wrench/src/scene.rs
@@ -45,27 +45,21 @@ impl SceneProperties {
 
         match property {
             PropertyBinding::Value(matrix) => matrix,
-            PropertyBinding::Binding(ref key) => self.transform_properties
+            PropertyBinding::Binding(ref key, v) => self.transform_properties
                 .get(&key.id)
                 .cloned()
-                .unwrap_or_else(|| {
-                    println!("Property binding {:?} has an invalid value.", key);
-                    LayoutTransform::identity()
-                }),
+                .unwrap_or(v),
         }
     }
 
     /// Get the current value for a float property.
-    pub fn resolve_float(&self, property: &PropertyBinding<f32>, default_value: f32) -> f32 {
+    pub fn resolve_float(&self, property: &PropertyBinding<f32>) -> f32 {
         match *property {
             PropertyBinding::Value(value) => value,
-            PropertyBinding::Binding(ref key) => self.float_properties
+            PropertyBinding::Binding(ref key, v) => self.float_properties
                 .get(&key.id)
                 .cloned()
-                .unwrap_or_else(|| {
-                    println!("Property binding {:?} has an invalid value.", key);
-                    default_value
-                }),
+                .unwrap_or(v),
         }
     }
 }

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -223,7 +223,7 @@ fn write_stacking_context(
             FilterOp::Invert(x) => { filters.push(Yaml::String(format!("invert({})", x))) }
             FilterOp::Opacity(x, _) => {
                 filters.push(Yaml::String(format!("opacity({})",
-                                                  properties.resolve_float(&x, 1.0))))
+                                                  properties.resolve_float(&x))))
             }
             FilterOp::Saturate(x) => { filters.push(Yaml::String(format!("saturate({})", x))) }
             FilterOp::Sepia(x) => { filters.push(Yaml::String(format!("sepia({})", x))) }


### PR DESCRIPTION
When animation is in-delay phase, there is no corresponding value in SceneProperties, so we have to store the static value and use it for the delay phase.
   
This patch lets PropertyBinding::Binding having the static value along with the key.

This is the change for https://bugzilla.mozilla.org/show_bug.cgi?id=1460389 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2750)
<!-- Reviewable:end -->
