### PR TITLE
Properly update the viewport rect on scroll nodes

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -216,9 +216,11 @@ impl ClipScrollNode {
             NodeType::ScrollFrame(ref mut scrolling) => {
                 let scroll_sensitivity = scrolling.scroll_sensitivity;
                 let scrollable_size = scrolling.scrollable_size;
+                let viewport_rect = scrolling.viewport_rect;
                 *scrolling = *old_scrolling_state;
                 scrolling.scroll_sensitivity = scroll_sensitivity;
                 scrolling.scrollable_size = scrollable_size;
+                scrolling.viewport_rect = viewport_rect;
             }
             _ if old_scrolling_state.offset != LayoutVector2D::zero() => {
                 warn!("Tried to scroll a non-scroll node.")


### PR DESCRIPTION
I introduced a regression in PR #2743 with the handling of updated
scroll frames. Instead of the new viewport size, the old one is used.
This lead to misbehavior of sticky elements in Gecko. Unfortunately, I
don't know a good way to test this with an automated test, but I've
confirmed that this fixes the issue manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2757)
<!-- Reviewable:end -->
