### PR TITLE
Allocate more bits for the clip chain rectangle and node IDs

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -24,6 +24,14 @@ void brush_vs(
 #define BRUSH_FLAG_SEGMENT_REPEAT_X             4
 #define BRUSH_FLAG_SEGMENT_REPEAT_Y             8
 
+//Note: these have to match `gpu_types` constants
+#define INT_BITS    (31)
+#define CLIP_CHAIN_RECT_BITS    (22)
+#define SEGMENT_BITS (INT_BITS - CLIP_CHAIN_RECT_BITS)
+#define EDGE_FLAG_BITS (4)
+#define BRUSH_FLAG_BITS (4)
+#define CLIP_SCROLL_INDEX_BITS (INT_BITS - EDGE_FLAG_BITS - BRUSH_FLAG_BITS)
+
 struct BrushInstance {
     int picture_address;
     int prim_address;
@@ -43,12 +51,12 @@ BrushInstance load_brush() {
     bi.picture_address = aData0.x & 0xffff;
     bi.clip_address = aData0.x >> 16;
     bi.prim_address = aData0.y;
-    bi.clip_chain_rect_index = aData0.z >> 16;
-    bi.scroll_node_id = aData0.z & 0xffff;
+    bi.clip_chain_rect_index = aData0.z  & ((1 << CLIP_CHAIN_RECT_BITS) - 1);
+    bi.segment_index = aData0.z >> CLIP_CHAIN_RECT_BITS;
     bi.z = aData0.w;
-    bi.segment_index = aData1.x & 0xffff;
-    bi.edge_mask = (aData1.x >> 16) & 0xff;
-    bi.flags = (aData1.x >> 24);
+    bi.scroll_node_id = aData1.x & ((1 << CLIP_SCROLL_INDEX_BITS) - 1);
+    bi.edge_mask = (aData1.x >> CLIP_SCROLL_INDEX_BITS) & 0xf;
+    bi.flags = (aData1.x >> (CLIP_SCROLL_INDEX_BITS + EDGE_FLAG_BITS)) & 0xf;
     bi.user_data = aData1.yzw;
 
     return bi;

--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -119,10 +119,10 @@ PrimitiveInstance fetch_prim_instance() {
 
     pi.prim_address = aData0.x;
     pi.specific_prim_address = pi.prim_address + VECS_PER_PRIM_HEADER;
-    pi.render_task_index = aData0.y;
-    pi.clip_task_index = aData0.z;
-    pi.clip_chain_rect_index = aData0.w / 65536;
-    pi.scroll_node_id = aData0.w % 65536;
+    pi.render_task_index = aData0.y % 0x10000;
+    pi.clip_task_index = aData0.y / 0x10000;
+    pi.clip_chain_rect_index = aData0.z;
+    pi.scroll_node_id = aData0.w;
     pi.z = aData1.x;
     pi.user_data0 = aData1.y;
     pi.user_data1 = aData1.z;

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -4,10 +4,21 @@
 
 use api::{DevicePoint, LayoutToWorldTransform, WorldToLayoutTransform};
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
-use prim_store::EdgeAaSegmentMask;
+use prim_store::{VECS_PER_SEGMENT, EdgeAaSegmentMask};
 use render_task::RenderTaskAddress;
+use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 
 // Contains type that must exactly match the same structures declared in GLSL.
+
+const INT_BITS: usize = 31; //TODO: convert to unsigned
+const CLIP_CHAIN_RECT_BITS: usize = 22;
+const SEGMENT_BITS: usize = INT_BITS - CLIP_CHAIN_RECT_BITS;
+// The guard ensures (at compile time) that the designated number of bits cover
+// the maximum supported segment count for the texture width.
+const _SEGMENT_GUARD: usize = (1 << SEGMENT_BITS) * VECS_PER_SEGMENT - MAX_VERTEX_TEXTURE_WIDTH;
+const EDGE_FLAG_BITS: usize = 4;
+const BRUSH_FLAG_BITS: usize = 4;
+const CLIP_SCROLL_INDEX_BITS: usize = INT_BITS - EDGE_FLAG_BITS - BRUSH_FLAG_BITS;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
@@ -18,7 +29,7 @@ pub struct ZBufferIdGenerator {
 }
 
 impl ZBufferIdGenerator {
-    pub fn new() -> ZBufferIdGenerator {
+    pub fn new() -> Self {
         ZBufferIdGenerator {
             next: 0
         }
@@ -133,9 +144,9 @@ impl SimplePrimitiveInstance {
         PrimitiveInstance {
             data: [
                 self.specific_prim_address.as_int(),
-                self.task_address.0 as i32,
-                self.clip_task_address.0 as i32,
-                ((self.clip_chain_rect_index.0 as i32) << 16) | self.scroll_id.0 as i32,
+                self.task_address.0 as i32 | (self.clip_task_address.0 as i32) << 16,
+                self.clip_chain_rect_index.0 as i32,
+                self.scroll_id.0 as i32,
                 self.z.0,
                 data0,
                 data1,
@@ -236,15 +247,18 @@ pub struct BrushInstance {
 
 impl From<BrushInstance> for PrimitiveInstance {
     fn from(instance: BrushInstance) -> Self {
+        debug_assert_eq!(0, instance.clip_chain_rect_index.0 >> CLIP_CHAIN_RECT_BITS);
+        debug_assert_eq!(0, instance.scroll_id.0 >> CLIP_SCROLL_INDEX_BITS);
+        debug_assert_eq!(0, instance.segment_index >> SEGMENT_BITS);
         PrimitiveInstance {
             data: [
                 instance.picture_address.0 as i32 | (instance.clip_task_address.0 as i32) << 16,
                 instance.prim_address.as_int(),
-                ((instance.clip_chain_rect_index.0 as i32) << 16) | instance.scroll_id.0 as i32,
+                instance.clip_chain_rect_index.0 as i32 | (instance.segment_index << CLIP_CHAIN_RECT_BITS),
                 instance.z.0,
-                instance.segment_index |
-                    ((instance.edge_flags.bits() as i32) << 16) |
-                    ((instance.brush_flags.bits() as i32) << 24),
+                instance.scroll_id.0 as i32 |
+                    ((instance.edge_flags.bits() as i32) << CLIP_SCROLL_INDEX_BITS) |
+                    ((instance.brush_flags.bits() as i32) << (CLIP_SCROLL_INDEX_BITS + EDGE_FLAG_BITS)),
                 instance.user_data[0],
                 instance.user_data[1],
                 instance.user_data[2],

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -36,6 +36,7 @@ use util::{pack_as_float, recycle_vec};
 
 
 const MIN_BRUSH_SPLIT_AREA: f32 = 256.0 * 256.0;
+pub const VECS_PER_SEGMENT: usize = 2;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ScrollNodeAndClipChain {
@@ -2764,6 +2765,7 @@ impl<'a> GpuDataRequest<'a> {
         local_rect: LayoutRect,
         extra_data: [f32; 4],
     ) {
+        let _ = VECS_PER_SEGMENT;
         self.push(local_rect);
         self.push(extra_data);
     }


### PR DESCRIPTION
We easily hit the max number of local rectangles, and the batch code happily converts those indices to negative... The PR is not a general solution, but gets us closer to a situation where we might as well crash out of memory than exceed our internal indices.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1439386 ~~(TODO: confirm)~~
Try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=74e50c08e063f049d1d11000278dd1719224f6c0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2761)
<!-- Reviewable:end -->
