### PR TITLE
Allow explicit indication of which missing pipelines are acceptable

### DIFF
--- a/webrender/examples/iframe.rs
+++ b/webrender/examples/iframe.rs
@@ -74,7 +74,7 @@ impl Example for App {
         );
         // red rect under the iframe: if this is visible, things have gone wrong
         builder.push_rect(&info, ColorF::new(1.0, 0.0, 0.0, 1.0));
-        builder.push_iframe(&info, sub_pipeline_id);
+        builder.push_iframe(&info, sub_pipeline_id, false);
         builder.pop_stacking_context();
     }
 }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -556,8 +556,7 @@ impl<'a> DisplayListFlattener<'a> {
         let pipeline = match self.scene.pipelines.get(&iframe_pipeline_id) {
             Some(pipeline) => pipeline,
             None => {
-                //TODO: assert/debug_assert?
-                error!("Unknown pipeline used for iframe {:?}", info);
+                debug_assert!(info.ignore_missing_pipeline);
                 return
             },
         };

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -543,6 +543,7 @@ pub enum FilterOp {
 pub struct IframeDisplayItem {
     pub clip_id: ClipId,
     pub pipeline_id: PipelineId,
+    pub ignore_missing_pipeline: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -1491,10 +1491,16 @@ impl DisplayListBuilder {
         assert!(!self.clip_stack.is_empty());
     }
 
-    pub fn push_iframe(&mut self, info: &LayoutPrimitiveInfo, pipeline_id: PipelineId) {
+    pub fn push_iframe(
+        &mut self,
+        info: &LayoutPrimitiveInfo,
+        pipeline_id: PipelineId,
+        ignore_missing_pipeline: bool
+    ) {
         let item = SpecificDisplayItem::Iframe(IframeDisplayItem {
             clip_id: self.generate_clip_id(),
             pipeline_id,
+            ignore_missing_pipeline,
         });
         self.push_item(item, info);
     }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -1243,7 +1243,8 @@ impl YamlFrameReader {
     ) {
         info.rect = item["bounds"].as_rect().expect("iframe must have bounds");
         let pipeline_id = item["id"].as_pipeline_id().unwrap();
-        dl.push_iframe(&info, pipeline_id);
+        let ignore = item["ignore_missing_pipeline"].as_bool().unwrap_or(true);
+        dl.push_iframe(&info, pipeline_id, ignore);
     }
 
     pub fn get_complex_clip_for_item(&mut self, yaml: &Yaml) -> Option<ComplexClipRegion> {

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -1013,6 +1013,7 @@ impl YamlFrameWriter {
                 Iframe(item) => {
                     str_node(&mut v, "type", "iframe");
                     u32_vec_node(&mut v, "id", &[item.pipeline_id.0, item.pipeline_id.1]);
+                    bool_node(&mut v, "ignore_missing_pipeline", item.ignore_missing_pipeline);
                 }
                 PushStackingContext(item) => {
                     str_node(&mut v, "type", "stacking-context");


### PR DESCRIPTION
In some cases Gecko includes iframes for pipelines that are in other
content processes, and the order in which the display lists reach the
compositor is not deterministic. So it would be better if we could just
have WebRender ignore those pipeline references. In all other cases we
can assert.

This is desirable for https://bugzilla.mozilla.org/show_bug.cgi?id=1454042

r? @kvark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2762)
<!-- Reviewable:end -->
