### PR TITLE
Preliminary cleanup for the blob image stuff

### DIFF
--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -138,12 +138,12 @@ impl CheckerboardRenderer {
 }
 
 impl api::BlobImageRenderer for CheckerboardRenderer {
-    fn add(&mut self, key: api::ImageKey, cmds: api::BlobImageData, _: Option<api::TileSize>) {
+    fn add(&mut self, key: api::ImageKey, cmds: Arc<api::BlobImageData>, _: Option<api::TileSize>) {
         self.image_cmds
             .insert(key, Arc::new(deserialize_blob(&cmds[..]).unwrap()));
     }
 
-    fn update(&mut self, key: api::ImageKey, cmds: api::BlobImageData, _dirty_rect: Option<api::DeviceUintRect>) {
+    fn update(&mut self, key: api::ImageKey, cmds: Arc<api::BlobImageData>, _dirty_rect: Option<api::DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
         self.image_cmds

--- a/webrender/examples/blob.rs
+++ b/webrender/examples/blob.rs
@@ -51,7 +51,7 @@ fn render_blob(
 
     // Allocate storage for the result. Right now the resource cache expects the
     // tiles to have have no stride or offset.
-    let mut texels = Vec::with_capacity((descriptor.width * descriptor.height * 4) as usize);
+    let mut texels = Vec::with_capacity((descriptor.size.width * descriptor.size.height * 4) as usize);
 
     // Generate a per-tile pattern to see it in the demo. For a real use case it would not
     // make sense for the rendered content to depend on its tile.
@@ -60,8 +60,8 @@ fn render_blob(
         None => true,
     };
 
-    for y in 0 .. descriptor.height {
-        for x in 0 .. descriptor.width {
+    for y in 0 .. descriptor.size.height {
+        for x in 0 .. descriptor.size.width {
             // Apply the tile's offset. This is important: all drawing commands should be
             // translated by this offset to give correct results with tiled blob images.
             let x2 = x + descriptor.offset.x as u32;
@@ -97,8 +97,7 @@ fn render_blob(
 
     Ok(api::RasterizedBlobImage {
         data: texels,
-        width: descriptor.width,
-        height: descriptor.height,
+        size: descriptor.size,
     })
 }
 

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, ClipMode, DeviceIntRect, DeviceIntSize};
-use api::{DeviceUintRect, DeviceUintPoint, DeviceUintSize, ExternalImageType, FilterOp, ImageRendering, LayoutRect};
+use api::{DeviceUintRect, DeviceUintPoint, ExternalImageType, FilterOp, ImageRendering, LayoutRect};
 use api::{DeviceIntPoint, SubpixelDirection, YuvColorSpace, YuvFormat};
 use api::{LayoutToWorldTransform, WorldPixel};
 use border::{BorderCornerInstance, BorderCornerSide, BorderEdgeKind};
@@ -1755,10 +1755,7 @@ pub fn resolve_image(
                         uv_rect_handle: cache_handle,
                         uv_rect: DeviceUintRect::new(
                             DeviceUintPoint::zero(),
-                            DeviceUintSize::new(
-                                image_properties.descriptor.width,
-                                image_properties.descriptor.height,
-                            )
+                            image_properties.descriptor.size,
                         ),
                         texture_layer: 0,
                     };

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -1605,8 +1605,8 @@ impl Device {
         let desc = self.gl_describe_format(img_desc.format);
         self.gl.read_pixels(
             0, 0,
-            img_desc.width as i32,
-            img_desc.height as i32,
+            img_desc.size.width as i32,
+            img_desc.size.height as i32,
             desc.external,
             desc.pixel_type,
         )

--- a/webrender/src/glyph_rasterizer/no_pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/no_pathfinder.rs
@@ -7,6 +7,7 @@
 
 use api::{GlyphKey, ImageData, ImageDescriptor, ImageFormat};
 use device::TextureFilter;
+use euclid::size2;
 use gpu_types::UvRectKind;
 use rayon::prelude::*;
 use std::sync::{Arc, MutexGuard};
@@ -172,8 +173,7 @@ impl GlyphRasterizer {
                         texture_cache.update(
                             &mut texture_cache_handle,
                             ImageDescriptor {
-                                width: glyph.width,
-                                height: glyph.height,
+                                size: size2(glyph.width, glyph.height),
                                 stride: None,
                                 format: ImageFormat::BGRA8,
                                 is_opaque: false,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, BorderRadius, BoxShadowClipMode, BuiltDisplayList, ClipMode, ColorF, ComplexClipRegion};
-use api::{DeviceIntRect, DeviceIntSize, DeviceUintSize, DevicePixelScale, Epoch, ExtendMode, FontRenderMode};
+use api::{DeviceIntRect, DeviceIntSize, DevicePixelScale, Epoch, ExtendMode, FontRenderMode};
 use api::{FilterOp, GlyphInstance, GlyphKey, GradientStop, ImageKey, ImageRendering, ItemRange, ItemTag, TileOffset};
 use api::{GlyphRasterSpace, LayoutPoint, LayoutRect, LayoutSize, LayoutToWorldTransform, LayoutVector2D};
 use api::{PipelineId, PremultipliedColorF, PropertyBinding, Shadow, YuvColorSpace, YuvFormat, DeviceIntSideOffsets};
@@ -1471,10 +1471,7 @@ impl PrimitiveStore {
                             if *tile_spacing != LayoutSize::zero() && !is_tiled {
                                 *source = ImageSource::Cache {
                                     // Size in device-pixels we need to allocate in render task cache.
-                                    size: DeviceIntSize::new(
-                                        image_properties.descriptor.width as i32,
-                                        image_properties.descriptor.height as i32
-                                    ),
+                                    size: image_properties.descriptor.size.to_i32(),
                                     handle: None,
                                 };
                             }
@@ -1572,10 +1569,7 @@ impl PrimitiveStore {
 
                             if let Some(tile_size) = image_properties.tiling {
 
-                                let device_image_size = DeviceUintSize::new(
-                                    image_properties.descriptor.width,
-                                    image_properties.descriptor.height,
-                                );
+                                let device_image_size = image_properties.descriptor.size;
 
                                 // Tighten the clip rect because decomposing the repeated image can
                                 // produce primitives that are partially covering the original image

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1898,7 +1898,7 @@ impl Renderer {
 
         let desc = ImageDescriptor::new(1024, 768, ImageFormat::BGRA8, true, false);
         let data = self.device.read_pixels(&desc);
-        let screenshot = debug_server::Screenshot::new(desc.width, desc.height, data);
+        let screenshot = debug_server::Screenshot::new(desc.size.width, desc.size.height, data);
 
         serde_json::to_string(&screenshot).unwrap()
     }
@@ -4411,7 +4411,7 @@ impl Renderer {
                         let (layer_count, filter) = (1, TextureFilter::Linear);
                         let plain_tex = PlainTexture {
                             data: e.key().clone(),
-                            size: (descriptor.width, descriptor.height, layer_count),
+                            size: (descriptor.size.width, descriptor.size.height, layer_count),
                             format: descriptor.format,
                             filter,
                             render_target: None,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -19,6 +19,7 @@ use capture::PlainExternalImage;
 #[cfg(any(feature = "replay", feature = "png"))]
 use capture::CaptureConfig;
 use device::TextureFilter;
+use euclid::size2;
 use glyph_cache::GlyphCache;
 #[cfg(not(feature = "pathfinder"))]
 use glyph_cache::GlyphCacheEntry;
@@ -148,24 +149,23 @@ pub struct ResourceClassCache<K: Hash + Eq, V, U: Default> {
 
 pub fn intersect_for_tile(
     dirty: DeviceUintRect,
-    width: u32,
-    height: u32,
+    clipped_tile_size: DeviceUintSize,
     tile_size: TileSize,
     tile_offset: TileOffset,
 
 ) -> Option<DeviceUintRect> {
-        dirty.intersection(&DeviceUintRect::new(
-            DeviceUintPoint::new(
-                tile_offset.x as u32 * tile_size as u32,
-                tile_offset.y as u32 * tile_size as u32
-            ),
-            DeviceUintSize::new(width, height),
-        )).map(|mut r| {
-                // we can't translate by a negative size so do it manually
-                r.origin.x -= tile_offset.x as u32 * tile_size as u32;
-                r.origin.y -= tile_offset.y as u32 * tile_size as u32;
-                r
-            })
+    dirty.intersection(&DeviceUintRect::new(
+        DeviceUintPoint::new(
+            tile_offset.x as u32 * tile_size as u32,
+            tile_offset.y as u32 * tile_size as u32
+        ),
+        clipped_tile_size,
+    )).map(|mut r| {
+        // we can't translate by a negative size so do it manually
+        r.origin.x -= tile_offset.x as u32 * tile_size as u32;
+        r.origin.y -= tile_offset.y as u32 * tile_size as u32;
+        r
+    })
 }
 
 
@@ -333,7 +333,7 @@ impl ResourceCache {
     }
 
     fn should_tile(limit: u32, descriptor: &ImageDescriptor, data: &ImageData) -> bool {
-        let size_check = descriptor.width > limit || descriptor.height > limit;
+        let size_check = descriptor.size.width > limit || descriptor.size.height > limit;
         match *data {
             ImageData::Raw(_) | ImageData::Blob(_) => size_check,
             ImageData::External(info) => {
@@ -516,8 +516,10 @@ impl ResourceCache {
             data,
             epoch: Epoch(0),
             tiling,
-            dirty_rect: Some(DeviceUintRect::new(DeviceUintPoint::zero(),
-                                                 DeviceUintSize::new(descriptor.width, descriptor.height))),
+            dirty_rect: Some(DeviceUintRect::new(
+                DeviceUintPoint::zero(),
+                descriptor.size,
+            )),
         };
 
         self.resources.image_templates.insert(image_key, resource);
@@ -600,12 +602,12 @@ impl ResourceCache {
         }
 
         let side_size =
-            template.tiling.map_or(cmp::max(template.descriptor.width, template.descriptor.height),
+            template.tiling.map_or(cmp::max(template.descriptor.size.width, template.descriptor.size.height),
                                    |tile_size| tile_size as u32);
         if side_size > self.texture_cache.max_texture_size() {
             // The image or tiling size is too big for hardware texture size.
             warn!("Dropping image, image:(w:{},h:{}, tile:{}) is too big for hardware!",
-                  template.descriptor.width, template.descriptor.height, template.tiling.unwrap_or(0));
+                  template.descriptor.size.width, template.descriptor.size.height, template.tiling.unwrap_or(0));
             self.cached_images.insert(request, Err(ImageCacheError::OverLimitSize));
             return;
         }
@@ -643,10 +645,10 @@ impl ResourceCache {
         //  - The blob hasn't already been requested this frame.
         if self.pending_image_requests.insert(request) && template.data.is_blob() {
             if let Some(ref mut renderer) = self.blob_image_renderer {
-                let (offset, w, h) = match template.tiling {
+                let (offset, size) = match template.tiling {
                     Some(tile_size) => {
                         let tile_offset = request.tile.unwrap();
-                        let (w, h) = compute_tile_size(
+                        let actual_size = compute_tile_size(
                             &template.descriptor,
                             tile_size,
                             tile_offset,
@@ -657,27 +659,22 @@ impl ResourceCache {
                         );
 
                         if let Some(dirty) = template.dirty_rect {
-                            if intersect_for_tile(dirty, w, h, tile_size, tile_offset).is_none() {
+                            if intersect_for_tile(dirty, actual_size, tile_size, tile_offset).is_none() {
                                 // don't bother requesting unchanged tiles
                                 return
                             }
                         }
 
-                        (offset, w, h)
+                        (offset, actual_size)
                     }
-                    None => (
-                        DevicePoint::zero(),
-                        template.descriptor.width,
-                        template.descriptor.height,
-                    ),
+                    None => (DevicePoint::zero(), template.descriptor.size),
                 };
 
                 renderer.request(
                     &self.resources,
                     request.into(),
                     &BlobImageDescriptor {
-                        width: w,
-                        height: h,
+                        size,
                         offset,
                         format: template.descriptor.format,
                     },
@@ -969,11 +966,10 @@ impl ResourceCache {
                 let tile_size = image_template.tiling.unwrap();
                 let image_descriptor = &image_template.descriptor;
 
-                let (actual_width, actual_height) =
-                    compute_tile_size(image_descriptor, tile_size, tile);
+                let clipped_tile_size = compute_tile_size(image_descriptor, tile_size, tile);
 
                 if let Some(dirty) = dirty_rect {
-                    dirty_rect = intersect_for_tile(dirty, actual_width, actual_height, tile_size, tile);
+                    dirty_rect = intersect_for_tile(dirty, clipped_tile_size, tile_size, tile);
                     if dirty_rect.is_none() {
                         continue
                     }
@@ -996,8 +992,7 @@ impl ResourceCache {
                 };
 
                 ImageDescriptor {
-                    width: actual_width,
-                    height: actual_height,
+                    size: clipped_tile_size,
                     stride,
                     offset,
                     ..*image_descriptor
@@ -1019,8 +1014,8 @@ impl ResourceCache {
                     // the most important use cases. We may want to support
                     // mip-maps on shared cache items in the future.
                     if descriptor.allow_mipmaps &&
-                       descriptor.width > 512 &&
-                       descriptor.height > 512 &&
+                       descriptor.size.width > 512 &&
+                       descriptor.size.height > 512 &&
                        !self.texture_cache.is_allowed_in_shared_cache(
                         TextureFilter::Linear,
                         &descriptor,
@@ -1103,24 +1098,24 @@ pub fn compute_tile_size(
     descriptor: &ImageDescriptor,
     base_size: TileSize,
     tile: TileOffset,
-) -> (u32, u32) {
+) -> DeviceUintSize {
     let base_size = base_size as u32;
     // Most tiles are going to have base_size as width and height,
     // except for tiles around the edges that are shrunk to fit the mage data
     // (See decompose_tiled_image in frame.rs).
-    let actual_width = if (tile.x as u32) < descriptor.width / base_size {
+    let actual_width = if (tile.x as u32) < descriptor.size.width / base_size {
         base_size
     } else {
-        descriptor.width % base_size
+        descriptor.size.width % base_size
     };
 
-    let actual_height = if (tile.y as u32) < descriptor.height / base_size {
+    let actual_height = if (tile.y as u32) < descriptor.size.height / base_size {
         base_size
     } else {
-        descriptor.height % base_size
+        descriptor.size.height % base_size
     };
 
-    (actual_width, actual_height)
+    size2(actual_width, actual_height)
 }
 
 #[cfg(any(feature = "capture", feature = "replay"))]
@@ -1246,7 +1241,7 @@ impl ResourceCache {
                     #[cfg(feature = "png")]
                     CaptureConfig::save_png(
                         root.join(format!("images/{}.png", image_id)),
-                        (desc.width, desc.height),
+                        (desc.size.width, desc.size.height),
                         ReadPixelsFormat::Standard(desc.format),
                         &arc,
                     );
@@ -1271,8 +1266,7 @@ impl ResourceCache {
                         &self.resources,
                         request,
                         &BlobImageDescriptor {
-                            width: desc.width,
-                            height: desc.height,
+                            size: desc.size,
                             offset: DevicePoint::zero(),
                             format: desc.format,
                         },
@@ -1280,14 +1274,14 @@ impl ResourceCache {
                     );
                     let result = renderer.resolve(request)
                         .expect("Blob resolve failed");
-                    assert_eq!((result.width, result.height), (desc.width, desc.height));
+                    assert_eq!(result.size, desc.size);
                     assert_eq!(result.data.len(), desc.compute_total_size() as usize);
 
                     num_blobs += 1;
                     #[cfg(feature = "png")]
                     CaptureConfig::save_png(
                         root.join(format!("blobs/{}.png", num_blobs)),
-                        (desc.width, desc.height),
+                        (desc.size.width, desc.size.height),
                         ReadPixelsFormat::Standard(desc.format),
                         &result.data,
                     );

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -6,7 +6,8 @@ extern crate serde_bytes;
 
 use font::{FontInstanceKey, FontKey, FontTemplate};
 use std::sync::Arc;
-use {DevicePoint, DeviceUintRect, IdNamespace, TileOffset, TileSize};
+use {DevicePoint, DeviceUintRect, DeviceUintSize, IdNamespace, TileOffset, TileSize};
+use euclid::size2;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -73,8 +74,7 @@ impl ImageFormat {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImageDescriptor {
     pub format: ImageFormat,
-    pub width: u32,
-    pub height: u32,
+    pub size: DeviceUintSize,
     pub stride: Option<u32>,
     pub offset: u32,
     pub is_opaque: bool,
@@ -90,8 +90,7 @@ impl ImageDescriptor {
         allow_mipmaps: bool,
     ) -> Self {
         ImageDescriptor {
-            width,
-            height,
+            size: size2(width, height),
             format,
             stride: None,
             offset: 0,
@@ -101,12 +100,11 @@ impl ImageDescriptor {
     }
 
     pub fn compute_stride(&self) -> u32 {
-        self.stride
-            .unwrap_or(self.width * self.format.bytes_per_pixel())
+        self.stride.unwrap_or(self.size.width * self.format.bytes_per_pixel())
     }
 
     pub fn compute_total_size(&self) -> u32 {
-        self.compute_stride() * self.height
+        self.compute_stride() * self.size.height
     }
 }
 
@@ -202,15 +200,13 @@ pub type BlobImageResult = Result<RasterizedBlobImage, BlobImageError>;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct BlobImageDescriptor {
-    pub width: u32,
-    pub height: u32,
+    pub size: DeviceUintSize,
     pub offset: DevicePoint,
     pub format: ImageFormat,
 }
 
 pub struct RasterizedBlobImage {
-    pub width: u32,
-    pub height: u32,
+    pub size: DeviceUintSize,
     pub data: Vec<u8>,
 }
 

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -113,7 +113,7 @@ impl ImageDescriptor {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ImageData {
     Raw(#[serde(with = "serde_image_data_raw")] Arc<Vec<u8>>),
-    Blob(#[serde(with = "serde_bytes")] BlobImageData),
+    Blob(#[serde(with = "serde_image_data_raw")] Arc<BlobImageData>),
     External(ExternalImageData),
 }
 
@@ -141,8 +141,8 @@ impl ImageData {
         ImageData::Raw(bytes)
     }
 
-    pub fn new_blob_image(commands: Vec<u8>) -> Self {
-        ImageData::Blob(commands)
+    pub fn new_blob_image(commands: BlobImageData) -> Self {
+        ImageData::Blob(Arc::new(commands))
     }
 
     #[inline]
@@ -172,9 +172,9 @@ pub trait BlobImageResources {
 }
 
 pub trait BlobImageRenderer: Send {
-    fn add(&mut self, key: ImageKey, data: BlobImageData, tiling: Option<TileSize>);
+    fn add(&mut self, key: ImageKey, data: Arc<BlobImageData>, tiling: Option<TileSize>);
 
-    fn update(&mut self, key: ImageKey, data: BlobImageData, dirty_rect: Option<DeviceUintRect>);
+    fn update(&mut self, key: ImageKey, data: Arc<BlobImageData>, dirty_rect: Option<DeviceUintRect>);
 
     fn delete(&mut self, key: ImageKey);
 

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use webrender::api::*;
 use webrender::intersect_for_tile;
+use euclid::size2;
 
 // Serialize/deserialize the blob.
 
@@ -41,7 +42,10 @@ fn render_blob(
 ) -> BlobImageResult {
     // Allocate storage for the result. Right now the resource cache expects the
     // tiles to have have no stride or offset.
-    let mut texels = vec![0u8; (descriptor.width * descriptor.height * descriptor.format.bytes_per_pixel()) as usize];
+    let buf_size = descriptor.size.width *
+        descriptor.size.height *
+        descriptor.format.bytes_per_pixel();
+    let mut texels = vec![0u8; (buf_size) as usize];
 
     // Generate a per-tile pattern to see it in the demo. For a real use case it would not
     // make sense for the rendered content to depend on its tile.
@@ -52,10 +56,10 @@ fn render_blob(
 
     let mut dirty_rect = dirty_rect.unwrap_or(DeviceUintRect::new(
         DeviceUintPoint::new(0, 0),
-        DeviceUintSize::new(descriptor.width, descriptor.height)));
+        DeviceUintSize::new(descriptor.size.width, descriptor.size.height)));
 
     if let Some((tile_size, tile)) = tile {
-        dirty_rect = intersect_for_tile(dirty_rect, tile_size as u32, tile_size as u32,
+        dirty_rect = intersect_for_tile(dirty_rect, size2(tile_size as u32, tile_size as u32),
                                         tile_size, tile)
             .expect("empty rects should be culled by webrender");
     }
@@ -80,13 +84,13 @@ fn render_blob(
             match descriptor.format {
                 ImageFormat::BGRA8 => {
                     let a = color.a * checker + tc;
-                    texels[((y * descriptor.width + x) * 4 + 0) as usize] = premul(color.b * checker + tc, a);
-                    texels[((y * descriptor.width + x) * 4 + 1) as usize] = premul(color.g * checker + tc, a);
-                    texels[((y * descriptor.width + x) * 4 + 2) as usize] = premul(color.r * checker + tc, a);
-                    texels[((y * descriptor.width + x) * 4 + 3) as usize] = a;
+                    texels[((y * descriptor.size.width + x) * 4 + 0) as usize] = premul(color.b * checker + tc, a);
+                    texels[((y * descriptor.size.width + x) * 4 + 1) as usize] = premul(color.g * checker + tc, a);
+                    texels[((y * descriptor.size.width + x) * 4 + 2) as usize] = premul(color.r * checker + tc, a);
+                    texels[((y * descriptor.size.width + x) * 4 + 3) as usize] = a;
                 }
                 ImageFormat::R8 => {
-                    texels[(y * descriptor.width + x) as usize] = color.a * checker + tc;
+                    texels[(y * descriptor.size.width + x) as usize] = color.a * checker + tc;
                 }
                 _ => {
                     return Err(BlobImageError::Other(
@@ -99,8 +103,7 @@ fn render_blob(
 
     Ok(RasterizedBlobImage {
         data: texels,
-        width: descriptor.width,
-        height: descriptor.height,
+        size: descriptor.size,
     })
 }
 

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -134,12 +134,12 @@ impl CheckerboardRenderer {
 }
 
 impl BlobImageRenderer for CheckerboardRenderer {
-    fn add(&mut self, key: ImageKey, cmds: BlobImageData, tile_size: Option<TileSize>) {
+    fn add(&mut self, key: ImageKey, cmds: Arc<BlobImageData>, tile_size: Option<TileSize>) {
         self.image_cmds
             .insert(key, (deserialize_blob(&cmds[..]).unwrap(), tile_size));
     }
 
-    fn update(&mut self, key: ImageKey, cmds: BlobImageData, _dirty_rect: Option<DeviceUintRect>) {
+    fn update(&mut self, key: ImageKey, cmds: Arc<BlobImageData>, _dirty_rect: Option<DeviceUintRect>) {
         // Here, updating is just replacing the current version of the commands with
         // the new one (no incremental updates).
         self.image_cmds.get_mut(&key).unwrap().0 = deserialize_blob(&cmds[..]).unwrap();

--- a/wrench/src/json_frame_writer.rs
+++ b/wrench/src/json_frame_writer.rs
@@ -116,7 +116,7 @@ impl JsonFrameWriter {
             match *update {
                 ResourceUpdate::AddImage(ref img) => {
                     let stride = img.descriptor.stride.unwrap_or(
-                        img.descriptor.width * img.descriptor.format.bytes_per_pixel(),
+                        img.descriptor.size.width * img.descriptor.format.bytes_per_pixel(),
                     );
                     let bytes = match img.data {
                         ImageData::Raw(ref v) => (**v).clone(),
@@ -127,8 +127,8 @@ impl JsonFrameWriter {
                     self.images.insert(
                         img.key,
                         CachedImage {
-                            width: img.descriptor.width,
-                            height: img.descriptor.height,
+                            width: img.descriptor.size.width,
+                            height: img.descriptor.size.height,
                             stride,
                             format: img.descriptor.format,
                             bytes: Some(bytes),
@@ -138,8 +138,8 @@ impl JsonFrameWriter {
                 }
                 ResourceUpdate::UpdateImage(ref img) => {
                     if let Some(ref mut data) = self.images.get_mut(&img.key) {
-                        assert_eq!(data.width, img.descriptor.width);
-                        assert_eq!(data.height, img.descriptor.height);
+                        assert_eq!(data.width, img.descriptor.size.width);
+                        assert_eq!(data.height, img.descriptor.size.height);
                         assert_eq!(data.format, img.descriptor.format);
 
                         if let ImageData::Raw(ref bytes) = img.data {

--- a/wrench/src/ron_frame_writer.rs
+++ b/wrench/src/ron_frame_writer.rs
@@ -100,8 +100,8 @@ impl RonFrameWriter {
                     self.images.insert(
                         img.key,
                         CachedImage {
-                            width: img.descriptor.width,
-                            height: img.descriptor.height,
+                            width: img.descriptor.size.width,
+                            height: img.descriptor.size.height,
                             format: img.descriptor.format,
                             bytes: Some(bytes),
                             path: None,
@@ -110,8 +110,8 @@ impl RonFrameWriter {
                 }
                 ResourceUpdate::UpdateImage(ref img) => {
                     if let Some(ref mut data) = self.images.get_mut(&img.key) {
-                        assert_eq!(data.width, img.descriptor.width);
-                        assert_eq!(data.height, img.descriptor.height);
+                        assert_eq!(data.width, img.descriptor.size.width);
+                        assert_eq!(data.height, img.descriptor.size.height);
                         assert_eq!(data.format, img.descriptor.format);
 
                         if let ImageData::Raw(ref bytes) = img.data {

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -516,7 +516,7 @@ impl YamlFrameReader {
         wrench.api.update_resources(resources);
         let val = (
             image_key,
-            LayoutSize::new(descriptor.width as f32, descriptor.height as f32),
+            LayoutSize::new(descriptor.size.width as f32, descriptor.size.height as f32),
         );
         self.image_map.insert(key, val);
         val

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -514,7 +514,7 @@ impl YamlFrameWriter {
                     }
 
                     let stride = img.descriptor.stride.unwrap_or(
-                        img.descriptor.width * img.descriptor.format.bytes_per_pixel(),
+                        img.descriptor.size.width * img.descriptor.format.bytes_per_pixel(),
                     );
                     let bytes = match img.data {
                         ImageData::Raw(ref v) => (**v).clone(),
@@ -525,8 +525,8 @@ impl YamlFrameWriter {
                     self.images.insert(
                         img.key,
                         CachedImage {
-                            width: img.descriptor.width,
-                            height: img.descriptor.height,
+                            width: img.descriptor.size.width,
+                            height: img.descriptor.size.height,
                             stride,
                             format: img.descriptor.format,
                             bytes: Some(bytes),
@@ -537,8 +537,8 @@ impl YamlFrameWriter {
                 }
                 ResourceUpdate::UpdateImage(ref img) => {
                     if let Some(ref mut data) = self.images.get_mut(&img.key) {
-                        assert_eq!(data.width, img.descriptor.width);
-                        assert_eq!(data.height, img.descriptor.height);
+                        assert_eq!(data.width, img.descriptor.size.width);
+                        assert_eq!(data.height, img.descriptor.size.height);
                         assert_eq!(data.format, img.descriptor.format);
 
                         if let ImageData::Raw(ref bytes) = img.data {


### PR DESCRIPTION
This PR stores the blob image data as an `Arc<Vec<u8>>` internally instead of a `Vec<u8>`. This is needed to do the pre-post scene building tracking of the blob data without needlessly cloning everything all the time.
Since I was going to do a slight breaking change I took the occasion to fix something that's been bothering me forever: storing image sizes as `DeviceUintSize` instead of pairs of `u32`s.

@staktrace heads up it's a slight API change, I'll put up a patch to fixup the bindings tomorrow.

r? anyone, all of the changes are mechanical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2763)
<!-- Reviewable:end -->
