### PR TITLE
Ensure epoch updates and callbacks fire for zero-pixel frames

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -129,25 +129,16 @@ impl TextureUpdateList {
     }
 }
 
-/// Mostly wraps a tiling::Frame, adding a bit of extra information.
+/// Wraps a tiling::Frame, but conceptually could hold more information
 pub struct RenderedDocument {
-    /// The pipeline info contains:
-    /// - The last rendered epoch for each pipeline present in the frame.
-    /// This information is used to know if a certain transformation on the layout has
-    /// been rendered, which is necessary for reftests.
-    /// - Pipelines that were removed from the scene.
-    pub pipeline_info: PipelineInfo,
-
     pub frame: tiling::Frame,
 }
 
 impl RenderedDocument {
     pub fn new(
-        pipeline_info: PipelineInfo,
         frame: tiling::Frame,
     ) -> Self {
         RenderedDocument {
-            pipeline_info,
             frame,
         }
     }
@@ -171,6 +162,7 @@ pub enum ResultMsg {
         updates: TextureUpdateList,
         cancel_rendering: bool,
     },
+    PublishPipelineInfo(PipelineInfo),
     PublishDocument(
         DocumentId,
         RenderedDocument,


### PR DESCRIPTION
Even if the window size is zero in some dimensions (which happens
legitimately in Gecko), we don't want to bail out completely at the
scene building step. We need to pretend to do the work, and send the
necessary epoch updates and callbacks back to Gecko. If we fail to do
this Gecko can end up in a stuck state where it is waiting for a render
that it thinks is going to happen but never does. This patch optimizes
out the rendering step in these cases, rather than doing an early-exit
on the entire codepath.

This is needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1451305

r? @glennw - let me know if there's a better way to do this, or more things we can optimize away. I didn't spend too much time on it, there might be further improvements possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2766)
<!-- Reviewable:end -->
