### PR TITLE
Add a hook for resource-update-only SB transaction completion.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3936,6 +3936,10 @@ pub trait SceneBuilderHooks {
     /// the updated epochs and pipelines removed in the new scene compared to
     /// the old scene.
     fn post_scene_swap(&self, info: PipelineInfo);
+    /// This is called after a resource update operation on the scene builder
+    /// thread, in the case where resource updates were applied without a scene
+    /// build.
+    fn post_resource_update(&self);
     /// This is a generic callback which provides an opportunity to run code
     /// on the scene builder thread. This is called as part of the main message
     /// loop of the scene builder thread, but outside of any specific message

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -162,6 +162,7 @@ impl SceneBuilder {
                     _ => (None, None, None),
                 };
 
+                let has_resources_updates = !resource_updates.is_empty();
                 self.tx.send(SceneBuilderResult::Transaction {
                     document_id,
                     built_scene,
@@ -184,6 +185,10 @@ impl SceneBuilder {
                         },
                         _ => (),
                     };
+                } else if has_resources_updates {
+                    if let &Some(ref hooks) = &self.hooks {
+                        hooks.post_resource_update();
+                    }
                 }
             }
             SceneBuilderRequest::Stop => {


### PR DESCRIPTION
The scene builder might process a transaction which has only resource
updates and no actual display list. In this case we still need to
trigger a composite after the transaction is processed, but we don't
need to the more heavyweight stuff that goes with a scene swap. This
patch adds a new hook that enables the caller to trigger the composite.

This is needed to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1463313

r? @nical or anybody else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2768)
<!-- Reviewable:end -->
