### PR TITLE
This adds an assertion to a rawtest to catch an intermittent

### DIFF
--- a/wrench/src/rawtest.rs
+++ b/wrench/src/rawtest.rs
@@ -253,7 +253,8 @@ impl<'a> RawtestHarness<'a> {
         let called_inner = Arc::clone(&called);
 
         self.wrench.callbacks.lock().unwrap().request = Box::new(move |_| {
-            called_inner.fetch_add(1, Ordering::SeqCst);
+            // we want to ensure this is only ever called once
+            assert_eq!(called_inner.fetch_add(1, Ordering::SeqCst), 0);
         });
 
         let pixels_first = self.render_and_get_pixels(window_rect);


### PR DESCRIPTION
It seems like this test sometimes fails. This should move the crash
earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2775)
<!-- Reviewable:end -->
