### PR TITLE
Clarify combination of old scroll state and new scroll state

### DIFF
--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -211,18 +211,12 @@ impl ClipScrollNode {
         self.children.push(child);
     }
 
-    pub fn apply_old_scrolling_state(&mut self, old_scrolling_state: &ScrollFrameInfo) {
+    pub fn apply_old_scrolling_state(&mut self, old_scroll_info: &ScrollFrameInfo) {
         match self.node_type {
             NodeType::ScrollFrame(ref mut scrolling) => {
-                let scroll_sensitivity = scrolling.scroll_sensitivity;
-                let scrollable_size = scrolling.scrollable_size;
-                let viewport_rect = scrolling.viewport_rect;
-                *scrolling = *old_scrolling_state;
-                scrolling.scroll_sensitivity = scroll_sensitivity;
-                scrolling.scrollable_size = scrollable_size;
-                scrolling.viewport_rect = viewport_rect;
+                *scrolling = scrolling.combine_with_old_scroll_info(old_scroll_info);
             }
-            _ if old_scrolling_state.offset != LayoutVector2D::zero() => {
+            _ if old_scroll_info.offset != LayoutVector2D::zero() => {
                 warn!("Tried to scroll a non-scroll node.")
             }
             _ => {}
@@ -766,6 +760,19 @@ impl ScrollFrameInfo {
         match self.scroll_sensitivity {
             ScrollSensitivity::ScriptAndInputEvents => true,
             ScrollSensitivity::Script => false,
+        }
+    }
+
+    pub fn combine_with_old_scroll_info(
+        self,
+        old_scroll_info: &ScrollFrameInfo
+    ) -> ScrollFrameInfo {
+        ScrollFrameInfo {
+            viewport_rect: self.viewport_rect,
+            offset: old_scroll_info.offset,
+            scroll_sensitivity: self.scroll_sensitivity,
+            scrollable_size: self.scrollable_size,
+            external_id: self.external_id,
         }
     }
 }


### PR DESCRIPTION
The old code led to a lot of errors where new members were not properly
preserved. This new design means that when a member is added, the author
must explicitly decide whether to use the new value or the old value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2780)
<!-- Reviewable:end -->
