### PR TITLE
Use a proper allow attribute.

### DIFF
--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -603,7 +603,7 @@ pub struct ProgramBinary {
 }
 
 impl ProgramBinary {
-    #![allow(unused_variables)]
+    #[allow(unused_variables)]
     fn new(binary: Vec<u8>,
            format: gl::GLenum,
            sources: &ProgramSources) -> Self {


### PR DESCRIPTION
`#![allow(..)]` is supposed to be global, I wouldn't have expected the code to compile, but in any case I suspect it may be allowing unused variables in the whole module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2781)
<!-- Reviewable:end -->
