### PR TITLE
Revert "Debug tracking of display items"

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -26,7 +26,6 @@ use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext};
 use tiling::{ScrollbarPrimitive, SpecialRenderPasses};
 use util::{self, MaxRect, WorldToLayoutFastTransform};
 
-
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -202,31 +202,20 @@ impl PicturePrimitive {
     pub fn add_primitive(
         &mut self,
         prim_index: PrimitiveIndex,
-        clip_and_scroll: ScrollNodeAndClipChain,
-        is_tracked_for_debug: bool,
+        clip_and_scroll: ScrollNodeAndClipChain
     ) {
         if let Some(ref mut run) = self.runs.last_mut() {
             if run.clip_and_scroll == clip_and_scroll &&
                run.base_prim_index.0 + run.count == prim_index.0 {
                 run.count += 1;
-                #[cfg(debug_assertions)]
-                {
-                    run.is_tracked_for_debug |= is_tracked_for_debug;
-                }
                 return;
             }
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            let _ = is_tracked_for_debug;
         }
 
         self.runs.push(PrimitiveRun {
             base_prim_index: prim_index,
             count: 1,
             clip_and_scroll,
-            #[cfg(debug_assertions)]
-            is_tracked_for_debug,
         });
     }
 

--- a/webrender_api/src/color.rs
+++ b/webrender_api/src/color.rs
@@ -115,7 +115,7 @@ pub struct ColorU {
 
 impl ColorU {
     /// Constructs a new additive `ColorU` from its components.
-    pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+    pub fn new(r: u8, g: u8, b: u8, a: u8) -> ColorU {
         ColorU { r, g, b, a }
     }
 }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -67,9 +67,6 @@ pub struct PrimitiveInfo<T> {
     pub clip_rect: TypedRect<f32, T>,
     pub is_backface_visible: bool,
     pub tag: Option<ItemTag>,
-    #[cfg(debug_assertions)]
-    #[serde(skip_serializing, default)]
-    pub is_tracked_for_debug: bool,
 }
 
 impl LayoutPrimitiveInfo {
@@ -86,20 +83,7 @@ impl LayoutPrimitiveInfo {
             clip_rect,
             is_backface_visible: true,
             tag: None,
-            #[cfg(debug_assertions)]
-            is_tracked_for_debug: false,
         }
-    }
-
-    #[cfg(debug_assertions)]
-    #[inline]
-    pub fn is_tracked(&self) -> bool {
-        self.is_tracked_for_debug
-    }
-    #[cfg(not(debug_assertions))]
-    #[inline]
-    pub fn is_tracked(&self) -> bool {
-        false
     }
 }
 

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -349,8 +349,6 @@ impl<'a, 'b> DisplayItemRef<'a, 'b> {
             clip_rect: info.clip_rect.translate(offset),
             is_backface_visible: info.is_backface_visible,
             tag: info.tag,
-            #[cfg(debug_assertions)]
-            is_tracked_for_debug: info.is_tracked_for_debug,
         }
     }
 


### PR DESCRIPTION
This reverts #2725, which causes chaos and destruction in Gecko tests: https://treeherder.mozilla.org/#/jobs?repo=try&revision=12a0fba7254666c7dfba9f4b738093e076de2381&selectedJob=180600645

I'll make sure to test the Gecko binding side before bringing this back.

r? @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2786)
<!-- Reviewable:end -->
