### PR TITLE
Add a debug indicator showing when frames and scene are built.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -132,16 +132,7 @@ impl TextureUpdateList {
 /// Wraps a tiling::Frame, but conceptually could hold more information
 pub struct RenderedDocument {
     pub frame: tiling::Frame,
-}
-
-impl RenderedDocument {
-    pub fn new(
-        frame: tiling::Frame,
-    ) -> Self {
-        RenderedDocument {
-            frame,
-        }
-    }
+    pub is_new_scene: bool,
 }
 
 pub enum DebugOutput {

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -1214,3 +1214,50 @@ impl Profiler {
         }
     }
 }
+
+#[cfg(feature = "debug_renderer")]
+pub struct ChangeIndicator {
+    counter: u32,
+}
+
+#[cfg(feature = "debug_renderer")]
+impl ChangeIndicator {
+    pub fn new() -> Self {
+        ChangeIndicator {
+            counter: 0
+        }
+    }
+
+    pub fn changed(&mut self) {
+        self.counter = (self.counter + 1) % 15;
+    }
+
+    pub fn draw(
+        &self,
+        x: f32, y: f32,
+        color: ColorU,
+        debug_renderer: &mut DebugRenderer
+    ) {
+        let margin = 0.0;
+        let w = 10.0;
+        let h = 5.0;
+        let tx = self.counter as f32 * w;
+        debug_renderer.add_quad(
+            x - margin,
+            y - margin,
+            x + 15.0 * w + margin,
+            y + h + margin,
+            ColorU::new(0, 0, 0, 150),
+            ColorU::new(0, 0, 0, 150),
+        );
+
+        debug_renderer.add_quad(
+            x + tx,
+            y,
+            x + tx + w,
+            y + h,
+            color,
+            ColorU::new(25, 25, 25, 255),
+        );
+    }
+}

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -266,6 +266,7 @@ impl Document {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         resource_profile: &mut ResourceProfileCounters,
+        is_new_scene: bool,
     ) -> RenderedDocument {
         let accumulated_scale_factor = self.view.accumulated_scale_factor();
         let pan = self.view.pan.to_f32() / accumulated_scale_factor;
@@ -289,7 +290,10 @@ impl Document {
             frame
         };
 
-        RenderedDocument::new(frame)
+        RenderedDocument {
+            frame,
+            is_new_scene,
+        }
     }
 
     pub fn updated_pipeline_info(&mut self) -> PipelineInfo {
@@ -1064,6 +1068,7 @@ impl RenderBackend {
                     &mut self.resource_cache,
                     &mut self.gpu_cache,
                     &mut profile_counters.resources,
+                    op.build,
                 );
 
                 debug!("generated frame for document {:?} with {} passes",
@@ -1257,6 +1262,7 @@ impl RenderBackend {
                     &mut self.resource_cache,
                     &mut self.gpu_cache,
                     &mut profile_counters.resources,
+                    true,
                 );
                 //TODO: write down doc's pipeline info?
                 // it has `pipeline_epoch_map`,
@@ -1370,7 +1376,7 @@ impl RenderBackend {
             let render_doc = match CaptureConfig::deserialize::<Frame, _>(root, frame_name) {
                 Some(frame) => {
                     info!("\tloaded a built frame with {} passes", frame.passes.len());
-                    RenderedDocument::new(frame)
+                    RenderedDocument { frame, is_new_scene: true }
                 }
                 None => {
                     last_scene_id += 1;
@@ -1379,6 +1385,7 @@ impl RenderBackend {
                         &mut self.resource_cache,
                         &mut self.gpu_cache,
                         &mut profile_counters.resources,
+                        true,
                     )
                 }
             };

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -561,6 +561,10 @@ pub enum DebugCommand {
     EnableGpuSampleQueries(bool),
     /// Configure if dual-source blending is used, if available.
     EnableDualSourceBlending(bool),
+    /// Show an indicator that moves every time a frame is rendered.
+    EnableNewFrameIndicator(bool),
+    /// Show an indicator that moves every time a scene is built.
+    EnableNewSceneIndicator(bool),
     /// Fetch current documents and display lists.
     FetchDocuments,
     /// Fetch current passes and batches.


### PR DESCRIPTION
This adds a simple way to see when we are rendering frames and building scenes by having a little bar at the top left of the screen that moves if anything changes (the blue one is for frames and the red one for scenes).

![screenshot from 2018-06-01 17-43-42](https://user-images.githubusercontent.com/264854/40849966-adefb3f0-65c3-11e8-8c2b-3d6ec7f0c02b.png)

We seem to run into situations in gecko sometimes where we continuously render at 60fps even though nothing seems to be changing on screen and the motivation is to have a non-intrusive way to spot when that happens (right now the only way is to is to have the profiler HUD on at all times).

This is a simple system and could be used for more things, for example have a pref that sets a time budget per frame beyond which we move an indicator, or to know when lots of textures get uploaded or when the number of batches is higher than what we'd like, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2798)
<!-- Reviewable:end -->
