### PR TITLE
Invalidate drop-shadow data when local rect is animating.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -83,6 +83,7 @@ pub struct PictureContext<'a> {
 pub struct PictureState {
     pub tasks: Vec<RenderTaskId>,
     pub has_non_root_coord_system: bool,
+    pub local_rect_changed: bool,
 }
 
 impl PictureState {
@@ -90,6 +91,7 @@ impl PictureState {
         PictureState {
             tasks: Vec::new(),
             has_non_root_coord_system: false,
+            local_rect_changed: false,
         }
     }
 }

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -467,6 +467,14 @@ impl PicturePrimitive {
                 pic_state.tasks.push(render_task_id);
                 self.surface = Some(PictureSurface::RenderTask(render_task_id));
 
+                // If the local rect of the contents changed, force the cache handle
+                // to be invalidated so that the primitive data below will get
+                // uploaded to the GPU this frame. This can occur during property
+                // animation.
+                if pic_state.local_rect_changed {
+                    frame_state.gpu_cache.invalidate(&mut self.extra_gpu_data_handle);
+                }
+
                 if let Some(mut request) = frame_state.gpu_cache.request(&mut self.extra_gpu_data_handle) {
                     // TODO(gw): This is very hacky code below! It stores an extra
                     //           brush primitive below for the special case of a

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2473,6 +2473,7 @@ impl PrimitiveStore {
                 if new_local_rect != metadata.local_rect {
                     metadata.local_rect = new_local_rect;
                     frame_state.gpu_cache.invalidate(&mut metadata.gpu_location);
+                    pic_state.local_rect_changed = true;
                 }
             }
         }


### PR DESCRIPTION
If the local rect of the content of a drop-shadow is changing
each frame, we also need to invalidate the GPU cache data for
the drop-shadow primitive.

Unfortunately we don't have a way in wrench right now to create
a regression test for this.

Fixes #2721.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2799)
<!-- Reviewable:end -->
