### PR TITLE
Remove TRANSFORM variant of text run shader.

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -22,11 +22,17 @@ VertexInfo write_text_vertex(vec2 clamped_local_pos,
                              PictureTask task,
                              RectWithSize snap_rect,
                              vec2 snap_bias) {
-#if defined(WR_FEATURE_GLYPH_TRANSFORM) || !defined(WR_FEATURE_TRANSFORM)
     // Ensure the transform does not contain a subpixel translation to ensure
     // that glyph snapping is stable for equivalent glyph subpixel positions.
-    scroll_node.transform[3].xy = floor(scroll_node.transform[3].xy + 0.5);
+#if defined(WR_FEATURE_GLYPH_TRANSFORM)
+    bool remove_subpx_offset = true;
+#else
+    bool remove_subpx_offset = scroll_node.is_axis_aligned;
 #endif
+
+    if (remove_subpx_offset) {
+        scroll_node.transform[3].xy = floor(scroll_node.transform[3].xy + 0.5);
+    }
 
     // Transform the current vertex to world space.
     vec4 world_pos = scroll_node.transform * vec4(clamped_local_pos, 0.0, 1.0);
@@ -42,14 +48,16 @@ VertexInfo write_text_vertex(vec2 clamped_local_pos,
 #ifdef WR_FEATURE_GLYPH_TRANSFORM
     // For transformed subpixels, we just need to align the glyph origin to a device pixel.
     final_pos += floor(snap_rect.p0 + snap_bias) - snap_rect.p0;
-#elif !defined(WR_FEATURE_TRANSFORM)
+#else
     // Compute the snapping offset only if the scroll node transform is axis-aligned.
-    final_pos += compute_snap_offset(
-        clamped_local_pos,
-        scroll_node.transform,
-        snap_rect,
-        snap_bias
-    );
+    if (scroll_node.is_axis_aligned) {
+        final_pos += compute_snap_offset(
+            clamped_local_pos,
+            scroll_node.transform,
+            snap_rect,
+            snap_bias
+        );
+    }
 #endif
 
     gl_Position = uTransform * vec4(final_pos, z, 1.0);

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -38,13 +38,6 @@ const OPAQUE_TASK_ADDRESS: RenderTaskAddress = RenderTaskAddress(0x7fff);
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub enum TransformBatchKind {
-    TextRun(GlyphFormat),
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum BrushBatchKind {
     Solid,
     Image(ImageBufferKind),
@@ -64,7 +57,7 @@ pub enum BrushBatchKind {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum BatchKind {
     SplitComposite,
-    Transformable(TransformedRectKind, TransformBatchKind),
+    TextRun(GlyphFormat),
     Brush(BrushBatchKind),
 }
 
@@ -1116,10 +1109,7 @@ impl AlphaBatchBuilder {
                             ],
                         };
 
-                        let kind = BatchKind::Transformable(
-                            transform_kind,
-                            TransformBatchKind::TextRun(glyph_format),
-                        );
+                        let kind = BatchKind::TextRun(glyph_format);
 
                         let (blend_mode, color_mode) = match glyph_format {
                             GlyphFormat::Subpixel |

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -16,7 +16,7 @@ use api::{RenderApiSender, RenderNotifier, TexelRect, TextureTarget};
 use api::{channel};
 use api::DebugCommand;
 use api::channel::PayloadReceiverHelperMethods;
-use batch::{BatchKind, BatchTextures, BrushBatchKind, TransformBatchKind};
+use batch::{BatchKind, BatchTextures, BrushBatchKind};
 #[cfg(any(feature = "capture", feature = "replay"))]
 use capture::{CaptureConfig, ExternalCaptureImage, PlainExternalImage};
 use debug_colors;
@@ -114,7 +114,7 @@ const GPU_TAG_BRUSH_MIXBLEND: GpuProfileTag = GpuProfileTag {
 };
 const GPU_TAG_BRUSH_BLEND: GpuProfileTag = GpuProfileTag {
     label: "B_Blend",
-    color: debug_colors::LIGHTBLUE,
+    color: debug_colors::ORANGE,
 };
 const GPU_TAG_BRUSH_IMAGE: GpuProfileTag = GpuProfileTag {
     label: "B_Image",
@@ -170,21 +170,6 @@ const GPU_SAMPLER_TAG_TRANSPARENT: GpuProfileTag = GpuProfileTag {
     color: debug_colors::BLACK,
 };
 
-impl TransformBatchKind {
-    #[cfg(feature = "debugger")]
-    fn debug_name(&self) -> &'static str {
-        match *self {
-            TransformBatchKind::TextRun(..) => "TextRun",
-        }
-    }
-
-    fn sampler_tag(&self) -> GpuProfileTag {
-        match *self {
-            TransformBatchKind::TextRun(..) => GPU_TAG_PRIM_TEXT_RUN,
-        }
-    }
-}
-
 impl BatchKind {
     #[cfg(feature = "debugger")]
     fn debug_name(&self) -> &'static str {
@@ -201,7 +186,7 @@ impl BatchKind {
                     BrushBatchKind::LinearGradient => "Brush (LinearGradient)",
                 }
             }
-            BatchKind::Transformable(_, batch_kind) => batch_kind.debug_name(),
+            BatchKind::TextRun(_) => "TextRun",
         }
     }
 
@@ -219,7 +204,7 @@ impl BatchKind {
                     BrushBatchKind::LinearGradient => GPU_TAG_BRUSH_LINEAR_GRADIENT,
                 }
             }
-            BatchKind::Transformable(_, batch_kind) => batch_kind.sampler_tag(),
+            BatchKind::TextRun(_) => GPU_TAG_PRIM_TEXT_RUN,
         }
     }
 }


### PR DESCRIPTION
This is a step towards converting the text run shader to be
a brush shader. Like brush shaders, we now determine whether to
apply pixel snapping based on a conditional, rather than a new
shader and batch break.

Remove TransformBatchKind enum, since it's no longer used.

Change the color of B_Blend shader in the profiler, since the
existing color was very close to the color used by the
B_LinearGradient shader, and hard to distinguish between them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2802)
<!-- Reviewable:end -->
