### PR TITLE
support arbitrarily large font sizes

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1094,7 +1094,7 @@ impl AlphaBatchBuilder {
 
                 let font = text_cpu.get_font(
                     ctx.device_pixel_scale,
-                    Some(scroll_node.transform),
+                    scroll_node.transform,
                 );
                 let subpx_dir = font.get_subpx_dir();
 

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -13,7 +13,6 @@ use api::{LineOrientation, LineStyle, LocalClip, NinePatchBorderSource, Pipeline
 use api::{PropertyBinding, ReferenceFrame, RepeatMode, ScrollFrameDisplayItem, ScrollSensitivity};
 use api::{Shadow, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect};
 use api::{TransformStyle, YuvColorSpace, YuvData};
-use app_units::Au;
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
 use clip_scroll_node::{ClipScrollNode, NodeType, StickyFrameInfo};
 use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
@@ -1886,16 +1885,6 @@ impl<'a> DisplayListFlattener<'a> {
 
             // Trivial early out checks
             if font_instance.size.0 <= 0 {
-                return;
-            }
-
-            // Sanity check - anything with glyphs bigger than this
-            // is probably going to consume too much memory to render
-            // efficiently anyway. This is specifically to work around
-            // the font_advance.html reftest, which creates a very large
-            // font as a crash test - the rendering is also ignored
-            // by the azure renderer.
-            if font_instance.size >= Au::from_px(4096) {
                 return;
             }
 

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -20,6 +20,7 @@ pub trait MatrixHelpers<Src, Dst> {
     fn preserves_2d_axis_alignment(&self) -> bool;
     fn has_perspective_component(&self) -> bool;
     fn has_2d_inverse(&self) -> bool;
+    fn exceeds_2d_scale(&self, limit: f64) -> bool;
     fn inverse_project(&self, target: &TypedPoint2D<f32, Dst>) -> Option<TypedPoint2D<f32, Src>>;
     fn inverse_rect_footprint(&self, rect: &TypedRect<f32, Dst>) -> TypedRect<f32, Src>;
     fn transform_kind(&self) -> TransformedRectKind;
@@ -66,6 +67,14 @@ impl<Src, Dst> MatrixHelpers<Src, Dst> for TypedTransform3D<f32, Src, Dst> {
 
     fn has_2d_inverse(&self) -> bool {
         self.m11 * self.m22 - self.m12 * self.m21 != 0.0
+    }
+
+    // Check if the matrix post-scaling on either the X or Y axes could cause geometry
+    // transformed by this matrix to have scaling exceeding the supplied limit.
+    fn exceeds_2d_scale(&self, limit: f64) -> bool {
+        let limit2 = (limit * limit) as f32;
+        self.m11 * self.m11 + self.m12 * self.m12 > limit2 ||
+        self.m21 * self.m21 + self.m22 * self.m22 > limit2
     }
 
     fn inverse_project(&self, target: &TypedPoint2D<f32, Dst>) -> Option<TypedPoint2D<f32, Src>> {

--- a/wrench/reftests/text/large-glyphs.yaml
+++ b/wrench/reftests/text/large-glyphs.yaml
@@ -1,0 +1,8 @@
+--- # Verify that large glyphs actually render at all.
+root: 
+  items: 
+    - text: "HI" 
+      origin: 0 1234
+      size: 1234
+      color: black
+      font: "VeraBd.ttf"

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -59,3 +59,4 @@ fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png
 fuzzy(1,71) platform(linux) == raster-space.yaml raster-space.png
 != allow-subpixel.yaml allow-subpixel-ref.yaml
 == bg-color.yaml bg-color-ref.yaml
+!= large-glyphs.yaml blank.yaml


### PR DESCRIPTION
This fixes Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1432241

At present, we just have a rudimentary check that ignores all fonts whose size is exceeds 4096, with no regard for device pixel scale or even transforms. This thus leads to probably large text will simply disappear from web-pages.

Gecko's Skia backend would normally, after the actual device size hits 1024, would render a glyph as a path instead of using glyph rasterization, which limits the growth of the glyph cache to be within reason.

Since we don't currently have an easy way of using paths right now in WR, as discussed with Glenn, this instead limits the maximum device size of the font to 1024 (like Skia), but from there just scales the glyph in the shader using the same mechanism we use for bitmap glyphs to support arbitrarily large scales. 

While not perfect, this at least allows large text to show up, rather than completely disappear and has similar benefits with respect to limiting the growth of the glyph cache without yet requiring us to conquer native path rendering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2809)
<!-- Reviewable:end -->
