### PR TITLE
Force the render if and only if a new scene is swapped in.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -719,9 +719,14 @@ impl RenderBackend {
                         render,
                         result_tx,
                     } => {
+                        let mut ops = DocumentOps::nop();
                         if let Some(doc) = self.documents.get_mut(&document_id) {
                             if let Some(mut built_scene) = built_scene.take() {
                                 doc.new_async_scene_ready(built_scene);
+                                // After applying the new scene we need to
+                                // rebuild the hit-tester, so we trigger a render
+                                // step.
+                                ops = DocumentOps::render();
                             }
                             if let Some(tx) = result_tx {
                                 let (resume_tx, resume_rx) = channel();
@@ -750,13 +755,13 @@ impl RenderBackend {
                             use_scene_builder_thread: false,
                         };
 
-                        if !transaction_msg.is_empty() {
+                        if !transaction_msg.is_empty() || ops.render {
                             self.update_document(
                                 document_id,
                                 transaction_msg,
                                 &mut frame_counter,
                                 &mut profile_counters,
-                                DocumentOps::render(),
+                                ops,
                             );
                         }
                     },


### PR DESCRIPTION
We need to do a render (or more precisely, rebuild the hit tester) after
an async built scene is swapped in. Prior to this patch, we were
triggering the render on non-empty transactions, but that could include
transactions that didn't actually swap in a scene (i.e just had resource
updates) and could skip cases where we *did* swap in a scene but had an
otherwise empty transaction. The former case led to unnecessary renders
and the latter case led to correctness problems. This patch makes it so
that we trigger the render if and only a new async built scene is
swapped in.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1436567

r? @nical or anybody else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2814)
<!-- Reviewable:end -->
