### PR TITLE
Get the new scene indicator to work with async scene building.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -762,6 +762,7 @@ impl RenderBackend {
                                 &mut frame_counter,
                                 &mut profile_counters,
                                 ops,
+                                true,
                             );
                         }
                     },
@@ -962,6 +963,7 @@ impl RenderBackend {
                     frame_counter,
                     profile_counters,
                     DocumentOps::nop(),
+                    false,
                 )
             }
         }
@@ -976,6 +978,7 @@ impl RenderBackend {
         frame_counter: &mut u32,
         profile_counters: &mut BackendProfileCounters,
         initial_op: DocumentOps,
+        has_built_scene: bool,
     ) {
         let mut op = initial_op;
 
@@ -1073,7 +1076,7 @@ impl RenderBackend {
                     &mut self.resource_cache,
                     &mut self.gpu_cache,
                     &mut profile_counters.resources,
-                    op.build,
+                    op.build || has_built_scene,
                 );
 
                 debug!("generated frame for document {:?} with {} passes",


### PR DESCRIPTION
The recently added new scene indicator only works without async scene building, we just need to patch the information that we just built the scene through `update_document`'s arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2832)
<!-- Reviewable:end -->
