### PR TITLE
Reduce per-instance size from 32 -> 16 bytes.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -16,7 +16,6 @@ void brush_vs(
     vec4 segment_data
 );
 
-#define VECS_PER_BRUSH_PRIM                 2
 #define VECS_PER_SEGMENT                    2
 
 #define BRUSH_FLAG_PERSPECTIVE_INTERPOLATION    1
@@ -24,76 +23,19 @@ void brush_vs(
 #define BRUSH_FLAG_SEGMENT_REPEAT_X             4
 #define BRUSH_FLAG_SEGMENT_REPEAT_Y             8
 
-//Note: these have to match `gpu_types` constants
-#define INT_BITS    (31)
-#define CLIP_CHAIN_RECT_BITS    (22)
-#define SEGMENT_BITS (INT_BITS - CLIP_CHAIN_RECT_BITS)
-#define EDGE_FLAG_BITS (4)
-#define BRUSH_FLAG_BITS (4)
-#define CLIP_SCROLL_INDEX_BITS (INT_BITS - EDGE_FLAG_BITS - BRUSH_FLAG_BITS)
-
-struct BrushInstance {
-    int picture_address;
-    int prim_address;
-    int clip_chain_rect_index;
-    int scroll_node_id;
-    int clip_address;
-    int z;
-    int segment_index;
-    int edge_mask;
-    int flags;
-    ivec3 user_data;
-};
-
-BrushInstance load_brush() {
-    BrushInstance bi;
-
-    bi.picture_address = aData0.x & 0xffff;
-    bi.clip_address = aData0.x >> 16;
-    bi.prim_address = aData0.y;
-    bi.clip_chain_rect_index = aData0.z  & ((1 << CLIP_CHAIN_RECT_BITS) - 1);
-    bi.segment_index = aData0.z >> CLIP_CHAIN_RECT_BITS;
-    bi.z = aData0.w;
-    bi.scroll_node_id = aData1.x & ((1 << CLIP_SCROLL_INDEX_BITS) - 1);
-    bi.edge_mask = (aData1.x >> CLIP_SCROLL_INDEX_BITS) & 0xf;
-    bi.flags = (aData1.x >> (CLIP_SCROLL_INDEX_BITS + EDGE_FLAG_BITS)) & 0xf;
-    bi.user_data = aData1.yzw;
-
-    return bi;
-}
-
-struct BrushPrimitive {
-    RectWithSize local_rect;
-    RectWithSize local_clip_rect;
-};
-
-BrushPrimitive fetch_brush_primitive(int address, int clip_chain_rect_index) {
-    vec4 data[2] = fetch_from_resource_cache_2(address);
-
-    RectWithSize clip_chain_rect = fetch_clip_chain_rect(clip_chain_rect_index);
-    RectWithSize brush_clip_rect = RectWithSize(data[1].xy, data[1].zw);
-    RectWithSize clip_rect = intersect_rects(clip_chain_rect, brush_clip_rect);
-
-    BrushPrimitive prim = BrushPrimitive(RectWithSize(data[0].xy, data[0].zw), clip_rect);
-
-    return prim;
-}
-
 void main(void) {
     // Load the brush instance from vertex attributes.
-    BrushInstance brush = load_brush();
-
-    // Load the geometry for this brush. For now, this is simply the
-    // local rect of the primitive. In the future, this will support
-    // loading segment rects, and other rect formats (glyphs).
-    BrushPrimitive brush_prim =
-        fetch_brush_primitive(brush.prim_address, brush.clip_chain_rect_index);
+    int prim_header_address = aData.x;
+    int clip_address = aData.y;
+    int segment_index = aData.z & 0xffff;
+    int edge_flags = (aData.z >> 16) & 0xff;
+    int brush_flags = (aData.z >> 24) & 0xff;
+    PrimitiveHeader ph = fetch_prim_header(prim_header_address);
 
     // Fetch the segment of this brush primitive we are drawing.
-    int segment_address = brush.prim_address +
-                          VECS_PER_BRUSH_PRIM +
+    int segment_address = ph.specific_prim_address +
                           VECS_PER_SPECIFIC_BRUSH +
-                          brush.segment_index * VECS_PER_SEGMENT;
+                          segment_index * VECS_PER_SEGMENT;
 
     vec4[2] segment_data = fetch_from_resource_cache_2(segment_address);
     RectWithSize local_segment_rect = RectWithSize(segment_data[0].xy, segment_data[0].zw);
@@ -101,20 +43,20 @@ void main(void) {
     VertexInfo vi;
 
     // Fetch the dynamic picture that we are drawing on.
-    PictureTask pic_task = fetch_picture_task(brush.picture_address);
-    ClipArea clip_area = fetch_clip_area(brush.clip_address);
+    PictureTask pic_task = fetch_picture_task(ph.render_task_index);
+    ClipArea clip_area = fetch_clip_area(clip_address);
 
-    ClipScrollNode scroll_node = fetch_clip_scroll_node(brush.scroll_node_id);
+    ClipScrollNode scroll_node = fetch_clip_scroll_node(ph.scroll_node_id);
 
     // Write the normal vertex information out.
     if (scroll_node.is_axis_aligned) {
         vi = write_vertex(
             local_segment_rect,
-            brush_prim.local_clip_rect,
-            float(brush.z),
+            ph.local_clip_rect,
+            ph.z,
             scroll_node,
             pic_task,
-            brush_prim.local_rect
+            ph.local_rect
         );
 
         // TODO(gw): transform bounds may be referenced by
@@ -127,15 +69,15 @@ void main(void) {
         init_transform_vs(vec4(vec2(-1000000.0), vec2(1000000.0)));
 #endif
     } else {
-        bvec4 edge_mask = notEqual(brush.edge_mask & ivec4(1, 2, 4, 8), ivec4(0));
-        bool do_perspective_interpolation = (brush.flags & BRUSH_FLAG_PERSPECTIVE_INTERPOLATION) != 0;
+        bvec4 edge_mask = notEqual(edge_flags & ivec4(1, 2, 4, 8), ivec4(0));
+        bool do_perspective_interpolation = (brush_flags & BRUSH_FLAG_PERSPECTIVE_INTERPOLATION) != 0;
 
         vi = write_transform_vertex(
             local_segment_rect,
-            brush_prim.local_rect,
-            brush_prim.local_clip_rect,
+            ph.local_rect,
+            ph.local_clip_rect,
             mix(vec4(0.0), vec4(1.0), edge_mask),
-            float(brush.z),
+            ph.z,
             scroll_node,
             pic_task,
             do_perspective_interpolation
@@ -158,13 +100,13 @@ void main(void) {
     // Run the specific brush VS code to write interpolators.
     brush_vs(
         vi,
-        brush.prim_address + VECS_PER_BRUSH_PRIM,
-        brush_prim.local_rect,
+        ph.specific_prim_address,
+        ph.local_rect,
         local_segment_rect,
-        brush.user_data,
+        ph.user_data,
         scroll_node.transform,
         pic_task,
-        brush.flags,
+        brush_flags,
         segment_data[1]
     );
 }

--- a/webrender/res/ps_split_composite.glsl
+++ b/webrender/res/ps_split_composite.glsl
@@ -44,10 +44,10 @@ struct SplitCompositeInstance {
 SplitCompositeInstance fetch_composite_instance() {
     SplitCompositeInstance ci;
 
-    ci.render_task_index = aData0.x;
-    ci.src_task_index = aData0.y;
-    ci.polygons_address = aData0.z;
-    ci.z = float(aData0.w);
+    ci.render_task_index = aData.x;
+    ci.src_task_index = aData.y;
+    ci.polygons_address = aData.z;
+    ci.z = float(aData.w);
 
     return ci;
 }

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -15,6 +15,8 @@ varying vec4 vUvClip;
 
 #ifdef WR_VERTEX_SHADER
 
+#define VECS_PER_TEXT_RUN           3
+
 struct Glyph {
     vec2 offset;
 };
@@ -55,84 +57,6 @@ struct TextRun {
 TextRun fetch_text_run(int address) {
     vec4 data[3] = fetch_from_resource_cache_3(address);
     return TextRun(data[0], data[1], data[2].xy);
-}
-
-struct PrimitiveInstance {
-    int prim_address;
-    int specific_prim_address;
-    int render_task_index;
-    int clip_task_index;
-    int scroll_node_id;
-    int clip_chain_rect_index;
-    int z;
-    int user_data0;
-    int user_data1;
-    int user_data2;
-};
-
-PrimitiveInstance fetch_prim_instance() {
-    PrimitiveInstance pi;
-
-    pi.prim_address = aData0.x;
-    pi.specific_prim_address = pi.prim_address + VECS_PER_PRIM_HEADER;
-    pi.render_task_index = aData0.y % 0x10000;
-    pi.clip_task_index = aData0.y / 0x10000;
-    pi.clip_chain_rect_index = aData0.z;
-    pi.scroll_node_id = aData0.w;
-    pi.z = aData1.x;
-    pi.user_data0 = aData1.y;
-    pi.user_data1 = aData1.z;
-    pi.user_data2 = aData1.w;
-
-    return pi;
-}
-
-struct Primitive {
-    ClipScrollNode scroll_node;
-    ClipArea clip_area;
-    PictureTask task;
-    RectWithSize local_rect;
-    RectWithSize local_clip_rect;
-    int specific_prim_address;
-    int user_data0;
-    int user_data1;
-    int user_data2;
-    float z;
-};
-
-struct PrimitiveGeometry {
-    RectWithSize local_rect;
-    RectWithSize local_clip_rect;
-};
-
-PrimitiveGeometry fetch_primitive_geometry(int address) {
-    vec4 geom[2] = fetch_from_resource_cache_2(address);
-    return PrimitiveGeometry(RectWithSize(geom[0].xy, geom[0].zw),
-                             RectWithSize(geom[1].xy, geom[1].zw));
-}
-
-Primitive load_primitive() {
-    PrimitiveInstance pi = fetch_prim_instance();
-
-    Primitive prim;
-
-    prim.scroll_node = fetch_clip_scroll_node(pi.scroll_node_id);
-    prim.clip_area = fetch_clip_area(pi.clip_task_index);
-    prim.task = fetch_picture_task(pi.render_task_index);
-
-    RectWithSize clip_chain_rect = fetch_clip_chain_rect(pi.clip_chain_rect_index);
-
-    PrimitiveGeometry geom = fetch_primitive_geometry(pi.prim_address);
-    prim.local_rect = geom.local_rect;
-    prim.local_clip_rect = intersect_rects(clip_chain_rect, geom.local_clip_rect);
-
-    prim.specific_prim_address = pi.specific_prim_address;
-    prim.user_data0 = pi.user_data0;
-    prim.user_data1 = pi.user_data1;
-    prim.user_data2 = pi.user_data2;
-    prim.z = float(pi.z);
-
-    return prim;
 }
 
 VertexInfo write_text_vertex(vec2 clamped_local_pos,
@@ -201,24 +125,30 @@ VertexInfo write_text_vertex(vec2 clamped_local_pos,
 }
 
 void main(void) {
-    Primitive prim = load_primitive();
-    TextRun text = fetch_text_run(prim.specific_prim_address);
+    int prim_header_address = aData.x;
+    int glyph_index = aData.y;
+    int resource_address = aData.z;
+    int subpx_dir = aData.w >> 16;
+    int color_mode = aData.w & 0xffff;
 
-    int glyph_index = prim.user_data0;
-    int resource_address = prim.user_data1;
-    int subpx_dir = prim.user_data2 >> 16;
-    int color_mode = prim.user_data2 & 0xffff;
+    PrimitiveHeader ph = fetch_prim_header(prim_header_address);
+
+    ClipScrollNode scroll_node = fetch_clip_scroll_node(ph.scroll_node_id);
+    ClipArea clip_area = fetch_clip_area(ph.clip_task_index);
+    PictureTask task = fetch_picture_task(ph.render_task_index);
+
+    TextRun text = fetch_text_run(ph.specific_prim_address);
 
     if (color_mode == COLOR_MODE_FROM_PASS) {
         color_mode = uMode;
     }
 
-    Glyph glyph = fetch_glyph(prim.specific_prim_address, glyph_index);
+    Glyph glyph = fetch_glyph(ph.specific_prim_address, glyph_index);
     GlyphResource res = fetch_glyph_resource(resource_address);
 
 #ifdef WR_FEATURE_GLYPH_TRANSFORM
     // Transform from local space to glyph space.
-    mat2 transform = mat2(prim.scroll_node.transform) * uDevicePixelRatio;
+    mat2 transform = mat2(scroll_node.transform) * uDevicePixelRatio;
 
     // Compute the glyph rect in glyph space.
     RectWithSize glyph_rect = RectWithSize(res.offset + transform * (text.offset + glyph.offset),
@@ -234,9 +164,9 @@ void main(void) {
     // If the glyph's local rect would fit inside the local clip rect, then select a corner from
     // the device space glyph rect to reduce overdraw of clipped pixels in the fragment shader.
     // Otherwise, fall back to clamping the glyph's local rect to the local clip rect.
-    local_pos = rect_inside_rect(local_rect, prim.local_clip_rect) ?
+    local_pos = rect_inside_rect(local_rect, ph.local_clip_rect) ?
                     inv * (glyph_rect.p0 + glyph_rect.size * aPosition.xy) :
-                    clamp_rect(local_pos, prim.local_clip_rect);
+                    clamp_rect(local_pos, ph.local_clip_rect);
 #else
     // Scale from glyph space to local space.
     float scale = res.scale / uDevicePixelRatio;
@@ -249,7 +179,7 @@ void main(void) {
     vec2 local_pos = glyph_rect.p0 + glyph_rect.size * aPosition.xy;
 
     // Clamp to the local clip rect.
-    local_pos = clamp_rect(local_pos, prim.local_clip_rect);
+    local_pos = clamp_rect(local_pos, ph.local_clip_rect);
 #endif
 
     vec2 snap_bias;
@@ -278,10 +208,10 @@ void main(void) {
     }
 
     VertexInfo vi = write_text_vertex(local_pos,
-                                      prim.local_clip_rect,
-                                      prim.z,
-                                      prim.scroll_node,
-                                      prim.task,
+                                      ph.local_clip_rect,
+                                      ph.z,
+                                      scroll_node,
+                                      task,
                                       text.offset,
                                       glyph_rect,
                                       snap_bias);
@@ -293,7 +223,7 @@ void main(void) {
     vec2 f = (vi.local_pos - glyph_rect.p0) / glyph_rect.size;
 #endif
 
-    write_clip(vi.screen_pos, prim.clip_area);
+    write_clip(vi.screen_pos, clip_area);
 
     switch (color_mode) {
         case COLOR_MODE_ALPHA:

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -11,10 +11,10 @@ use clip_scroll_tree::{CoordinateSystemId};
 use euclid::{TypedTransform3D, vec3};
 use glyph_rasterizer::GlyphFormat;
 use gpu_cache::{GpuCache, GpuCacheHandle, GpuCacheAddress};
-use gpu_types::{BrushFlags, BrushInstance, ClipChainRectIndex};
+use gpu_types::{BrushFlags, BrushInstance, PrimitiveHeaders};
 use gpu_types::{ClipMaskInstance, ClipScrollNodeIndex, SplitCompositeInstance};
-use gpu_types::{PrimitiveInstance, RasterizationSpace, GlyphInstance, ZBufferId};
-use gpu_types::ZBufferIdGenerator;
+use gpu_types::{PrimitiveInstance, RasterizationSpace, GlyphInstance};
+use gpu_types::{PrimitiveHeader, PrimitiveHeaderIndex};
 use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{PictureCompositeMode, PicturePrimitive, PictureSurface};
 use plane_split::{BspSplitter, Polygon, Splitter};
@@ -455,7 +455,7 @@ impl AlphaBatchBuilder {
         gpu_cache: &mut GpuCache,
         render_tasks: &RenderTaskTree,
         deferred_resolves: &mut Vec<DeferredResolve>,
-        z_generator: &mut ZBufferIdGenerator,
+        prim_headers: &mut PrimitiveHeaders,
     ) {
         let task_address = render_tasks.get_task_address(task_id);
 
@@ -488,7 +488,7 @@ impl AlphaBatchBuilder {
                 deferred_resolves,
                 &mut splitter,
                 content_origin,
-                z_generator,
+                prim_headers,
             );
         }
 
@@ -526,7 +526,7 @@ impl AlphaBatchBuilder {
                 task_address,
                 source_task_address,
                 gpu_address,
-                z_generator.next(),
+                prim_headers.z_generator.next(),
             );
 
             batch.push(PrimitiveInstance::from(instance));
@@ -548,7 +548,7 @@ impl AlphaBatchBuilder {
         deferred_resolves: &mut Vec<DeferredResolve>,
         splitter: &mut BspSplitter<f64, WorldPixel>,
         content_origin: DeviceIntPoint,
-        z_generator: &mut ZBufferIdGenerator,
+        prim_headers: &mut PrimitiveHeaders,
     ) {
         for i in 0 .. run.count {
             let prim_index = PrimitiveIndex(run.base_prim_index.0 + i);
@@ -556,7 +556,6 @@ impl AlphaBatchBuilder {
 
             if metadata.screen_rect.is_some() {
                 self.add_prim_to_batch(
-                    metadata.clip_chain_rect_index,
                     scroll_id,
                     prim_index,
                     ctx,
@@ -567,7 +566,7 @@ impl AlphaBatchBuilder {
                     deferred_resolves,
                     splitter,
                     content_origin,
-                    z_generator,
+                    prim_headers,
                 );
             }
         }
@@ -579,7 +578,6 @@ impl AlphaBatchBuilder {
     // in that picture are being drawn into the same target.
     fn add_prim_to_batch(
         &mut self,
-        clip_chain_rect_index: ClipChainRectIndex,
         scroll_id: ClipScrollNodeIndex,
         prim_index: PrimitiveIndex,
         ctx: &RenderTargetContext,
@@ -590,9 +588,8 @@ impl AlphaBatchBuilder {
         deferred_resolves: &mut Vec<DeferredResolve>,
         splitter: &mut BspSplitter<f64, WorldPixel>,
         content_origin: DeviceIntPoint,
-        z_generator: &mut ZBufferIdGenerator,
+        prim_headers: &mut PrimitiveHeaders,
     ) {
-        let z = z_generator.next();
         let prim_metadata = ctx.prim_store.get_metadata(prim_index);
         #[cfg(debug_assertions)] //TODO: why is this needed?
         debug_assert_eq!(prim_metadata.prepared_frame_id, render_tasks.frame_id());
@@ -648,6 +645,15 @@ impl AlphaBatchBuilder {
             BlendMode::None
         };
 
+        let prim_header = PrimitiveHeader {
+            local_rect: prim_metadata.local_rect,
+            local_clip_rect: prim_metadata.combined_local_clip_rect,
+            task_address,
+            specific_prim_address: prim_cache_address,
+            clip_task_address,
+            scroll_id,
+        };
+
         match prim_metadata.prim_kind {
             PrimitiveKind::Brush => {
                 let brush = &ctx.prim_store.cpu_brushes[prim_metadata.cpu_prim_index.0];
@@ -701,23 +707,19 @@ impl AlphaBatchBuilder {
                                                     textures,
                                                 );
                                                 let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
+                                                let prim_header_index = prim_headers.push(&prim_header, [
+                                                    uv_rect_address.as_int(),
+                                                    (ShaderColorMode::ColorBitmap as i32) << 16 |
+                                                    RasterizationSpace::Screen as i32,
+                                                    0,
+                                                ]);
 
                                                 let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
-                                                    clip_task_address,
-                                                    z,
+                                                    prim_header_index,
                                                     segment_index: 0,
                                                     edge_flags: EdgeAaSegmentMask::empty(),
                                                     brush_flags: BrushFlags::empty(),
-                                                    user_data: [
-                                                        uv_rect_address.as_int(),
-                                                        (ShaderColorMode::ColorBitmap as i32) << 16 |
-                                                        RasterizationSpace::Screen as i32,
-                                                        0,
-                                                    ],
+                                                    clip_task_address,
                                                 };
                                                 batch.push(PrimitiveInstance::from(instance));
                                                 false
@@ -727,7 +729,7 @@ impl AlphaBatchBuilder {
                                             }
                                         }
                                     }
-                                    FilterOp::DropShadow(..) => {
+                                    FilterOp::DropShadow(offset, ..) => {
                                         // Draw an instance of the shadow first, following by the content.
 
                                         // Both the shadow and the content get drawn as a brush image.
@@ -768,33 +770,44 @@ impl AlphaBatchBuilder {
                                             // Get the GPU cache address of the extra data handle.
                                             let shadow_prim_address = gpu_cache.get_address(&picture.extra_gpu_data_handle);
 
+                                            let content_prim_header_index = prim_headers.push(&prim_header, [
+                                                content_uv_rect_address,
+                                                (ShaderColorMode::ColorBitmap as i32) << 16 |
+                                                RasterizationSpace::Screen as i32,
+                                                0,
+                                            ]);
+
+                                            let shadow_rect = prim_metadata.local_rect.translate(&offset);
+                                            let shadow_clip_rect = prim_metadata.local_clip_rect.translate(&offset);
+
+                                            let shadow_prim_header = PrimitiveHeader {
+                                                local_rect: shadow_rect,
+                                                local_clip_rect: shadow_clip_rect,
+                                                specific_prim_address: shadow_prim_address,
+                                                ..prim_header
+                                            };
+
+                                            let shadow_prim_header_index = prim_headers.push(&shadow_prim_header, [
+                                                shadow_uv_rect_address,
+                                                (ShaderColorMode::Alpha as i32) << 16 |
+                                                RasterizationSpace::Screen as i32,
+                                                0,
+                                            ]);
+
                                             let shadow_instance = BrushInstance {
-                                                picture_address: task_address,
-                                                prim_address: shadow_prim_address,
-                                                clip_chain_rect_index,
-                                                scroll_id,
+                                                prim_header_index: shadow_prim_header_index,
                                                 clip_task_address,
-                                                z,
                                                 segment_index: 0,
                                                 edge_flags: EdgeAaSegmentMask::empty(),
                                                 brush_flags: BrushFlags::empty(),
-                                                user_data: [
-                                                    shadow_uv_rect_address,
-                                                    (ShaderColorMode::Alpha as i32) << 16 |
-                                                    RasterizationSpace::Screen as i32,
-                                                    0,
-                                                ],
                                             };
 
                                             let content_instance = BrushInstance {
-                                                prim_address: prim_cache_address,
-                                                user_data: [
-                                                    content_uv_rect_address,
-                                                    (ShaderColorMode::ColorBitmap as i32) << 16 |
-                                                    RasterizationSpace::Screen as i32,
-                                                    0,
-                                                ],
-                                                ..shadow_instance
+                                                prim_header_index: content_prim_header_index,
+                                                clip_task_address,
+                                                segment_index: 0,
+                                                edge_flags: EdgeAaSegmentMask::empty(),
+                                                brush_flags: BrushFlags::empty(),
                                             };
 
                                             self.batch_list
@@ -856,22 +869,18 @@ impl AlphaBatchBuilder {
 
                                                 let cache_task_id = surface.resolve_render_task_id();
                                                 let cache_task_address = render_tasks.get_task_address(cache_task_id);
+                                                let prim_header_index = prim_headers.push(&prim_header, [
+                                                    cache_task_address.0 as i32,
+                                                    filter_mode,
+                                                    user_data,
+                                                ]);
 
                                                 let instance = BrushInstance {
-                                                    picture_address: task_address,
-                                                    prim_address: prim_cache_address,
-                                                    clip_chain_rect_index,
-                                                    scroll_id,
+                                                    prim_header_index,
                                                     clip_task_address,
-                                                    z,
                                                     segment_index: 0,
                                                     edge_flags: EdgeAaSegmentMask::empty(),
                                                     brush_flags: BrushFlags::empty(),
-                                                    user_data: [
-                                                        cache_task_address.0 as i32,
-                                                        filter_mode,
-                                                        user_data,
-                                                    ],
                                                 };
 
                                                 let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
@@ -907,22 +916,18 @@ impl AlphaBatchBuilder {
                                 let batch = self.batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
                                 let backdrop_task_address = render_tasks.get_task_address(backdrop_id);
                                 let source_task_address = render_tasks.get_task_address(cache_task_id);
+                                let prim_header_index = prim_headers.push(&prim_header, [
+                                    mode as u32 as i32,
+                                    backdrop_task_address.0 as i32,
+                                    source_task_address.0 as i32,
+                                ]);
 
                                 let instance = BrushInstance {
-                                    picture_address: task_address,
-                                    prim_address: prim_cache_address,
-                                    clip_chain_rect_index,
-                                    scroll_id,
+                                    prim_header_index,
                                     clip_task_address,
-                                    z,
                                     segment_index: 0,
                                     edge_flags: EdgeAaSegmentMask::empty(),
                                     brush_flags: BrushFlags::empty(),
-                                    user_data: [
-                                        mode as u32 as i32,
-                                        backdrop_task_address.0 as i32,
-                                        source_task_address.0 as i32,
-                                    ],
                                 };
 
                                 batch.push(PrimitiveInstance::from(instance));
@@ -950,23 +955,19 @@ impl AlphaBatchBuilder {
                                 let uv_rect_address = render_tasks[cache_task_id]
                                     .get_texture_address(gpu_cache)
                                     .as_int();
+                                let prim_header_index = prim_headers.push(&prim_header, [
+                                    uv_rect_address,
+                                    (ShaderColorMode::ColorBitmap as i32) << 16 |
+                                    RasterizationSpace::Screen as i32,
+                                    0,
+                                ]);
 
                                 let instance = BrushInstance {
-                                    picture_address: task_address,
-                                    prim_address: prim_cache_address,
-                                    clip_chain_rect_index,
-                                    scroll_id,
+                                    prim_header_index,
                                     clip_task_address,
-                                    z,
                                     segment_index: 0,
                                     edge_flags: EdgeAaSegmentMask::empty(),
                                     brush_flags: BrushFlags::empty(),
-                                    user_data: [
-                                        uv_rect_address,
-                                        (ShaderColorMode::ColorBitmap as i32) << 16 |
-                                        RasterizationSpace::Screen as i32,
-                                        0,
-                                    ],
                                 };
                                 batch.push(PrimitiveInstance::from(instance));
                                 false
@@ -986,7 +987,7 @@ impl AlphaBatchBuilder {
                                 gpu_cache,
                                 render_tasks,
                                 deferred_resolves,
-                                z_generator,
+                                prim_headers,
                             );
                         }
                     }
@@ -999,18 +1000,21 @@ impl AlphaBatchBuilder {
                                     request.with_tile(tile.tile_offset),
                             ) {
                                 let prim_cache_address = gpu_cache.get_address(&tile.handle);
+                                let prim_header = PrimitiveHeader {
+                                    specific_prim_address: prim_cache_address,
+                                    local_rect: tile.local_rect,
+                                    local_clip_rect: tile.local_clip_rect,
+                                    ..prim_header
+                                };
+                                let prim_header_index = prim_headers.push(&prim_header, user_data);
+
                                 self.add_image_tile_to_batch(
                                     batch_kind,
                                     specified_blend_mode,
                                     textures,
-                                    clip_chain_rect_index,
+                                    prim_header_index,
                                     clip_task_address,
                                     &task_relative_bounding_rect,
-                                    prim_cache_address,
-                                    scroll_id,
-                                    task_address,
-                                    z,
-                                    user_data,
                                     tile.edge_flags
                                 );
                             }
@@ -1023,13 +1027,11 @@ impl AlphaBatchBuilder {
                             BrushBatchKind::LinearGradient,
                             specified_blend_mode,
                             &task_relative_bounding_rect,
-                            clip_chain_rect_index,
-                            scroll_id,
-                            task_address,
                             clip_task_address,
-                            z,
                             gpu_cache,
                             &mut self.batch_list,
+                            &prim_header,
+                            prim_headers,
                         );
                     }
                     BrushKind::RadialGradient { ref stops_handle, ref visible_tiles, .. } if !visible_tiles.is_empty() => {
@@ -1039,13 +1041,11 @@ impl AlphaBatchBuilder {
                             BrushBatchKind::RadialGradient,
                             specified_blend_mode,
                             &task_relative_bounding_rect,
-                            clip_chain_rect_index,
-                            scroll_id,
-                            task_address,
                             clip_task_address,
-                            z,
                             gpu_cache,
                             &mut self.batch_list,
+                            &prim_header,
+                            prim_headers,
                         );
                     }
                     _ => {
@@ -1054,6 +1054,8 @@ impl AlphaBatchBuilder {
                                 gpu_cache,
                                 deferred_resolves,
                         ) {
+                            let prim_header_index = prim_headers.push(&prim_header, user_data);
+
                             self.add_brush_to_batch(
                                 brush,
                                 prim_metadata,
@@ -1061,16 +1063,11 @@ impl AlphaBatchBuilder {
                                 specified_blend_mode,
                                 non_segmented_blend_mode,
                                 textures,
-                                clip_chain_rect_index,
+                                prim_header_index,
                                 clip_task_address,
                                 &task_relative_bounding_rect,
-                                prim_cache_address,
-                                scroll_id,
-                                task_address,
                                 transform_kind,
-                                z,
                                 render_tasks,
-                                user_data,
                             );
                         }
                     }
@@ -1155,15 +1152,11 @@ impl AlphaBatchBuilder {
                             }
                         };
 
+                        let prim_header_index = prim_headers.push(&prim_header, [0; 3]);
                         let key = BatchKey::new(kind, blend_mode, textures);
                         let batch = batch_list.get_suitable_batch(key, &task_relative_bounding_rect);
                         let base_instance = GlyphInstance::new(
-                            prim_cache_address,
-                            task_address,
-                            clip_task_address,
-                            clip_chain_rect_index,
-                            scroll_id,
-                            z,
+                            prim_header_index,
                         );
 
                         for glyph in glyphs {
@@ -1185,27 +1178,17 @@ impl AlphaBatchBuilder {
         batch_kind: BrushBatchKind,
         blend_mode: BlendMode,
         textures: BatchTextures,
-        clip_chain_rect_index: ClipChainRectIndex,
+        prim_header_index: PrimitiveHeaderIndex,
         clip_task_address: RenderTaskAddress,
         task_relative_bounding_rect: &DeviceIntRect,
-        prim_cache_address: GpuCacheAddress,
-        scroll_id: ClipScrollNodeIndex,
-        task_address: RenderTaskAddress,
-        z: ZBufferId,
-        user_data: [i32; 3],
         edge_flags: EdgeAaSegmentMask,
     ) {
         let base_instance = BrushInstance {
-            picture_address: task_address,
-            prim_address: prim_cache_address,
-            clip_chain_rect_index,
-            scroll_id,
+            prim_header_index,
             clip_task_address,
-            z,
             segment_index: 0,
             edge_flags,
             brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-            user_data,
         };
 
         self.batch_list.add_bounding_rect(task_relative_bounding_rect);
@@ -1227,28 +1210,18 @@ impl AlphaBatchBuilder {
         alpha_blend_mode: BlendMode,
         non_segmented_blend_mode: BlendMode,
         textures: BatchTextures,
-        clip_chain_rect_index: ClipChainRectIndex,
+        prim_header_index: PrimitiveHeaderIndex,
         clip_task_address: RenderTaskAddress,
         task_relative_bounding_rect: &DeviceIntRect,
-        prim_cache_address: GpuCacheAddress,
-        scroll_id: ClipScrollNodeIndex,
-        task_address: RenderTaskAddress,
         transform_kind: TransformedRectKind,
-        z: ZBufferId,
         render_tasks: &RenderTaskTree,
-        user_data: [i32; 3],
     ) {
         let base_instance = BrushInstance {
-            picture_address: task_address,
-            prim_address: prim_cache_address,
-            clip_chain_rect_index,
-            scroll_id,
+            prim_header_index,
             clip_task_address,
-            z,
             segment_index: 0,
             edge_flags: EdgeAaSegmentMask::all(),
             brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-            user_data,
         };
 
         self.batch_list.add_bounding_rect(task_relative_bounding_rect);
@@ -1326,13 +1299,11 @@ fn add_gradient_tiles(
     kind: BrushBatchKind,
     blend_mode: BlendMode,
     task_relative_bounding_rect: &DeviceIntRect,
-    clip_chain_rect_index: ClipChainRectIndex,
-    scroll_id: ClipScrollNodeIndex,
-    task_address: RenderTaskAddress,
     clip_task_address: RenderTaskAddress,
-    z: ZBufferId,
     gpu_cache: &GpuCache,
     batch_list: &mut BatchList,
+    base_prim_header: &PrimitiveHeader,
+    prim_headers: &mut PrimitiveHeaders,
 ) {
     batch_list.add_bounding_rect(task_relative_bounding_rect);
     let batch = batch_list.get_suitable_batch(
@@ -1346,24 +1317,22 @@ fn add_gradient_tiles(
 
     let user_data = [stops_handle.as_int(gpu_cache), 0, 0];
 
-    let base_instance = BrushInstance {
-        picture_address: task_address,
-        prim_address: GpuCacheAddress::invalid(),
-        clip_chain_rect_index,
-        scroll_id,
-        clip_task_address,
-        z,
-        segment_index: 0,
-        edge_flags: EdgeAaSegmentMask::all(),
-        brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
-        user_data,
-    };
-
     for tile in visible_tiles {
+        let prim_header = PrimitiveHeader {
+            specific_prim_address: gpu_cache.get_address(&tile.handle),
+            local_rect: tile.local_rect,
+            local_clip_rect: tile.local_clip_rect,
+            ..*base_prim_header
+        };
+        let prim_header_index = prim_headers.push(&prim_header, user_data);
+
         batch.push(PrimitiveInstance::from(
             BrushInstance {
-                prim_address: gpu_cache.get_address(&tile.handle),
-                ..base_instance
+                prim_header_index,
+                clip_task_address,
+                segment_index: 0,
+                edge_flags: EdgeAaSegmentMask::all(),
+                brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
             }
         ));
     }

--- a/webrender/src/device.rs
+++ b/webrender/src/device.rs
@@ -2234,6 +2234,11 @@ impl Device {
                 external: gl::RGBA,
                 pixel_type: gl::FLOAT,
             },
+            ImageFormat::RGBAI32 => FormatDesc {
+                internal: gl::RGBA32I as _,
+                external: gl::RGBA_INTEGER,
+                pixel_type: gl::INT,
+            },
             ImageFormat::RG8 => FormatDesc {
                 internal: gl::RG8 as _,
                 external: gl::RG,
@@ -2360,6 +2365,7 @@ impl<'a> UploadTarget<'a> {
             ImageFormat::BGRA8 => (self.bgra_format, 4, gl::UNSIGNED_BYTE),
             ImageFormat::RG8 => (gl::RG, 2, gl::UNSIGNED_BYTE),
             ImageFormat::RGBAF32 => (gl::RGBA, 16, gl::FLOAT),
+            ImageFormat::RGBAI32 => (gl::RGBA_INTEGER, 16, gl::INT),
         };
 
         let row_length = match chunk.stride {

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -2,29 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DevicePoint, DeviceSize, DeviceRect, LayoutToWorldTransform};
+use api::{DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform};
 use api::{PremultipliedColorF, WorldToLayoutTransform};
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
-use prim_store::{VECS_PER_SEGMENT, EdgeAaSegmentMask};
+use prim_store::{EdgeAaSegmentMask};
 use render_task::RenderTaskAddress;
-use renderer::MAX_VERTEX_TEXTURE_WIDTH;
 
 // Contains type that must exactly match the same structures declared in GLSL.
 
-const INT_BITS: usize = 31; //TODO: convert to unsigned
-const CLIP_CHAIN_RECT_BITS: usize = 22;
-const SEGMENT_BITS: usize = INT_BITS - CLIP_CHAIN_RECT_BITS;
-// The guard ensures (at compile time) that the designated number of bits cover
-// the maximum supported segment count for the texture width.
-const _SEGMENT_GUARD: usize = (1 << SEGMENT_BITS) * VECS_PER_SEGMENT - MAX_VERTEX_TEXTURE_WIDTH;
-const EDGE_FLAG_BITS: usize = 4;
-const BRUSH_FLAG_BITS: usize = 4;
-const CLIP_SCROLL_INDEX_BITS: usize = INT_BITS - EDGE_FLAG_BITS - BRUSH_FLAG_BITS;
-
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct ZBufferId(i32);
 
+#[derive(Debug)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct ZBufferIdGenerator {
     next: i32,
 }
@@ -135,50 +129,124 @@ pub struct ClipMaskBorderCornerDotDash {
     pub dot_dash_data: [f32; 8],
 }
 
-// 32 bytes per instance should be enough for anyone!
+// 16 bytes per instance should be enough for anyone!
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PrimitiveInstance {
-    data: [i32; 8],
+    data: [i32; 4],
+}
+
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct PrimitiveHeaderIndex(pub i32);
+
+#[derive(Debug)]
+#[repr(C)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct PrimitiveHeaders {
+    // The integer-type headers for a primitive.
+    pub headers_int: Vec<PrimitiveHeaderI>,
+    // The float-type headers for a primitive.
+    pub headers_float: Vec<PrimitiveHeaderF>,
+    // Used to generated a unique z-buffer value per primitive.
+    pub z_generator: ZBufferIdGenerator,
+}
+
+impl PrimitiveHeaders {
+    pub fn new() -> PrimitiveHeaders {
+        PrimitiveHeaders {
+            headers_int: Vec::new(),
+            headers_float: Vec::new(),
+            z_generator: ZBufferIdGenerator::new(),
+        }
+    }
+
+    // Add a new primitive header.
+    pub fn push(
+        &mut self,
+        prim_header: &PrimitiveHeader,
+        user_data: [i32; 3],
+    ) -> PrimitiveHeaderIndex {
+        debug_assert_eq!(self.headers_int.len(), self.headers_float.len());
+        let id = self.headers_float.len();
+
+        self.headers_float.push(PrimitiveHeaderF {
+            local_rect: prim_header.local_rect,
+            local_clip_rect: prim_header.local_clip_rect,
+        });
+
+        self.headers_int.push(PrimitiveHeaderI {
+            z: self.z_generator.next(),
+            task_address: prim_header.task_address,
+            specific_prim_address: prim_header.specific_prim_address.as_int(),
+            clip_task_address: prim_header.clip_task_address,
+            scroll_id: prim_header.scroll_id,
+            user_data,
+        });
+
+        PrimitiveHeaderIndex(id as i32)
+    }
+}
+
+// This is a convenience type used to make it easier to pass
+// the common parts around during batching.
+pub struct PrimitiveHeader {
+    pub local_rect: LayoutRect,
+    pub local_clip_rect: LayoutRect,
+    pub task_address: RenderTaskAddress,
+    pub specific_prim_address: GpuCacheAddress,
+    pub clip_task_address: RenderTaskAddress,
+    pub scroll_id: ClipScrollNodeIndex,
+}
+
+// f32 parts of a primitive header
+#[derive(Debug)]
+#[repr(C)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct PrimitiveHeaderF {
+    pub local_rect: LayoutRect,
+    pub local_clip_rect: LayoutRect,
+}
+
+// i32 parts of a primitive header
+// TODO(gw): Compress parts of these down to u16
+#[derive(Debug)]
+#[repr(C)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct PrimitiveHeaderI {
+    pub z: ZBufferId,
+    pub task_address: RenderTaskAddress,
+    pub specific_prim_address: i32,
+    pub clip_task_address: RenderTaskAddress,
+    pub scroll_id: ClipScrollNodeIndex,
+    pub user_data: [i32; 3],
 }
 
 pub struct GlyphInstance {
-    pub specific_prim_address: GpuCacheAddress,
-    pub task_address: RenderTaskAddress,
-    pub clip_task_address: RenderTaskAddress,
-    pub clip_chain_rect_index: ClipChainRectIndex,
-    pub scroll_id: ClipScrollNodeIndex,
-    pub z: ZBufferId,
+    pub prim_header_index: PrimitiveHeaderIndex,
 }
 
 impl GlyphInstance {
     pub fn new(
-        specific_prim_address: GpuCacheAddress,
-        task_address: RenderTaskAddress,
-        clip_task_address: RenderTaskAddress,
-        clip_chain_rect_index: ClipChainRectIndex,
-        scroll_id: ClipScrollNodeIndex,
-        z: ZBufferId,
+        prim_header_index: PrimitiveHeaderIndex,
     ) -> Self {
         GlyphInstance {
-            specific_prim_address,
-            task_address,
-            clip_task_address,
-            clip_chain_rect_index,
-            scroll_id,
-            z,
+            prim_header_index,
         }
     }
 
+    // TODO(gw): Some of these fields can be moved to the primitive
+    //           header since they are constant, and some can be
+    //           compressed to a smaller size.
     pub fn build(&self, data0: i32, data1: i32, data2: i32) -> PrimitiveInstance {
         PrimitiveInstance {
             data: [
-                self.specific_prim_address.as_int(),
-                self.task_address.0 as i32 | (self.clip_task_address.0 as i32) << 16,
-                self.clip_chain_rect_index.0 as i32,
-                self.scroll_id.0 as i32,
-                self.z.0,
+                self.prim_header_index.0 as i32,
                 data0,
                 data1,
                 data2,
@@ -218,10 +286,6 @@ impl From<SplitCompositeInstance> for PrimitiveInstance {
                 instance.src_task_address.0 as i32,
                 instance.polygons_address.as_int(),
                 instance.z.0,
-                0,
-                0,
-                0,
-                0,
             ],
         }
     }
@@ -243,44 +307,28 @@ bitflags! {
     }
 }
 
-// TODO(gw): While we are converting things over, we
-//           need to have the instance be the same
-//           size as an old PrimitiveInstance. In the
-//           future, we can compress this vertex
-//           format a lot - e.g. z, render task
-//           addresses etc can reasonably become
-//           a u16 type.
+// TODO(gw): Some of these fields can be moved to the primitive
+//           header since they are constant, and some can be
+//           compressed to a smaller size.
 #[repr(C)]
 pub struct BrushInstance {
-    pub picture_address: RenderTaskAddress,
-    pub prim_address: GpuCacheAddress,
-    pub clip_chain_rect_index: ClipChainRectIndex,
-    pub scroll_id: ClipScrollNodeIndex,
+    pub prim_header_index: PrimitiveHeaderIndex,
     pub clip_task_address: RenderTaskAddress,
-    pub z: ZBufferId,
     pub segment_index: i32,
     pub edge_flags: EdgeAaSegmentMask,
     pub brush_flags: BrushFlags,
-    pub user_data: [i32; 3],
 }
 
 impl From<BrushInstance> for PrimitiveInstance {
     fn from(instance: BrushInstance) -> Self {
-        debug_assert_eq!(0, instance.clip_chain_rect_index.0 >> CLIP_CHAIN_RECT_BITS);
-        debug_assert_eq!(0, instance.scroll_id.0 >> CLIP_SCROLL_INDEX_BITS);
-        debug_assert_eq!(0, instance.segment_index >> SEGMENT_BITS);
         PrimitiveInstance {
             data: [
-                instance.picture_address.0 as i32 | (instance.clip_task_address.0 as i32) << 16,
-                instance.prim_address.as_int(),
-                instance.clip_chain_rect_index.0 as i32 | (instance.segment_index << CLIP_CHAIN_RECT_BITS),
-                instance.z.0,
-                instance.scroll_id.0 as i32 |
-                    ((instance.edge_flags.bits() as i32) << CLIP_SCROLL_INDEX_BITS) |
-                    ((instance.brush_flags.bits() as i32) << (CLIP_SCROLL_INDEX_BITS + EDGE_FLAG_BITS)),
-                instance.user_data[0],
-                instance.user_data[1],
-                instance.user_data[2],
+                instance.prim_header_index.0,
+                instance.clip_task_address.0 as i32,
+                instance.segment_index |
+                ((instance.edge_flags.bits() as i32) << 16) |
+                ((instance.brush_flags.bits() as i32) << 24),
+                0,
             ]
         }
     }
@@ -313,10 +361,6 @@ impl ClipScrollNodeData {
         }
     }
 }
-
-#[derive(Copy, Debug, Clone, PartialEq)]
-#[repr(C)]
-pub struct ClipChainRectIndex(pub usize);
 
 // Texture cache resources can be either a simple rect, or define
 // a polygon within a rect by specifying a UV coordinate for each

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -489,16 +489,9 @@ impl PicturePrimitive {
                     //           that writes a brush primitive header.
 
                     // Basic brush primitive header is (see end of prepare_prim_for_render_inner in prim_store.rs)
-                    //  local_rect
-                    //  clip_rect
                     //  [brush specific data]
                     //  [segment_rect, segment data]
                     let shadow_rect = prim_metadata.local_rect.translate(&offset);
-                    let shadow_clip_rect = prim_metadata.local_clip_rect.translate(&offset);
-
-                    // local_rect, clip_rect
-                    request.push(shadow_rect);
-                    request.push(shadow_clip_rect);
 
                     // ImageBrush colors
                     request.push(color.premultiplied());

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -277,7 +277,8 @@ pub(crate) enum TextureSampler {
     // the *first* pass. Items rendered in this target are
     // available as inputs to tasks in any subsequent pass.
     SharedCacheA8,
-    LocalClipRects
+    PrimitiveHeadersF,
+    PrimitiveHeadersI,
 }
 
 impl TextureSampler {
@@ -306,7 +307,8 @@ impl Into<TextureSlot> for TextureSampler {
             TextureSampler::RenderTasks => TextureSlot(7),
             TextureSampler::Dither => TextureSlot(8),
             TextureSampler::SharedCacheA8 => TextureSlot(9),
-            TextureSampler::LocalClipRects => TextureSlot(10),
+            TextureSampler::PrimitiveHeadersF => TextureSlot(10),
+            TextureSampler::PrimitiveHeadersI => TextureSlot(11),
         }
     }
 }
@@ -330,12 +332,7 @@ pub(crate) mod desc {
         ],
         instance_attributes: &[
             VertexAttribute {
-                name: "aData0",
-                count: 4,
-                kind: VertexAttributeKind::I32,
-            },
-            VertexAttribute {
-                name: "aData1",
+                name: "aData",
                 count: 4,
                 kind: VertexAttributeKind::I32,
             },
@@ -1215,8 +1212,14 @@ struct VertexDataTexture {
 }
 
 impl VertexDataTexture {
-    fn new(device: &mut Device) -> VertexDataTexture {
-        let texture = device.create_texture(TextureTarget::Default, ImageFormat::RGBAF32);
+    fn new(
+        device: &mut Device,
+        format: ImageFormat,
+    ) -> VertexDataTexture {
+        let texture = device.create_texture(
+            TextureTarget::Default,
+            format,
+        );
         let pbo = device.create_pbo();
 
         VertexDataTexture { texture, pbo }
@@ -1369,8 +1372,9 @@ pub struct Renderer {
     pub gpu_profile: GpuProfiler<GpuProfileTag>,
     vaos: RendererVAOs,
 
+    prim_header_f_texture: VertexDataTexture,
+    prim_header_i_texture: VertexDataTexture,
     node_data_texture: VertexDataTexture,
-    local_clip_rects_texture: VertexDataTexture,
     render_task_texture: VertexDataTexture,
     gpu_cache_texture: CacheTexture,
 
@@ -1629,9 +1633,10 @@ impl Renderer {
 
         let texture_resolver = SourceTextureResolver::new(&mut device);
 
-        let node_data_texture = VertexDataTexture::new(&mut device);
-        let local_clip_rects_texture = VertexDataTexture::new(&mut device);
-        let render_task_texture = VertexDataTexture::new(&mut device);
+        let prim_header_f_texture = VertexDataTexture::new(&mut device, ImageFormat::RGBAF32);
+        let prim_header_i_texture = VertexDataTexture::new(&mut device, ImageFormat::RGBAI32);
+        let node_data_texture = VertexDataTexture::new(&mut device, ImageFormat::RGBAF32);
+        let render_task_texture = VertexDataTexture::new(&mut device, ImageFormat::RGBAF32);
 
         let gpu_cache_texture = CacheTexture::new(
             &mut device,
@@ -1785,7 +1790,8 @@ impl Renderer {
                 border_vao,
             },
             node_data_texture,
-            local_clip_rects_texture,
+            prim_header_i_texture,
+            prim_header_f_texture,
             render_task_texture,
             pipeline_info: PipelineInfo::default(),
             dither_matrix_texture,
@@ -3533,17 +3539,26 @@ impl Renderer {
         let _timer = self.gpu_profile.start_timer(GPU_TAG_SETUP_DATA);
         self.device.set_device_pixel_ratio(frame.device_pixel_ratio);
 
-        self.node_data_texture.update(&mut self.device, &mut frame.node_data);
-        self.device.bind_texture(TextureSampler::ClipScrollNodes, &self.node_data_texture.texture);
-
-        self.local_clip_rects_texture.update(
+        self.prim_header_f_texture.update(
             &mut self.device,
-            &mut frame.clip_chain_local_clip_rects
+            &mut frame.prim_headers.headers_float,
         );
         self.device.bind_texture(
-            TextureSampler::LocalClipRects,
-            &self.local_clip_rects_texture.texture
+            TextureSampler::PrimitiveHeadersF,
+            &self.prim_header_f_texture.texture,
         );
+
+        self.prim_header_i_texture.update(
+            &mut self.device,
+            &mut frame.prim_headers.headers_int,
+        );
+        self.device.bind_texture(
+            TextureSampler::PrimitiveHeadersI,
+            &self.prim_header_i_texture.texture,
+        );
+
+        self.node_data_texture.update(&mut self.device, &mut frame.node_data);
+        self.device.bind_texture(TextureSampler::ClipScrollNodes, &self.node_data_texture.texture);
 
         self.render_task_texture
             .update(&mut self.device, &mut frame.render_tasks.task_data);
@@ -3930,7 +3945,8 @@ impl Renderer {
             self.device.delete_texture(dither_matrix_texture);
         }
         self.node_data_texture.deinit(&mut self.device);
-        self.local_clip_rects_texture.deinit(&mut self.device);
+        self.prim_header_f_texture.deinit(&mut self.device);
+        self.prim_header_i_texture.deinit(&mut self.device);
         self.render_task_texture.deinit(&mut self.device);
         self.device.delete_pbo(self.texture_cache_upload_pbo);
         self.texture_resolver.deinit(&mut self.device);

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -355,7 +355,8 @@ fn create_prim_shader(
                 ("sRenderTasks", TextureSampler::RenderTasks),
                 ("sResourceCache", TextureSampler::ResourceCache),
                 ("sSharedCacheA8", TextureSampler::SharedCacheA8),
-                ("sLocalClipRects", TextureSampler::LocalClipRects),
+                ("sPrimitiveHeadersF", TextureSampler::PrimitiveHeadersF),
+                ("sPrimitiveHeadersI", TextureSampler::PrimitiveHeadersI),
             ],
         );
     }
@@ -383,7 +384,8 @@ fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program
                 ("sRenderTasks", TextureSampler::RenderTasks),
                 ("sResourceCache", TextureSampler::ResourceCache),
                 ("sSharedCacheA8", TextureSampler::SharedCacheA8),
-                ("sLocalClipRects", TextureSampler::LocalClipRects),
+                ("sPrimitiveHeadersF", TextureSampler::PrimitiveHeadersF),
+                ("sPrimitiveHeadersI", TextureSampler::PrimitiveHeadersI),
             ],
         );
     }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -501,6 +501,7 @@ impl TextureCache {
             (ImageFormat::BGRA8, TextureFilter::Nearest) => &mut self.array_rgba8_nearest,
             (ImageFormat::RGBAF32, _) |
             (ImageFormat::RG8, _) |
+            (ImageFormat::RGBAI32, _) |
             (ImageFormat::R8, TextureFilter::Nearest) |
             (ImageFormat::R8, TextureFilter::Trilinear) |
             (ImageFormat::BGRA8, TextureFilter::Trilinear) => unreachable!(),
@@ -725,6 +726,7 @@ impl TextureCache {
             (ImageFormat::BGRA8, TextureFilter::Linear) => &mut self.array_rgba8_linear,
             (ImageFormat::BGRA8, TextureFilter::Nearest) => &mut self.array_rgba8_nearest,
             (ImageFormat::RGBAF32, _) |
+            (ImageFormat::RGBAI32, _) |
             (ImageFormat::R8, TextureFilter::Nearest) |
             (ImageFormat::R8, TextureFilter::Trilinear) |
             (ImageFormat::BGRA8, TextureFilter::Trilinear) |

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -27,8 +27,8 @@ use {StickyFrameDisplayItem, StickyOffsetBounds, TextDisplayItem, TransformStyle
 use {YuvData, YuvImageDisplayItem};
 
 // We don't want to push a long text-run. If a text-run is too long, split it into several parts.
-// This needs to be set to (renderer::MAX_VERTEX_TEXTURE_WIDTH - VECS_PER_PRIM_HEADER - VECS_PER_TEXT_RUN) * 2
-pub const MAX_TEXT_RUN_LENGTH: usize = 2038;
+// This needs to be set to (renderer::MAX_VERTEX_TEXTURE_WIDTH - VECS_PER_TEXT_RUN) * 2
+pub const MAX_TEXT_RUN_LENGTH: usize = 2040;
 
 // We start at 2, because the root reference is always 0 and the root scroll node is always 1.
 const FIRST_CLIP_ID: usize = 2;

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -59,6 +59,7 @@ pub enum ImageFormat {
     BGRA8 = 3,
     RGBAF32 = 4,
     RG8 = 5,
+    RGBAI32 = 6,
 }
 
 impl ImageFormat {
@@ -68,6 +69,7 @@ impl ImageFormat {
             ImageFormat::BGRA8 => 4,
             ImageFormat::RGBAF32 => 16,
             ImageFormat::RG8 => 2,
+            ImageFormat::RGBAI32 => 16,
         }
     }
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -173,7 +173,8 @@ fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
         }
         ImageFormat::RG8 => true,
         ImageFormat::R8 => false,
-        ImageFormat::RGBAF32 => unreachable!(),
+        ImageFormat::RGBAF32 |
+        ImageFormat::RGBAI32 => unreachable!(),
     }
 }
 


### PR DESCRIPTION
Add a new PrimitiveHeader concept, which contains all the common
information for a given primitive (such as scroll node, render
task, z value etc).

Instances contain an index to the primitive header, and read the
information from that. This allows the instance size to be
halved. There is a slight extra vertex shader cost, due to
an extra indirection. However, this was not apparent in any
profiling I did, since the vertex shader time typically makes
up a very small amount of overall time. Additionally, the
primitive header texels are likely to be in the texture cache
for each glyph that is fetched. A possible future improvement
is to remove that extra indirection by writing some of that
data, such as the render task address, directly into the primitive
header.

On sites such as nytimes.com or wikipedia.org, where there are
typically a large number of glyphs, this saves several hundred
kB per frame of data being sent to the GPU, which improves the
compositor / driver CPU time.

Also remove the local_clip_chains vector and texture. Now, we just
calculate this as part of the primitive header and include it
there. This can save significant amounts of texture upload on
pages that have a lot of clip chains or clip nodes, relative to
the visible primitive count.

In future, both the PrimitiveHeader and instance structures can
easily be further compressed again, but this can be done as a
follow up.

Finally, although this is a useful optimization by itself, it's
mostly prep work for some changes I have planned related to
how we store and upload scroll nodes. Hopefully these changes will
be both an optimization and make it easier to fix some of the
correctness issues we have with nested 3d transforms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2839)
<!-- Reviewable:end -->
