### PR TITLE
Move device.rs in a folder

### DIFF
--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::shader_source;
+use super::super::shader_source;
 use api::{ColorF, ImageFormat};
 use api::{DeviceIntPoint, DeviceIntRect, DeviceUintRect, DeviceUintSize};
 use api::TextureTarget;

--- a/webrender/src/device/mod.rs
+++ b/webrender/src/device/mod.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+mod gl;
+
+pub use self::gl::*;


### PR DESCRIPTION
Created a `device` folder where we can place new backend implementations in the future, and moved the existing `device.rs` implementation into it with a new name `(gl.rs) `.

cc @kvark @gw3583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2840)
<!-- Reviewable:end -->
