### PR TITLE
Cache the used font instance during prepare, for batching.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1077,17 +1077,13 @@ impl AlphaBatchBuilder {
                 let text_cpu =
                     &ctx.prim_store.cpu_text_runs[prim_metadata.cpu_prim_index.0];
 
-                let font = text_cpu.get_font(
-                    ctx.device_pixel_scale,
-                    scroll_node.transform,
-                );
-                let subpx_dir = font.get_subpx_dir();
+                let subpx_dir = text_cpu.used_font.get_subpx_dir();
 
                 let glyph_fetch_buffer = &mut self.glyph_fetch_buffer;
                 let batch_list = &mut self.batch_list;
 
                 ctx.resource_cache.fetch_glyphs(
-                    font,
+                    text_cpu.used_font.clone(),
                     &text_cpu.glyph_keys,
                     glyph_fetch_buffer,
                     gpu_cache,
@@ -1114,7 +1110,7 @@ impl AlphaBatchBuilder {
                         let (blend_mode, color_mode) = match glyph_format {
                             GlyphFormat::Subpixel |
                             GlyphFormat::TransformedSubpixel => {
-                                if text_cpu.font.bg_color.a != 0 {
+                                if text_cpu.used_font.bg_color.a != 0 {
                                     (
                                         BlendMode::SubpixelWithBgColor,
                                         ShaderColorMode::FromRenderPassMode,
@@ -1126,7 +1122,7 @@ impl AlphaBatchBuilder {
                                     )
                                 } else {
                                     (
-                                        BlendMode::SubpixelConstantTextColor(text_cpu.font.color.into()),
+                                        BlendMode::SubpixelConstantTextColor(text_cpu.used_font.color.into()),
                                         ShaderColorMode::SubpixelConstantTextColor,
                                     )
                                 }


### PR DESCRIPTION
Instead of calling get_font() during batching, this is now
stored as a used_font field in the text run primitive.

This is a small optimization, but is mostly tidy up work in
preparation for some upcoming picture caching patches. The
reason for this change is to ensure that the batching code
doesn't need to access the *value* of the scroll node
matrices, which will be important once pictures can be
rasterized in different spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2841)
<!-- Reviewable:end -->
