### PR TITLE
Fix local clip rect for tiled images.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1687,7 +1687,9 @@ impl PrimitiveStore {
                                 // Tighten the clip rect because decomposing the repeated image can
                                 // produce primitives that are partially covering the original image
                                 // rect and we want to clip these extra parts out.
-                                let tight_clip_rect = metadata.local_clip_rect.intersection(&metadata.local_rect).unwrap();
+                                let tight_clip_rect = metadata
+                                    .combined_local_clip_rect
+                                    .intersection(&metadata.local_rect).unwrap();
 
                                 let visible_rect = compute_conservative_visible_rect(
                                     prim_run_context,
@@ -2689,7 +2691,9 @@ fn decompose_repeated_primitive(
     // Tighten the clip rect because decomposing the repeated image can
     // produce primitives that are partially covering the original image
     // rect and we want to clip these extra parts out.
-    let tight_clip_rect = metadata.local_clip_rect.intersection(&metadata.local_rect).unwrap();
+    let tight_clip_rect = metadata
+        .combined_local_clip_rect
+        .intersection(&metadata.local_rect).unwrap();
 
     let visible_rect = compute_conservative_visible_rect(
         prim_run_context,

--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -6,3 +6,4 @@ fuzzy(1,331264) == tile-repeat-prim-or-decompose.yaml tile-repeat-prim-or-decomp
 platform(linux,mac) options(allow-mipmaps) == downscale.yaml downscale.png
 == segments.yaml segments.png
 platform(linux,mac) == yuv.yaml yuv.png
+== tiled-clip-chain.yaml tiled-clip-chain-ref.yaml

--- a/wrench/reftests/image/tiled-clip-chain-ref.yaml
+++ b/wrench/reftests/image/tiled-clip-chain-ref.yaml
@@ -1,0 +1,10 @@
+root:
+  items:
+    - image: checkerboard(2, 16, 16)
+      bounds: [10, 10, 260, 260]
+    - type: rect
+      bounds: [10, 110, 200, 200]
+      color: white
+    - type: rect
+      bounds: [110, 10, 200, 270]
+      color: white

--- a/wrench/reftests/image/tiled-clip-chain.yaml
+++ b/wrench/reftests/image/tiled-clip-chain.yaml
@@ -1,0 +1,10 @@
+# Test that local clip rects from clip-chains are correctly
+# propagated into the local clip rect for tiled images.
+root:
+  items:
+    - type: clip
+      bounds: [10, 10, 100, 100]
+      items:
+        - image: checkerboard(2, 16, 16)
+          bounds: [10, 10, 260, 260]
+          tile-size: 64


### PR DESCRIPTION
This fixes a reftest failure in Gecko that was introduced by
the patch in #2839.

Make sure that the tight local clip rect used for image and
gradient tiles also includes the local clip rect provided
by the clip-chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2843)
<!-- Reviewable:end -->
