### PR TITLE
Fix tiling and dirty rect calculations for external images

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -641,10 +641,17 @@ impl ResourceCache {
             return
         };
 
+        if !self.pending_image_requests.insert(request) {
+            return
+        }
+
+        // If we are tiling, then we need to confirm the dirty rect intersects
+        // the tile before leaving the request in the pending queue.
+        //
         // We can start a worker thread rasterizing right now, if:
         //  - The image is a blob.
         //  - The blob hasn't already been requested this frame.
-        if self.pending_image_requests.insert(request) && template.data.is_blob() {
+        if template.data.is_blob() || dirty_rect.is_some() {
             let (offset, size) = match template.tiling {
                 Some(tile_size) => {
                     let tile_offset = request.tile.unwrap();
@@ -671,17 +678,19 @@ impl ResourceCache {
                 None => (DevicePoint::zero(), template.descriptor.size),
             };
 
-            if let Some(ref mut renderer) = self.blob_image_renderer {
-                renderer.request(
-                    &self.resources,
-                    request.into(),
-                    &BlobImageDescriptor {
-                        size,
-                        offset,
-                        format: template.descriptor.format,
-                    },
-                    dirty_rect,
-                );
+            if template.data.is_blob() {
+                if let Some(ref mut renderer) = self.blob_image_renderer {
+                    renderer.request(
+                        &self.resources,
+                        request.into(),
+                        &BlobImageDescriptor {
+                            size,
+                            offset,
+                            format: template.descriptor.format,
+                        },
+                        dirty_rect,
+                    );
+                }
             }
         }
     }
@@ -923,6 +932,8 @@ impl ResourceCache {
     }
 
     fn update_texture_cache(&mut self, gpu_cache: &mut GpuCache) {
+        let mut keys_to_clear_dirty_rect = FastHashSet::default();
+
         for request in self.pending_image_requests.drain() {
             let image_template = self.resources.image_templates.get_mut(request.key).unwrap();
             debug_assert!(image_template.data.uses_texture_cache());
@@ -963,23 +974,24 @@ impl ResourceCache {
 
             let entry = self.cached_images.get_mut(&request).as_mut().unwrap();
             let mut descriptor = image_template.descriptor.clone();
-            //TODO: erasing the dirty rectangle here is incorrect for tiled images,
-            // since other tile requests may follow that depend on it
-            let mut local_dirty_rect = image_template.dirty_rect.take();
+            let local_dirty_rect;
 
             if let Some(tile) = request.tile {
                 let tile_size = image_template.tiling.unwrap();
                 let clipped_tile_size = compute_tile_size(&descriptor, tile_size, tile);
 
-                if let Some(ref mut rect) = local_dirty_rect {
-                    match intersect_for_tile(*rect, clipped_tile_size, tile_size, tile) {
-                        Some(intersection) => *rect = intersection,
-                        None => {
-                            // if re-uploaded, the dirty rect is ignored anyway
-                            debug_assert!(self.texture_cache.needs_upload(&entry.texture_cache_handle))
-                        }
-                    }
-                }
+                local_dirty_rect = if let Some(ref rect) = image_template.dirty_rect {
+                    keys_to_clear_dirty_rect.insert(request.key.clone());
+
+                    // We should either have a dirty rect, or we are re-uploading where the dirty
+                    // rect is ignored anyway.
+                    let intersection = intersect_for_tile(*rect, clipped_tile_size, tile_size, tile);
+                    debug_assert!(intersection.is_some() ||
+                                  self.texture_cache.needs_upload(&entry.texture_cache_handle));
+                    intersection
+                } else {
+                    None
+                };
 
                 // The tiled image could be stored on the CPU as one large image or be
                 // already broken up into tiles. This affects the way we compute the stride
@@ -995,6 +1007,8 @@ impl ResourceCache {
                 }
 
                 descriptor.size = clipped_tile_size;
+            } else {
+                local_dirty_rect = image_template.dirty_rect.take();
             }
 
             let filter = match request.rendering {
@@ -1035,6 +1049,11 @@ impl ResourceCache {
                 None,
                 UvRectKind::Rect,
             );
+        }
+
+        for key in keys_to_clear_dirty_rect.drain() {
+            let image_template = self.resources.image_templates.get_mut(key).unwrap();
+            image_template.dirty_rect.take();
         }
     }
 


### PR DESCRIPTION
- When we have a dirty rect, we should cull all tiled requests which do
not overlap with the dirty rect, not just blob image requests.

- We should not take the dirty rect from the image template until we
have processed all of the requests. This will allow each tile to
re-upload only the modified segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2847)
<!-- Reviewable:end -->
