### PR TITLE
Forbid segmentation of tiled images

### DIFF
--- a/wrench/reftests/image/reftest.list
+++ b/wrench/reftests/image/reftest.list
@@ -7,3 +7,4 @@ platform(linux,mac) options(allow-mipmaps) == downscale.yaml downscale.png
 == segments.yaml segments.png
 platform(linux,mac) == yuv.yaml yuv.png
 == tiled-clip-chain.yaml tiled-clip-chain-ref.yaml
+== tiled-complex-clip.yaml tiled-complex-clip-ref.yaml

--- a/wrench/reftests/image/tiled-complex-clip-ref.yaml
+++ b/wrench/reftests/image/tiled-complex-clip-ref.yaml
@@ -1,0 +1,10 @@
+root:
+  items:
+    - type: clip
+      bounds: [10, 10, 100, 100]
+      complex:
+            - rect: [10, 10, 100, 100]
+              radius: 32
+      items:
+        - image: checkerboard(2, 16, 16)
+          bounds: [10, 10, 260, 260]

--- a/wrench/reftests/image/tiled-complex-clip.yaml
+++ b/wrench/reftests/image/tiled-complex-clip.yaml
@@ -1,0 +1,13 @@
+# Test that complex clips from clip-chains are correctly
+# taken into account for tiled images.
+root:
+  items:
+    - type: clip
+      bounds: [10, 10, 100, 100]
+      complex:
+            - rect: [10, 10, 100, 100]
+              radius: 32
+      items:
+        - image: checkerboard(2, 16, 16)
+          bounds: [10, 10, 260, 260]
+          tile-size: 64


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1470855
r? @gw3583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2850)
<!-- Reviewable:end -->
