### PR TITLE
Fix a small typo in the wrench window title

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -257,7 +257,7 @@ fn make_window(
                 })
                 .with_vsync(vsync);
             let window_builder = winit::WindowBuilder::new()
-                .with_title("WRech")
+                .with_title("WRench")
                 .with_multitouch()
                 .with_dimensions(size.width, size.height);
 


### PR DESCRIPTION
This is almost inconsequential, but always makes me do a double-take.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2851)
<!-- Reviewable:end -->
