### PR TITLE
Fix crashtest panic in ResourceCache::request_image.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -652,9 +652,9 @@ impl ResourceCache {
         //  - The image is a blob.
         //  - The blob hasn't already been requested this frame.
         if template.data.is_blob() || dirty_rect.is_some() {
-            let (offset, size) = match template.tiling {
-                Some(tile_size) => {
-                    let tile_offset = request.tile.unwrap();
+            let (offset, size) = match request.tile {
+                Some(tile_offset) => {
+                    let tile_size = template.tiling.unwrap();
                     let actual_size = compute_tile_size(
                         &template.descriptor,
                         tile_size,


### PR DESCRIPTION
ResourceCache::update_texture_cache checks if the request has a tile
associated with it, and if so, adjusts the descriptor and dirty rect for
the individual texture updates. If the image should have been tiled, but
the request did not provide such information, it still attempts to
proceed without tiling.

ResourceCache::request_image was changed to verify that the dirty rect
for the associated image intersects with the request, to avoid
requesting updates for tiled requests which are unchanged. Before it
only did this check for blob images, but it is now necessary for
external images as well which can provide a dirty rect.

We assume here that all requests for an image that must be tiled will have
the necessary tiling information provided, but that does not appear to be
the case. Clipped and YUV images do not provide tiling information as an
example. This patch reverses the check ordering to be consistent with
update_texture_cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2853)
<!-- Reviewable:end -->
