### PR TITLE
configurable angle for synthetic italics

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1832,6 +1832,7 @@ impl<'a> DisplayListFlattener<'a> {
                 font_instance.bg_color,
                 render_mode,
                 flags,
+                font_instance.synthetic_italics,
                 font_instance.platform_options,
                 font_instance.variations.clone(),
             );

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -5,7 +5,7 @@
 use api::{ColorF, ColorU, DevicePoint};
 use api::{FontInstanceFlags, FontInstancePlatformOptions};
 use api::{FontKey, FontRenderMode, FontTemplate, FontVariation};
-use api::{GlyphIndex, GlyphDimensions};
+use api::{GlyphIndex, GlyphDimensions, SyntheticItalics};
 use api::{LayoutPoint, LayoutToWorldTransform, WorldPoint};
 use app_units::Au;
 use euclid::approxeq::ApproxEq;
@@ -111,7 +111,8 @@ impl FontTransform {
         self.pre_scale(x_scale.recip() as f32, y_scale.recip() as f32)
     }
 
-    pub fn synthesize_italics(&self, skew_factor: f32) -> Self {
+    pub fn synthesize_italics(&self, angle: SyntheticItalics) -> Self {
+        let skew_factor = angle.to_skew();
         FontTransform::new(
             self.scale_x,
             self.skew_x - self.scale_x * skew_factor,
@@ -176,6 +177,7 @@ pub struct FontInstance {
     pub bg_color: ColorU,
     pub render_mode: FontRenderMode,
     pub flags: FontInstanceFlags,
+    pub synthetic_italics: SyntheticItalics,
     pub platform_options: Option<FontInstancePlatformOptions>,
     pub variations: Vec<FontVariation>,
     pub transform: FontTransform,
@@ -189,6 +191,7 @@ impl FontInstance {
         bg_color: ColorU,
         render_mode: FontRenderMode,
         flags: FontInstanceFlags,
+        synthetic_italics: SyntheticItalics,
         platform_options: Option<FontInstancePlatformOptions>,
         variations: Vec<FontVariation>,
     ) -> Self {
@@ -203,6 +206,7 @@ impl FontInstance {
             bg_color,
             render_mode,
             flags,
+            synthetic_italics,
             platform_options,
             variations,
             transform: FontTransform::identity(),
@@ -708,6 +712,7 @@ mod test_glyph_rasterizer {
             ColorF::new(0.0, 0.0, 0.0, 1.0),
             ColorU::new(0, 0, 0, 0),
             FontRenderMode::Subpixel,
+            Default::default(),
             Default::default(),
             None,
             Vec::new(),

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -451,6 +451,7 @@ impl ResourceCache {
             render_mode,
             flags,
             bg_color,
+            synthetic_italics,
             ..
         } = options.unwrap_or_default();
         let instance = FontInstance::new(
@@ -460,6 +461,7 @@ impl ResourceCache {
             bg_color,
             render_mode,
             flags,
+            synthetic_italics,
             platform_options,
             variations,
         );

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -155,7 +155,6 @@ bitflags! {
     #[derive(Deserialize, Serialize)]
     pub struct FontInstanceFlags: u32 {
         // Common flags
-        const SYNTHETIC_ITALICS = 1 << 0;
         const SYNTHETIC_BOLD    = 1 << 1;
         const EMBEDDED_BITMAPS  = 1 << 2;
         const SUBPIXEL_BGR      = 1 << 3;
@@ -199,6 +198,51 @@ impl Default for FontInstanceFlags {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct SyntheticItalics {
+    // Angle in degrees (-90..90) for synthetic italics in 8.8 fixed-point.
+    pub angle: i16,
+}
+
+impl SyntheticItalics {
+    pub const ANGLE_SCALE: f32 = 256.0;
+
+    pub fn from_degrees(degrees: f32) -> Self {
+        SyntheticItalics { angle: (degrees.max(-89.0).min(89.0) * Self::ANGLE_SCALE) as i16 }
+    }
+
+    pub fn to_degrees(&self) -> f32 {
+        self.angle as f32 / Self::ANGLE_SCALE
+    }
+
+    pub fn to_radians(&self) -> f32 {
+        self.to_degrees().to_radians()
+    }
+
+    pub fn to_skew(&self) -> f32 {
+        self.to_radians().tan()
+    }
+
+    pub fn enabled() -> Self {
+        Self::from_degrees(14.0)
+    }
+
+    pub fn disabled() -> Self {
+        SyntheticItalics { angle: 0 }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.angle != 0
+    }
+}
+
+impl Default for SyntheticItalics {
+    fn default() -> Self {
+        SyntheticItalics::disabled()
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct FontInstanceOptions {
     pub render_mode: FontRenderMode,
     pub flags: FontInstanceFlags,
@@ -206,6 +250,7 @@ pub struct FontInstanceOptions {
     /// the text will be rendered with bg_color.r/g/b as an opaque estimated
     /// background color.
     pub bg_color: ColorU,
+    pub synthetic_italics: SyntheticItalics,
 }
 
 impl Default for FontInstanceOptions {
@@ -214,6 +259,7 @@ impl Default for FontInstanceOptions {
             render_mode: FontRenderMode::Subpixel,
             flags: Default::default(),
             bg_color: ColorU::new(0, 0, 0, 0),
+            synthetic_italics: SyntheticItalics::disabled(),
         }
     }
 }

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -27,6 +27,8 @@ fuzzy(1,1) platform(linux) == shadow-ordering.yaml shadow-ordering-ref.yaml
 fuzzy(1,1786) options(disable-subpixel) == synthetic-bold-transparent.yaml synthetic-bold-transparent-ref.yaml
 != synthetic-bold-transparent.yaml synthetic-bold.yaml
 != synthetic-italics.yaml synthetic-italics-ref.yaml
+!= synthetic-italics-custom.yaml synthetic-italics-ref.yaml
+!= synthetic-italics-custom.yaml synthetic-italics.yaml
 options(disable-aa) == ahem.yaml ahem-ref.yaml
 platform(linux) == isolated-text.yaml isolated-text.png
 platform(mac) == white-opacity.yaml white-opacity.png

--- a/wrench/reftests/text/synthetic-italics-custom.yaml
+++ b/wrench/reftests/text/synthetic-italics-custom.yaml
@@ -1,0 +1,7 @@
+root:
+  items:
+    - text: "Fake italics are great"
+      origin: 20 40
+      size: 20
+      synthetic-italics: 45
+

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -460,7 +460,7 @@ impl Wrench {
         flags: FontInstanceFlags,
         render_mode: Option<FontRenderMode>,
         bg_color: Option<ColorU>,
-        synthetic_italics: bool,
+        synthetic_italics: SyntheticItalics,
     ) -> FontInstanceKey {
         let key = self.api.generate_font_instance_key();
         let mut txn = Transaction::new();
@@ -472,9 +472,7 @@ impl Wrench {
         if let Some(bg_color) = bg_color {
             options.bg_color = bg_color;
         }
-        if synthetic_italics {
-            options.synthetic_italics = SyntheticItalics::enabled();
-        }
+        options.synthetic_italics = synthetic_italics;
         txn.add_font_instance(key, font_key, size, Some(options), None, Vec::new());
         self.api.update_resources(txn.resource_updates);
         key

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -460,6 +460,7 @@ impl Wrench {
         flags: FontInstanceFlags,
         render_mode: Option<FontRenderMode>,
         bg_color: Option<ColorU>,
+        synthetic_italics: bool,
     ) -> FontInstanceKey {
         let key = self.api.generate_font_instance_key();
         let mut txn = Transaction::new();
@@ -470,6 +471,9 @@ impl Wrench {
         }
         if let Some(bg_color) = bg_color {
             options.bg_color = bg_color;
+        }
+        if synthetic_italics {
+            options.synthetic_italics = SyntheticItalics::enabled();
         }
         txn.add_font_instance(key, font_key, size, Some(options), None, Vec::new());
         self.api.update_resources(txn.resource_updates);

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -199,7 +199,7 @@ pub struct YamlFrameReader {
     image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
     fonts: HashMap<FontDescriptor, FontKey>,
-    font_instances: HashMap<(FontKey, Au, FontInstanceFlags, Option<ColorU>), FontInstanceKey>,
+    font_instances: HashMap<(FontKey, Au, FontInstanceFlags, Option<ColorU>, bool), FontInstanceKey>,
     font_render_mode: Option<FontRenderMode>,
     allow_mipmaps: bool,
 
@@ -563,12 +563,13 @@ impl YamlFrameReader {
         size: Au,
         bg_color: Option<ColorU>,
         flags: FontInstanceFlags,
+        synthetic_italics: bool,
         wrench: &mut Wrench,
     ) -> FontInstanceKey {
         let font_render_mode = self.font_render_mode;
 
         *self.font_instances
-            .entry((font_key, size, flags, bg_color))
+            .entry((font_key, size, flags, bg_color, synthetic_italics))
             .or_insert_with(|| {
                 wrench.add_font_instance(
                     font_key,
@@ -576,6 +577,7 @@ impl YamlFrameReader {
                     flags,
                     font_render_mode,
                     bg_color,
+                    synthetic_italics,
                 )
             })
     }
@@ -1134,11 +1136,9 @@ impl YamlFrameReader {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
         let bg_color = item["bg-color"].as_colorf().map(|c| c.into());
+        let synthetic_italics = item["synthetic-italics"].as_bool().unwrap_or(false);
 
         let mut flags = FontInstanceFlags::empty();
-        if item["synthetic-italics"].as_bool().unwrap_or(false) {
-            flags |= FontInstanceFlags::SYNTHETIC_ITALICS;
-        }
         if item["synthetic-bold"].as_bool().unwrap_or(false) {
             flags |= FontInstanceFlags::SYNTHETIC_BOLD;
         }
@@ -1166,6 +1166,7 @@ impl YamlFrameReader {
                                                                  size,
                                                                  bg_color,
                                                                  flags,
+                                                                 synthetic_italics,
                                                                  wrench);
 
         assert!(

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -199,7 +199,7 @@ pub struct YamlFrameReader {
     image_map: HashMap<(PathBuf, Option<i64>), (ImageKey, LayoutSize)>,
 
     fonts: HashMap<FontDescriptor, FontKey>,
-    font_instances: HashMap<(FontKey, Au, FontInstanceFlags, Option<ColorU>, bool), FontInstanceKey>,
+    font_instances: HashMap<(FontKey, Au, FontInstanceFlags, Option<ColorU>, SyntheticItalics), FontInstanceKey>,
     font_render_mode: Option<FontRenderMode>,
     allow_mipmaps: bool,
 
@@ -563,7 +563,7 @@ impl YamlFrameReader {
         size: Au,
         bg_color: Option<ColorU>,
         flags: FontInstanceFlags,
-        synthetic_italics: bool,
+        synthetic_italics: SyntheticItalics,
         wrench: &mut Wrench,
     ) -> FontInstanceKey {
         let font_render_mode = self.font_render_mode;
@@ -1136,7 +1136,13 @@ impl YamlFrameReader {
         let size = item["size"].as_pt_to_au().unwrap_or(Au::from_f32_px(16.0));
         let color = item["color"].as_colorf().unwrap_or(*BLACK_COLOR);
         let bg_color = item["bg-color"].as_colorf().map(|c| c.into());
-        let synthetic_italics = item["synthetic-italics"].as_bool().unwrap_or(false);
+        let synthetic_italics = if let Some(angle) = item["synthetic-italics"].as_f32() {
+            SyntheticItalics::from_degrees(angle)
+        } else if item["synthetic-italics"].as_bool().unwrap_or(false) {
+            SyntheticItalics::enabled()
+        } else {
+            SyntheticItalics::disabled()
+        };
 
         let mut flags = FontInstanceFlags::empty();
         if item["synthetic-bold"].as_bool().unwrap_or(false) {


### PR DESCRIPTION
This fixes Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1460259

Gecko no longer uses a fixed angle for synthetic italics, so the old strategy of just trying to use fixed per-platform values that match Gecko also no longer works.

We thus need to be able to pass in a per-font angle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2855)
<!-- Reviewable:end -->
