### PR TITLE
Split the ClipScrollTree

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -475,8 +475,8 @@ impl AlphaBatchBuilder {
 
         // Add each run in this picture to the batch.
         for run in &pic.runs {
-            let scroll_node = &ctx.clip_scroll_tree.nodes[run.clip_and_scroll.scroll_node_id.0];
-            let transform_id = ctx.transforms.get_id(scroll_node.transform_index);
+            let transform_id =
+                ctx.transforms.get_id(run.clip_and_scroll.scroll_node_id.transform_index());
             self.add_run_to_batch(
                 run,
                 transform_id,
@@ -670,7 +670,7 @@ impl AlphaBatchBuilder {
                             debug_assert!(picture.surface.is_some());
 
                             let real_xf = &ctx.clip_scroll_tree
-                                .nodes[picture.reference_frame_index.0]
+                                .spatial_nodes[picture.reference_frame_index.0]
                                 .world_content_transform
                                 .into();
                             let polygon = make_polygon(

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -7,11 +7,11 @@ use api::{ImageRendering, LayoutRect, LayoutSize, LayoutPoint, LayoutVector2D, L
 use api::{BoxShadowClipMode, LayoutToWorldScale, LineOrientation, LineStyle};
 use border::{ensure_no_corner_overlap};
 use box_shadow::{BLUR_SAMPLE_SCALE, BoxShadowClipSource, BoxShadowCacheKey};
-use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId, TransformIndex};
+use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId};
 use ellipse::Ellipse;
 use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
-use gpu_types::{BoxShadowStretchMode};
+use gpu_types::{BoxShadowStretchMode, TransformIndex};
 use prim_store::{ClipData, ImageMaskData};
 use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};

--- a/webrender/src/clip_scroll_node.rs
+++ b/webrender/src/clip_scroll_node.rs
@@ -6,17 +6,17 @@ use api::{DevicePixelScale, ExternalScrollId, LayoutPixel, LayoutPoint, LayoutRe
 use api::{LayoutVector2D, LayoutTransform, PipelineId, PropertyBinding};
 use api::{ScrollClamping, ScrollLocation, ScrollSensitivity, StickyOffsetBounds};
 use clip::{ClipChain, ClipChainNode, ClipSourcesHandle, ClipStore, ClipWorkItem};
-use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, CoordinateSystemId};
-use clip_scroll_tree::{TransformUpdateState, TransformIndex};
+use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId, SpatialNodeIndex};
+use clip_scroll_tree::{TransformUpdateState};
 use euclid::SideOffsets2D;
 use gpu_cache::GpuCache;
-use gpu_types::{TransformData, TransformPalette};
+use gpu_types::{TransformData, TransformIndex, TransformPalette};
 use resource_cache::ResourceCache;
 use scene::SceneProperties;
 use util::{LayoutToWorldFastTransform, LayoutFastTransform};
 use util::{TransformedRectKind};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StickyFrameInfo {
     pub frame_rect: LayoutRect,
     pub margins: SideOffsets2D<Option<f32>>,
@@ -46,7 +46,97 @@ impl StickyFrameInfo {
 }
 
 #[derive(Debug)]
-pub enum SpatialNodeKind {
+pub struct ClipNode {
+    /// The node that determines how this clip node is positioned.
+    pub spatial_node: SpatialNodeIndex,
+
+    /// A handle to this clip nodes clips in the ClipStore.
+    pub handle: Option<ClipSourcesHandle>,
+
+    /// An index to a ClipChain defined by this ClipNode's hiearchy in the display
+    /// list.
+    pub clip_chain_index: ClipChainIndex,
+
+    /// The index of the parent ClipChain of this node's hiearchical ClipChain.
+    pub parent_clip_chain_index: ClipChainIndex,
+
+    /// A copy of the ClipChainNode this node would produce. We need to keep a copy,
+    /// because the ClipChain may not contain our node if is optimized out, but API
+    /// defined ClipChains will still need to access it.
+    pub clip_chain_node: Option<ClipChainNode>,
+}
+
+impl ClipNode {
+    const EMPTY: ClipNode = ClipNode {
+        spatial_node: SpatialNodeIndex(0),
+        handle: None,
+        clip_chain_index: ClipChainIndex(0),
+        parent_clip_chain_index: ClipChainIndex(0),
+        clip_chain_node: None,
+    };
+
+    pub fn empty() -> ClipNode {
+        ClipNode::EMPTY
+    }
+
+    pub fn update(
+        &mut self,
+        spatial_node: &SpatialNode,
+        device_pixel_scale: DevicePixelScale,
+        clip_store: &mut ClipStore,
+        resource_cache: &mut ResourceCache,
+        gpu_cache: &mut GpuCache,
+        clip_chains: &mut [ClipChain],
+    ) {
+        let (clip_sources, weak_handle) = match self.handle {
+            Some(ref handle) => (clip_store.get_mut(handle), handle.weak()),
+            None => {
+                warn!("Tried to process an empty clip node");
+                return;
+            }
+        };
+        clip_sources.update(gpu_cache, resource_cache, device_pixel_scale);
+
+        let (screen_inner_rect, screen_outer_rect) = clip_sources.get_screen_bounds(
+            &spatial_node.world_content_transform,
+            device_pixel_scale,
+            None,
+        );
+
+        // All clipping SpatialNodes should have outer rectangles, because they never
+        // use the BorderCorner clip type and they always have at last one non-ClipOut
+        // Rectangle ClipSource.
+        let screen_outer_rect = screen_outer_rect
+            .expect("Clipping node didn't have outer rect.");
+        let local_outer_rect = clip_sources.local_outer_rect
+            .expect("Clipping node didn't have outer rect.");
+
+        let new_node = ClipChainNode {
+            work_item: ClipWorkItem {
+                transform_index: self.spatial_node.transform_index(),
+                clip_sources: weak_handle,
+                coordinate_system_id: spatial_node.coordinate_system_id,
+            },
+            local_clip_rect: spatial_node
+                .coordinate_system_relative_transform
+                .transform_rect(&local_outer_rect),
+            screen_outer_rect,
+            screen_inner_rect,
+            prev: None,
+        };
+
+        let mut clip_chain =
+            clip_chains[self.parent_clip_chain_index.0]
+            .new_with_added_node(&new_node);
+
+        self.clip_chain_node = Some(new_node);
+        clip_chain.parent_index = Some(self.parent_clip_chain_index);
+        clip_chains[self.clip_chain_index.0] = clip_chain;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SpatialNodeType {
     /// A special kind of node that adjusts its position based on the position
     /// of its parent node and a given set of sticky positioning offset bounds.
     /// Sticky positioned is described in the CSS Positioned Layout Module Level 3 here:
@@ -59,43 +149,25 @@ pub enum SpatialNodeKind {
 
     /// A reference frame establishes a new coordinate space in the tree.
     ReferenceFrame(ReferenceFrameInfo),
-}
-
-#[derive(Debug)]
-pub enum NodeType {
-    Spatial {
-        kind: SpatialNodeKind,
-    },
-
-    /// Other nodes just do clipping, but no transformation.
-    Clip {
-        handle: ClipSourcesHandle,
-        clip_chain_index: ClipChainIndex,
-
-        /// A copy of the ClipChainNode this node would produce. We need to keep a copy,
-        /// because the ClipChain may not contain our node if is optimized out, but API
-        /// defined ClipChains will still need to access it.
-        clip_chain_node: Option<ClipChainNode>,
-    },
 
     /// An empty node, used to pad the ClipScrollTree's array of nodes so that
-    /// we can immediately use each assigned ClipScrollNodeIndex. After display
+    /// we can immediately use each assigned SpatialNodeIndex. After display
     /// list flattening this node type should never be used.
     Empty,
 }
 
-impl NodeType {
+impl SpatialNodeType {
     fn is_reference_frame(&self) -> bool {
         match *self {
-            NodeType::Spatial { kind: SpatialNodeKind::ReferenceFrame(_), .. } => true,
+            SpatialNodeType::ReferenceFrame(_) => true,
             _ => false,
         }
     }
 }
 
 /// Contains information common among all types of ClipScrollTree nodes.
-#[derive(Debug)]
-pub struct ClipScrollNode {
+#[derive(Clone, Debug)]
+pub struct SpatialNode {
     /// The transformation for this viewport in world coordinates is the transformation for
     /// our parent reference frame, plus any accumulated scrolling offsets from nodes
     /// between our reference frame and this node. For reference frames, we also include
@@ -112,13 +184,13 @@ pub struct ClipScrollNode {
     pub pipeline_id: PipelineId,
 
     /// Parent layer. If this is None, we are the root node.
-    pub parent: Option<ClipScrollNodeIndex>,
+    pub parent: Option<SpatialNodeIndex>,
 
     /// Child layers
-    pub children: Vec<ClipScrollNodeIndex>,
+    pub children: Vec<SpatialNodeIndex>,
 
     /// The type of this node and any data associated with that node type.
-    pub node_type: NodeType,
+    pub node_type: SpatialNodeType,
 
     /// True if this node is transformed by an invertible transform.  If not, display items
     /// transformed by this node will not be displayed and display items not transformed by this
@@ -132,21 +204,15 @@ pub struct ClipScrollNode {
     /// system (same coordinate system id) and us. This can change via scroll offsets and via new
     /// reference frame transforms.
     pub coordinate_system_relative_transform: LayoutFastTransform,
-
-    /// The index of the spatial node that provides positioning information for this node.
-    /// For reference frames, scroll and sticky frames it is a unique identfier.
-    /// For clip nodes, this is the nearest ancestor spatial node.
-    pub transform_index: TransformIndex,
 }
 
-impl ClipScrollNode {
+impl SpatialNode {
     pub fn new(
         pipeline_id: PipelineId,
-        parent_index: Option<ClipScrollNodeIndex>,
-        node_type: NodeType,
-        transform_index: TransformIndex,
+        parent_index: Option<SpatialNodeIndex>,
+        node_type: SpatialNodeType,
     ) -> Self {
-        ClipScrollNode {
+        SpatialNode {
             world_viewport_transform: LayoutToWorldFastTransform::identity(),
             world_content_transform: LayoutToWorldFastTransform::identity(),
             transform_kind: TransformedRectKind::AxisAligned,
@@ -157,30 +223,22 @@ impl ClipScrollNode {
             invertible: true,
             coordinate_system_id: CoordinateSystemId(0),
             coordinate_system_relative_transform: LayoutFastTransform::identity(),
-            transform_index,
         }
     }
 
-    pub fn empty() -> ClipScrollNode {
-        Self::new(
-            PipelineId::dummy(),
-            None,
-            NodeType::Empty,
-            TransformIndex(0),
-        )
+    pub fn empty() -> SpatialNode {
+        Self::new(PipelineId::dummy(), None, SpatialNodeType::Empty)
     }
 
     pub fn new_scroll_frame(
         pipeline_id: PipelineId,
-        parent_index: ClipScrollNodeIndex,
+        parent_index: SpatialNodeIndex,
         external_id: Option<ExternalScrollId>,
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
-        transform_index: TransformIndex,
     ) -> Self {
-        let node_type = NodeType::Spatial {
-            kind: SpatialNodeKind::ScrollFrame(ScrollFrameInfo::new(
+        let node_type = SpatialNodeType::ScrollFrame(ScrollFrameInfo::new(
                 *frame_rect,
                 scroll_sensitivity,
                 LayoutSize::new(
@@ -188,24 +246,18 @@ impl ClipScrollNode {
                     (content_size.height - frame_rect.size.height).max(0.0)
                 ),
                 external_id,
-            )),
-        };
+            )
+        );
 
-        Self::new(
-            pipeline_id,
-            Some(parent_index),
-            node_type,
-            transform_index,
-        )
+        Self::new(pipeline_id, Some(parent_index), node_type)
     }
 
     pub fn new_reference_frame(
-        parent_index: Option<ClipScrollNodeIndex>,
+        parent_index: Option<SpatialNodeIndex>,
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
         pipeline_id: PipelineId,
-        transform_index: TransformIndex,
     ) -> Self {
         let identity = LayoutTransform::identity();
         let source_perspective = source_perspective.map_or_else(
@@ -217,41 +269,25 @@ impl ClipScrollNode {
             origin_in_parent_reference_frame,
             invertible: true,
         };
-        Self::new(
-            pipeline_id,
-            parent_index,
-            NodeType::Spatial {
-                kind: SpatialNodeKind::ReferenceFrame(info),
-            },
-            transform_index,
-        )
+        Self::new(pipeline_id, parent_index, SpatialNodeType:: ReferenceFrame(info))
     }
 
     pub fn new_sticky_frame(
-        parent_index: ClipScrollNodeIndex,
+        parent_index: SpatialNodeIndex,
         sticky_frame_info: StickyFrameInfo,
         pipeline_id: PipelineId,
-        transform_index: TransformIndex,
     ) -> Self {
-        let node_type = NodeType::Spatial {
-            kind: SpatialNodeKind::StickyFrame(sticky_frame_info),
-        };
-        Self::new(
-            pipeline_id,
-            Some(parent_index),
-            node_type,
-            transform_index,
-        )
+        Self::new(pipeline_id, Some(parent_index), SpatialNodeType::StickyFrame(sticky_frame_info))
     }
 
 
-    pub fn add_child(&mut self, child: ClipScrollNodeIndex) {
+    pub fn add_child(&mut self, child: SpatialNodeIndex) {
         self.children.push(child);
     }
 
     pub fn apply_old_scrolling_state(&mut self, old_scroll_info: &ScrollFrameInfo) {
         match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(ref mut scrolling), .. } => {
+            SpatialNodeType::ScrollFrame(ref mut scrolling) => {
                 *scrolling = scrolling.combine_with_old_scroll_info(old_scroll_info);
             }
             _ if old_scroll_info.offset != LayoutVector2D::zero() => {
@@ -267,7 +303,7 @@ impl ClipScrollNode {
         let scrollable_height = scrollable_size.height;
 
         let scrolling = match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(ref mut scrolling), .. } => scrolling,
+            SpatialNodeType::ScrollFrame(ref mut scrolling) => scrolling,
             _ => {
                 warn!("Tried to scroll a non-scroll node.");
                 return false;
@@ -306,41 +342,36 @@ impl ClipScrollNode {
     pub fn push_gpu_data(
         &mut self,
         transform_palette: &mut TransformPalette,
+        node_index: SpatialNodeIndex,
     ) {
-        if let NodeType::Spatial { .. } = self.node_type {
-            if !self.invertible {
-                transform_palette.set(self.transform_index, TransformData::invalid());
+        let transform_index = TransformIndex(node_index.0 as u32);
+        if !self.invertible {
+            transform_palette.set(transform_index, TransformData::invalid());
+            return;
+        }
+
+        let inv_transform = match self.world_content_transform.inverse() {
+            Some(inverted) => inverted.to_transform(),
+            None => {
+                transform_palette.set(transform_index, TransformData::invalid());
                 return;
             }
+        };
 
-            let inv_transform = match self.world_content_transform.inverse() {
-                Some(inverted) => inverted.to_transform(),
-                None => {
-                    transform_palette.set(self.transform_index, TransformData::invalid());
-                    return;
-                }
-            };
+        let data = TransformData {
+            transform: self.world_content_transform.into(),
+            inv_transform,
+        };
 
-            let data = TransformData {
-                transform: self.world_content_transform.into(),
-                inv_transform,
-            };
-
-            // Write the data that will be made available to the GPU for this node.
-            transform_palette.set(self.transform_index, data);
-        }
+        // Write the data that will be made available to the GPU for this node.
+        transform_palette.set(transform_index, data);
     }
 
     pub fn update(
         &mut self,
         state: &mut TransformUpdateState,
         next_coordinate_system_id: &mut CoordinateSystemId,
-        device_pixel_scale: DevicePixelScale,
-        clip_store: &mut ClipStore,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
         scene_properties: &SceneProperties,
-        clip_chains: &mut Vec<ClipChain>,
     ) {
         // If any of our parents was not rendered, we are not rendered either and can just
         // quit here.
@@ -361,82 +392,12 @@ impl ClipScrollNode {
         // For non-reference-frames we assume that they will produce only additional
         // translations which should be invertible.
         match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ReferenceFrame(info), .. } if !info.invertible => {
+            SpatialNodeType::ReferenceFrame(info) if !info.invertible => {
                 self.mark_uninvertible();
                 return;
             }
             _ => self.invertible = true,
         }
-
-        self.update_clip_work_item(
-            state,
-            device_pixel_scale,
-            clip_store,
-            resource_cache,
-            gpu_cache,
-            clip_chains,
-        );
-    }
-
-    pub fn update_clip_work_item(
-        &mut self,
-        state: &mut TransformUpdateState,
-        device_pixel_scale: DevicePixelScale,
-        clip_store: &mut ClipStore,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
-        clip_chains: &mut [ClipChain],
-    ) {
-        let (clip_sources_handle, clip_chain_index, stored_clip_chain_node) = match self.node_type {
-            NodeType::Clip { ref handle, clip_chain_index, ref mut clip_chain_node, .. } =>
-                (handle, clip_chain_index, clip_chain_node),
-            _ => {
-                self.invertible = true;
-                return;
-            }
-        };
-
-        let clip_sources = clip_store.get_mut(clip_sources_handle);
-        clip_sources.update(
-            gpu_cache,
-            resource_cache,
-            device_pixel_scale,
-        );
-
-        let (screen_inner_rect, screen_outer_rect) = clip_sources.get_screen_bounds(
-            &self.world_viewport_transform,
-            device_pixel_scale,
-            None,
-        );
-
-        // All clipping ClipScrollNodes should have outer rectangles, because they never
-        // use the BorderCorner clip type and they always have at last one non-ClipOut
-        // Rectangle ClipSource.
-        let screen_outer_rect = screen_outer_rect
-            .expect("Clipping node didn't have outer rect.");
-        let local_outer_rect = clip_sources.local_outer_rect
-            .expect("Clipping node didn't have outer rect.");
-
-        let new_node = ClipChainNode {
-            work_item: ClipWorkItem {
-                transform_index: self.transform_index,
-                clip_sources: clip_sources_handle.weak(),
-                coordinate_system_id: state.current_coordinate_system_id,
-            },
-            local_clip_rect:
-                self.coordinate_system_relative_transform.transform_rect(&local_outer_rect),
-            screen_outer_rect,
-            screen_inner_rect,
-            prev: None,
-        };
-
-        let mut clip_chain =
-            clip_chains[state.parent_clip_chain_index.0].new_with_added_node(&new_node);
-
-        *stored_clip_chain_node = Some(new_node);
-        clip_chain.parent_index = Some(state.parent_clip_chain_index);
-        clip_chains[clip_chain_index.0] = clip_chain;
-        state.parent_clip_chain_index = clip_chain_index;
     }
 
     pub fn update_transform(
@@ -483,7 +444,7 @@ impl ClipScrollNode {
         self.coordinate_system_relative_transform =
             state.coordinate_system_relative_transform.offset(added_offset);
 
-        if let NodeType::Spatial { kind: SpatialNodeKind::StickyFrame(ref mut info), .. } = self.node_type {
+        if let SpatialNodeType::StickyFrame(ref mut info) = self.node_type {
             info.current_offset = sticky_offset;
         }
 
@@ -497,7 +458,7 @@ impl ClipScrollNode {
         scene_properties: &SceneProperties,
     ) {
         let info = match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ReferenceFrame(ref mut info), .. } => info,
+            SpatialNodeType::ReferenceFrame(ref mut info) => info,
             _ => unreachable!("Called update_transform_for_reference_frame on non-ReferenceFrame"),
         };
 
@@ -545,7 +506,7 @@ impl ClipScrollNode {
         viewport_rect: &LayoutRect,
     ) -> LayoutVector2D {
         let info = match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::StickyFrame(ref info), .. } => info,
+            SpatialNodeType::StickyFrame(ref info) => info,
             _ => return LayoutVector2D::zero(),
         };
 
@@ -659,48 +620,43 @@ impl ClipScrollNode {
         // between us and the parent reference frame. If we are a reference frame,
         // we need to reset both these values.
         match self.node_type {
-            NodeType::Spatial { ref kind, .. } => {
-                match *kind {
-                    SpatialNodeKind::StickyFrame(ref info) => {
-                        // We don't translate the combined rect by the sticky offset, because sticky
-                        // offsets actually adjust the node position itself, whereas scroll offsets
-                        // only apply to contents inside the node.
-                        state.parent_accumulated_scroll_offset =
-                            info.current_offset + state.parent_accumulated_scroll_offset;
-                    }
-                    SpatialNodeKind::ScrollFrame(ref scrolling) => {
-                        state.parent_accumulated_scroll_offset =
-                            scrolling.offset + state.parent_accumulated_scroll_offset;
-                        state.nearest_scrolling_ancestor_offset = scrolling.offset;
-                        state.nearest_scrolling_ancestor_viewport = scrolling.viewport_rect;
-                    }
-                    SpatialNodeKind::ReferenceFrame(ref info) => {
-                        state.parent_reference_frame_transform = self.world_viewport_transform;
-                        state.parent_accumulated_scroll_offset = LayoutVector2D::zero();
-                        state.coordinate_system_relative_transform =
-                            self.coordinate_system_relative_transform.clone();
-                        let translation = -info.origin_in_parent_reference_frame;
-                        state.nearest_scrolling_ancestor_viewport =
-                            state.nearest_scrolling_ancestor_viewport
-                               .translate(&translation);
-                    }
-                }
+            SpatialNodeType::StickyFrame(ref info) => {
+                // We don't translate the combined rect by the sticky offset, because sticky
+                // offsets actually adjust the node position itself, whereas scroll offsets
+                // only apply to contents inside the node.
+                state.parent_accumulated_scroll_offset =
+                    info.current_offset + state.parent_accumulated_scroll_offset;
             }
-            NodeType::Clip{ .. } => { }
-            NodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
+            SpatialNodeType::ScrollFrame(ref scrolling) => {
+                state.parent_accumulated_scroll_offset =
+                    scrolling.offset + state.parent_accumulated_scroll_offset;
+                state.nearest_scrolling_ancestor_offset = scrolling.offset;
+                state.nearest_scrolling_ancestor_viewport = scrolling.viewport_rect;
+            }
+            SpatialNodeType::ReferenceFrame(ref info) => {
+                state.parent_reference_frame_transform = self.world_viewport_transform;
+                state.parent_accumulated_scroll_offset = LayoutVector2D::zero();
+                state.coordinate_system_relative_transform =
+                    self.coordinate_system_relative_transform.clone();
+                let translation = -info.origin_in_parent_reference_frame;
+                state.nearest_scrolling_ancestor_viewport =
+                    state.nearest_scrolling_ancestor_viewport
+                       .translate(&translation);
+            }
+            SpatialNodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
         }
     }
 
     pub fn scrollable_size(&self) -> LayoutSize {
         match self.node_type {
-           NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(state), .. } => state.scrollable_size,
+           SpatialNodeType::ScrollFrame(state) => state.scrollable_size,
             _ => LayoutSize::zero(),
         }
     }
 
     pub fn scroll(&mut self, scroll_location: ScrollLocation) -> bool {
         let scrolling = match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(ref mut scrolling), .. } => scrolling,
+            SpatialNodeType::ScrollFrame(ref mut scrolling) => scrolling,
             _ => return false,
         };
 
@@ -750,14 +706,14 @@ impl ClipScrollNode {
 
     pub fn scroll_offset(&self) -> LayoutVector2D {
         match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(ref scrolling), .. } => scrolling.offset,
+            SpatialNodeType::ScrollFrame(ref scrolling) => scrolling.offset,
             _ => LayoutVector2D::zero(),
         }
     }
 
     pub fn matches_external_id(&self, external_id: ExternalScrollId) -> bool {
         match self.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(info), .. } if info.external_id == Some(external_id) => true,
+            SpatialNodeType::ScrollFrame(info) if info.external_id == Some(external_id) => true,
             _ => false,
         }
     }

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -6,9 +6,9 @@ use api::{DeviceIntRect, DevicePixelScale, ExternalScrollId, LayoutPoint, Layout
 use api::{PipelineId, ScrollClamping, ScrollLocation, ScrollNodeState};
 use api::{LayoutSize, LayoutTransform, PropertyBinding, ScrollSensitivity, WorldPoint};
 use clip::{ClipChain, ClipSourcesHandle, ClipStore};
-use clip_scroll_node::{ClipScrollNode, NodeType, SpatialNodeKind, ScrollFrameInfo, StickyFrameInfo};
+use clip_scroll_node::{ClipNode, ScrollFrameInfo, SpatialNode, SpatialNodeType, StickyFrameInfo};
 use gpu_cache::GpuCache;
-use gpu_types::TransformPalette;
+use gpu_types::{TransformIndex, TransformPalette};
 use internal_types::{FastHashMap, FastHashSet};
 use print_tree::{PrintTree, PrintTreePrinter};
 use resource_cache::ResourceCache;
@@ -27,19 +27,19 @@ pub type ScrollStates = FastHashMap<ExternalScrollId, ScrollFrameInfo>;
 pub struct CoordinateSystemId(pub u32);
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
-pub struct ClipScrollNodeIndex(pub usize);
+pub struct SpatialNodeIndex(pub usize);
 
-// Used to index the smaller subset of nodes in the CST that define
-// new transform / positioning.
-// TODO(gw): In the future if we split the CST into a positioning and
-//           clipping tree, this can be tidied up a bit.
-#[derive(Copy, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct TransformIndex(pub u32);
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub struct ClipNodeIndex(pub usize);
 
-const ROOT_REFERENCE_FRAME_INDEX: ClipScrollNodeIndex = ClipScrollNodeIndex(0);
-const TOPMOST_SCROLL_NODE_INDEX: ClipScrollNodeIndex = ClipScrollNodeIndex(1);
+impl SpatialNodeIndex {
+    pub fn transform_index(&self) -> TransformIndex {
+        TransformIndex(self.0 as u32)
+    }
+}
+
+const ROOT_REFERENCE_FRAME_INDEX: SpatialNodeIndex = SpatialNodeIndex(0);
+const TOPMOST_SCROLL_NODE_INDEX: SpatialNodeIndex = SpatialNodeIndex(1);
 
 impl CoordinateSystemId {
     pub fn root() -> Self {
@@ -59,14 +59,19 @@ impl CoordinateSystemId {
 pub struct ClipChainDescriptor {
     pub index: ClipChainIndex,
     pub parent: Option<ClipChainIndex>,
-    pub clips: Vec<ClipScrollNodeIndex>,
+    pub clips: Vec<ClipNodeIndex>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClipChainIndex(pub usize);
 
 pub struct ClipScrollTree {
-    pub nodes: Vec<ClipScrollNode>,
+    /// Nodes which determine the positions (offsets and transforms) for primitives
+    /// and clips.
+    pub spatial_nodes: Vec<SpatialNode>,
+
+    /// Nodes which clip primitives.
+    pub clip_nodes: Vec<ClipNode>,
 
     /// A Vec of all descriptors that describe ClipChains in the order in which they are
     /// encountered during display list flattening. ClipChains are expected to never be
@@ -82,10 +87,6 @@ pub struct ClipScrollTree {
     /// A set of pipelines which should be discarded the next time this
     /// tree is drained.
     pub pipelines_to_discard: FastHashSet<PipelineId>,
-
-    /// The number of nodes in the CST that are spatial. Currently, this is all
-    /// nodes that are not clip nodes.
-    spatial_node_count: usize,
 }
 
 #[derive(Clone)]
@@ -94,9 +95,6 @@ pub struct TransformUpdateState {
     pub parent_accumulated_scroll_offset: LayoutVector2D,
     pub nearest_scrolling_ancestor_offset: LayoutVector2D,
     pub nearest_scrolling_ancestor_viewport: LayoutRect,
-
-    /// The index of the current parent's clip chain.
-    pub parent_clip_chain_index: ClipChainIndex,
 
     /// An id for keeping track of the axis-aligned space of this node. This is used in
     /// order to to track what kinds of clip optimizations can be done for a particular
@@ -116,35 +114,35 @@ pub struct TransformUpdateState {
 impl ClipScrollTree {
     pub fn new() -> Self {
         ClipScrollTree {
-            nodes: Vec::new(),
+            spatial_nodes: Vec::new(),
+            clip_nodes: Vec::new(),
             clip_chains_descriptors: Vec::new(),
             clip_chains: vec![ClipChain::empty(&DeviceIntRect::zero())],
             pending_scroll_offsets: FastHashMap::default(),
             pipelines_to_discard: FastHashSet::default(),
-            spatial_node_count: 0,
         }
     }
 
     /// The root reference frame, which is the true root of the ClipScrollTree. Initially
-    /// this ID is not valid, which is indicated by ```nodes``` being empty.
-    pub fn root_reference_frame_index(&self) -> ClipScrollNodeIndex {
+    /// this ID is not valid, which is indicated by ```spatial_nodes``` being empty.
+    pub fn root_reference_frame_index(&self) -> SpatialNodeIndex {
         // TODO(mrobinson): We should eventually make this impossible to misuse.
-        debug_assert!(!self.nodes.is_empty());
+        debug_assert!(!self.spatial_nodes.is_empty());
         ROOT_REFERENCE_FRAME_INDEX
     }
 
     /// The root scroll node which is the first child of the root reference frame.
-    /// Initially this ID is not valid, which is indicated by ```nodes``` being empty.
-    pub fn topmost_scroll_node_index(&self) -> ClipScrollNodeIndex {
+    /// Initially this ID is not valid, which is indicated by ```spatial_nodes``` being empty.
+    pub fn topmost_scroll_node_index(&self) -> SpatialNodeIndex {
         // TODO(mrobinson): We should eventually make this impossible to misuse.
-        debug_assert!(self.nodes.len() >= 1);
+        debug_assert!(self.spatial_nodes.len() >= 1);
         TOPMOST_SCROLL_NODE_INDEX
     }
 
     pub fn get_scroll_node_state(&self) -> Vec<ScrollNodeState> {
         let mut result = vec![];
-        for node in &self.nodes {
-            if let NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(info), .. } = node.node_type {
+        for node in &self.spatial_nodes {
+            if let SpatialNodeType::ScrollFrame(info) = node.node_type {
                 if let Some(id) = info.external_id {
                     result.push(ScrollNodeState { id, scroll_offset: info.offset })
                 }
@@ -155,20 +153,20 @@ impl ClipScrollTree {
 
     pub fn drain(&mut self) -> ScrollStates {
         let mut scroll_states = FastHashMap::default();
-        for old_node in &mut self.nodes.drain(..) {
+        for old_node in &mut self.spatial_nodes.drain(..) {
             if self.pipelines_to_discard.contains(&old_node.pipeline_id) {
                 continue;
             }
 
             match old_node.node_type {
-                NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(info), .. } if info.external_id.is_some() => {
+                SpatialNodeType::ScrollFrame(info) if info.external_id.is_some() => {
                     scroll_states.insert(info.external_id.unwrap(), info);
                 }
                 _ => {}
             }
         }
 
-        self.spatial_node_count = 0;
+        self.clip_nodes.clear();
         self.pipelines_to_discard.clear();
         self.clip_chains = vec![ClipChain::empty(&DeviceIntRect::zero())];
         self.clip_chains_descriptors.clear();
@@ -181,7 +179,7 @@ impl ClipScrollTree {
         id: ExternalScrollId,
         clamp: ScrollClamping
     ) -> bool {
-        for node in &mut self.nodes {
+        for node in &mut self.spatial_nodes {
             if node.matches_external_id(id) {
                 return node.set_scroll_origin(&origin, clamp);
             }
@@ -193,16 +191,16 @@ impl ClipScrollTree {
 
     fn find_nearest_scrolling_ancestor(
         &self,
-        index: Option<ClipScrollNodeIndex>
-    ) -> ClipScrollNodeIndex {
+        index: Option<SpatialNodeIndex>
+    ) -> SpatialNodeIndex {
         let index = match index {
             Some(index) => index,
             None => return self.topmost_scroll_node_index(),
         };
 
-        let node = &self.nodes[index.0];
+        let node = &self.spatial_nodes[index.0];
         match node.node_type {
-            NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(state), .. } if state.sensitive_to_input_events() => index,
+            SpatialNodeType::ScrollFrame(state) if state.sensitive_to_input_events() => index,
             _ => self.find_nearest_scrolling_ancestor(node.parent)
         }
     }
@@ -210,13 +208,13 @@ impl ClipScrollTree {
     pub fn scroll_nearest_scrolling_ancestor(
         &mut self,
         scroll_location: ScrollLocation,
-        node_index: Option<ClipScrollNodeIndex>,
+        node_index: Option<SpatialNodeIndex>,
     ) -> bool {
-        if self.nodes.is_empty() {
+        if self.spatial_nodes.is_empty() {
             return false;
         }
         let node_index = self.find_nearest_scrolling_ancestor(node_index);
-        self.nodes[node_index.0].scroll(scroll_location)
+        self.spatial_nodes[node_index.0].scroll(scroll_location)
     }
 
     pub fn update_tree(
@@ -229,50 +227,54 @@ impl ClipScrollTree {
         pan: WorldPoint,
         scene_properties: &SceneProperties,
     ) -> TransformPalette {
-        let mut transform_palette = TransformPalette::new(self.spatial_node_count);
+        let mut transform_palette = TransformPalette::new(self.spatial_nodes.len());
+        if self.spatial_nodes.is_empty() {
+            return transform_palette;
+        }
 
-        if !self.nodes.is_empty() {
-            self.clip_chains[0] = ClipChain::empty(screen_rect);
+        self.clip_chains[0] = ClipChain::empty(screen_rect);
 
-            let root_reference_frame_index = self.root_reference_frame_index();
-            let mut state = TransformUpdateState {
-                parent_reference_frame_transform: LayoutVector2D::new(pan.x, pan.y).into(),
-                parent_accumulated_scroll_offset: LayoutVector2D::zero(),
-                nearest_scrolling_ancestor_offset: LayoutVector2D::zero(),
-                nearest_scrolling_ancestor_viewport: LayoutRect::zero(),
-                parent_clip_chain_index: ClipChainIndex(0),
-                current_coordinate_system_id: CoordinateSystemId::root(),
-                coordinate_system_relative_transform: LayoutFastTransform::identity(),
-                invertible: true,
-            };
-            let mut next_coordinate_system_id = state.current_coordinate_system_id.next();
-            self.update_node(
-                root_reference_frame_index,
-                &mut state,
-                &mut next_coordinate_system_id,
+        let root_reference_frame_index = self.root_reference_frame_index();
+        let mut state = TransformUpdateState {
+            parent_reference_frame_transform: LayoutVector2D::new(pan.x, pan.y).into(),
+            parent_accumulated_scroll_offset: LayoutVector2D::zero(),
+            nearest_scrolling_ancestor_offset: LayoutVector2D::zero(),
+            nearest_scrolling_ancestor_viewport: LayoutRect::zero(),
+            current_coordinate_system_id: CoordinateSystemId::root(),
+            coordinate_system_relative_transform: LayoutFastTransform::identity(),
+            invertible: true,
+        };
+
+        let mut next_coordinate_system_id = state.current_coordinate_system_id.next();
+        self.update_node(
+            root_reference_frame_index,
+            &mut state,
+            &mut next_coordinate_system_id,
+            &mut transform_palette,
+            scene_properties,
+        );
+
+        for clip_node in &mut self.clip_nodes {
+            let spatial_node = &self.spatial_nodes[clip_node.spatial_node.0];
+            clip_node.update(
+                spatial_node,
                 device_pixel_scale,
                 clip_store,
                 resource_cache,
                 gpu_cache,
-                &mut transform_palette,
-                scene_properties,
+                &mut self.clip_chains,
             );
-
-            self.build_clip_chains(screen_rect);
         }
+        self.build_clip_chains(screen_rect);
 
         transform_palette
     }
 
     fn update_node(
         &mut self,
-        node_index: ClipScrollNodeIndex,
+        node_index: SpatialNodeIndex,
         state: &mut TransformUpdateState,
         next_coordinate_system_id: &mut CoordinateSystemId,
-        device_pixel_scale: DevicePixelScale,
-        clip_store: &mut ClipStore,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
         transform_palette: &mut TransformPalette,
         scene_properties: &SceneProperties,
     ) {
@@ -280,23 +282,13 @@ impl ClipScrollTree {
         //           Restructure this to avoid the clones!
         let mut state = state.clone();
         let node_children = {
-            let node = match self.nodes.get_mut(node_index.0) {
+            let node = match self.spatial_nodes.get_mut(node_index.0) {
                 Some(node) => node,
                 None => return,
             };
 
-            node.update(
-                &mut state,
-                next_coordinate_system_id,
-                device_pixel_scale,
-                clip_store,
-                resource_cache,
-                gpu_cache,
-                scene_properties,
-                &mut self.clip_chains,
-            );
-
-            node.push_gpu_data(transform_palette);
+            node.update(&mut state, next_coordinate_system_id, scene_properties);
+            node.push_gpu_data(transform_palette, node_index);
 
             if node.children.is_empty() {
                 return;
@@ -311,10 +303,6 @@ impl ClipScrollTree {
                 child_node_index,
                 &mut state,
                 next_coordinate_system_id,
-                device_pixel_scale,
-                clip_store,
-                resource_cache,
-                gpu_cache,
                 transform_palette,
                 scene_properties,
             );
@@ -324,22 +312,21 @@ impl ClipScrollTree {
     pub fn build_clip_chains(&mut self, screen_rect: &DeviceIntRect) {
         for descriptor in &self.clip_chains_descriptors {
             // A ClipChain is an optional parent (which is another ClipChain) and a list of
-            // ClipScrollNode clipping nodes. Here we start the ClipChain with a clone of the
+            // SpatialNode clipping nodes. Here we start the ClipChain with a clone of the
             // parent's node, if necessary.
             let mut chain = match descriptor.parent {
                 Some(index) => self.clip_chains[index.0].clone(),
                 None => ClipChain::empty(screen_rect),
             };
 
-            // Now we walk through each ClipScrollNode in the vector of clip nodes and
-            // extract their ClipChain nodes to construct the final list.
+            // Now we walk through each ClipNode in the vector and extract their ClipChain nodes to
+            // construct the final list.
             for clip_index in &descriptor.clips {
-                match self.nodes[clip_index.0].node_type {
-                    NodeType::Clip { clip_chain_node: Some(ref node), .. } => {
+                match self.clip_nodes[clip_index.0] {
+                    ClipNode { clip_chain_node: Some(ref node), .. } => {
                         chain.add_node(node.clone());
                     }
-                    NodeType::Clip { .. } => warn!("Found uninitialized clipping ClipScrollNode."),
-                    _ => warn!("Tried to create a clip chain with non-clipping node."),
+                    ClipNode { .. } => warn!("Found uninitialized clipping ClipNode."),
                 };
             }
 
@@ -349,9 +336,9 @@ impl ClipScrollTree {
     }
 
     pub fn finalize_and_apply_pending_scroll_offsets(&mut self, old_states: ScrollStates) {
-        for node in &mut self.nodes {
+        for node in &mut self.spatial_nodes {
             let external_id = match node.node_type {
-                NodeType::Spatial { kind: SpatialNodeKind::ScrollFrame(ScrollFrameInfo { external_id: Some(id), ..} ), .. } => id,
+                SpatialNodeType::ScrollFrame(ScrollFrameInfo { external_id: Some(id), ..} ) => id,
                 _ => continue,
             };
 
@@ -365,133 +352,131 @@ impl ClipScrollTree {
         }
     }
 
-    // Generate the next valid TransformIndex for the CST.
-    fn next_transform_index(&mut self) -> TransformIndex {
-        let transform_index = TransformIndex(self.spatial_node_count as u32);
-        self.spatial_node_count += 1;
-        transform_index
-    }
-
     pub fn add_clip_node(
         &mut self,
-        index: ClipScrollNodeIndex,
-        parent_index: ClipScrollNodeIndex,
+        index: ClipNodeIndex,
+        parent_clip_chain_index: ClipChainIndex,
+        spatial_node: SpatialNodeIndex,
         handle: ClipSourcesHandle,
-        pipeline_id: PipelineId,
     )  -> ClipChainIndex {
         let clip_chain_index = self.allocate_clip_chain();
-        let transform_index = self.nodes[parent_index.0].transform_index;
-
-        let node_type = NodeType::Clip {
-            handle,
+        let node = ClipNode {
+            parent_clip_chain_index,
+            spatial_node,
+            handle: Some(handle),
             clip_chain_index,
             clip_chain_node: None,
         };
-        let node = ClipScrollNode::new(
-            pipeline_id,
-            Some(parent_index),
-            node_type,
-            transform_index,
-        );
-        self.add_node(node, index);
+        self.push_clip_node(node, index);
         clip_chain_index
     }
 
     pub fn add_scroll_frame(
         &mut self,
-        index: ClipScrollNodeIndex,
-        parent_index: ClipScrollNodeIndex,
+        index: SpatialNodeIndex,
+        parent_index: SpatialNodeIndex,
         external_id: Option<ExternalScrollId>,
         pipeline_id: PipelineId,
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
     ) {
-        let node = ClipScrollNode::new_scroll_frame(
+        let node = SpatialNode::new_scroll_frame(
             pipeline_id,
             parent_index,
             external_id,
             frame_rect,
             content_size,
             scroll_sensitivity,
-            self.next_transform_index(),
         );
-        self.add_node(node, index);
+        self.add_spatial_node(node, index);
     }
 
     pub fn add_reference_frame(
         &mut self,
-        index: ClipScrollNodeIndex,
-        parent_index: Option<ClipScrollNodeIndex>,
+        index: SpatialNodeIndex,
+        parent_index: Option<SpatialNodeIndex>,
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
         pipeline_id: PipelineId,
     ) {
-        let node = ClipScrollNode::new_reference_frame(
+        let node = SpatialNode::new_reference_frame(
             parent_index,
             source_transform,
             source_perspective,
             origin_in_parent_reference_frame,
             pipeline_id,
-            self.next_transform_index(),
         );
-        self.add_node(node, index);
+        self.add_spatial_node(node, index);
     }
 
     pub fn add_sticky_frame(
         &mut self,
-        index: ClipScrollNodeIndex,
-        parent_index: ClipScrollNodeIndex,
+        index: SpatialNodeIndex,
+        parent_index: SpatialNodeIndex,
         sticky_frame_info: StickyFrameInfo,
         pipeline_id: PipelineId,
     ) {
-        let node = ClipScrollNode::new_sticky_frame(
+        let node = SpatialNode::new_sticky_frame(
             parent_index,
             sticky_frame_info,
             pipeline_id,
-            self.next_transform_index(),
         );
-        self.add_node(node, index);
+        self.add_spatial_node(node, index);
     }
 
     pub fn add_clip_chain_descriptor(
         &mut self,
         parent: Option<ClipChainIndex>,
-        clips: Vec<ClipScrollNodeIndex>
+        clips: Vec<ClipNodeIndex>
     ) -> ClipChainIndex {
         let index = self.allocate_clip_chain();
         self.clip_chains_descriptors.push(ClipChainDescriptor { index, parent, clips });
         index
     }
 
-    pub fn add_node(&mut self, node: ClipScrollNode, index: ClipScrollNodeIndex) {
-        // When the parent node is None this means we are adding the root.
-        if let Some(parent_index) = node.parent {
-            self.nodes[parent_index.0].add_child(index);
-        }
-
-        if index.0 == self.nodes.len() {
-            self.nodes.push(node);
+    pub fn push_clip_node(&mut self, node: ClipNode, index: ClipNodeIndex) {
+        if index.0 == self.clip_nodes.len() {
+            self.clip_nodes.push(node);
             return;
         }
 
-
-        if let Some(empty_node) = self.nodes.get_mut(index.0) {
+        if let Some(empty_node) = self.clip_nodes.get_mut(index.0) {
             *empty_node = node;
             return
         }
 
-        let length_to_reserve = index.0 + 1 - self.nodes.len();
-        self.nodes.reserve_exact(length_to_reserve);
+        let length_to_reserve = index.0 + 1 - self.clip_nodes.len();
+        self.clip_nodes.reserve_exact(length_to_reserve);
 
         // We would like to use `Vec::resize` here, but the Clone trait is not supported
-        // for ClipScrollNodes. We can fix this either by splitting the clip nodes out into
-        // their own tree or when support is added for something like `Vec::resize_default`.
-        let length_to_extend = self.nodes.len() .. index.0;
-        self.nodes.extend(length_to_extend.map(|_| ClipScrollNode::empty()));
+        // for ClipNodes. We can fix this either when support is added for something like
+        // `Vec::resize_default`.
+        let length_to_extend = self.clip_nodes.len() .. index.0;
+        self.clip_nodes.extend(length_to_extend.map(|_| ClipNode::empty()));
+        self.clip_nodes.push(node);
+    }
 
-        self.nodes.push(node);
+    pub fn add_spatial_node(&mut self, node: SpatialNode, index: SpatialNodeIndex) {
+        // When the parent node is None this means we are adding the root.
+        if let Some(parent_index) = node.parent {
+            self.spatial_nodes[parent_index.0].add_child(index);
+        }
+
+        if index.0 == self.spatial_nodes.len() {
+            self.spatial_nodes.push(node);
+            return;
+        }
+
+        if let Some(empty_node) = self.spatial_nodes.get_mut(index.0) {
+            *empty_node = node;
+            return
+        }
+
+        debug_assert!(index.0 > self.spatial_nodes.len() - 1);
+        self.spatial_nodes.resize(index.0, SpatialNode::empty());
+        self.spatial_nodes.push(node);
     }
 
     pub fn discard_frame_state_for_pipeline(&mut self, pipeline_id: PipelineId) {
@@ -500,44 +485,29 @@ impl ClipScrollTree {
 
     fn print_node<T: PrintTreePrinter>(
         &self,
-        index: ClipScrollNodeIndex,
+        index: SpatialNodeIndex,
         pt: &mut T,
         clip_store: &ClipStore
     ) {
-        let node = &self.nodes[index.0];
+        let node = &self.spatial_nodes[index.0];
         match node.node_type {
-            NodeType::Spatial { ref kind, .. } => {
-                match *kind {
-                    SpatialNodeKind::StickyFrame(ref sticky_frame_info) => {
-                        pt.new_level(format!("StickyFrame"));
-                        pt.add_item(format!("index: {:?}", index));
-                        pt.add_item(format!("sticky info: {:?}", sticky_frame_info));
-                    }
-                    SpatialNodeKind::ScrollFrame(scrolling_info) => {
-                        pt.new_level(format!("ScrollFrame"));
-                        pt.add_item(format!("index: {:?}", index));
-                        pt.add_item(format!("viewport: {:?}", scrolling_info.viewport_rect));
-                        pt.add_item(format!("scrollable_size: {:?}", scrolling_info.scrollable_size));
-                        pt.add_item(format!("scroll offset: {:?}", scrolling_info.offset));
-                    }
-                    SpatialNodeKind::ReferenceFrame(ref info) => {
-                        pt.new_level(format!("ReferenceFrame {:?}", info.resolved_transform));
-                        pt.add_item(format!("index: {:?}", index));
-                    }
-                }
-            }
-            NodeType::Clip { ref handle, .. } => {
-                pt.new_level("Clip".to_owned());
-
+            SpatialNodeType::StickyFrame(ref sticky_frame_info) => {
+                pt.new_level(format!("StickyFrame"));
                 pt.add_item(format!("index: {:?}", index));
-                let clips = clip_store.get(handle).clips();
-                pt.new_level(format!("Clip Sources [{}]", clips.len()));
-                for source in clips {
-                    pt.add_item(format!("{:?}", source));
-                }
-                pt.end_level();
+                pt.add_item(format!("sticky info: {:?}", sticky_frame_info));
             }
-            NodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
+            SpatialNodeType::ScrollFrame(scrolling_info) => {
+                pt.new_level(format!("ScrollFrame"));
+                pt.add_item(format!("index: {:?}", index));
+                pt.add_item(format!("viewport: {:?}", scrolling_info.viewport_rect));
+                pt.add_item(format!("scrollable_size: {:?}", scrolling_info.scrollable_size));
+                pt.add_item(format!("scroll offset: {:?}", scrolling_info.offset));
+            }
+            SpatialNodeType::ReferenceFrame(ref info) => {
+                pt.new_level(format!("ReferenceFrame {:?}", info.resolved_transform));
+                pt.add_item(format!("index: {:?}", index));
+            }
+            SpatialNodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
         }
 
         pt.add_item(format!("world_viewport_transform: {:?}", node.world_viewport_transform));
@@ -553,14 +523,14 @@ impl ClipScrollTree {
 
     #[allow(dead_code)]
     pub fn print(&self, clip_store: &ClipStore) {
-        if !self.nodes.is_empty() {
+        if !self.spatial_nodes.is_empty() {
             let mut pt = PrintTree::new("clip_scroll tree");
             self.print_with(clip_store, &mut pt);
         }
     }
 
     pub fn print_with<T: PrintTreePrinter>(&self, clip_store: &ClipStore, pt: &mut T) {
-        if !self.nodes.is_empty() {
+        if !self.spatial_nodes.is_empty() {
             self.print_node(self.root_reference_frame_index(), pt, clip_store);
         }
     }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -14,8 +14,8 @@ use api::{PropertyBinding, ReferenceFrame, RepeatMode, ScrollFrameDisplayItem, S
 use api::{Shadow, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect};
 use api::{TransformStyle, YuvColorSpace, YuvData};
 use clip::{ClipRegion, ClipSource, ClipSources, ClipStore};
-use clip_scroll_node::{NodeType, SpatialNodeKind, StickyFrameInfo};
-use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
+use clip_scroll_node::{SpatialNodeType, StickyFrameInfo};
+use clip_scroll_tree::{ClipChainIndex, ClipNodeIndex, ClipScrollTree, SpatialNodeIndex};
 use euclid::vec2;
 use frame_builder::{ChasePrimitive, FrameBuilder, FrameBuilderConfig};
 use glyph_rasterizer::FontInstance;
@@ -44,9 +44,16 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF {
     a: 0.6,
 };
 
+#[derive(Clone, Copy)]
+pub struct PipelineOffset {
+    pipeline: PipelineId,
+    spatial_offset: usize,
+    clip_offset: usize,
+}
+
 /// A data structure that keeps track of mapping between API ClipIds and the indices used
 /// internally in the ClipScrollTree to avoid having to do HashMap lookups. ClipIdToIndexMapper is
-/// responsible for mapping both ClipId to ClipChainIndex and ClipId to ClipScrollNodeIndex.  We
+/// responsible for mapping both ClipId to ClipChainIndex and ClipId to SpatialNodeIndex.  We
 /// also include two small LRU caches. Currently the caches are small (1 entry), but in the future
 /// we could use uluru here to do something more involved.
 #[derive(Default)]
@@ -60,18 +67,23 @@ pub struct ClipIdToIndexMapper {
     /// HashMap lookups.
     cached_clip_chain_index: Option<(ClipId, ClipChainIndex)>,
 
-    /// The offset in the ClipScrollTree's array of ClipScrollNodes for a particular pipeline.
-    /// This is used to convert a ClipId into a ClipScrollNodeIndex.
-    pipeline_offsets: FastHashMap<PipelineId, usize>,
+    /// The offset in the ClipScrollTree's array of SpatialNodes and ClipNodes for a particular
+    /// pipeline.  This is used to convert ClipIds into SpatialNodeIndex or ClipNodeIndex.
+    pipeline_offsets: FastHashMap<PipelineId, PipelineOffset>,
 
     /// The last mapped pipeline offset for this mapper. This is used to avoid having to
     /// consult `pipeline_offsets` repeatedly when flattening the display list.
-    cached_pipeline_offset: Option<(PipelineId, usize)>,
+    cached_pipeline_offset: Option<PipelineOffset>,
 
-    /// The next available pipeline offset for ClipScrollNodeIndex. When we encounter a pipeline
-    /// we will use this value and increment it by the total number of ClipScrollNodes in the
+    /// The next available pipeline offset for ClipNodeIndex. When we encounter a pipeline
+    /// we will use this value and increment it by the total number of clip nodes in the
     /// pipeline's display list.
-    next_available_offset: usize,
+    next_available_clip_offset: usize,
+
+    /// The next available pipeline offset for SpatialNodeIndex. When we encounter a pipeline
+    /// we will use this value and increment it by the total number of spatial nodes in the
+    /// pipeline's display list.
+    next_available_spatial_offset: usize,
 }
 
 impl ClipIdToIndexMapper {
@@ -101,39 +113,46 @@ impl ClipIdToIndexMapper {
         index
     }
 
-    pub fn map_clip_and_scroll(&mut self, info: &ClipAndScrollInfo) -> ScrollNodeAndClipChain {
-        ScrollNodeAndClipChain::new(
-            self.get_node_index(info.scroll_node_id),
-            self.get_clip_chain_index_and_cache_result(&info.clip_node_id())
-        )
-    }
-
-    pub fn simple_scroll_and_clip_chain(&mut self, id: &ClipId) -> ScrollNodeAndClipChain {
-        self.map_clip_and_scroll(&ClipAndScrollInfo::simple(*id))
-    }
-
     pub fn initialize_for_pipeline(&mut self, pipeline: &ScenePipeline) {
         debug_assert!(!self.pipeline_offsets.contains_key(&pipeline.pipeline_id));
-        self.pipeline_offsets.insert(pipeline.pipeline_id, self.next_available_offset);
-        self.next_available_offset += pipeline.display_list.total_clip_ids();
+        self.pipeline_offsets.insert(
+            pipeline.pipeline_id,
+            PipelineOffset {
+                pipeline: pipeline.pipeline_id,
+                spatial_offset: self.next_available_spatial_offset,
+                clip_offset: self.next_available_clip_offset,
+            }
+        );
+
+        self.next_available_clip_offset += pipeline.display_list.total_clip_nodes();
+        self.next_available_spatial_offset += pipeline.display_list.total_spatial_nodes();
     }
 
-    pub fn get_node_index(&mut self, id: ClipId) -> ClipScrollNodeIndex {
-        let (index, pipeline_id) = match id {
-            ClipId::Clip(index, pipeline_id) => (index, pipeline_id),
-            ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
-        };
-
-        let pipeline_offset = match self.cached_pipeline_offset {
-            Some((last_used_id, offset)) if last_used_id == pipeline_id => offset,
+    pub fn get_pipeline_offet<'a>(&'a mut self, id: PipelineId) -> &'a PipelineOffset {
+        match self.cached_pipeline_offset {
+            Some(ref offset) if offset.pipeline == id => offset,
             _ => {
-                let offset = self.pipeline_offsets[&pipeline_id];
-                self.cached_pipeline_offset = Some((pipeline_id, offset));
+                let offset = &self.pipeline_offsets[&id];
+                self.cached_pipeline_offset = Some(*offset);
                 offset
             }
-        };
+        }
+    }
 
-        ClipScrollNodeIndex(pipeline_offset + index)
+    pub fn get_clip_node_index(&mut self, id: ClipId) -> ClipNodeIndex {
+        match id {
+            ClipId::Clip(index, pipeline_id) => {
+                let pipeline_offset = self.get_pipeline_offet(pipeline_id);
+                ClipNodeIndex(pipeline_offset.clip_offset + index)
+            }
+            ClipId::Spatial(..) => {
+                // We could theoretically map back to the containing clip node with the current
+                // design, but we will eventually fully separate out clipping from spatial nodes
+                // in the display list. We don't ever need to do this anyway.
+                panic!("Tried to use positioning node as clip node.");
+            }
+            ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
+        }
     }
 }
 
@@ -160,7 +179,7 @@ pub struct DisplayListFlattener<'a> {
 
     /// A stack of scroll nodes used during display list processing to properly
     /// parent new scroll nodes.
-    reference_frame_stack: Vec<(ClipId, ClipScrollNodeIndex)>,
+    reference_frame_stack: Vec<(ClipId, SpatialNodeIndex)>,
 
     /// A stack of stacking context properties.
     sc_stack: Vec<FlattenedStackingContext>,
@@ -273,14 +292,12 @@ impl<'a> DisplayListFlattener<'a> {
 
     fn flatten_root(&mut self, pipeline: &'a ScenePipeline, frame_size: &LayoutSize) {
         let pipeline_id = pipeline.pipeline_id;
-        let reference_frame_info = self.id_to_index_mapper.simple_scroll_and_clip_chain(
-            &ClipId::root_reference_frame(pipeline_id)
+        let reference_frame_info = self.simple_scroll_and_clip_chain(
+            &ClipId::root_reference_frame(pipeline_id),
         );
 
         let root_scroll_node = ClipId::root_scroll_node(pipeline_id);
-        let scroll_frame_info = self.id_to_index_mapper.simple_scroll_and_clip_chain(
-            &root_scroll_node,
-        );
+        let scroll_frame_info = self.simple_scroll_and_clip_chain(&root_scroll_node);
 
         self.push_stacking_context(
             pipeline_id,
@@ -380,7 +397,7 @@ impl<'a> DisplayListFlattener<'a> {
             info.previously_applied_offset,
         );
 
-        let index = self.id_to_index_mapper.get_node_index(info.id);
+        let index = self.get_spatial_node_index_for_clip_id(info.id);
         self.clip_scroll_tree.add_sticky_frame(
             index,
             clip_and_scroll.scroll_node_id, /* parent id */
@@ -407,7 +424,7 @@ impl<'a> DisplayListFlattener<'a> {
         );
         // Just use clip rectangle as the frame rect for this scroll frame.
         // This is useful when calculating scroll extents for the
-        // ClipScrollNode::scroll(..) API as well as for properly setting sticky
+        // SpatialNode::scroll(..) API as well as for properly setting sticky
         // positioning offsets.
         let frame_rect = item.clip_rect().translate(reference_frame_relative_offset);
         let content_rect = item.rect().translate(reference_frame_relative_offset);
@@ -556,7 +573,7 @@ impl<'a> DisplayListFlattener<'a> {
         reference_frame_relative_offset: LayoutVector2D,
     ) -> Option<BuiltDisplayListIter<'a>> {
         let clip_and_scroll_ids = item.clip_and_scroll();
-        let clip_and_scroll = self.id_to_index_mapper.map_clip_and_scroll(&clip_and_scroll_ids);
+        let clip_and_scroll = self.map_clip_and_scroll(&clip_and_scroll_ids);
 
         let prim_info = item.get_layout_primitive_info(&reference_frame_relative_offset);
         match *item.item() {
@@ -717,7 +734,7 @@ impl<'a> DisplayListFlattener<'a> {
             SpecificDisplayItem::ClipChain(ref info) => {
                 let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items())
                                 .iter()
-                                .map(|id| self.id_to_index_mapper.get_node_index(*id))
+                                .map(|id| self.id_to_index_mapper.get_clip_node_index(*id))
                                 .collect();
                 let parent = info.parent.map(|id|
                      self.id_to_index_mapper.get_clip_chain_index(&ClipId::ClipChain(id))
@@ -883,7 +900,7 @@ impl<'a> DisplayListFlattener<'a> {
         transform_style: TransformStyle,
         is_backface_visible: bool,
         is_pipeline_root: bool,
-        positioning_node: ClipId,
+        spatial_node: ClipId,
         clipping_node: Option<ClipId>,
         glyph_raster_space: GlyphRasterSpace,
     ) {
@@ -892,7 +909,7 @@ impl<'a> DisplayListFlattener<'a> {
             None => ClipChainIndex(0), // This means no clipping.
         };
         let clip_and_scroll = ScrollNodeAndClipChain::new(
-            self.id_to_index_mapper.get_node_index(positioning_node),
+            self.get_spatial_node_index_for_clip_id(spatial_node),
             clip_chain_id
         );
 
@@ -1191,9 +1208,9 @@ impl<'a> DisplayListFlattener<'a> {
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
-    ) -> ClipScrollNodeIndex {
-        let index = self.id_to_index_mapper.get_node_index(reference_frame_id);
-        let parent_index = parent_id.map(|id| self.id_to_index_mapper.get_node_index(id));
+    ) -> SpatialNodeIndex {
+        let index = self.get_spatial_node_index_for_clip_id(reference_frame_id);
+        let parent_index = parent_id.map(|id| self.get_spatial_node_index_for_clip_id(id));
         self.clip_scroll_tree.add_reference_frame(
             index,
             parent_index,
@@ -1212,7 +1229,7 @@ impl<'a> DisplayListFlattener<'a> {
         index
     }
 
-    pub fn current_reference_frame_index(&self) -> ClipScrollNodeIndex {
+    pub fn current_reference_frame_index(&self) -> SpatialNodeIndex {
         self.reference_frame_stack.last().unwrap().1
     }
 
@@ -1223,8 +1240,8 @@ impl<'a> DisplayListFlattener<'a> {
     ) {
         let viewport_offset = (inner_rect.origin.to_vector().to_f32() / device_pixel_scale).round();
         let root_id = self.clip_scroll_tree.root_reference_frame_index();
-        let root_node = &mut self.clip_scroll_tree.nodes[root_id.0];
-        if let NodeType::Spatial { kind: SpatialNodeKind::ReferenceFrame(ref mut info), .. } = root_node.node_type {
+        let root_node = &mut self.clip_scroll_tree.spatial_nodes[root_id.0];
+        if let SpatialNodeType::ReferenceFrame(ref mut info) = root_node.node_type {
             info.resolved_transform =
                 LayoutVector2D::new(viewport_offset.x, viewport_offset.y).into();
         }
@@ -1261,19 +1278,21 @@ impl<'a> DisplayListFlattener<'a> {
         new_node_id: ClipId,
         parent_id: ClipId,
         clip_region: ClipRegion,
-    ) -> ClipScrollNodeIndex {
+    ) {
         let clip_sources = ClipSources::from(clip_region);
         let handle = self.clip_store.insert(clip_sources);
 
-        let node_index = self.id_to_index_mapper.get_node_index(new_node_id);
+        let node_index = self.id_to_index_mapper.get_clip_node_index(new_node_id);
+        let parent_clip_chain_index =
+            self.id_to_index_mapper.get_clip_chain_index_and_cache_result(&parent_id);
+        let spatial_node = self.get_spatial_node_index_for_clip_id(parent_id);
         let clip_chain_index = self.clip_scroll_tree.add_clip_node(
             node_index,
-            self.id_to_index_mapper.get_node_index(parent_id),
+            parent_clip_chain_index,
+            spatial_node,
             handle,
-            new_node_id.pipeline_id(),
         );
         self.id_to_index_mapper.add_clip_chain(new_node_id, clip_chain_index);
-        node_index
     }
 
     pub fn add_scroll_frame(
@@ -1285,11 +1304,12 @@ impl<'a> DisplayListFlattener<'a> {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
-    ) -> ClipScrollNodeIndex {
-        let node_index = self.id_to_index_mapper.get_node_index(new_node_id);
+    ) -> SpatialNodeIndex {
+        let node_index = self.get_spatial_node_index_for_clip_id(new_node_id);
+        let parent_node_index = self.get_spatial_node_index_for_clip_id(parent_id);
         self.clip_scroll_tree.add_scroll_frame(
             node_index,
-            self.id_to_index_mapper.get_node_index(parent_id),
+            parent_node_index,
             external_id,
             pipeline_id,
             frame_rect,
@@ -1933,6 +1953,31 @@ impl<'a> DisplayListFlattener<'a> {
             PrimitiveContainer::Brush(prim),
         );
     }
+
+    pub fn map_clip_and_scroll(&mut self, info: &ClipAndScrollInfo) -> ScrollNodeAndClipChain {
+        ScrollNodeAndClipChain::new(
+            self.get_spatial_node_index_for_clip_id(info.scroll_node_id),
+            self.id_to_index_mapper.get_clip_chain_index_and_cache_result(&info.clip_node_id())
+        )
+    }
+
+    pub fn simple_scroll_and_clip_chain(&mut self, id: &ClipId) -> ScrollNodeAndClipChain {
+        self.map_clip_and_scroll(&ClipAndScrollInfo::simple(*id))
+    }
+
+    pub fn get_spatial_node_index_for_clip_id(&mut self, id: ClipId,) -> SpatialNodeIndex {
+        match id {
+            ClipId::Spatial(index, pipeline_id) => {
+                let pipeline_offset = self.id_to_index_mapper.get_pipeline_offet(pipeline_id);
+                SpatialNodeIndex(pipeline_offset.spatial_offset + index)
+            }
+            ClipId::Clip(..) => {
+                let clip_node_index = self.id_to_index_mapper.get_clip_node_index(id);
+                self.clip_scroll_tree.clip_nodes[clip_node_index.0].spatial_node
+            }
+            ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
+        }
+    }
 }
 
 pub fn build_scene(config: &FrameBuilderConfig, request: SceneRequest) -> BuiltScene {
@@ -1987,4 +2032,4 @@ struct FlattenedStackingContext {
 }
 
 #[derive(Debug)]
-pub struct ScrollbarInfo(pub ClipScrollNodeIndex, pub LayoutRect);
+pub struct ScrollbarInfo(pub SpatialNodeIndex, pub LayoutRect);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -6,11 +6,11 @@ use api::{BuiltDisplayList, ColorF, DeviceIntPoint, DeviceIntRect, DevicePixelSc
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentLayer, FontRenderMode};
 use api::{LayoutPoint, LayoutRect, LayoutSize, PipelineId, WorldPoint};
 use clip::{ClipChain, ClipStore};
-use clip_scroll_node::{ClipScrollNode};
-use clip_scroll_tree::{ClipScrollNodeIndex, ClipScrollTree};
+use clip_scroll_node::{SpatialNode};
+use clip_scroll_tree::{ClipScrollTree, SpatialNodeIndex};
 use display_list_flattener::{DisplayListFlattener};
 use gpu_cache::GpuCache;
-use gpu_types::{PrimitiveHeaders, TransformData, UvRectKind};
+use gpu_types::{PrimitiveHeaders, TransformData, TransformIndex, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
 use picture::PictureSurface;
@@ -88,7 +88,7 @@ pub struct FrameBuildingState<'a> {
 pub struct PictureContext<'a> {
     pub pipeline_id: PipelineId,
     pub prim_runs: Vec<PrimitiveRun>,
-    pub original_reference_frame_index: Option<ClipScrollNodeIndex>,
+    pub original_reference_frame_index: Option<SpatialNodeIndex>,
     pub display_list: &'a BuiltDisplayList,
     pub inv_world_transform: Option<WorldToLayoutFastTransform>,
     pub apply_local_clip_rect: bool,
@@ -114,20 +114,23 @@ impl PictureState {
 
 pub struct PrimitiveRunContext<'a> {
     pub clip_chain: &'a ClipChain,
-    pub scroll_node: &'a ClipScrollNode,
+    pub scroll_node: &'a SpatialNode,
+    pub transform_index: TransformIndex,
     pub local_clip_rect: LayoutRect,
 }
 
 impl<'a> PrimitiveRunContext<'a> {
     pub fn new(
         clip_chain: &'a ClipChain,
-        scroll_node: &'a ClipScrollNode,
+        scroll_node: &'a SpatialNode,
+        transform_index: TransformIndex,
         local_clip_rect: LayoutRect,
     ) -> Self {
         PrimitiveRunContext {
             clip_chain,
             scroll_node,
             local_clip_rect,
+            transform_index,
         }
     }
 }
@@ -196,7 +199,7 @@ impl FrameBuilder {
 
         // The root picture is always the first one added.
         let root_clip_scroll_node =
-            &clip_scroll_tree.nodes[clip_scroll_tree.root_reference_frame_index().0];
+            &clip_scroll_tree.spatial_nodes[clip_scroll_tree.root_reference_frame_index().0];
 
         let display_list = &pipelines
             .get(&root_clip_scroll_node.pipeline_id)
@@ -270,7 +273,7 @@ impl FrameBuilder {
 
         for scrollbar_prim in &self.scrollbar_prims {
             let metadata = &mut self.prim_store.cpu_metadata[scrollbar_prim.prim_index.0];
-            let scroll_frame = &clip_scroll_tree.nodes[scrollbar_prim.scroll_frame_index.0];
+            let scroll_frame = &clip_scroll_tree.spatial_nodes[scrollbar_prim.scroll_frame_index.0];
 
             // Invalidate what's in the cache so it will get rebuilt.
             gpu_cache.invalidate(&metadata.gpu_location);

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -4,7 +4,6 @@
 
 use api::{DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform};
 use api::{PremultipliedColorF, WorldToLayoutTransform};
-use clip_scroll_tree::TransformIndex;
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use prim_store::{EdgeAaSegmentMask};
 use render_task::RenderTaskAddress;
@@ -399,6 +398,11 @@ pub struct TransformPalette {
     pub transforms: Vec<TransformData>,
     metadata: Vec<TransformMetadata>,
 }
+
+#[derive(Copy, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct TransformIndex(pub u32);
 
 impl TransformPalette {
     pub fn new(spatial_node_count: usize) -> TransformPalette {

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -5,8 +5,8 @@
 use api::{BorderRadius, ClipMode, HitTestFlags, HitTestItem, HitTestResult, ItemTag, LayoutPoint};
 use api::{LayoutPrimitiveInfo, LayoutRect, PipelineId, WorldPoint};
 use clip::{ClipSource, ClipStore, rounded_rectangle_contains_point};
-use clip_scroll_node::{ClipScrollNode, NodeType};
-use clip_scroll_tree::{ClipChainIndex, ClipScrollNodeIndex, ClipScrollTree};
+use clip_scroll_node::ClipNode;
+use clip_scroll_tree::{ClipChainIndex, ClipNodeIndex, SpatialNodeIndex, ClipScrollTree};
 use internal_types::FastHashMap;
 use prim_store::ScrollNodeAndClipChain;
 use util::LayoutToWorldFastTransform;
@@ -14,19 +14,24 @@ use util::LayoutToWorldFastTransform;
 /// A copy of important clip scroll node data to use during hit testing. This a copy of
 /// data from the ClipScrollTree that will persist as a new frame is under construction,
 /// allowing hit tests consistent with the currently rendered frame.
-pub struct HitTestClipScrollNode {
+pub struct HitTestSpatialNode {
     /// The pipeline id of this node.
     pipeline_id: PipelineId,
-
-    /// A particular point must be inside all of these regions to be considered clipped in
-    /// for the purposes of a hit test.
-    regions: Vec<HitTestRegion>,
 
     /// World transform for content transformed by this node.
     world_content_transform: LayoutToWorldFastTransform,
 
     /// World viewport transform for content transformed by this node.
     world_viewport_transform: LayoutToWorldFastTransform,
+}
+
+pub struct HitTestClipNode {
+    /// The positioning node for this clip node.
+    spatial_node: SpatialNodeIndex,
+
+    /// A particular point must be inside all of these regions to be considered clipped in
+    /// for the purposes of a hit test.
+    regions: Vec<HitTestRegion>,
 }
 
 /// A description of a clip chain in the HitTester. This is used to describe
@@ -37,7 +42,7 @@ pub struct HitTestClipScrollNode {
 #[derive(Clone)]
 struct HitTestClipChainDescriptor {
     parent: Option<ClipChainIndex>,
-    clips: Vec<ClipScrollNodeIndex>,
+    clips: Vec<ClipNodeIndex>,
 }
 
 impl HitTestClipChainDescriptor {
@@ -93,9 +98,10 @@ impl HitTestRegion {
 
 pub struct HitTester {
     runs: Vec<HitTestingRun>,
-    nodes: Vec<HitTestClipScrollNode>,
+    spatial_nodes: Vec<HitTestSpatialNode>,
+    clip_nodes: Vec<HitTestClipNode>,
     clip_chains: Vec<HitTestClipChainDescriptor>,
-    pipeline_root_nodes: FastHashMap<PipelineId, ClipScrollNodeIndex>,
+    pipeline_root_nodes: FastHashMap<PipelineId, SpatialNodeIndex>,
 }
 
 impl HitTester {
@@ -106,7 +112,8 @@ impl HitTester {
     ) -> HitTester {
         let mut hit_tester = HitTester {
             runs: runs.clone(),
-            nodes: Vec::new(),
+            spatial_nodes: Vec::new(),
+            clip_nodes: Vec::new(),
             clip_chains: Vec::new(),
             pipeline_root_nodes: FastHashMap::default(),
         };
@@ -119,33 +126,41 @@ impl HitTester {
         clip_scroll_tree: &ClipScrollTree,
         clip_store: &ClipStore
     ) {
-        self.nodes.clear();
+        self.spatial_nodes.clear();
         self.clip_chains.clear();
         self.clip_chains.resize(
             clip_scroll_tree.clip_chains.len(),
             HitTestClipChainDescriptor::empty()
         );
 
-        for (index, node) in clip_scroll_tree.nodes.iter().enumerate() {
-            let index = ClipScrollNodeIndex(index);
+        for (index, node) in clip_scroll_tree.spatial_nodes.iter().enumerate() {
+            let index = SpatialNodeIndex(index);
 
             // If we haven't already seen a node for this pipeline, record this one as the root
             // node.
             self.pipeline_root_nodes.entry(node.pipeline_id).or_insert(index);
 
-            self.nodes.push(HitTestClipScrollNode {
+            self.spatial_nodes.push(HitTestSpatialNode {
                 pipeline_id: node.pipeline_id,
-                regions: get_regions_for_clip_scroll_node(node, clip_store),
                 world_content_transform: node.world_content_transform,
                 world_viewport_transform: node.world_viewport_transform,
             });
+        }
 
-            if let NodeType::Clip { clip_chain_index, .. } = node.node_type {
-              let clip_chain = self.clip_chains.get_mut(clip_chain_index.0).unwrap();
-              clip_chain.parent =
-                  clip_scroll_tree.get_clip_chain(clip_chain_index).parent_index;
-              clip_chain.clips = vec![index];
-            }
+        for (index, node) in clip_scroll_tree.clip_nodes.iter().enumerate() {
+            let regions = match get_regions_for_clip_node(node, clip_store) {
+                Some(regions) => regions,
+                None => continue,
+            };
+            self.clip_nodes.push(HitTestClipNode {
+                spatial_node: node.spatial_node,
+                regions,
+            });
+
+             let clip_chain = self.clip_chains.get_mut(node.clip_chain_index.0).unwrap();
+             clip_chain.parent =
+                 clip_scroll_tree.get_clip_chain(node.clip_chain_index).parent_index;
+             clip_chain.clips = vec![ClipNodeIndex(index)];
         }
 
         for descriptor in &clip_scroll_tree.clip_chains_descriptors {
@@ -177,7 +192,7 @@ impl HitTester {
         }
 
         for clip_node_index in &descriptor.clips {
-            if !self.is_point_clipped_in_for_node(point, *clip_node_index, test) {
+            if !self.is_point_clipped_in_for_clip_node(point, *clip_node_index, test) {
                 test.set_in_clip_chain_cache(clip_chain_index, ClippedIn::NotClippedIn);
                 return false;
             }
@@ -187,18 +202,18 @@ impl HitTester {
         true
     }
 
-    fn is_point_clipped_in_for_node(
+    fn is_point_clipped_in_for_clip_node(
         &self,
         point: WorldPoint,
-        node_index: ClipScrollNodeIndex,
+        node_index: ClipNodeIndex,
         test: &mut HitTest
     ) -> bool {
         if let Some(clipped_in) = test.node_cache.get(&node_index) {
             return *clipped_in == ClippedIn::ClippedIn;
         }
 
-        let node = &self.nodes[node_index.0];
-        let transform = node.world_viewport_transform;
+        let node = &self.clip_nodes[node_index.0];
+        let transform = self.spatial_nodes[node.spatial_node.0].world_viewport_transform;
         let transformed_point = match transform.inverse() {
             Some(inverted) => inverted.transform_point2d(&point),
             None => {
@@ -218,12 +233,12 @@ impl HitTester {
         true
     }
 
-    pub fn find_node_under_point(&self, mut test: HitTest) -> Option<ClipScrollNodeIndex> {
+    pub fn find_node_under_point(&self, mut test: HitTest) -> Option<SpatialNodeIndex> {
         let point = test.get_absolute_point(self);
 
         for &HitTestingRun(ref items, ref clip_and_scroll) in self.runs.iter().rev() {
             let scroll_node_id = clip_and_scroll.scroll_node_id;
-            let scroll_node = &self.nodes[scroll_node_id.0];
+            let scroll_node = &self.spatial_nodes[scroll_node_id.0];
             let transform = scroll_node.world_content_transform;
             let point_in_layer = match transform.inverse() {
                 Some(inverted) => inverted.transform_point2d(&point),
@@ -257,7 +272,7 @@ impl HitTester {
         let mut result = HitTestResult::default();
         for &HitTestingRun(ref items, ref clip_and_scroll) in self.runs.iter().rev() {
             let scroll_node_id = clip_and_scroll.scroll_node_id;
-            let scroll_node = &self.nodes[scroll_node_id.0];
+            let scroll_node = &self.spatial_nodes[scroll_node_id.0];
             let pipeline_id = scroll_node.pipeline_id;
             match (test.pipeline_id, pipeline_id) {
                 (Some(id), node_id) if node_id != id => continue,
@@ -296,7 +311,7 @@ impl HitTester {
                 // the pipeline of the hit item. If we cannot get a transformed point, we are
                 // in a situation with an uninvertible transformation so we should just skip this
                 // result.
-                let root_node = &self.nodes[self.pipeline_root_nodes[&pipeline_id].0];
+                let root_node = &self.spatial_nodes[self.pipeline_root_nodes[&pipeline_id].0];
                 let point_in_viewport = match root_node.world_viewport_transform.inverse() {
                     Some(inverted) => inverted.transform_point2d(&point),
                     None => continue,
@@ -318,21 +333,25 @@ impl HitTester {
         result
     }
 
-    pub fn get_pipeline_root(&self, pipeline_id: PipelineId) -> &HitTestClipScrollNode {
-        &self.nodes[self.pipeline_root_nodes[&pipeline_id].0]
+    pub fn get_pipeline_root(&self, pipeline_id: PipelineId) -> &HitTestSpatialNode {
+        &self.spatial_nodes[self.pipeline_root_nodes[&pipeline_id].0]
     }
 }
 
-fn get_regions_for_clip_scroll_node(
-    node: &ClipScrollNode,
+fn get_regions_for_clip_node(
+    node: &ClipNode,
     clip_store: &ClipStore
-) -> Vec<HitTestRegion> {
-    let clips = match node.node_type {
-        NodeType::Clip{ ref handle, .. } => clip_store.get(handle).clips(),
-        _ => return Vec::new(),
+) -> Option<Vec<HitTestRegion>> {
+    let handle = match node.handle.as_ref() {
+        Some(handle) => handle,
+        None => {
+            warn!("Encountered an empty clip node unexpectedly.");
+            return None;
+        }
     };
 
-    clips.iter().map(|source| {
+    let clips = clip_store.get(handle).clips();
+    Some(clips.iter().map(|source| {
         match source.0 {
             ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),
             ClipSource::RoundedRectangle(ref rect, ref radii, ref mode) =>
@@ -343,7 +362,7 @@ fn get_regions_for_clip_scroll_node(
                 unreachable!("Didn't expect to hit test against BorderCorner / BoxShadow / LineDecoration");
             }
         }
-    }).collect()
+    }).collect())
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -356,7 +375,7 @@ pub struct HitTest {
     pipeline_id: Option<PipelineId>,
     point: WorldPoint,
     flags: HitTestFlags,
-    node_cache: FastHashMap<ClipScrollNodeIndex, ClippedIn>,
+    node_cache: FastHashMap<ClipNodeIndex, ClippedIn>,
     clip_chain_cache: Vec<Option<ClippedIn>>,
 }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -6,8 +6,8 @@ use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF};
 use api::{DeviceIntRect, DeviceIntSize, DevicePoint, LayoutPoint, LayoutRect};
 use api::{DevicePixelScale, PictureIntPoint, PictureIntRect, PictureIntSize};
 use box_shadow::{BLUR_SAMPLE_SCALE};
-use clip_scroll_node::ClipScrollNode;
-use clip_scroll_tree::ClipScrollNodeIndex;
+use clip_scroll_node::SpatialNode;
+use clip_scroll_tree::SpatialNodeIndex;
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState, PrimitiveRunContext};
 use gpu_cache::{GpuCacheHandle};
 use gpu_types::UvRectKind;
@@ -150,7 +150,7 @@ pub struct PicturePrimitive {
     // The original reference frame ID for this picture.
     // It is only different if this is part of a 3D
     // rendering context.
-    pub reference_frame_index: ClipScrollNodeIndex,
+    pub reference_frame_index: SpatialNodeIndex,
     pub real_local_rect: LayoutRect,
     // An optional cache handle for storing extra data
     // in the GPU cache, depending on the type of
@@ -183,7 +183,7 @@ impl PicturePrimitive {
         composite_mode: Option<PictureCompositeMode>,
         is_in_3d_context: bool,
         pipeline_id: PipelineId,
-        reference_frame_index: ClipScrollNodeIndex,
+        reference_frame_index: SpatialNodeIndex,
         frame_output_pipeline_id: Option<PipelineId>,
         apply_local_clip_rect: bool,
     ) -> Self {
@@ -590,7 +590,7 @@ impl PicturePrimitive {
 // Calculate a single screen-space UV for a picture.
 fn calculate_screen_uv(
     local_pos: &LayoutPoint,
-    clip_scroll_node: &ClipScrollNode,
+    clip_scroll_node: &SpatialNode,
     rendered_rect: &DeviceRect,
     device_pixel_scale: DevicePixelScale,
 ) -> DevicePoint {
@@ -616,7 +616,7 @@ fn calculate_screen_uv(
 // vertex positions of a picture.
 fn calculate_uv_rect_kind(
     local_rect: &LayoutRect,
-    clip_scroll_node: &ClipScrollNode,
+    clip_scroll_node: &SpatialNode,
     rendered_rect: &DeviceIntRect,
     device_pixel_scale: DevicePixelScale,
 ) -> UvRectKind {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -14,7 +14,7 @@ use api::channel::{MsgReceiver, Payload};
 use api::CaptureBits;
 #[cfg(feature = "replay")]
 use api::CapturedDocument;
-use clip_scroll_tree::{ClipScrollNodeIndex, ClipScrollTree};
+use clip_scroll_tree::{SpatialNodeIndex, ClipScrollTree};
 #[cfg(feature = "debugger")]
 use debug_server;
 use display_list_flattener::DisplayListFlattener;
@@ -89,9 +89,9 @@ struct Document {
 
     view: DocumentView,
 
-    /// The ClipScrollTree for this document which tracks both ClipScrollNodes and ClipChains.
-    /// This is stored here so that we are able to preserve scrolling positions between
-    /// rendered frames.
+    /// The ClipScrollTree for this document which tracks SpatialNodes, ClipNodes, and ClipChains.
+    /// This is stored here so that we are able to preserve scrolling positions between rendered
+    /// frames.
     clip_scroll_tree: ClipScrollTree,
 
     /// The id of the current frame.
@@ -313,7 +313,7 @@ impl Document {
     pub fn scroll_nearest_scrolling_ancestor(
         &mut self,
         scroll_location: ScrollLocation,
-        scroll_node_index: Option<ClipScrollNodeIndex>,
+        scroll_node_index: Option<SpatialNodeIndex>,
     ) -> bool {
         self.clip_scroll_tree.scroll_nearest_scrolling_ancestor(scroll_location, scroll_node_index)
     }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -7,7 +7,7 @@ use api::{DeviceUintRect, DeviceUintSize, DocumentLayer, FilterOp, ImageFormat, 
 use api::{MixBlendMode, PipelineId};
 use batch::{AlphaBatchBuilder, AlphaBatchContainer, ClipBatcher, resolve_image};
 use clip::{ClipStore};
-use clip_scroll_tree::{ClipScrollTree, ClipScrollNodeIndex};
+use clip_scroll_tree::{ClipScrollTree, SpatialNodeIndex};
 use device::{FrameId, Texture};
 #[cfg(feature = "pathfinder")]
 use euclid::{TypedPoint2D, TypedVector2D};
@@ -31,7 +31,7 @@ const MIN_TARGET_SIZE: u32 = 2048;
 
 #[derive(Debug)]
 pub struct ScrollbarPrimitive {
-    pub scroll_frame_index: ClipScrollNodeIndex,
+    pub scroll_frame_index: SpatialNodeIndex,
     pub prim_index: PrimitiveIndex,
     pub frame_rect: LayoutRect,
 }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -806,6 +806,7 @@ pub struct ClipChainId(pub u64, pub PipelineId);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ClipId {
+    Spatial(usize, PipelineId),
     Clip(usize, PipelineId),
     ClipChain(ClipChainId),
 }
@@ -815,15 +816,16 @@ const ROOT_SCROLL_NODE_CLIP_ID: usize = 1;
 
 impl ClipId {
     pub fn root_scroll_node(pipeline_id: PipelineId) -> ClipId {
-        ClipId::Clip(ROOT_SCROLL_NODE_CLIP_ID, pipeline_id)
+        ClipId::Spatial(ROOT_SCROLL_NODE_CLIP_ID, pipeline_id)
     }
 
     pub fn root_reference_frame(pipeline_id: PipelineId) -> ClipId {
-        ClipId::Clip(ROOT_REFERENCE_FRAME_CLIP_ID, pipeline_id)
+        ClipId::Spatial(ROOT_REFERENCE_FRAME_CLIP_ID, pipeline_id)
     }
 
     pub fn pipeline_id(&self) -> PipelineId {
         match *self {
+            ClipId::Spatial(_, pipeline_id) |
             ClipId::Clip(_, pipeline_id) |
             ClipId::ClipChain(ClipChainId(_, pipeline_id)) => pipeline_id,
         }
@@ -831,14 +833,14 @@ impl ClipId {
 
     pub fn is_root_scroll_node(&self) -> bool {
         match *self {
-            ClipId::Clip(1, _) => true,
+            ClipId::Spatial(ROOT_SCROLL_NODE_CLIP_ID, _) => true,
             _ => false,
         }
     }
 
     pub fn is_root_reference_frame(&self) -> bool {
         match *self {
-            ClipId::Clip(1, _) => true,
+            ClipId::Spatial(ROOT_REFERENCE_FRAME_CLIP_ID, _) => true,
             _ => false,
         }
     }

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -31,7 +31,12 @@ use {YuvData, YuvImageDisplayItem};
 pub const MAX_TEXT_RUN_LENGTH: usize = 2040;
 
 // We start at 2, because the root reference is always 0 and the root scroll node is always 1.
-const FIRST_CLIP_ID: usize = 2;
+// TODO(mrobinson): It would be a good idea to eliminate the root scroll frame which is only
+// used by Servo.
+const FIRST_SPATIAL_NODE_INDEX: usize = 2;
+
+// There are no default clips, so we start at the 0 index for clips.
+const FIRST_CLIP_NODE_INDEX: usize = 0;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -79,8 +84,10 @@ pub struct BuiltDisplayListDescriptor {
     builder_finish_time: u64,
     /// The third IPC time stamp: just before sending
     send_start_time: u64,
-    /// The amount of clips ids assigned while building this display list.
-    total_clip_ids: usize,
+    /// The amount of clipping nodes created while building this display list.
+    total_clip_nodes: usize,
+    /// The amount of spatial nodes created while building this display list.
+    total_spatial_nodes: usize,
 }
 
 pub struct BuiltDisplayListIter<'a> {
@@ -146,8 +153,12 @@ impl BuiltDisplayList {
         )
     }
 
-    pub fn total_clip_ids(&self) -> usize {
-        self.descriptor.total_clip_ids
+    pub fn total_clip_nodes(&self) -> usize {
+        self.descriptor.total_clip_nodes
+    }
+
+    pub fn total_spatial_nodes(&self) -> usize {
+        self.descriptor.total_spatial_nodes
     }
 
     pub fn iter(&self) -> BuiltDisplayListIter {
@@ -517,12 +528,13 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
 
         let mut data = Vec::new();
         let mut temp = Vec::new();
-        let mut total_clip_ids = FIRST_CLIP_ID;
+        let mut total_clip_nodes = FIRST_CLIP_NODE_INDEX;
+        let mut total_spatial_nodes = FIRST_SPATIAL_NODE_INDEX;
         for complete in list {
             let item = DisplayItem {
                 item: match complete.item {
                     Clip(specific_item, complex_clips) => {
-                        total_clip_ids += 1;
+                        total_clip_nodes += 1;
                         DisplayListBuilder::push_iter_impl(&mut temp, complex_clips);
                         SpecificDisplayItem::Clip(specific_item)
                     },
@@ -531,12 +543,13 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
                         SpecificDisplayItem::ClipChain(specific_item)
                     }
                     ScrollFrame(specific_item, complex_clips) => {
-                        total_clip_ids += 2;
+                        total_spatial_nodes += 1;
+                        total_clip_nodes += 1;
                         DisplayListBuilder::push_iter_impl(&mut temp, complex_clips);
                         SpecificDisplayItem::ScrollFrame(specific_item)
                     },
                     StickyFrame(specific_item) => {
-                        total_clip_ids += 1;
+                        total_spatial_nodes += 1;
                         SpecificDisplayItem::StickyFrame(specific_item)
                     }
                     Rectangle(specific_item) => SpecificDisplayItem::Rectangle(specific_item),
@@ -554,7 +567,7 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
                     RadialGradient(specific_item) =>
                         SpecificDisplayItem::RadialGradient(specific_item),
                     Iframe(specific_item) => {
-                        total_clip_ids += 1;
+                        total_clip_nodes += 1;
                         SpecificDisplayItem::Iframe(specific_item)
                     }
                     PushStackingContext(specific_item, filters) => {
@@ -563,7 +576,7 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
                     },
                     PopStackingContext => SpecificDisplayItem::PopStackingContext,
                     PushReferenceFrame(specific_item) => {
-                        total_clip_ids += 1;
+                        total_spatial_nodes += 1;
                         SpecificDisplayItem::PushReferenceFrame(specific_item)
                     }
                     PopReferenceFrame => SpecificDisplayItem::PopReferenceFrame,
@@ -588,7 +601,8 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
                 builder_start_time: 0,
                 builder_finish_time: 1,
                 send_start_time: 0,
-                total_clip_ids,
+                total_clip_nodes,
+                total_spatial_nodes,
             },
         })
     }
@@ -813,7 +827,8 @@ impl<'a, 'b> Read for UnsafeReader<'a, 'b> {
 pub struct SaveState {
     dl_len: usize,
     clip_stack_len: usize,
-    next_clip_id: usize,
+    next_clip_index: usize,
+    next_spatial_index: usize,
     next_clip_chain_id: u64,
 }
 
@@ -822,7 +837,8 @@ pub struct DisplayListBuilder {
     pub data: Vec<u8>,
     pub pipeline_id: PipelineId,
     clip_stack: Vec<ClipAndScrollInfo>,
-    next_clip_id: usize,
+    next_clip_index: usize,
+    next_spatial_index: usize,
     next_clip_chain_id: u64,
     builder_start_time: u64,
 
@@ -850,7 +866,8 @@ impl DisplayListBuilder {
             clip_stack: vec![
                 ClipAndScrollInfo::simple(ClipId::root_scroll_node(pipeline_id)),
             ],
-            next_clip_id: FIRST_CLIP_ID,
+            next_clip_index: FIRST_CLIP_NODE_INDEX,
+            next_spatial_index: FIRST_SPATIAL_NODE_INDEX,
             next_clip_chain_id: 0,
             builder_start_time: start_time,
             content_size,
@@ -876,7 +893,8 @@ impl DisplayListBuilder {
         self.save_state = Some(SaveState {
             clip_stack_len: self.clip_stack.len(),
             dl_len: self.data.len(),
-            next_clip_id: self.next_clip_id,
+            next_clip_index: self.next_clip_index,
+            next_spatial_index: self.next_spatial_index,
             next_clip_chain_id: self.next_clip_chain_id,
         });
     }
@@ -887,7 +905,8 @@ impl DisplayListBuilder {
 
         self.clip_stack.truncate(state.clip_stack_len);
         self.data.truncate(state.dl_len);
-        self.next_clip_id = state.next_clip_id;
+        self.next_clip_index = state.next_clip_index;
+        self.next_spatial_index = state.next_spatial_index;
         self.next_clip_chain_id = state.next_clip_chain_id;
     }
 
@@ -1288,7 +1307,7 @@ impl DisplayListBuilder {
         transform: Option<PropertyBinding<LayoutTransform>>,
         perspective: Option<LayoutTransform>,
     ) -> ClipId {
-        let id = self.generate_clip_id();
+        let id = self.generate_spatial_index();
         let item = SpecificDisplayItem::PushReferenceFrame(PushReferenceFrameDisplayListItem {
             reference_frame: ReferenceFrame {
                 transform,
@@ -1338,9 +1357,14 @@ impl DisplayListBuilder {
         self.push_iter(stops);
     }
 
-    fn generate_clip_id(&mut self) -> ClipId {
-        self.next_clip_id += 1;
-        ClipId::Clip(self.next_clip_id - 1, self.pipeline_id)
+    fn generate_clip_index(&mut self) -> ClipId {
+        self.next_clip_index += 1;
+        ClipId::Clip(self.next_clip_index - 1, self.pipeline_id)
+    }
+
+    fn generate_spatial_index(&mut self) -> ClipId {
+        self.next_spatial_index += 1;
+        ClipId::Spatial(self.next_spatial_index - 1, self.pipeline_id)
     }
 
     fn generate_clip_chain_id(&mut self) -> ClipChainId {
@@ -1386,8 +1410,8 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
-        let clip_id = self.generate_clip_id();
-        let scroll_frame_id = self.generate_clip_id();
+        let clip_id = self.generate_clip_index();
+        let scroll_frame_id = self.generate_spatial_index();
         let item = SpecificDisplayItem::ScrollFrame(ScrollFrameDisplayItem {
             clip_id,
             scroll_frame_id,
@@ -1451,7 +1475,7 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
-        let id = self.generate_clip_id();
+        let id = self.generate_clip_index();
         let item = SpecificDisplayItem::Clip(ClipDisplayItem {
             id,
             image_mask,
@@ -1474,7 +1498,7 @@ impl DisplayListBuilder {
         previously_applied_offset: LayoutVector2D,
 
     ) -> ClipId {
-        let id = self.generate_clip_id();
+        let id = self.generate_spatial_index();
         let item = SpecificDisplayItem::StickyFrame(StickyFrameDisplayItem {
             id,
             margins,
@@ -1512,7 +1536,7 @@ impl DisplayListBuilder {
         ignore_missing_pipeline: bool
     ) {
         let item = SpecificDisplayItem::Iframe(IframeDisplayItem {
-            clip_id: self.generate_clip_id(),
+            clip_id: self.generate_clip_index(),
             pipeline_id,
             ignore_missing_pipeline,
         });
@@ -1541,7 +1565,8 @@ impl DisplayListBuilder {
                     builder_start_time: self.builder_start_time,
                     builder_finish_time: end_time,
                     send_start_time: 0,
-                    total_clip_ids: self.next_clip_id,
+                    total_clip_nodes: self.next_clip_index,
+                    total_spatial_nodes: self.next_spatial_index,
                 },
                 data: self.data,
             },


### PR DESCRIPTION
Split the ClipScrollTree into a collection of spatial nodes and a
collection of clipping nodes. This makes it so that no unnecessary work
is done or storage is used for clipping nodes. It also allows us to
simplify certain bits of code that had to deal with both types of nodes.

During display list "flattening," positioning ClipIds are converted to
SpatialNodeIndices by consulting the ClipNode for their positioning
node. ClipIds were already converted directly into ClipChainIndices.

Eventually this change should make it to the API, meaning that we expose
the difference between the different node types. This will make it
harder to misuse the API and allow us to do away with looking up the
positioning node of clips during flattening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2871)
<!-- Reviewable:end -->
