### PR TITLE
Update angle shader validation features and add a missing newline

### DIFF
--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -18,9 +18,11 @@ struct Shader {
 
 const SHADER_PREFIX: &str = "#define WR_MAX_VERTEX_TEXTURE_WIDTH 1024\n";
 
+const BRUSH_FEATURES: &[&str] = &["", "ALPHA_PASS"];
 const CLIP_FEATURES: &[&str] = &["TRANSFORM"];
 const CACHE_FEATURES: &[&str] = &[""];
-const PRIM_FEATURES: &[&str] = &["", "TRANSFORM"];
+const GRADIENT_FEATURES: &[&str] = &[ "", "DITHERING", "ALPHA_PASS", "DITHERING,ALPHA_PASS" ];
+const PRIM_FEATURES: &[&str] = &[""];
 
 const SHADERS: &[Shader] = &[
     // Clip mask shaders
@@ -43,7 +45,7 @@ const SHADERS: &[Shader] = &[
     // Cache shaders
     Shader {
         name: "cs_blur",
-        features: CACHE_FEATURES,
+        features: &[ "ALPHA_TARGET", "COLOR_TARGET" ],
     },
     Shader {
         name: "cs_border_segment",
@@ -56,36 +58,43 @@ const SHADERS: &[Shader] = &[
     },
     Shader {
         name: "ps_text_run",
-        features: PRIM_FEATURES,
+        features: &[ "", "GLYPH_TRANSFORM" ],
     },
     // Brush shaders
     Shader {
         name: "brush_yuv_image",
-        features: &["", "YUV_NV12", "YUV_PLANAR", "YUV_INTERLEAVED", "YUV_NV12,TEXTURE_RECT"],
+        features: &[
+            "",
+            "YUV_NV12",
+            "YUV_PLANAR",
+            "YUV_INTERLEAVED",
+            "TEXTURE_2D,YUV_NV12",
+            "YUV_NV12,ALPHA_PASS",
+        ],
     },
     Shader {
         name: "brush_solid",
-        features: &[],
+        features: BRUSH_FEATURES,
     },
     Shader {
         name: "brush_image",
-        features: &["", "ALPHA_PASS"],
+        features: BRUSH_FEATURES,
     },
     Shader {
         name: "brush_blend",
-        features: &[],
+        features: BRUSH_FEATURES,
     },
     Shader {
         name: "brush_mix_blend",
-        features: &[],
+        features: BRUSH_FEATURES,
     },
     Shader {
         name: "brush_radial_gradient",
-        features: &[ "DITHERING" ],
+        features: GRADIENT_FEATURES,
     },
     Shader {
         name: "brush_linear_gradient",
-        features: &[],
+        features: GRADIENT_FEATURES,
     },
 ];
 
@@ -108,7 +117,7 @@ fn validate_shaders() {
             features.push_str(SHADER_PREFIX);
 
             for feature in config.split(",") {
-                features.push_str(&format!("#define WR_FEATURE_{}", feature));
+                features.push_str(&format!("#define WR_FEATURE_{}\n", feature));
             }
 
             let (vs, fs) =


### PR DESCRIPTION
This adds the missing new line to the end of the the feature strings, which I described in https://github.com/servo/webrender/issues/2872.
Also updated the features which the angle validator uses for testing, since `TRANSFORM` is no longer a Primitive shader feature and Brush shaders have their own feature set too.

Fixes #2872

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2873)
<!-- Reviewable:end -->
