### PR TITLE
Inherit the clip chain of IFrame

### DIFF
--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -34,8 +34,8 @@ impl ClipNode {
     const EMPTY: ClipNode = ClipNode {
         spatial_node: SpatialNodeIndex(0),
         handle: None,
-        clip_chain_index: ClipChainIndex(0),
-        parent_clip_chain_index: ClipChainIndex(0),
+        clip_chain_index: ClipChainIndex::NO_CLIP,
+        parent_clip_chain_index: ClipChainIndex::NO_CLIP,
         clip_chain_node: None,
     };
 

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -62,6 +62,10 @@ pub struct ClipChainDescriptor {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ClipChainIndex(pub usize);
 
+impl ClipChainIndex {
+    pub const NO_CLIP: Self = ClipChainIndex(0);
+}
+
 pub struct ClipScrollTree {
     /// Nodes which determine the positions (offsets and transforms) for primitives
     /// and clips.


### PR DESCRIPTION
~~This is an experiment to fix #2834 on our side by inheriting the clip chains of the iFrames.~~
Fixes #2834
~~I really don't like the way it turns out... and the old code got me confused because the `info.clip_node_id` was completely ignored in `flatten_iframe`.~~
@mrobinson please take a look, cc @staktrace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2875)
<!-- Reviewable:end -->
