### PR TITLE
Reset the active shader to whatever it was before after rendering

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2241,7 +2241,11 @@ impl Renderer {
         &mut self,
         framebuffer_size: DeviceUintSize,
     ) -> Result<RendererStats, Vec<RendererError>> {
-        self.render_impl(Some(framebuffer_size))
+        let mut current_program = [0_i32];
+        unsafe { self.device.gl().get_integer_v(gl::CURRENT_PROGRAM, &mut current_program) };
+        let result = self.render_impl(Some(framebuffer_size));
+        self.device.gl().use_program(current_program[0] as u32);
+        result
     }
 
     // If framebuffer_size is None, don't render


### PR DESCRIPTION
Some external toolkits (such as glium) can't see that webrender
has changed the shader under their feet. glium, for example,
assumes that the active shader program hasn't changed, but in
reality, webrender sets the active shader to 0 after a draw call,
so glium::use_program() doesn't do anything because glium thinks
that the original shader is still active.

Generally, to be a good citizen in OpenGL-land, it's not a good
idea to leave and state changes behind after one frame - the
webrenders rendering should be invisible to any other toolkits,
otherwise workarounds around this no-cleanup "feature" would be
required.

Also see: https://github.com/glium/glium/issues/1696

cc @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2880)
<!-- Reviewable:end -->
