### PR TITLE
use WS_EX_NOREDIRECTIONBITMAP direct-composition app

### DIFF
--- a/direct-composition/src/main_windows.rs
+++ b/direct-composition/src/main_windows.rs
@@ -12,7 +12,7 @@ extern crate winit;
 use direct_composition::DirectComposition;
 use std::sync::mpsc;
 use webrender::api;
-use winit::os::windows::WindowExt;
+use winit::os::windows::{WindowExt, WindowBuilderExt};
 use glutin::dpi::LogicalSize;
 
 fn main() {
@@ -24,6 +24,9 @@ fn main() {
     let window = winit::WindowBuilder::new()
         .with_title("WebRender + ANGLE + DirectComposition")
         .with_dimensions(LogicalSize::new(1024., 768.))
+        .with_decorations(true)
+        .with_transparency(true)
+        .with_no_redirection_bitmap(true)
         .build(&events_loop)
         .unwrap();
 


### PR DESCRIPTION
`with_no_redirection_bitmap` API added to master branch of `winit=0.16.0`.
It is useful for direct-composition samples.

resubmit #2838 PR,
Thanks! #2878, #2877.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2886)
<!-- Reviewable:end -->
