### PR TITLE
Reduce glyph key to 32 bits

### DIFF
--- a/webrender/src/glyph_rasterizer/pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/pathfinder.rs
@@ -194,9 +194,9 @@ impl GlyphRasterizer {
 
                 // TODO: pathfinder will need to support 2D subpixel offset
                 let pathfinder_subpixel_offset =
-                    pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset.0 as u8);
+                    pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset().0 as u8);
                 let pathfinder_glyph_key =
-                    pathfinder_font_renderer::GlyphKey::new(glyph_key.index,
+                    pathfinder_font_renderer::GlyphKey::new(glyph_key.index(),
                                                             pathfinder_subpixel_offset);
 
                 if let Ok(glyph_dimensions) =
@@ -281,9 +281,9 @@ fn request_render_task_from_pathfinder(glyph_key: &GlyphKey,
 
     // TODO: pathfinder will need to support 2D subpixel offset
     let pathfinder_subpixel_offset =
-        pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset.0 as u8);
-    let glyph_subpixel_offset: f64 = glyph_key.subpixel_offset.0.into();
-    let pathfinder_glyph_key = pathfinder_font_renderer::GlyphKey::new(glyph_key.index,
+        pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset().0 as u8);
+    let glyph_subpixel_offset: f64 = glyph_key.subpixel_offset().0.into();
+    let pathfinder_glyph_key = pathfinder_font_renderer::GlyphKey::new(glyph_key.index(),
                                                                        pathfinder_subpixel_offset);
 
     // TODO(pcwalton): Fall back to CPU rendering if Pathfinder fails to collect the outline.

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -361,7 +361,7 @@ impl FontContext {
     ) -> Option<GlyphDimensions> {
         self.get_ct_font(font.font_key, font.size, &font.variations)
             .and_then(|ref ct_font| {
-                let glyph = key.index as CGGlyph;
+                let glyph = key.index() as CGGlyph;
                 let bitmap = is_bitmap_font(ct_font);
                 let (x_offset, y_offset) = if bitmap { (0.0, 0.0) } else { font.get_subpx_offset(key) };
                 let transform = if font.synthetic_italics.is_enabled() ||
@@ -525,7 +525,7 @@ impl FontContext {
             None
         };
 
-        let glyph = key.index as CGGlyph;
+        let glyph = key.index() as CGGlyph;
         let (strike_scale, pixel_step) = if bitmap { (y_scale, 1.0) } else { (x_scale, y_scale / x_scale) };
         let extra_strikes = font.get_extra_strikes(strike_scale / scale);
         let metrics = get_glyph_metrics(

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -328,7 +328,7 @@ impl FontContext {
         };
 
         if succeeded(result) {
-            result = unsafe { FT_Load_Glyph(face.face, glyph.index as FT_UInt, load_flags as FT_Int32) };
+            result = unsafe { FT_Load_Glyph(face.face, glyph.index() as FT_UInt, load_flags as FT_Int32) };
         };
 
         if succeeded(result) {
@@ -356,7 +356,7 @@ impl FontContext {
             error!("Unable to load glyph");
             debug!(
                 "{} of size {:?} from font {:?}, {:?}",
-                glyph.index,
+                glyph.index(),
                 font.size,
                 font.font_key,
                 result

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -203,7 +203,7 @@ impl FontContext {
         bitmaps: bool,
     ) -> dwrote::GlyphRunAnalysis {
         let face = self.get_font_face(font);
-        let glyph = key.index as u16;
+        let glyph = key.index() as u16;
         let advance = 0.0f32;
         let offset = dwrote::GlyphOffset {
             advanceOffset: 0.0,
@@ -298,7 +298,7 @@ impl FontContext {
         }
 
         let face = self.get_font_face(font);
-        face.get_design_glyph_metrics(&[key.index as u16], false)
+        face.get_design_glyph_metrics(&[key.index() as u16], false)
             .first()
             .map(|metrics| {
                 let em_size = size / 16.;


### PR DESCRIPTION
Related to #2890.

As we do quite a few hashmap accesses (at least one per frame per glyph) by this key, reducing its size should help.

r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2894)
<!-- Reviewable:end -->
