### PR TITLE
allow custom gamma and contrast for DWrite fonts

### DIFF
--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -15,6 +15,7 @@ cfg_if! {
         use pathfinder_font_renderer::{PathfinderComPtr, IDWriteFontFace};
         use glyph_rasterizer::NativeFontHandleWrapper;
     } else if #[cfg(not(feature = "pathfinder"))] {
+        use api::FontInstancePlatformOptions;
         use glyph_rasterizer::{GlyphFormat, GlyphRasterResult, RasterizedGlyph};
         use gamma_lut::GammaLut;
     }
@@ -33,9 +34,7 @@ pub struct FontContext {
     fonts: FastHashMap<FontKey, dwrote::FontFace>,
     simulations: FastHashMap<(FontKey, dwrote::DWRITE_FONT_SIMULATIONS), dwrote::FontFace>,
     #[cfg(not(feature = "pathfinder"))]
-    gamma_lut: GammaLut,
-    #[cfg(not(feature = "pathfinder"))]
-    gdi_gamma_lut: GammaLut,
+    gamma_luts: FastHashMap<(u16, u16), GammaLut>,
 }
 
 // DirectWrite is safe to use on multiple threads and non-shareable resources are
@@ -99,24 +98,11 @@ fn is_bitmap_font(font: &FontInstance) -> bool {
 
 impl FontContext {
     pub fn new() -> Result<FontContext, ResourceCacheError> {
-        // These are the default values we use in Gecko.
-        // We use a gamma value of 2.3 for gdi fonts
-        // TODO: Fetch this data from Gecko itself.
-        cfg_if! {
-            if #[cfg(not(feature = "pathfinder"))] {
-                const CONTRAST: f32 = 1.0;
-                const GAMMA: f32 = 1.8;
-                const GDI_GAMMA: f32 = 2.3;
-            }
-        }
-
         Ok(FontContext {
             fonts: FastHashMap::default(),
             simulations: FastHashMap::default(),
             #[cfg(not(feature = "pathfinder"))]
-            gamma_lut: GammaLut::new(CONTRAST, GAMMA, GAMMA),
-            #[cfg(not(feature = "pathfinder"))]
-            gdi_gamma_lut: GammaLut::new(CONTRAST, GDI_GAMMA, GDI_GAMMA),
+            gamma_luts: FastHashMap::default(),
         })
     }
 
@@ -432,17 +418,30 @@ impl FontContext {
         let pixels = analysis.create_alpha_texture(texture_type, bounds);
         let mut bgra_pixels = self.convert_to_bgra(&pixels, font.render_mode, bitmaps);
 
-        let lut_correction = match font.render_mode {
-            FontRenderMode::Mono => &self.gdi_gamma_lut,
+        // These are the default values we use in Gecko.
+        // We use a gamma value of 2.3 for gdi fonts
+        const GDI_GAMMA: u16 = 230;
+
+        let FontInstancePlatformOptions { gamma, contrast, .. } = font.platform_options.unwrap_or_default();
+        let gdi_gamma = match font.render_mode {
+            FontRenderMode::Mono => GDI_GAMMA,
             FontRenderMode::Alpha | FontRenderMode::Subpixel => {
                 if bitmaps || font.flags.contains(FontInstanceFlags::FORCE_GDI) {
-                    &self.gdi_gamma_lut
+                    GDI_GAMMA
                 } else {
-                    &self.gamma_lut
+                    gamma
                 }
             }
         };
-        lut_correction.preblend(&mut bgra_pixels, font.color);
+        let gamma_lut = self.gamma_luts
+            .entry((gdi_gamma, contrast))
+            .or_insert_with(||
+                GammaLut::new(
+                    contrast as f32 / 100.0,
+                    gdi_gamma as f32 / 100.0,
+                    gdi_gamma as f32 / 100.0,
+                ));
+        gamma_lut.preblend(&mut bgra_pixels, font.color);
 
         GlyphRasterResult::Bitmap(RasterizedGlyph {
             left: bounds.left as f32,

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -268,14 +268,16 @@ impl Default for FontInstanceOptions {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub struct FontInstancePlatformOptions {
-    pub unused: u32,
+    pub gamma: u16, // percent
+    pub contrast: u16, // percent
 }
 
 #[cfg(target_os = "windows")]
 impl Default for FontInstancePlatformOptions {
     fn default() -> FontInstancePlatformOptions {
         FontInstancePlatformOptions {
-            unused: 0,
+            gamma: 180, // Default DWrite gamma
+            contrast: 100,
         }
     }
 }


### PR DESCRIPTION
This is to resolve Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1474968

This passes in gamma and contrast so we can parameterize preblending more closely to how Skia is doing so in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2896)
<!-- Reviewable:end -->
