### PR TITLE
Tidy up SpatialNodeIndex and TransformIndex.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -475,8 +475,9 @@ impl AlphaBatchBuilder {
 
         // Add each run in this picture to the batch.
         for run in &pic.runs {
-            let transform_id =
-                ctx.transforms.get_id(run.clip_and_scroll.scroll_node_id.transform_index());
+            let transform_id = ctx
+                .transforms
+                .get_id(run.clip_and_scroll.scroll_node_id);
             self.add_run_to_batch(
                 run,
                 transform_id,
@@ -1770,7 +1771,7 @@ impl ClipBatcher {
         for work_item in clips.iter() {
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
-                transform_id: transforms.get_id(work_item.transform_index),
+                transform_id: transforms.get_id(work_item.spatial_node_index),
                 segment: 0,
                 clip_data_address: GpuCacheAddress::invalid(),
                 resource_address: GpuCacheAddress::invalid(),

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -7,11 +7,11 @@ use api::{ImageRendering, LayoutRect, LayoutSize, LayoutPoint, LayoutVector2D, L
 use api::{BoxShadowClipMode, LayoutToWorldScale, LineOrientation, LineStyle};
 use border::{ensure_no_corner_overlap};
 use box_shadow::{BLUR_SAMPLE_SCALE, BoxShadowClipSource, BoxShadowCacheKey};
-use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId};
+use clip_scroll_tree::{ClipChainIndex, CoordinateSystemId, SpatialNodeIndex};
 use ellipse::Ellipse;
 use freelist::{FreeList, FreeListHandle, WeakFreeListHandle};
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
-use gpu_types::{BoxShadowStretchMode, TransformIndex};
+use gpu_types::BoxShadowStretchMode;
 use prim_store::{ClipData, ImageMaskData};
 use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
@@ -647,7 +647,7 @@ impl Iterator for ClipChainNodeIter {
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct ClipWorkItem {
-    pub transform_index: TransformIndex,
+    pub spatial_node_index: SpatialNodeIndex,
     pub clip_sources: ClipSourcesWeakHandle,
     pub coordinate_system_id: CoordinateSystemId,
 }

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -77,7 +77,7 @@ impl ClipNode {
 
         let new_node = ClipChainNode {
             work_item: ClipWorkItem {
-                transform_index: self.spatial_node.transform_index(),
+                spatial_node_index: self.spatial_node,
                 clip_sources: weak_handle,
                 coordinate_system_id: spatial_node.coordinate_system_id,
             },

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -8,7 +8,7 @@ use api::{LayoutSize, LayoutTransform, PropertyBinding, ScrollSensitivity, World
 use clip::{ClipChain, ClipSourcesHandle, ClipStore};
 use clip_node::ClipNode;
 use gpu_cache::GpuCache;
-use gpu_types::{TransformIndex, TransformPalette};
+use gpu_types::TransformPalette;
 use internal_types::{FastHashMap, FastHashSet};
 use print_tree::{PrintTree, PrintTreePrinter};
 use resource_cache::ResourceCache;
@@ -28,16 +28,12 @@ pub type ScrollStates = FastHashMap<ExternalScrollId, ScrollFrameInfo>;
 pub struct CoordinateSystemId(pub u32);
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct SpatialNodeIndex(pub usize);
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub struct ClipNodeIndex(pub usize);
-
-impl SpatialNodeIndex {
-    pub fn transform_index(&self) -> TransformIndex {
-        TransformIndex(self.0 as u32)
-    }
-}
 
 const ROOT_REFERENCE_FRAME_INDEX: SpatialNodeIndex = SpatialNodeIndex(0);
 const TOPMOST_SCROLL_NODE_INDEX: SpatialNodeIndex = SpatialNodeIndex(1);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -9,7 +9,7 @@ use clip::{ClipChain, ClipStore};
 use clip_scroll_tree::{ClipScrollTree, SpatialNodeIndex};
 use display_list_flattener::{DisplayListFlattener};
 use gpu_cache::GpuCache;
-use gpu_types::{PrimitiveHeaders, TransformData, TransformIndex, UvRectKind};
+use gpu_types::{PrimitiveHeaders, TransformData, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
 use picture::PictureSurface;
@@ -115,7 +115,7 @@ impl PictureState {
 pub struct PrimitiveRunContext<'a> {
     pub clip_chain: &'a ClipChain,
     pub scroll_node: &'a SpatialNode,
-    pub transform_index: TransformIndex,
+    pub spatial_node_index: SpatialNodeIndex,
     pub local_clip_rect: LayoutRect,
 }
 
@@ -123,14 +123,14 @@ impl<'a> PrimitiveRunContext<'a> {
     pub fn new(
         clip_chain: &'a ClipChain,
         scroll_node: &'a SpatialNode,
-        transform_index: TransformIndex,
+        spatial_node_index: SpatialNodeIndex,
         local_clip_rect: LayoutRect,
     ) -> Self {
         PrimitiveRunContext {
             clip_chain,
             scroll_node,
             local_clip_rect,
-            transform_index,
+            spatial_node_index,
         }
     }
 }

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -4,6 +4,7 @@
 
 use api::{DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform};
 use api::{PremultipliedColorF, WorldToLayoutTransform};
+use clip_scroll_tree::SpatialNodeIndex;
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use prim_store::{EdgeAaSegmentMask};
 use render_task::RenderTaskAddress;
@@ -399,11 +400,6 @@ pub struct TransformPalette {
     metadata: Vec<TransformMetadata>,
 }
 
-#[derive(Copy, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct TransformIndex(pub u32);
-
 impl TransformPalette {
     pub fn new(spatial_node_count: usize) -> TransformPalette {
         TransformPalette {
@@ -416,7 +412,7 @@ impl TransformPalette {
     // node in the transform palette.
     pub fn set(
         &mut self,
-        index: TransformIndex,
+        index: SpatialNodeIndex,
         data: TransformData,
     ) {
         let index = index.0 as usize;
@@ -443,9 +439,15 @@ impl TransformPalette {
     // TODO(gw): In the future, it will be possible to specify
     //           a coordinate system id here, to allow retrieving
     //           transforms in the local space of a given spatial node.
-    pub fn get_id(&self, index: TransformIndex) -> TransformPaletteId {
+    pub fn get_id(
+        &self,
+        index: SpatialNodeIndex,
+    ) -> TransformPaletteId {
         let transform_kind = self.metadata[index.0 as usize].transform_kind as u32;
-        TransformPaletteId(index.0 | (transform_kind << 24))
+        TransformPaletteId(
+            (index.0 as u32) |
+            (transform_kind << 24)
+        )
     }
 }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2060,7 +2060,7 @@ impl PrimitiveStore {
             // of doing that, only segment with clips that have the same positioning node.
             // TODO(mrobinson, #2858): It may make sense to include these nodes, resegmenting only
             // when necessary while scrolling.
-            if clip_item.transform_index != prim_run_context.transform_index {
+            if clip_item.spatial_node_index != prim_run_context.spatial_node_index {
                 // We don't need to generate a global clip mask for rectangle clips because we are
                 // in the same coordinate system and rectangular clips are handled by the local
                 // clip chain rectangle.
@@ -2293,7 +2293,7 @@ impl PrimitiveStore {
 
                 Arc::new(ClipChainNode {
                     work_item: ClipWorkItem {
-                        transform_index: prim_run_context.transform_index,
+                        spatial_node_index: prim_run_context.spatial_node_index,
                         clip_sources: clip_sources.weak(),
                         coordinate_system_id: prim_coordinate_system_id,
                     },
@@ -2712,7 +2712,7 @@ impl PrimitiveStore {
             let child_prim_run_context = PrimitiveRunContext::new(
                 clip_chain,
                 scroll_node,
-                run.clip_and_scroll.scroll_node_id.transform_index(),
+                run.clip_and_scroll.scroll_node_id,
                 local_clip_chain_rect,
             );
 

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -8,7 +8,7 @@ use api::{LayoutVector2D, PipelineId, PropertyBinding, ScrollClamping, ScrollLoc
 use api::{ScrollSensitivity, StickyOffsetBounds};
 use clip_scroll_tree::{CoordinateSystemId, SpatialNodeIndex, TransformUpdateState};
 use euclid::SideOffsets2D;
-use gpu_types::{TransformData, TransformIndex, TransformPalette};
+use gpu_types::{TransformData, TransformPalette};
 use scene::SceneProperties;
 use util::{LayoutFastTransform, LayoutToWorldFastTransform, TransformedRectKind};
 
@@ -221,16 +221,15 @@ impl SpatialNode {
         transform_palette: &mut TransformPalette,
         node_index: SpatialNodeIndex,
     ) {
-        let transform_index = TransformIndex(node_index.0 as u32);
         if !self.invertible {
-            transform_palette.set(transform_index, TransformData::invalid());
+            transform_palette.set(node_index, TransformData::invalid());
             return;
         }
 
         let inv_transform = match self.world_content_transform.inverse() {
             Some(inverted) => inverted.to_transform(),
             None => {
-                transform_palette.set(transform_index, TransformData::invalid());
+                transform_palette.set(node_index, TransformData::invalid());
                 return;
             }
         };
@@ -241,7 +240,7 @@ impl SpatialNode {
         };
 
         // Write the data that will be made available to the GPU for this node.
-        transform_palette.set(transform_index, data);
+        transform_palette.set(node_index, data);
     }
 
     pub fn update(


### PR DESCRIPTION
TransformIndex is no longer needed, now that the clip-scroll tree
has been split, and we have SpatialNodeIndex implemented.

The basic idea going forward (not quite implemented yet) is:
 - SpatialNodeIndex is a unique id for a positioning node (per DL).
 - From the TransformPalette, code can retrieve a TransformId, by
   supplying a SpatialNodeIndex, and *optionally* a coordinate
   system ID that this transform should be relative to.

The relationship between SpatialNodeIndex and a TransformId is
currently 1:1, but with the changes above, will be 1:n.

This will allow code to optionally rasterize each Picture using
a different coordinate space, as required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2897)
<!-- Reviewable:end -->
