### PR TITLE
Push an empty hit testing clip node for empty ClipNodes

### DIFF
--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -148,13 +148,9 @@ impl HitTester {
         }
 
         for (index, node) in clip_scroll_tree.clip_nodes.iter().enumerate() {
-            let regions = match get_regions_for_clip_node(node, clip_store) {
-                Some(regions) => regions,
-                None => continue,
-            };
             self.clip_nodes.push(HitTestClipNode {
                 spatial_node: node.spatial_node,
-                regions,
+                regions: get_regions_for_clip_node(node, clip_store),
             });
 
              let clip_chain = self.clip_chains.get_mut(node.clip_chain_index.0).unwrap();
@@ -341,17 +337,17 @@ impl HitTester {
 fn get_regions_for_clip_node(
     node: &ClipNode,
     clip_store: &ClipStore
-) -> Option<Vec<HitTestRegion>> {
+) -> Vec<HitTestRegion> {
     let handle = match node.handle.as_ref() {
         Some(handle) => handle,
         None => {
             warn!("Encountered an empty clip node unexpectedly.");
-            return None;
+            return Vec::new()
         }
     };
 
     let clips = clip_store.get(handle).clips();
-    Some(clips.iter().map(|source| {
+    clips.iter().map(|source| {
         match source.0 {
             ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),
             ClipSource::RoundedRectangle(ref rect, ref radii, ref mode) =>
@@ -362,7 +358,7 @@ fn get_regions_for_clip_node(
                 unreachable!("Didn't expect to hit test against BorderCorner / BoxShadow / LineDecoration");
             }
         }
-    }).collect())
+    }).collect()
 }
 
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Some Gecko display lists produce out-of-sequence ClipIds for ClipNodes
(#2898) which leads to empty ClipNodes. Previously the HitTester was
just discarding those nodes. This is an obvious problem because it means
that subsequent ClipNodeIndices are out-of-sync with the HitTester's
list of clipping nodes. This change fixes this by also adding empty
clipping nodes in the HitTester.

Unfortunately, we can't make a test for this until we figure out how and
why Gecko is producing display lists with out-of-sequence ClipIds.
Hopefully once we do that, we will no longer need to create empty
HitTester nodes at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2899)
<!-- Reviewable:end -->
