### PR TITLE
Glyph visibility culling

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1083,7 +1083,7 @@ impl AlphaBatchBuilder {
 
                 ctx.resource_cache.fetch_glyphs(
                     text_cpu.used_font.clone(),
-                    &text_cpu.glyph_keys,
+                    &text_cpu.visible_keys,
                     glyph_fetch_buffer,
                     gpu_cache,
                     |texture_id, mut glyph_format, glyphs| {

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -370,7 +370,7 @@ impl Into<f64> for SubpixelOffset {
     }
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Ord, PartialOrd)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct GlyphKey(u32);

--- a/webrender/src/glyph_rasterizer/no_pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/no_pathfinder.rs
@@ -35,7 +35,6 @@ impl FontContexts {
 }
 
 impl GlyphRasterizer {
-
     pub fn request_glyphs(
         &mut self,
         glyph_cache: &mut GlyphCache,

--- a/webrender/src/glyph_rasterizer/pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/pathfinder.rs
@@ -194,9 +194,9 @@ impl GlyphRasterizer {
 
                 // TODO: pathfinder will need to support 2D subpixel offset
                 let pathfinder_subpixel_offset =
-                    pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset.0 as u8);
+                    pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset().0 as u8);
                 let pathfinder_glyph_key =
-                    pathfinder_font_renderer::GlyphKey::new(glyph_key.index,
+                    pathfinder_font_renderer::GlyphKey::new(glyph_key.index(),
                                                             pathfinder_subpixel_offset);
 
                 if let Ok(glyph_dimensions) =
@@ -281,9 +281,9 @@ fn request_render_task_from_pathfinder(glyph_key: &GlyphKey,
 
     // TODO: pathfinder will need to support 2D subpixel offset
     let pathfinder_subpixel_offset =
-        pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset.0 as u8);
-    let glyph_subpixel_offset: f64 = glyph_key.subpixel_offset.0.into();
-    let pathfinder_glyph_key = pathfinder_font_renderer::GlyphKey::new(glyph_key.index,
+        pathfinder_font_renderer::SubpixelOffset(glyph_key.subpixel_offset().0 as u8);
+    let glyph_subpixel_offset: f64 = glyph_key.subpixel_offset().0.into();
+    let pathfinder_glyph_key = pathfinder_font_renderer::GlyphKey::new(glyph_key.index(),
                                                                        pathfinder_subpixel_offset);
 
     // TODO(pcwalton): Fall back to CPU rendering if Pathfinder fails to collect the outline.

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -361,7 +361,7 @@ impl FontContext {
     ) -> Option<GlyphDimensions> {
         self.get_ct_font(font.font_key, font.size, &font.variations)
             .and_then(|ref ct_font| {
-                let glyph = key.index as CGGlyph;
+                let glyph = key.index() as CGGlyph;
                 let bitmap = is_bitmap_font(ct_font);
                 let (x_offset, y_offset) = if bitmap { (0.0, 0.0) } else { font.get_subpx_offset(key) };
                 let transform = if font.synthetic_italics.is_enabled() ||
@@ -525,7 +525,7 @@ impl FontContext {
             None
         };
 
-        let glyph = key.index as CGGlyph;
+        let glyph = key.index() as CGGlyph;
         let (strike_scale, pixel_step) = if bitmap { (y_scale, 1.0) } else { (x_scale, y_scale / x_scale) };
         let extra_strikes = font.get_extra_strikes(strike_scale / scale);
         let metrics = get_glyph_metrics(

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -328,7 +328,7 @@ impl FontContext {
         };
 
         if succeeded(result) {
-            result = unsafe { FT_Load_Glyph(face.face, glyph.index as FT_UInt, load_flags as FT_Int32) };
+            result = unsafe { FT_Load_Glyph(face.face, glyph.index() as FT_UInt, load_flags as FT_Int32) };
         };
 
         if succeeded(result) {
@@ -356,7 +356,7 @@ impl FontContext {
             error!("Unable to load glyph");
             debug!(
                 "{} of size {:?} from font {:?}, {:?}",
-                glyph.index,
+                glyph.index(),
                 font.size,
                 font.font_key,
                 result

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -203,7 +203,7 @@ impl FontContext {
         bitmaps: bool,
     ) -> dwrote::GlyphRunAnalysis {
         let face = self.get_font_face(font);
-        let glyph = key.index as u16;
+        let glyph = key.index() as u16;
         let advance = 0.0f32;
         let offset = dwrote::GlyphOffset {
             advanceOffset: 0.0,
@@ -298,7 +298,7 @@ impl FontContext {
         }
 
         let face = self.get_font_face(font);
-        face.get_design_glyph_metrics(&[key.index as u16], false)
+        face.get_design_glyph_metrics(&[key.index() as u16], false)
             .first()
             .map(|metrics| {
                 let em_size = size / 16.;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -768,6 +768,7 @@ pub struct TextRunPrimitiveCpu {
     pub offset: LayoutVector2D,
     pub glyph_range: ItemRange<GlyphInstance>,
     pub glyph_keys: Vec<GlyphKey>,
+    pub visible_keys: Vec<GlyphKey>,
     pub glyph_gpu_blocks: Vec<GpuBlockData>,
     pub shadow: bool,
     pub glyph_raster_space: GlyphRasterSpace,
@@ -788,6 +789,7 @@ impl TextRunPrimitiveCpu {
             offset,
             glyph_range,
             glyph_keys,
+            visible_keys: Vec::new(),
             glyph_gpu_blocks: Vec::new(),
             shadow,
             glyph_raster_space,
@@ -861,33 +863,39 @@ impl TextRunPrimitiveCpu {
         allow_subpixel_aa: bool,
         display_list: &BuiltDisplayList,
         frame_building_state: &mut FrameBuildingState,
+        local_clip_rect: &LayoutRect,
     ) {
         let cache_dirty = self.update_font_instance(
             device_pixel_scale,
             transform,
             allow_subpixel_aa,
         );
+        let first_run = self.glyph_keys.is_empty();
+        if cache_dirty || first_run {
+            self.glyph_gpu_blocks.clear();
+        }
 
-        // Cache the glyph positions, if not in the cache already.
-        // TODO(gw): In the future, remove `glyph_instances`
-        //           completely, and just reference the glyphs
-        //           directly from the display list.
-        if self.glyph_keys.is_empty() || cache_dirty {
-            let subpx_dir = self.used_font.get_subpx_dir();
-            let src_glyphs = display_list.get(self.glyph_range);
+        self.visible_keys.clear();
+        let subpx_dir = self.used_font.get_subpx_dir();
+        let src_glyphs = display_list.get(self.glyph_range);
+        let mut gpu_block = [0.0; 4];
 
-            // TODO(gw): If we support chunks() on AuxIter
-            //           in the future, this code below could
-            //           be much simpler...
-            let mut gpu_block = [0.0; 4];
-            for (i, src) in src_glyphs.enumerate() {
+        for (i, src) in src_glyphs.enumerate() {
+            let key = if first_run {
                 let world_offset = self.used_font.transform.transform(&src.point);
                 let device_offset = device_pixel_scale.transform_point(&world_offset);
                 let key = GlyphKey::new(src.index, device_offset, subpx_dir);
+                debug_assert_eq!(i, self.glyph_keys.len());
                 self.glyph_keys.push(key);
-
+                key
+            } else {
+                self.glyph_keys[i]
+            };
+            if local_clip_rect.contains(&src.point) {
+                self.visible_keys.push(key);
+            }
+            if cache_dirty || first_run {
                 // Two glyphs are packed per GPU block.
-
                 if (i & 1) == 0 {
                     gpu_block[0] = src.point.x;
                     gpu_block[1] = src.point.y;
@@ -897,20 +905,23 @@ impl TextRunPrimitiveCpu {
                     self.glyph_gpu_blocks.push(gpu_block.into());
                 }
             }
-
-            // Ensure the last block is added in the case
-            // of an odd number of glyphs.
-            if (self.glyph_keys.len() & 1) != 0 {
-                self.glyph_gpu_blocks.push(gpu_block.into());
-            }
         }
 
-        frame_building_state.resource_cache
-                            .request_glyphs(self.used_font.clone(),
-                                            &self.glyph_keys,
-                                            frame_building_state.gpu_cache,
-                                            frame_building_state.render_tasks,
-                                            frame_building_state.special_render_passes);
+        // Ensure the last block is added in the case
+        // of an odd number of glyphs.
+        if (cache_dirty || first_run) && (self.glyph_keys.len() & 1) != 0 {
+            self.glyph_gpu_blocks.push(gpu_block.into());
+        }
+
+        if !self.visible_keys.is_empty() {
+            frame_building_state.resource_cache.request_glyphs(
+                self.used_font.clone(),
+                &self.visible_keys,
+                frame_building_state.gpu_cache,
+                frame_building_state.render_tasks,
+                frame_building_state.special_render_passes,
+            );
+        }
     }
 
     fn write_gpu_blocks(&self, request: &mut GpuDataRequest) {
@@ -1565,6 +1576,7 @@ impl PrimitiveStore {
                     pic_context.allow_subpixel_aa,
                     pic_context.display_list,
                     frame_state,
+                    &metadata.combined_local_clip_rect,
                 );
             }
             PrimitiveKind::Brush => {

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -882,6 +882,9 @@ impl ResourceCache {
         F: FnMut(SourceTexture, GlyphFormat, &[GlyphFetchResult]),
     {
         debug_assert_eq!(self.state, State::QueryResources);
+        if glyph_keys.is_empty() {
+            return
+        }
 
         self.glyph_rasterizer.prepare_font(&mut font);
         let glyph_key_cache = self.cached_glyphs.get_glyph_key_cache_for_font(&font);

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -211,12 +211,7 @@ impl EvictionNotice {
     }
 
     pub fn check(&self) -> bool {
-        if self.evicted.get() {
-            self.evicted.set(false);
-            true
-        } else {
-            false
-        }
+        self.evicted.replace(false)
     }
 }
 


### PR DESCRIPTION
Helps #2890 quite a bit, includes #2894.
Reduces the vertex count from 6.8M to ~10K
TODO:
- [ ] try push
- [ ] profile in actual release
- [ ] reviews!

cc @gw3583 @lsalzman

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2901)
<!-- Reviewable:end -->
