### PR TITLE
Add Transform struct, decouple some prim code from SpatialNode.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -477,7 +477,7 @@ impl AlphaBatchBuilder {
         for run in &pic.runs {
             let transform_id = ctx
                 .transforms
-                .get_id(run.clip_and_scroll.scroll_node_id);
+                .get_id(run.clip_and_scroll.spatial_node_index);
             self.add_run_to_batch(
                 run,
                 transform_id,

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -337,7 +337,7 @@ impl<'a> DisplayListFlattener<'a> {
                 reference_frame_info,
                 &LayoutPrimitiveInfo::new(scrollbar_rect),
                 DEFAULT_SCROLLBAR_COLOR,
-                ScrollbarInfo(scroll_frame_info.scroll_node_id, container_rect),
+                ScrollbarInfo(scroll_frame_info.spatial_node_index, container_rect),
             );
         }
 
@@ -400,7 +400,7 @@ impl<'a> DisplayListFlattener<'a> {
         let index = self.get_spatial_node_index_for_clip_id(info.id);
         self.clip_scroll_tree.add_sticky_frame(
             index,
-            clip_and_scroll.scroll_node_id, /* parent id */
+            clip_and_scroll.spatial_node_index, /* parent id */
             sticky_frame_info,
             info.id.pipeline_id(),
         );

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -6,7 +6,7 @@ use api::{DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransfor
 use api::{PremultipliedColorF, WorldToLayoutTransform};
 use clip_scroll_tree::SpatialNodeIndex;
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
-use prim_store::{EdgeAaSegmentMask};
+use prim_store::{EdgeAaSegmentMask, Transform};
 use render_task::RenderTaskAddress;
 use util::{MatrixHelpers, TransformedRectKind};
 
@@ -433,6 +433,26 @@ impl TransformPalette {
             transform_kind: data.transform.transform_kind(),
         };
         self.transforms[index] = data;
+    }
+
+    // Get the relevant information about a given transform that is
+    // used by the CPU code during culling and primitive prep pass.
+    // TODO(gw): In the future, it will be possible to specify
+    //           a coordinate system id here, to allow retrieving
+    //           transforms in the local space of a given spatial node.
+    pub fn get_transform(
+        &self,
+        index: SpatialNodeIndex,
+    ) -> Transform {
+        let index = index.0;
+        let transform = &self.transforms[index];
+        let metadata = &self.metadata[index];
+
+        Transform {
+            m: transform.transform,
+            transform_kind: metadata.transform_kind,
+            backface_is_visible: transform.transform.is_backface_visible(),
+        }
     }
 
     // Get a transform palette id for the given spatial node.

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -233,8 +233,8 @@ impl HitTester {
         let point = test.get_absolute_point(self);
 
         for &HitTestingRun(ref items, ref clip_and_scroll) in self.runs.iter().rev() {
-            let scroll_node_id = clip_and_scroll.scroll_node_id;
-            let scroll_node = &self.spatial_nodes[scroll_node_id.0];
+            let spatial_node_index = clip_and_scroll.spatial_node_index;
+            let scroll_node = &self.spatial_nodes[spatial_node_index.0];
             let transform = scroll_node.world_content_transform;
             let point_in_layer = match transform.inverse() {
                 Some(inverted) => inverted.transform_point2d(&point),
@@ -255,7 +255,7 @@ impl HitTester {
                     break;
                 }
 
-                return Some(scroll_node_id);
+                return Some(spatial_node_index);
             }
         }
 
@@ -267,8 +267,8 @@ impl HitTester {
 
         let mut result = HitTestResult::default();
         for &HitTestingRun(ref items, ref clip_and_scroll) in self.runs.iter().rev() {
-            let scroll_node_id = clip_and_scroll.scroll_node_id;
-            let scroll_node = &self.spatial_nodes[scroll_node_id.0];
+            let spatial_node_index = clip_and_scroll.spatial_node_index;
+            let scroll_node = &self.spatial_nodes[spatial_node_index.0];
             let pipeline_id = scroll_node.pipeline_id;
             match (test.pipeline_id, pipeline_id) {
                 (Some(id), node_id) if node_id != id => continue,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -6,13 +6,12 @@ use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF};
 use api::{DeviceIntRect, DeviceIntSize, DevicePoint, LayoutPoint, LayoutRect};
 use api::{DevicePixelScale, PictureIntPoint, PictureIntRect, PictureIntSize};
 use box_shadow::{BLUR_SAMPLE_SCALE};
-use spatial_node::SpatialNode;
 use clip_scroll_tree::SpatialNodeIndex;
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState, PrimitiveRunContext};
 use gpu_cache::{GpuCacheHandle};
 use gpu_types::UvRectKind;
 use prim_store::{PrimitiveIndex, PrimitiveRun, PrimitiveRunLocalRect};
-use prim_store::{PrimitiveMetadata, ScrollNodeAndClipChain};
+use prim_store::{PrimitiveMetadata, ScrollNodeAndClipChain, Transform};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
 use scene::{FilterOpHelpers, SceneProperties};
@@ -323,7 +322,7 @@ impl PicturePrimitive {
 
                 let uv_rect_kind = calculate_uv_rect_kind(
                     &prim_metadata.local_rect,
-                    &prim_run_context.scroll_node,
+                    &prim_run_context.transform,
                     &device_rect,
                     frame_context.device_pixel_scale,
                 );
@@ -442,7 +441,7 @@ impl PicturePrimitive {
 
                 let uv_rect_kind = calculate_uv_rect_kind(
                     &prim_metadata.local_rect,
-                    &prim_run_context.scroll_node,
+                    &prim_run_context.transform,
                     &device_rect,
                     frame_context.device_pixel_scale,
                 );
@@ -511,7 +510,7 @@ impl PicturePrimitive {
             Some(PictureCompositeMode::MixBlend(..)) => {
                 let uv_rect_kind = calculate_uv_rect_kind(
                     &prim_metadata.local_rect,
-                    &prim_run_context.scroll_node,
+                    &prim_run_context.transform,
                     &prim_screen_rect.clipped,
                     frame_context.device_pixel_scale,
                 );
@@ -546,7 +545,7 @@ impl PicturePrimitive {
 
                 let uv_rect_kind = calculate_uv_rect_kind(
                     &prim_metadata.local_rect,
-                    &prim_run_context.scroll_node,
+                    &prim_run_context.transform,
                     &prim_screen_rect.clipped,
                     frame_context.device_pixel_scale,
                 );
@@ -566,7 +565,7 @@ impl PicturePrimitive {
             Some(PictureCompositeMode::Blit) | None => {
                 let uv_rect_kind = calculate_uv_rect_kind(
                     &prim_metadata.local_rect,
-                    &prim_run_context.scroll_node,
+                    &prim_run_context.transform,
                     &prim_screen_rect.clipped,
                     frame_context.device_pixel_scale,
                 );
@@ -590,18 +589,16 @@ impl PicturePrimitive {
 // Calculate a single screen-space UV for a picture.
 fn calculate_screen_uv(
     local_pos: &LayoutPoint,
-    spatial_node: &SpatialNode,
+    transform: &Transform,
     rendered_rect: &DeviceRect,
     device_pixel_scale: DevicePixelScale,
 ) -> DevicePoint {
-    let world_pos = spatial_node
-        .world_content_transform
-        .transform_point2d(local_pos);
+    let world_pos = transform.m.transform_point2d(local_pos);
 
     let mut device_pos = world_pos * device_pixel_scale;
 
     // Apply snapping for axis-aligned scroll nodes, as per prim_shared.glsl.
-    if spatial_node.transform_kind == TransformedRectKind::AxisAligned {
+    if transform.transform_kind == TransformedRectKind::AxisAligned {
         device_pos.x = (device_pos.x + 0.5).floor();
         device_pos.y = (device_pos.y + 0.5).floor();
     }
@@ -616,7 +613,7 @@ fn calculate_screen_uv(
 // vertex positions of a picture.
 fn calculate_uv_rect_kind(
     local_rect: &LayoutRect,
-    spatial_node: &SpatialNode,
+    transform: &Transform,
     rendered_rect: &DeviceIntRect,
     device_pixel_scale: DevicePixelScale,
 ) -> UvRectKind {
@@ -624,28 +621,28 @@ fn calculate_uv_rect_kind(
 
     let top_left = calculate_screen_uv(
         &local_rect.origin,
-        spatial_node,
+        transform,
         &rendered_rect,
         device_pixel_scale,
     );
 
     let top_right = calculate_screen_uv(
         &local_rect.top_right(),
-        spatial_node,
+        transform,
         &rendered_rect,
         device_pixel_scale,
     );
 
     let bottom_left = calculate_screen_uv(
         &local_rect.bottom_left(),
-        spatial_node,
+        transform,
         &rendered_rect,
         device_pixel_scale,
     );
 
     let bottom_right = calculate_screen_uv(
         &local_rect.bottom_right(),
-        spatial_node,
+        transform,
         &rendered_rect,
         device_pixel_scale,
     );


### PR DESCRIPTION
The transform information in a SpatialNode contains a complete
local -> screen space transform. In the future, we want to be
able to selectively rasterize certain pictures in local space
(e.g. in a nested 3d transform with perspective).

To achieve this, TransformPalette will be extended to allow
construction of a Transform relative to a given coordinate
system / spatial node.

This patch starts decoupling the culling / prim CPU code from
directly referencing a SpatialNode, and instead retrieving the
relevant information from a Transform provided by the
TransformPalette.

Also rename some instances of scroll_node_id to spatial_node_index
as appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2902)
<!-- Reviewable:end -->
