### PR TITLE
Remove some redundant rectangle transform and union code.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2765,12 +2765,6 @@ impl PrimitiveStore {
                         result.local_rect_in_original_parent_space =
                             result.local_rect_in_original_parent_space.union(&bounds);
                     }
-
-                    if let Some(ref matrix) = parent_relative_transform {
-                        let bounds = matrix.transform_rect(&prim_local_rect);
-                        result.local_rect_in_actual_parent_space =
-                            result.local_rect_in_actual_parent_space.union(&bounds);
-                    }
                 }
             }
         }


### PR DESCRIPTION
This was probably a merge error - this is already accounted for
a few lines above when we transform the clipped_rect field.

Saves a rectangle transform + union per primitive per frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2905)
<!-- Reviewable:end -->
