### PR TITLE
Decouple batching from clip-scroll tree.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -670,13 +670,12 @@ impl AlphaBatchBuilder {
                             // Push into parent plane splitter.
                             debug_assert!(picture.surface.is_some());
 
-                            let real_xf = &ctx.clip_scroll_tree
-                                .spatial_nodes[picture.reference_frame_index.0]
-                                .world_content_transform
-                                .into();
+                            let real_xf = &ctx
+                                .transforms
+                                .get_transform(picture.reference_frame_index);
                             let polygon = make_polygon(
                                 picture.real_local_rect,
-                                real_xf,
+                                &real_xf.m,
                                 prim_index.0,
                             );
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -72,6 +72,7 @@ pub struct FrameBuildingContext<'a> {
     pub pipelines: &'a FastHashMap<PipelineId, Arc<ScenePipeline>>,
     pub screen_rect: DeviceIntRect,
     pub clip_scroll_tree: &'a ClipScrollTree,
+    pub clip_chains: &'a [ClipChain],
     pub transforms: &'a TransformPalette,
     pub max_local_clip: LayoutRect,
 }
@@ -218,6 +219,7 @@ impl FrameBuilder {
             pipelines,
             screen_rect: self.screen_rect.to_i32(),
             clip_scroll_tree,
+            clip_chains: &clip_scroll_tree.clip_chains,
             transforms: transform_palette,
             max_local_clip: LayoutRect::new(
                 LayoutPoint::new(-MAX_CLIP_COORD, -MAX_CLIP_COORD),
@@ -397,7 +399,6 @@ impl FrameBuilder {
                 device_pixel_scale,
                 prim_store: &self.prim_store,
                 resource_cache,
-                clip_scroll_tree,
                 use_dual_source_blending,
                 transforms: &transform_palette,
             };

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2653,9 +2653,8 @@ impl PrimitiveStore {
             let scroll_node = &frame_context
                 .clip_scroll_tree
                 .spatial_nodes[run.clip_and_scroll.spatial_node_index.0];
-            let clip_chain = frame_context
-                .clip_scroll_tree
-                .get_clip_chain(run.clip_and_scroll.clip_chain_index);
+            let clip_chain = &frame_context
+                .clip_chains[run.clip_and_scroll.clip_chain_index.0];
 
             // Mark whether this picture contains any complex coordinate
             // systems, due to either the scroll node or the clip-chain.

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -7,7 +7,7 @@ use api::{DeviceUintRect, DeviceUintSize, DocumentLayer, FilterOp, ImageFormat, 
 use api::{MixBlendMode, PipelineId};
 use batch::{AlphaBatchBuilder, AlphaBatchContainer, ClipBatcher, resolve_image};
 use clip::{ClipStore};
-use clip_scroll_tree::{ClipScrollTree, SpatialNodeIndex};
+use clip_scroll_tree::SpatialNodeIndex;
 use device::{FrameId, Texture};
 #[cfg(feature = "pathfinder")]
 use euclid::{TypedPoint2D, TypedVector2D};
@@ -45,7 +45,6 @@ pub struct RenderTargetContext<'a, 'rc> {
     pub device_pixel_scale: DevicePixelScale,
     pub prim_store: &'a PrimitiveStore,
     pub resource_cache: &'rc mut ResourceCache,
-    pub clip_scroll_tree: &'a ClipScrollTree,
     pub use_dual_source_blending: bool,
     pub transforms: &'a TransformPalette,
 }


### PR DESCRIPTION
A couple small tidy ups in the spatial node code, and also remove
the last dependency during batching on direct references to the
clip-scroll tree.

Once this is complete for culling, we'll be able to selectively
pick which coordinate system an offscreen surface (picture) is
rendered with, via the TransformPalette.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2906)
<!-- Reviewable:end -->
