### PR TITLE
Framebuffer size wrong in examples

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -152,7 +152,10 @@ pub fn main_wrapper<E: Example>(
     };
 
     let framebuffer_size = {
-        let size = window.get_inner_size().unwrap();
+        let size = window
+            .get_inner_size()
+            .unwrap()
+            .to_physical(device_pixel_ratio as f64);
         DeviceUintSize::new(size.width as u32, size.height as u32)
     };
     let notifier = Box::new(Notifier::new(events_loop.create_proxy()));


### PR DESCRIPTION
I believe framebuffer size should be in physical pixels. Please correct me if I'm wrong.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2910)
<!-- Reviewable:end -->
