### PR TITLE
Don't panic when rendering huge border corners

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -9,9 +9,19 @@ use app_units::Au;
 use ellipse::Ellipse;
 use display_list_flattener::DisplayListFlattener;
 use gpu_types::{BorderInstance, BorderSegment, BrushFlags};
-use prim_store::{BrushKind, BrushPrimitive, BrushSegment};
+use prim_store::{BrushKind, BrushPrimitive, BrushSegment, VECS_PER_SEGMENT};
 use prim_store::{BorderSource, EdgeAaSegmentMask, PrimitiveContainer, ScrollNodeAndClipChain};
+use renderer::{MAX_VERTEX_TEXTURE_WIDTH};
 use util::{lerp, RectHelpers};
+
+// Using 2048 as the maximum radius in device space before which we
+// start stretching is up for debate.
+// the value must be chosen so that the corners will not use an
+// unreasonable amount of memory but should allow crisp corners in the
+// common cases.
+
+/// Maximum resolution in device pixels at which borders are rasterized.
+pub const MAX_BORDER_RESOLUTION: u32 = 2048;
 
 trait AuSizeConverter {
     fn to_au(&self) -> LayoutSizeAu;
@@ -345,18 +355,24 @@ impl BorderCornerClipSource {
             1.0 - 2.0 * outer_scale.y,
         );
 
+        // No point in pushing more clips as it will blow up the maximum amount of
+        // segments per primitive later down the road.
+        // See #2915 for a better fix.
+        let clip_limit = MAX_VERTEX_TEXTURE_WIDTH / VECS_PER_SEGMENT;
+        let max_clip_count = self.max_clip_count.min(clip_limit);
+
         match self.kind {
             BorderCornerClipKind::Dash => {
                 // Get the correct dash arc length.
                 let dash_arc_length =
-                    0.5 * self.ellipse.total_arc_length / self.max_clip_count as f32;
+                    0.5 * self.ellipse.total_arc_length / max_clip_count as f32;
                 // Start the first dash at one quarter the length of a single dash
                 // along the arc line. This is arbitrary but looks reasonable in
                 // most cases. We need to spend some time working on a more
                 // sophisticated dash placement algorithm that takes into account
                 // the offset of the dashes along edge segments.
                 let mut current_arc_length = 0.25 * dash_arc_length;
-                for _ in 0 .. self.max_clip_count {
+                for _ in 0 .. max_clip_count {
                     let arc_length0 = current_arc_length;
                     current_arc_length += dash_arc_length;
 
@@ -401,7 +417,7 @@ impl BorderCornerClipSource {
                     ]);
                 }
             }
-            BorderCornerClipKind::Dot if self.max_clip_count == 1 => {
+            BorderCornerClipKind::Dot if max_clip_count == 1 => {
                 let dot_diameter = lerp(self.widths.width, self.widths.height, 0.5);
                 dot_dash_data.push([
                     self.widths.width / 2.0, self.widths.height / 2.0, 0.5 * dot_diameter, 0.,
@@ -422,7 +438,7 @@ impl BorderCornerClipSource {
                     self.widths.height,
                 ));
 
-                for dot_index in 0 .. self.max_clip_count {
+                for dot_index in 0 .. max_clip_count {
                     let prev_forward_pos = *forward_dots.last().unwrap();
                     let prev_back_pos = *back_dots.last().unwrap();
 
@@ -926,6 +942,23 @@ impl BorderRenderTaskInfo {
         }
 
         instances
+    }
+
+    /// Computes the maximum scale that we allow for this set of border radii.
+    /// capping the scale will result in rendering very large corners at a lower
+    /// resolution and stretching them, so they will have the right shape, but
+    /// blurrier.
+    pub fn get_max_scale(radii: &BorderRadius) -> LayoutToDeviceScale {
+        let r = radii.top_left.width
+            .max(radii.top_left.height)
+            .max(radii.top_right.width)
+            .max(radii.top_right.height)
+            .max(radii.bottom_left.width)
+            .max(radii.bottom_left.height)
+            .max(radii.bottom_right.width)
+            .max(radii.bottom_right.height);
+
+        LayoutToDeviceScale::new(MAX_BORDER_RESOLUTION as f32 / r)
     }
 }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1495,7 +1495,9 @@ impl PrimitiveStore {
                 //           scale factor from the world transform to get an appropriately
                 //           sized border task.
                 let world_scale = LayoutToWorldScale::new(1.0);
-                let scale = world_scale * frame_context.device_pixel_scale;
+                let mut scale = world_scale * frame_context.device_pixel_scale;
+                let max_scale = BorderRenderTaskInfo::get_max_scale(&border.radius);
+                scale.0 = scale.0.min(max_scale.0);
                 let scale_au = Au::from_f32_px(scale.0);
                 let needs_update = scale_au != cache_key.scale;
                 let mut new_segments = Vec::new();


### PR DESCRIPTION
This is a simple workaround for huge border corners which currently try to allocate very large surfaces to render the mask.

The basic idea is to render them at a lower resolution (the maximum resolution being 2048x2048 device pixels per corner) and let the brush stretch them. As a result huge corners (with a radius bigger than 2048 device pixels) can render blurry, however we don't crash anymore and the code is very simple.
I toyed with rendering only the visible portion of the corner without down scaling, but it required adding a lot of code for a use case that I think isn't worth the maintenance cost in my opinion.

The patch also sets a limit on the number of dots/dashes so that we don't hit the maximum number of segments per primitive. This isn't great but fixing it properly isn't our highest priority. I filed #2915.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2916)
<!-- Reviewable:end -->
