### PR TITLE
Add native texture animation to yuv example.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -54,7 +54,7 @@ name = "yuv"
 path = "yuv.rs"
 
 [features]
-debug = ["webrender/capture", "webrender/debugger", "webrender/profiler"]
+debug = ["webrender/capture", "webrender/debugger", "webrender/profiler", "webrender/debug_renderer"]
 
 [dependencies]
 app_units = "0.6"

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -81,7 +81,12 @@ pub trait Example {
         pipeline_id: PipelineId,
         document_id: DocumentId,
     );
-    fn on_event(&mut self, winit::WindowEvent, &RenderApi, DocumentId) -> bool {
+    fn on_event(
+        &mut self,
+        winit::WindowEvent,
+        &RenderApi,
+        DocumentId,
+    ) -> bool {
         false
     }
     fn get_image_handlers(
@@ -91,7 +96,7 @@ pub trait Example {
           Option<Box<webrender::OutputImageHandler>>) {
         (None, None)
     }
-    fn draw_custom(&self, _gl: &gl::Gl) {
+    fn draw_custom(&mut self, _gl: &gl::Gl) {
     }
 }
 
@@ -248,10 +253,18 @@ pub fn main_wrapper<E: Example>(
                         winit::Event::WindowEvent { event, .. } => event,
                         _ => unreachable!()
                     };
-                    custom_event = example.on_event(win_event, &api, document_id)
+                    custom_event = example.on_event(
+                        win_event,
+                        &api,
+                        document_id,
+                    )
                 },
             },
-            winit::Event::WindowEvent { event, .. } => custom_event = example.on_event(event, &api, document_id),
+            winit::Event::WindowEvent { event, .. } => custom_event = example.on_event(
+                event,
+                &api,
+                document_id,
+            ),
             _ => return winit::ControlFlow::Continue,
         };
 

--- a/examples/yuv.rs
+++ b/examples/yuv.rs
@@ -72,6 +72,8 @@ impl webrender::ExternalImageHandler for YuvImageProvider {
 }
 
 struct App {
+    texture_id: gl::GLuint,
+    current_value: u8,
 }
 
 impl Example for App {
@@ -187,12 +189,27 @@ impl Example for App {
         gl: &gl::Gl,
     ) -> (Option<Box<webrender::ExternalImageHandler>>,
           Option<Box<webrender::OutputImageHandler>>) {
-        (Some(Box::new(YuvImageProvider::new(gl))), None)
+        let provider = YuvImageProvider::new(gl);
+        self.texture_id = provider.texture_ids[0];
+        (Some(Box::new(provider)), None)
+    }
+
+    fn draw_custom(&mut self, gl: &gl::Gl) {
+        init_gl_texture(self.texture_id, gl::RED, gl::RED, &[self.current_value; 100 * 100], gl);
+        self.current_value = self.current_value.wrapping_add(1);
     }
 }
 
 fn main() {
     let mut app = App {
+        texture_id: 0,
+        current_value: 0,
     };
-    boilerplate::main_wrapper(&mut app, None);
+
+    let opts = webrender::RendererOptions {
+        debug_flags: webrender::DebugFlags::NEW_FRAME_INDICATOR | webrender::DebugFlags::NEW_SCENE_INDICATOR,
+        ..Default::default()
+    };
+
+    boilerplate::main_wrapper(&mut app, Some(opts));
 }


### PR DESCRIPTION
This updates the yuv example to animate the contents of an external
texture handle each composite. It's useful to confirm that an
external native texture will be updated even if no frame is being
built, since the render() step will always request an updated
external native texture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2918)
<!-- Reviewable:end -->
