### PR TITLE
Set wrench's window title before the event loop starts.

### DIFF
--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -489,6 +489,12 @@ fn main() {
         notifier,
     );
 
+    if let Some(window_title) = wrench.take_title() {
+        if !cfg!(windows) {
+            window.set_title(&window_title);
+        }
+    }
+
     if let Some(subargs) = args.subcommand_matches("show") {
         render(&mut wrench, &mut window, size, &mut events_loop, subargs);
     } else if let Some(subargs) = args.subcommand_matches("png") {
@@ -567,12 +573,6 @@ fn render<'a>(
     thing.do_frame(wrench);
 
     let mut body = |wrench: &mut Wrench, global_event: winit::Event| {
-        if let Some(window_title) = wrench.take_title() {
-            if !cfg!(windows) { //TODO: calling `set_title` from inside the `run_forever` loop is illegal...
-                window.set_title(&window_title);
-            }
-        }
-
         let mut do_frame = false;
         let mut do_render = false;
 


### PR DESCRIPTION
Fixes #2465.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2919)
<!-- Reviewable:end -->
