### PR TITLE
Don't panic when compiling the debug overlay shaders fail.

### DIFF
--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -4,7 +4,7 @@
 
 use api::{ColorU, DeviceIntRect, DeviceUintSize, ImageFormat, TextureTarget};
 use debug_font_data;
-use device::{Device, Program, Texture, TextureSlot, VertexDescriptor, VAO};
+use device::{Device, Program, Texture, TextureSlot, VertexDescriptor, ShaderError, VAO};
 use device::{TextureFilter, VertexAttribute, VertexAttributeKind, VertexUsageHint};
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
@@ -104,13 +104,11 @@ pub struct DebugRenderer {
 }
 
 impl DebugRenderer {
-    pub fn new(device: &mut Device) -> Self {
-        let font_program = device.create_program("debug_font", "", &DESC_FONT).unwrap();
+    pub fn new(device: &mut Device) -> Result<Self, ShaderError> {
+        let font_program = device.create_program("debug_font", "", &DESC_FONT)?;
         device.bind_shader_samplers(&font_program, &[("sColor0", DebugSampler::Font)]);
 
-        let color_program = device
-            .create_program("debug_color", "", &DESC_COLOR)
-            .unwrap();
+        let color_program = device.create_program("debug_color", "", &DESC_COLOR)?;
 
         let font_vao = device.create_vao(&DESC_FONT);
         let line_vao = device.create_vao(&DESC_COLOR);
@@ -127,7 +125,7 @@ impl DebugRenderer {
             Some(&debug_font_data::FONT_BITMAP),
         );
 
-        DebugRenderer {
+        Ok(DebugRenderer {
             font_vertices: Vec::new(),
             font_indices: Vec::new(),
             line_vertices: Vec::new(),
@@ -139,7 +137,7 @@ impl DebugRenderer {
             font_vao,
             line_vao,
             font_texture,
-        }
+        })
     }
 
     pub fn deinit(self, device: &mut Device) {

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -561,7 +561,7 @@ impl Wrench {
         ];
 
         let color_and_offset = [(*BLACK_COLOR, 2.0), (*WHITE_COLOR, 0.0)];
-        let dr = self.renderer.debug_renderer();
+        let dr = self.renderer.debug_renderer().unwrap();
 
         for ref co in &color_and_offset {
             let x = self.device_pixel_ratio * (15.0 + co.1);


### PR DESCRIPTION
Fixes #2808.
There is always going to be a silly driver out there that will fail for whatever reason so let's not panic for something that isn't important to the user.
I did leave the unwrap in wrench sort of on purpose because in the unlikely event that someone using wrench hits the driver bug, they'll be in a much better place to fix or report the issue than our average user, and if we are lucky enough to hit this kind of bug a developer's machine we'll be able can try to fix it.

I'm tempted to remove the debug_render feature. It's not buying much since the shader is compiled lazily and it adds noise to the code (and feature flags are annoyingly easy to break).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2920)
<!-- Reviewable:end -->
