### PR TITLE
Simplify the ClipId -> CST id mapping code.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1772,16 +1772,16 @@ impl ClipBatcher {
     ) {
         let mut coordinate_system_id = coordinate_system_id;
         for work_item in clips.iter() {
+            let info = clip_store
+                .get_opt(&work_item.clip_sources)
+                .expect("bug: clip handle should be valid");
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
-                transform_id: transforms.get_id(work_item.spatial_node_index),
+                transform_id: transforms.get_id(info.spatial_node_index),
                 segment: 0,
                 clip_data_address: GpuCacheAddress::invalid(),
                 resource_address: GpuCacheAddress::invalid(),
             };
-            let info = clip_store
-                .get_opt(&work_item.clip_sources)
-                .expect("bug: clip handle should be valid");
 
             for &(ref source, ref handle) in &info.clips {
                 let gpu_address = gpu_cache.get_address(handle);

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -4,16 +4,13 @@
 
 use api::DevicePixelScale;
 use clip::{ClipChain, ClipChainNode, ClipSourcesHandle, ClipStore, ClipWorkItem};
-use clip_scroll_tree::{ClipChainIndex, SpatialNodeIndex};
+use clip_scroll_tree::{ClipChainIndex};
 use gpu_cache::GpuCache;
 use resource_cache::ResourceCache;
 use spatial_node::SpatialNode;
 
 #[derive(Debug)]
 pub struct ClipNode {
-    /// The node that determines how this clip node is positioned.
-    pub spatial_node: SpatialNodeIndex,
-
     /// A handle to this clip nodes clips in the ClipStore.
     pub handle: ClipSourcesHandle,
 
@@ -33,15 +30,16 @@ pub struct ClipNode {
 impl ClipNode {
     pub fn update(
         &mut self,
-        spatial_node: &SpatialNode,
         device_pixel_scale: DevicePixelScale,
         clip_store: &mut ClipStore,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         clip_chains: &mut [ClipChain],
+        spatial_nodes: &[SpatialNode],
     ) {
         let clip_sources = clip_store.get_mut(&self.handle);
         clip_sources.update(gpu_cache, resource_cache, device_pixel_scale);
+        let spatial_node = &spatial_nodes[clip_sources.spatial_node_index.0];
 
         let (screen_inner_rect, screen_outer_rect) = clip_sources.get_screen_bounds(
             &spatial_node.world_content_transform,

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -59,7 +59,6 @@ impl ClipNode {
 
         let new_node = ClipChainNode {
             work_item: ClipWorkItem {
-                spatial_node_index: self.spatial_node,
                 clip_sources: self.handle.weak(),
                 coordinate_system_id: spatial_node.coordinate_system_id,
             },

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -256,14 +256,13 @@ impl ClipScrollTree {
         );
 
         for clip_node in &mut self.clip_nodes {
-            let spatial_node = &self.spatial_nodes[clip_node.spatial_node.0];
             clip_node.update(
-                spatial_node,
                 device_pixel_scale,
                 clip_store,
                 resource_cache,
                 gpu_cache,
                 &mut self.clip_chains,
+                &self.spatial_nodes,
             );
         }
         self.build_clip_chains(screen_rect);
@@ -356,13 +355,11 @@ impl ClipScrollTree {
     pub fn add_clip_node(
         &mut self,
         parent_clip_chain_index: ClipChainIndex,
-        spatial_node: SpatialNodeIndex,
         handle: ClipSourcesHandle,
     ) -> (ClipNodeIndex, ClipChainIndex) {
         let clip_chain_index = self.allocate_clip_chain();
         let node = ClipNode {
             parent_clip_chain_index,
-            spatial_node,
             handle,
             clip_chain_index,
             clip_chain_node: None,

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -33,7 +33,7 @@ use resource_cache::{FontInstanceMap, ImageRequest};
 use scene::{Scene, ScenePipeline, StackingContextHelpers};
 use scene_builder::{BuiltScene, SceneRequest};
 use spatial_node::{SpatialNodeType, StickyFrameInfo};
-use std::{f32, mem, usize};
+use std::{f32, mem};
 use tiling::{CompositeOps, ScrollbarPrimitive};
 use util::{MaxRect, RectHelpers, recycle_vec};
 
@@ -44,46 +44,14 @@ static DEFAULT_SCROLLBAR_COLOR: ColorF = ColorF {
     a: 0.6,
 };
 
-#[derive(Clone, Copy)]
-pub struct PipelineOffset {
-    pipeline: PipelineId,
-    spatial_offset: usize,
-    clip_offset: usize,
-}
-
 /// A data structure that keeps track of mapping between API ClipIds and the indices used
 /// internally in the ClipScrollTree to avoid having to do HashMap lookups. ClipIdToIndexMapper is
-/// responsible for mapping both ClipId to ClipChainIndex and ClipId to SpatialNodeIndex.  We
-/// also include two small LRU caches. Currently the caches are small (1 entry), but in the future
-/// we could use uluru here to do something more involved.
+/// responsible for mapping both ClipId to ClipChainIndex and ClipId to SpatialNodeIndex.
 #[derive(Default)]
 pub struct ClipIdToIndexMapper {
-    /// A map which converts a ClipId for a clipping node or an API-defined ClipChain into
-    /// a ClipChainIndex, which is the index used internally in the ClipScrollTree to
-    /// identify ClipChains.
     clip_chain_map: FastHashMap<ClipId, ClipChainIndex>,
-
-    /// The last mapped ClipChainIndex, used to avoid having to do lots of consecutive
-    /// HashMap lookups.
-    cached_clip_chain_index: Option<(ClipId, ClipChainIndex)>,
-
-    /// The offset in the ClipScrollTree's array of SpatialNodes and ClipNodes for a particular
-    /// pipeline.  This is used to convert ClipIds into SpatialNodeIndex or ClipNodeIndex.
-    pipeline_offsets: FastHashMap<PipelineId, PipelineOffset>,
-
-    /// The last mapped pipeline offset for this mapper. This is used to avoid having to
-    /// consult `pipeline_offsets` repeatedly when flattening the display list.
-    cached_pipeline_offset: Option<PipelineOffset>,
-
-    /// The next available pipeline offset for ClipNodeIndex. When we encounter a pipeline
-    /// we will use this value and increment it by the total number of clip nodes in the
-    /// pipeline's display list.
-    next_available_clip_offset: usize,
-
-    /// The next available pipeline offset for SpatialNodeIndex. When we encounter a pipeline
-    /// we will use this value and increment it by the total number of spatial nodes in the
-    /// pipeline's display list.
-    next_available_spatial_offset: usize,
+    clip_node_map: FastHashMap<ClipId, ClipNodeIndex>,
+    spatial_node_map: FastHashMap<ClipId, SpatialNodeIndex>,
 }
 
 impl ClipIdToIndexMapper {
@@ -97,59 +65,42 @@ impl ClipIdToIndexMapper {
         self.add_clip_chain(id, parent_chain_index);
     }
 
-    pub fn get_clip_chain_index(&mut self, id: &ClipId) -> ClipChainIndex {
-        match self.cached_clip_chain_index {
-            Some((cached_id, cached_clip_chain_index)) if cached_id == *id =>
-                return cached_clip_chain_index,
-            _ => {}
-        }
+    pub fn map_spatial_node(&mut self, id: ClipId, index: SpatialNodeIndex) {
+        debug_assert!(!self.spatial_node_map.contains_key(&id));
+        self.spatial_node_map.insert(id, index);
+    }
 
+    pub fn map_clip_node(&mut self, id: ClipId, index: ClipNodeIndex) {
+        debug_assert!(!self.clip_node_map.contains_key(&id));
+        self.clip_node_map.insert(id, index);
+    }
+
+    pub fn get_clip_chain_index(&self, id: &ClipId) -> ClipChainIndex {
         self.clip_chain_map[id]
     }
 
-    pub fn get_clip_chain_index_and_cache_result(&mut self, id: &ClipId) -> ClipChainIndex {
-        let index = self.get_clip_chain_index(id);
-        self.cached_clip_chain_index = Some((*id, index));
-        index
-    }
-
-    pub fn initialize_for_pipeline(&mut self, pipeline: &ScenePipeline) {
-        debug_assert!(!self.pipeline_offsets.contains_key(&pipeline.pipeline_id));
-        self.pipeline_offsets.insert(
-            pipeline.pipeline_id,
-            PipelineOffset {
-                pipeline: pipeline.pipeline_id,
-                spatial_offset: self.next_available_spatial_offset,
-                clip_offset: self.next_available_clip_offset,
-            }
-        );
-
-        self.next_available_clip_offset += pipeline.display_list.total_clip_nodes();
-        self.next_available_spatial_offset += pipeline.display_list.total_spatial_nodes();
-    }
-
-    pub fn get_pipeline_offet<'a>(&'a mut self, id: PipelineId) -> &'a PipelineOffset {
-        match self.cached_pipeline_offset {
-            Some(ref offset) if offset.pipeline == id => offset,
-            _ => {
-                let offset = &self.pipeline_offsets[&id];
-                self.cached_pipeline_offset = Some(*offset);
-                offset
-            }
-        }
-    }
-
-    pub fn get_clip_node_index(&mut self, id: ClipId) -> ClipNodeIndex {
+    pub fn get_clip_node_index(&self, id: ClipId) -> ClipNodeIndex {
         match id {
-            ClipId::Clip(index, pipeline_id) => {
-                let pipeline_offset = self.get_pipeline_offet(pipeline_id);
-                ClipNodeIndex(pipeline_offset.clip_offset + index)
+            ClipId::Clip(..) => {
+                self.clip_node_map[&id]
             }
             ClipId::Spatial(..) => {
                 // We could theoretically map back to the containing clip node with the current
                 // design, but we will eventually fully separate out clipping from spatial nodes
                 // in the display list. We don't ever need to do this anyway.
                 panic!("Tried to use positioning node as clip node.");
+            }
+            ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
+        }
+    }
+
+    pub fn get_spatial_node_index(&self, id: ClipId) -> SpatialNodeIndex {
+        match id {
+            ClipId::Clip(..) => {
+                panic!("Tried to use clip node as positioning node.");
+            }
+            ClipId::Spatial(..) => {
+                self.spatial_node_map[&id]
             }
             ClipId::ClipChain(_) => panic!("Tried to use ClipChain as scroll node."),
         }
@@ -248,7 +199,6 @@ impl<'a> DisplayListFlattener<'a> {
             clip_store: old_builder.clip_store.recycle(),
         };
 
-        flattener.id_to_index_mapper.initialize_for_pipeline(root_pipeline);
         flattener.push_root(
             root_pipeline_id,
             &root_pipeline.viewport_size,
@@ -401,13 +351,12 @@ impl<'a> DisplayListFlattener<'a> {
             info.previously_applied_offset,
         );
 
-        let index = self.get_spatial_node_index_for_clip_id(info.id);
-        self.clip_scroll_tree.add_sticky_frame(
-            index,
+        let index = self.clip_scroll_tree.add_sticky_frame(
             clip_and_scroll.spatial_node_index, /* parent id */
             sticky_frame_info,
             info.id.pipeline_id(),
         );
+        self.id_to_index_mapper.map_spatial_node(info.id, index);
         self.id_to_index_mapper.map_to_parent_clip_chain(info.id, parent_id);
     }
 
@@ -531,8 +480,6 @@ impl<'a> DisplayListFlattener<'a> {
                 return
             },
         };
-
-        self.id_to_index_mapper.initialize_for_pipeline(pipeline);
 
         //TODO: use or assert on `clip_and_scroll_ids.clip_node_id` ?
         let clip_chain_index = self.add_clip_node(
@@ -1219,10 +1166,8 @@ impl<'a> DisplayListFlattener<'a> {
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
     ) -> SpatialNodeIndex {
-        let index = self.get_spatial_node_index_for_clip_id(reference_frame_id);
         let parent_index = parent_id.map(|id| self.get_spatial_node_index_for_clip_id(id));
-        self.clip_scroll_tree.add_reference_frame(
-            index,
+        let index = self.clip_scroll_tree.add_reference_frame(
             parent_index,
             source_transform,
             source_perspective,
@@ -1230,6 +1175,7 @@ impl<'a> DisplayListFlattener<'a> {
             pipeline_id,
         );
         self.reference_frame_stack.push((reference_frame_id, index));
+        self.id_to_index_mapper.map_spatial_node(reference_frame_id, index);
 
         match parent_id {
             Some(ref parent_id) =>
@@ -1292,16 +1238,14 @@ impl<'a> DisplayListFlattener<'a> {
         let clip_sources = ClipSources::from(clip_region);
         let handle = self.clip_store.insert(clip_sources);
 
-        let node_index = self.id_to_index_mapper.get_clip_node_index(new_node_id);
-        let parent_clip_chain_index =
-            self.id_to_index_mapper.get_clip_chain_index_and_cache_result(&parent_id);
+        let parent_clip_chain_index = self.id_to_index_mapper.get_clip_chain_index(&parent_id);
         let spatial_node = self.get_spatial_node_index_for_clip_id(parent_id);
-        let clip_chain_index = self.clip_scroll_tree.add_clip_node(
-            node_index,
+        let (node_index, clip_chain_index) = self.clip_scroll_tree.add_clip_node(
             parent_clip_chain_index,
             spatial_node,
             handle,
         );
+        self.id_to_index_mapper.map_clip_node(new_node_id, node_index);
         self.id_to_index_mapper.add_clip_chain(new_node_id, clip_chain_index);
         clip_chain_index
     }
@@ -1316,10 +1260,8 @@ impl<'a> DisplayListFlattener<'a> {
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
     ) -> SpatialNodeIndex {
-        let node_index = self.get_spatial_node_index_for_clip_id(new_node_id);
         let parent_node_index = self.get_spatial_node_index_for_clip_id(parent_id);
-        self.clip_scroll_tree.add_scroll_frame(
-            node_index,
+        let node_index = self.clip_scroll_tree.add_scroll_frame(
             parent_node_index,
             external_id,
             pipeline_id,
@@ -1327,6 +1269,7 @@ impl<'a> DisplayListFlattener<'a> {
             content_size,
             scroll_sensitivity,
         );
+        self.id_to_index_mapper.map_spatial_node(new_node_id, node_index);
         self.id_to_index_mapper.map_to_parent_clip_chain(new_node_id, &parent_id);
         node_index
     }
@@ -1968,7 +1911,7 @@ impl<'a> DisplayListFlattener<'a> {
     pub fn map_clip_and_scroll(&mut self, info: &ClipAndScrollInfo) -> ScrollNodeAndClipChain {
         ScrollNodeAndClipChain::new(
             self.get_spatial_node_index_for_clip_id(info.scroll_node_id),
-            self.id_to_index_mapper.get_clip_chain_index_and_cache_result(&info.clip_node_id())
+            self.id_to_index_mapper.get_clip_chain_index(&info.clip_node_id())
         )
     }
 
@@ -1976,11 +1919,10 @@ impl<'a> DisplayListFlattener<'a> {
         self.map_clip_and_scroll(&ClipAndScrollInfo::simple(*id))
     }
 
-    pub fn get_spatial_node_index_for_clip_id(&mut self, id: ClipId,) -> SpatialNodeIndex {
+    pub fn get_spatial_node_index_for_clip_id(&mut self, id: ClipId) -> SpatialNodeIndex {
         match id {
-            ClipId::Spatial(index, pipeline_id) => {
-                let pipeline_offset = self.id_to_index_mapper.get_pipeline_offet(pipeline_id);
-                SpatialNodeIndex(pipeline_offset.spatial_offset + index)
+            ClipId::Spatial(..) => {
+                self.id_to_index_mapper.get_spatial_node_index(id)
             }
             ClipId::Clip(..) => {
                 let clip_node_index = self.id_to_index_mapper.get_clip_node_index(id);

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -56,8 +56,8 @@ pub struct ClipIdToIndexMapper {
 
 impl ClipIdToIndexMapper {
     pub fn add_clip_chain(&mut self, id: ClipId, index: ClipChainIndex) {
-        debug_assert!(!self.clip_chain_map.contains_key(&id));
-        self.clip_chain_map.insert(id, index);
+        let _old_value = self.clip_chain_map.insert(id, index);
+        debug_assert!(_old_value.is_none());
     }
 
     pub fn map_to_parent_clip_chain(&mut self, id: ClipId, parent_id: &ClipId) {
@@ -66,13 +66,13 @@ impl ClipIdToIndexMapper {
     }
 
     pub fn map_spatial_node(&mut self, id: ClipId, index: SpatialNodeIndex) {
-        debug_assert!(!self.spatial_node_map.contains_key(&id));
-        self.spatial_node_map.insert(id, index);
+        let _old_value = self.spatial_node_map.insert(id, index);
+        debug_assert!(_old_value.is_none());
     }
 
     pub fn map_clip_node(&mut self, id: ClipId, index: ClipNodeIndex) {
-        debug_assert!(!self.clip_node_map.contains_key(&id));
-        self.clip_node_map.insert(id, index);
+        let _old_value = self.clip_node_map.insert(id, index);
+        debug_assert!(_old_value.is_none());
     }
 
     pub fn get_clip_chain_index(&self, id: &ClipId) -> ClipChainIndex {

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -35,7 +35,7 @@ pub struct HitTestClipNode {
 }
 
 impl HitTestClipNode {
-    fn new(node: &ClipNode, clip_store: &ClipStore) -> HitTestClipNode {
+    fn new(node: &ClipNode, clip_store: &ClipStore) -> Self {
         let clips = clip_store.get(&node.handle);
         let regions = clips.clips().iter().map(|source| {
             match source.0 {

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -34,6 +34,29 @@ pub struct HitTestClipNode {
     regions: Vec<HitTestRegion>,
 }
 
+impl HitTestClipNode {
+    fn new(node: &ClipNode, clip_store: &ClipStore) -> HitTestClipNode {
+        let clips = clip_store.get(&node.handle);
+        let regions = clips.clips().iter().map(|source| {
+            match source.0 {
+                ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),
+                ClipSource::RoundedRectangle(ref rect, ref radii, ref mode) =>
+                    HitTestRegion::RoundedRectangle(*rect, *radii, *mode),
+                ClipSource::Image(ref mask) => HitTestRegion::Rectangle(mask.rect, ClipMode::Clip),
+                ClipSource::LineDecoration(_) |
+                ClipSource::BoxShadow(_) => {
+                    unreachable!("Didn't expect to hit test against BorderCorner / BoxShadow / LineDecoration");
+                }
+            }
+        }).collect();
+
+        HitTestClipNode {
+            spatial_node: clips.spatial_node_index,
+            regions,
+        }
+    }
+}
+
 /// A description of a clip chain in the HitTester. This is used to describe
 /// hierarchical clip scroll nodes as well as ClipChains, so that they can be
 /// handled the same way during hit testing. Once we represent all ClipChains
@@ -148,15 +171,11 @@ impl HitTester {
         }
 
         for (index, node) in clip_scroll_tree.clip_nodes.iter().enumerate() {
-            self.clip_nodes.push(HitTestClipNode {
-                spatial_node: node.spatial_node,
-                regions: get_regions_for_clip_node(node, clip_store),
-            });
-
-             let clip_chain = self.clip_chains.get_mut(node.clip_chain_index.0).unwrap();
-             clip_chain.parent =
-                 clip_scroll_tree.get_clip_chain(node.clip_chain_index).parent_index;
-             clip_chain.clips = vec![ClipNodeIndex(index)];
+            self.clip_nodes.push(HitTestClipNode::new(node, clip_store));
+            let clip_chain = self.clip_chains.get_mut(node.clip_chain_index.0).unwrap();
+            clip_chain.parent =
+                clip_scroll_tree.get_clip_chain(node.clip_chain_index).parent_index;
+            clip_chain.clips = vec![ClipNodeIndex(index)];
         }
 
         for descriptor in &clip_scroll_tree.clip_chains_descriptors {
@@ -344,25 +363,6 @@ impl HitTester {
     pub fn get_pipeline_root(&self, pipeline_id: PipelineId) -> &HitTestSpatialNode {
         &self.spatial_nodes[self.pipeline_root_nodes[&pipeline_id].0]
     }
-}
-
-fn get_regions_for_clip_node(
-    node: &ClipNode,
-    clip_store: &ClipStore
-) -> Vec<HitTestRegion> {
-    let clips = clip_store.get(&node.handle).clips();
-    clips.iter().map(|source| {
-        match source.0 {
-            ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),
-            ClipSource::RoundedRectangle(ref rect, ref radii, ref mode) =>
-                HitTestRegion::RoundedRectangle(*rect, *radii, *mode),
-            ClipSource::Image(ref mask) => HitTestRegion::Rectangle(mask.rect, ClipMode::Clip),
-            ClipSource::LineDecoration(_) |
-            ClipSource::BoxShadow(_) => {
-                unreachable!("Didn't expect to hit test against BorderCorner / BoxShadow / LineDecoration");
-            }
-        }
-    }).collect()
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -350,15 +350,7 @@ fn get_regions_for_clip_node(
     node: &ClipNode,
     clip_store: &ClipStore
 ) -> Vec<HitTestRegion> {
-    let handle = match node.handle.as_ref() {
-        Some(handle) => handle,
-        None => {
-            warn!("Encountered an empty clip node unexpectedly.");
-            return Vec::new()
-        }
-    };
-
-    let clips = clip_store.get(handle).clips();
+    let clips = clip_store.get(&node.handle).clips();
     clips.iter().map(|source| {
         match source.0 {
             ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2074,7 +2074,7 @@ impl PrimitiveStore {
             // of doing that, only segment with clips that have the same positioning node.
             // TODO(mrobinson, #2858): It may make sense to include these nodes, resegmenting only
             // when necessary while scrolling.
-            if clip_item.spatial_node_index != prim_run_context.spatial_node_index {
+            if local_clips.spatial_node_index != prim_run_context.spatial_node_index {
                 // We don't need to generate a global clip mask for rectangle clips because we are
                 // in the same coordinate system and rectangular clips are handled by the local
                 // clip chain rectangle.
@@ -2307,7 +2307,6 @@ impl PrimitiveStore {
 
                 Arc::new(ClipChainNode {
                     work_item: ClipWorkItem {
-                        spatial_node_index: prim_run_context.spatial_node_index,
                         clip_sources: clip_sources.weak(),
                         coordinate_system_id: prim_coordinate_system_id,
                     },

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -26,11 +26,6 @@ pub enum SpatialNodeType {
 
     /// A reference frame establishes a new coordinate space in the tree.
     ReferenceFrame(ReferenceFrameInfo),
-
-    /// An empty node, used to pad the ClipScrollTree's array of nodes so that
-    /// we can immediately use each assigned SpatialNodeIndex. After display
-    /// list flattening this node type should never be used.
-    Empty,
 }
 
 /// Contains information common among all types of ClipScrollTree nodes.
@@ -92,10 +87,6 @@ impl SpatialNode {
             coordinate_system_id: CoordinateSystemId(0),
             coordinate_system_relative_transform: LayoutFastTransform::identity(),
         }
-    }
-
-    pub fn empty() -> SpatialNode {
-        Self::new(PipelineId::dummy(), None, SpatialNodeType::Empty)
     }
 
     pub fn new_scroll_frame(
@@ -494,7 +485,6 @@ impl SpatialNode {
                     state.nearest_scrolling_ancestor_viewport
                        .translate(&translation);
             }
-            SpatialNodeType::Empty => unreachable!("Empty node remaining in ClipScrollTree."),
         }
     }
 


### PR DESCRIPTION
There are some upcoming changes which will modify how and when
we store and represent clip nodes and chains. These changes are
necessary to allow WR to rasterize pictures in a different coordinate
space than just screen space.

This patch simplifies the mapping of ClipId to array indices in
the clip-scroll tree. This will make it simpler to make the
changes discussed above - specifically, we can unify how we handle
clip nodes with the per-primitive complex clips.

The code this removes was a performance optimization to avoid
hashmap lookups. I did some profiling on a number of real world
sites and also on some gecko layer stress tests, and didn't find
any noticeable regression from simplifying this code. However,
once the work above has been completed, we could re-investigate
how to optimize this mapping process, if it ever shows up in a
profile.

In one of the stress tests [1] for spatial and clip node creation,
the code is now slightly faster with this patch (28ms vs 29ms).

[1] https://mattwoodrow.github.io/dl-test/dl-test.html?count=50000&layer=inactive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2925)
<!-- Reviewable:end -->
