### PR TITLE
Avoid always reuploading blob images.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -875,9 +875,15 @@ impl ResourceCache {
             ImageResult::Err(_) => panic!("Errors should already have been handled"),
         };
 
-        self.texture_cache.request(&entry.texture_cache_handle, gpu_cache);
+        let needs_upload = self.texture_cache.request(&entry.texture_cache_handle, gpu_cache);
 
-        self.pending_image_requests.insert(request);
+        if !needs_upload && entry.dirty_rect.is_none() {
+            return
+        }
+
+        if !self.pending_image_requests.insert(request) {
+            return
+        }
 
         if template.data.is_blob() {
             let request: BlobImageRequest = request.into();


### PR DESCRIPTION
This might not be the best solution but it's good enough to get
past the worst of the performance problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2926)
<!-- Reviewable:end -->
