### PR TITLE
Only trigger a frame build if scene properties have changed.

### DIFF
--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1090,7 +1090,7 @@ impl<T> From<T> for PropertyBinding<T> {
 
 /// The current value of an animated property. This is
 /// supplied by the calling code.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct PropertyValue<T> {
     pub key: PropertyBindingKey<T>,
     pub value: T,
@@ -1099,7 +1099,7 @@ pub struct PropertyValue<T> {
 /// When using `generate_frame()`, a list of `PropertyValue` structures
 /// can optionally be supplied to provide the current value of any
 /// animated properties.
-#[derive(Clone, Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Default)]
 pub struct DynamicProperties {
     pub transforms: Vec<PropertyValue<LayoutTransform>>,
     pub floats: Vec<PropertyValue<f32>>,


### PR DESCRIPTION
In many important use cases (e.g. video playback on youtube) the
display list doesn't change very often. Typically, the only
thing changing between frames are the natively decoded video
texture surfaces.

In these cases, we can save a significant amount of CPU usage
and battery power by not building a frame at all.

Previously, any call to set/update dynamic properties would
trigger a frame rebuild. However, it's often the case that
Gecko sends dynamic properties updates that are either empty
or exactly the same as the previous frame.

With this change, WR will compare the scene properties and
only trigger a frame rebuild if they have actually changed.

This is a partial step towards fixing #2917 - a couple of
other changes are also needed to completely avoid a frame
rebuiild in this use case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2927)
<!-- Reviewable:end -->
