### PR TITLE
Trim the render work done after a scene build

### DIFF
--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -30,14 +30,16 @@ impl ClipNode {
         &mut self,
         device_pixel_scale: DevicePixelScale,
         clip_store: &mut ClipStore,
-        render_context: &mut ClipRenderContext,
+        render_context: &mut Option<ClipRenderContext>,
         clip_chains: &mut [ClipChain],
         spatial_nodes: &[SpatialNode],
     ) {
         let clip_sources = clip_store.get_mut(self.clip_sources_index);
-        clip_sources.update(render_context.gpu_cache,
-                            render_context.resource_cache,
-                            device_pixel_scale);
+        if let &mut Some(ref mut context) = render_context {
+            clip_sources.update(context.gpu_cache,
+                                context.resource_cache,
+                                device_pixel_scale);
+        }
         let spatial_node = &spatial_nodes[clip_sources.spatial_node_index.0];
 
         let (screen_inner_rect, screen_outer_rect) = clip_sources.get_screen_bounds(

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -4,9 +4,7 @@
 
 use api::DevicePixelScale;
 use clip::{ClipChain, ClipChainNode, ClipSourcesIndex, ClipStore, ClipWorkItem};
-use clip_scroll_tree::{ClipChainIndex};
-use gpu_cache::GpuCache;
-use resource_cache::ResourceCache;
+use clip_scroll_tree::{ClipChainIndex, ClipRenderContext};
 use spatial_node::SpatialNode;
 
 #[derive(Debug)]
@@ -32,13 +30,14 @@ impl ClipNode {
         &mut self,
         device_pixel_scale: DevicePixelScale,
         clip_store: &mut ClipStore,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
+        render_context: &mut ClipRenderContext,
         clip_chains: &mut [ClipChain],
         spatial_nodes: &[SpatialNode],
     ) {
         let clip_sources = clip_store.get_mut(self.clip_sources_index);
-        clip_sources.update(gpu_cache, resource_cache, device_pixel_scale);
+        clip_sources.update(render_context.gpu_cache,
+                            render_context.resource_cache,
+                            device_pixel_scale);
         let spatial_node = &spatial_nodes[clip_sources.spatial_node_index.0];
 
         let (screen_inner_rect, screen_outer_rect) = clip_sources.get_screen_bounds(

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -66,6 +66,11 @@ impl ClipChainIndex {
     pub const NO_CLIP: Self = ClipChainIndex(0);
 }
 
+pub struct ClipRenderContext<'a> {
+    pub resource_cache: &'a mut ResourceCache,
+    pub gpu_cache: &'a mut GpuCache,
+}
+
 pub struct ClipScrollTree {
     /// Nodes which determine the positions (offsets and transforms) for primitives
     /// and clips.
@@ -223,8 +228,7 @@ impl ClipScrollTree {
         screen_rect: &DeviceIntRect,
         device_pixel_scale: DevicePixelScale,
         clip_store: &mut ClipStore,
-        resource_cache: &mut ResourceCache,
-        gpu_cache: &mut GpuCache,
+        render_context: &mut ClipRenderContext,
         pan: WorldPoint,
         scene_properties: &SceneProperties,
     ) -> TransformPalette {
@@ -259,8 +263,7 @@ impl ClipScrollTree {
             clip_node.update(
                 device_pixel_scale,
                 clip_store,
-                resource_cache,
-                gpu_cache,
+                render_context,
                 &mut self.clip_chains,
                 &self.spatial_nodes,
             );

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -331,7 +331,7 @@ impl FrameBuilder {
         gpu_cache.begin_frame();
 
         let transform_palette = {
-            let mut clip_render_context = ClipRenderContext {
+            let clip_render_context = ClipRenderContext {
                 resource_cache,
                 gpu_cache,
             };
@@ -339,10 +339,10 @@ impl FrameBuilder {
                 &self.screen_rect.to_i32(),
                 device_pixel_scale,
                 &mut self.clip_store,
-                &mut clip_render_context,
+                &mut Some(clip_render_context),
                 pan,
                 scene_properties,
-            )
+            ).expect("Must get a palette since we provided a render context")
         };
 
         self.update_scroll_bars(clip_scroll_tree, gpu_cache);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -302,6 +302,24 @@ impl FrameBuilder {
         }
     }
 
+    pub fn update_clip_scroll_tree(
+        &mut self,
+        clip_render_context: &mut Option<ClipRenderContext>,
+        clip_scroll_tree: &mut ClipScrollTree,
+        device_pixel_scale: DevicePixelScale,
+        pan: WorldPoint,
+        scene_properties: &SceneProperties,
+    ) -> Option<TransformPalette> {
+        clip_scroll_tree.update_tree(
+            &self.screen_rect.to_i32(),
+            device_pixel_scale,
+            &mut self.clip_store,
+            clip_render_context,
+            pan,
+            scene_properties,
+        )
+    }
+
     pub fn build(
         &mut self,
         resource_cache: &mut ResourceCache,
@@ -335,15 +353,14 @@ impl FrameBuilder {
                 resource_cache,
                 gpu_cache,
             };
-            clip_scroll_tree.update_tree(
-                &self.screen_rect.to_i32(),
-                device_pixel_scale,
-                &mut self.clip_store,
+            self.update_clip_scroll_tree(
                 &mut Some(clip_render_context),
+                clip_scroll_tree,
+                device_pixel_scale,
                 pan,
-                scene_properties,
-            ).expect("Must get a palette since we provided a render context")
-        };
+                scene_properties
+            )
+        }.expect("Must get a palette since we provided a render context");
 
         self.update_scroll_bars(clip_scroll_tree, gpu_cache);
 

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -359,6 +359,22 @@ impl Document {
         }).unwrap();
     }
 
+    fn rebuild_hit_tester(&mut self) {
+        let accumulated_scale_factor = self.view.accumulated_scale_factor();
+        let pan = self.view.pan.to_f32() / accumulated_scale_factor;
+
+        let frame_builder = self.frame_builder.as_mut().unwrap();
+        let palette = frame_builder.update_clip_scroll_tree(
+            &mut None,
+            &mut self.clip_scroll_tree,
+            accumulated_scale_factor,
+            pan,
+            &self.dynamic_properties,
+        );
+        debug_assert!(!palette.is_some());
+        self.hit_tester = Some(frame_builder.create_hit_tester(&self.clip_scroll_tree));
+    }
+
     fn render(
         &mut self,
         resource_cache: &mut ResourceCache,
@@ -448,6 +464,7 @@ impl Document {
 struct DocumentOps {
     scroll: bool,
     build: bool,
+    rebuild_hit_tester: bool,
     render: bool,
     composite: bool,
 }
@@ -457,6 +474,7 @@ impl DocumentOps {
         DocumentOps {
             scroll: false,
             build: false,
+            rebuild_hit_tester: false,
             render: false,
             composite: false,
         }
@@ -469,9 +487,9 @@ impl DocumentOps {
         }
     }
 
-    fn render() -> Self {
+    fn rebuild_hit_tester() -> Self {
         DocumentOps {
-            render: true,
+            rebuild_hit_tester: true,
             ..DocumentOps::nop()
         }
     }
@@ -479,6 +497,7 @@ impl DocumentOps {
     fn combine(&mut self, other: Self) {
         self.scroll = self.scroll || other.scroll;
         self.build = self.build || other.build;
+        self.rebuild_hit_tester = self.rebuild_hit_tester || other.rebuild_hit_tester;
         self.render = self.render || other.render;
         self.composite = self.composite || other.composite;
     }
@@ -730,9 +749,8 @@ impl RenderBackend {
                             if let Some(mut built_scene) = built_scene.take() {
                                 doc.new_async_scene_ready(built_scene);
                                 // After applying the new scene we need to
-                                // rebuild the hit-tester, so we trigger a render
-                                // step.
-                                ops = DocumentOps::render();
+                                // rebuild the hit-tester.
+                                ops = DocumentOps::rebuild_hit_tester();
                             }
                             if let Some(tx) = result_tx {
                                 let (resume_tx, resume_rx) = channel();
@@ -766,7 +784,7 @@ impl RenderBackend {
                             self.resource_cache.set_blob_rasterizer(rasterizer);
                         }
 
-                        if !transaction_msg.is_empty() || ops.render {
+                        if !transaction_msg.is_empty() || ops.rebuild_hit_tester {
                             self.update_document(
                                 document_id,
                                 transaction_msg,
@@ -1061,7 +1079,7 @@ impl RenderBackend {
         // fiddle with things after a potentially long scene build, but just
         // before rendering. This is useful for rendering with the latest
         // async transforms.
-        if op.render || transaction_msg.generate_frame {
+        if op.render || op.rebuild_hit_tester || transaction_msg.generate_frame {
             if let Some(ref sampler) = self.sampler {
                 transaction_msg.frame_ops.append(&mut sampler.sample());
             }
@@ -1148,6 +1166,8 @@ impl RenderBackend {
             // new_frame_ready callback below) has the right flags.
             let msg = ResultMsg::PublishPipelineInfo(doc.updated_pipeline_info());
             self.result_tx.send(msg).unwrap();
+        } else if op.rebuild_hit_tester {
+            doc.rebuild_hit_tester();
         }
 
         if transaction_msg.generate_frame {


### PR DESCRIPTION
Fixes #2807. I'm not totally sure that I'm including all the work that is necessary for hit-testing but it seems to pass my ad-hoc testing and CI. But still, please review with care to make sure I'm not violating assumptions or leaving behind inconsistent state by just doing the bits of the clip scroll tree update that don't touch the resource cache, gpu cache, and transform palette.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2936)
<!-- Reviewable:end -->
