### PR TITLE
Add ClipStore struct, and use flat vec for clip sources.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1788,9 +1788,7 @@ impl ClipBatcher {
     ) {
         let mut coordinate_system_id = coordinate_system_id;
         for work_item in clips.iter() {
-            let info = clip_store
-                .get_opt(&work_item.clip_sources)
-                .expect("bug: clip handle should be valid");
+            let info = clip_store.get(work_item.clip_sources_index);
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
                 transform_id: transforms.get_id(info.spatial_node_index),

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::DevicePixelScale;
-use clip::{ClipChain, ClipChainNode, ClipSourcesHandle, ClipStore, ClipWorkItem};
+use clip::{ClipChain, ClipChainNode, ClipSourcesIndex, ClipStore, ClipWorkItem};
 use clip_scroll_tree::{ClipChainIndex};
 use gpu_cache::GpuCache;
 use resource_cache::ResourceCache;
@@ -12,7 +12,7 @@ use spatial_node::SpatialNode;
 #[derive(Debug)]
 pub struct ClipNode {
     /// A handle to this clip nodes clips in the ClipStore.
-    pub handle: ClipSourcesHandle,
+    pub clip_sources_index: ClipSourcesIndex,
 
     /// An index to a ClipChain defined by this ClipNode's hiearchy in the display
     /// list.
@@ -37,7 +37,7 @@ impl ClipNode {
         clip_chains: &mut [ClipChain],
         spatial_nodes: &[SpatialNode],
     ) {
-        let clip_sources = clip_store.get_mut(&self.handle);
+        let clip_sources = clip_store.get_mut(self.clip_sources_index);
         clip_sources.update(gpu_cache, resource_cache, device_pixel_scale);
         let spatial_node = &spatial_nodes[clip_sources.spatial_node_index.0];
 
@@ -57,7 +57,7 @@ impl ClipNode {
 
         let new_node = ClipChainNode {
             work_item: ClipWorkItem {
-                clip_sources: self.handle.weak(),
+                clip_sources_index: self.clip_sources_index,
                 coordinate_system_id: spatial_node.coordinate_system_id,
             },
             local_clip_rect: spatial_node

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -5,7 +5,7 @@
 use api::{DeviceIntRect, DevicePixelScale, ExternalScrollId, LayoutPoint, LayoutRect, LayoutVector2D};
 use api::{PipelineId, ScrollClamping, ScrollLocation, ScrollNodeState};
 use api::{LayoutSize, LayoutTransform, PropertyBinding, ScrollSensitivity, WorldPoint};
-use clip::{ClipChain, ClipSourcesHandle, ClipStore};
+use clip::{ClipChain, ClipSourcesIndex, ClipStore};
 use clip_node::ClipNode;
 use gpu_cache::GpuCache;
 use gpu_types::TransformPalette;
@@ -355,12 +355,12 @@ impl ClipScrollTree {
     pub fn add_clip_node(
         &mut self,
         parent_clip_chain_index: ClipChainIndex,
-        handle: ClipSourcesHandle,
+        clip_sources_index: ClipSourcesIndex,
     ) -> (ClipNodeIndex, ClipChainIndex) {
         let clip_chain_index = self.allocate_clip_chain();
         let node = ClipNode {
             parent_clip_chain_index,
-            handle,
+            clip_sources_index,
             clip_chain_index,
             clip_chain_node: None,
         };

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -13,7 +13,7 @@ use api::{LineOrientation, LineStyle, LocalClip, NinePatchBorderSource, Pipeline
 use api::{PropertyBinding, ReferenceFrame, RepeatMode, ScrollFrameDisplayItem, ScrollSensitivity};
 use api::{Shadow, SpecificDisplayItem, StackingContext, StickyFrameDisplayItem, TexelRect};
 use api::{TransformStyle, YuvColorSpace, YuvData};
-use clip::{ClipRegion, ClipSource, ClipSources, ClipSourcesHandle, ClipStore};
+use clip::{ClipRegion, ClipSource, ClipSources, ClipSourcesIndex, ClipStore};
 use clip_scroll_tree::{ClipChainIndex, ClipNodeIndex, ClipScrollTree, SpatialNodeIndex};
 use euclid::vec2;
 use frame_builder::{ChasePrimitive, FrameBuilder, FrameBuilderConfig};
@@ -740,7 +740,7 @@ impl<'a> DisplayListFlattener<'a> {
         &mut self,
         clip_sources: Vec<ClipSource>,
         spatial_node_index: SpatialNodeIndex,
-    ) -> Option<ClipSourcesHandle> {
+    ) -> Option<ClipSourcesIndex> {
         if clip_sources.is_empty() {
             None
         } else {
@@ -754,7 +754,7 @@ impl<'a> DisplayListFlattener<'a> {
     pub fn create_primitive(
         &mut self,
         info: &LayoutPrimitiveInfo,
-        clip_sources: Option<ClipSourcesHandle>,
+        clip_sources: Option<ClipSourcesIndex>,
         container: PrimitiveContainer,
     ) -> PrimitiveIndex {
         let stacking_context = self.sc_stack.last().expect("bug: no stacking context!");

--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::marker::PhantomData;
-use util::recycle_vec;
 
 // TODO(gw): Add an occupied list head, for fast
 //           iteration of the occupied list to implement
@@ -80,15 +79,6 @@ impl<T, M> FreeList<T, M> {
     pub fn new() -> Self {
         FreeList {
             slots: Vec::new(),
-            free_list_head: None,
-            active_count: 0,
-            _marker: PhantomData,
-        }
-    }
-
-    pub fn recycle(self) -> FreeList<T, M> {
-        FreeList {
-            slots: recycle_vec(self.slots),
             free_list_head: None,
             active_count: 0,
             _marker: PhantomData,

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -36,7 +36,7 @@ pub struct HitTestClipNode {
 
 impl HitTestClipNode {
     fn new(node: &ClipNode, clip_store: &ClipStore) -> Self {
-        let clips = clip_store.get(&node.handle);
+        let clips = clip_store.get(node.clip_sources_index);
         let regions = clips.clips().iter().map(|source| {
             match source.0 {
                 ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -403,7 +403,7 @@ impl RenderTask {
         //           whether a ClipSources contains any box-shadows and skip
         //           this iteration for the majority of cases.
         for clip_item in &clips {
-            let clip_sources = clip_store.get_opt_mut(&clip_item.clip_sources).expect("bug");
+            let clip_sources = clip_store.get_mut(clip_item.clip_sources_index);
             for &mut (ref mut clip, _) in &mut clip_sources.clips {
                 match *clip {
                     ClipSource::BoxShadow(ref mut info) => {


### PR DESCRIPTION
We previously used a free list for clip sources, since it was
possible to add/remove clip sources lists within a single
display list. That's no longer used, so switch to a flat vec
which is a bit simpler and slightly more efficient.

Add a ClipStore struct. This currently holds clip sources only,
but as we start to support clip chains in different coordinate
systems, we'll move the clip chains from the CST to live here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2937)
<!-- Reviewable:end -->
