### PR TITLE
Avoid transform copies where not necessary

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -14,8 +14,8 @@ use gpu_types::BoxShadowStretchMode;
 use prim_store::{ClipData, ImageMaskData};
 use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
-use util::{LayoutToWorldFastTransform, MaxRect, calculate_screen_bounding_rect};
-use util::{extract_inner_rect_safe, pack_as_float, recycle_vec};
+use util::{LayoutToWorldFastTransform, MaxRect, TransformedRectKind};
+use util::{calculate_screen_bounding_rect, extract_inner_rect_safe, pack_as_float, recycle_vec};
 use std::{iter, ops};
 use std::sync::Arc;
 
@@ -571,7 +571,8 @@ impl ClipSources {
         // rectangle so that we can do screen inner rectangle optimizations for these kind of
         // cilps.
         let can_calculate_inner_rect =
-            transform.preserves_2d_axis_alignment() && !transform.has_perspective_component();
+            transform.kind() == TransformedRectKind::AxisAligned &&
+            !transform.has_perspective_component();
         let screen_inner_rect = if can_calculate_inner_rect {
             calculate_screen_bounding_rect(transform, &self.local_inner_rect, device_pixel_scale, screen_rect)
                 .unwrap_or(DeviceIntRect::zero())

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -104,7 +104,7 @@ pub struct PictureState {
 }
 
 impl PictureState {
-    pub fn new() -> PictureState {
+    pub fn new() -> Self {
         PictureState {
             tasks: Vec::new(),
             has_non_root_coord_system: false,
@@ -117,7 +117,7 @@ pub struct PrimitiveRunContext<'a> {
     pub clip_chain: &'a ClipChain,
     pub scroll_node: &'a SpatialNode,
     pub spatial_node_index: SpatialNodeIndex,
-    pub transform: Transform,
+    pub transform: Transform<'a>,
     pub local_clip_rect: LayoutRect,
 }
 
@@ -127,7 +127,7 @@ impl<'a> PrimitiveRunContext<'a> {
         scroll_node: &'a SpatialNode,
         spatial_node_index: SpatialNodeIndex,
         local_clip_rect: LayoutRect,
-        transform: Transform,
+        transform: Transform<'a>,
     ) -> Self {
         PrimitiveRunContext {
             clip_chain,

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -8,7 +8,7 @@ use clip_scroll_tree::SpatialNodeIndex;
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use prim_store::{EdgeAaSegmentMask, Transform};
 use render_task::RenderTaskAddress;
-use util::{MatrixHelpers, TransformedRectKind};
+use util::{LayoutToWorldFastTransform, TransformedRectKind};
 
 // Contains type that must exactly match the same structures declared in GLSL.
 
@@ -374,12 +374,12 @@ impl TransformPaletteId {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 #[repr(C)]
 pub struct TransformData {
-    pub transform: LayoutToWorldTransform,
-    pub inv_transform: WorldToLayoutTransform,
+    transform: LayoutToWorldTransform,
+    inv_transform: WorldToLayoutTransform,
 }
 
 impl TransformData {
-    pub fn invalid() -> Self {
+    fn invalid() -> Self {
         TransformData {
             transform: LayoutToWorldTransform::identity(),
             inv_transform: WorldToLayoutTransform::identity(),
@@ -389,7 +389,7 @@ impl TransformData {
 
 // Extra data stored about each transform palette entry.
 pub struct TransformMetadata {
-    pub transform_kind: TransformedRectKind,
+    transform_kind: TransformedRectKind,
 }
 
 // Stores a contiguous list of TransformData structs, that
@@ -405,38 +405,60 @@ pub struct TransformPalette {
 }
 
 impl TransformPalette {
-    pub fn new(spatial_node_count: usize) -> TransformPalette {
+    pub fn new(spatial_node_count: usize) -> Self {
         TransformPalette {
             transforms: Vec::with_capacity(spatial_node_count),
             metadata: Vec::with_capacity(spatial_node_count),
         }
     }
 
-    // Set the local -> world transform for a given spatial
-    // node in the transform palette.
-    pub fn set(
-        &mut self,
-        index: SpatialNodeIndex,
-        data: TransformData,
-    ) {
-        let index = index.0 as usize;
-
+    #[inline]
+    fn grow(&mut self, index: SpatialNodeIndex) {
         // Pad the vectors out if they are not long enough to
         // account for this index. This can occur, for instance,
         // when we stop recursing down the CST due to encountering
         // a node with an invalid transform.
-        while index >= self.transforms.len() {
+        while self.transforms.len() <= index.0 as usize {
             self.transforms.push(TransformData::invalid());
             self.metadata.push(TransformMetadata {
                 transform_kind: TransformedRectKind::AxisAligned,
             });
         }
+    }
 
-        // Store the transform itself, along with metadata about it.
-        self.metadata[index] = TransformMetadata {
-            transform_kind: data.transform.transform_kind(),
+    pub fn invalidate(&mut self, index: SpatialNodeIndex) {
+        self.grow(index);
+        self.metadata[index.0 as usize] = TransformMetadata {
+            transform_kind: TransformedRectKind::AxisAligned,
         };
-        self.transforms[index] = data;
+        self.transforms[index.0 as usize] = TransformData::invalid();
+    }
+
+    // Set the local -> world transform for a given spatial
+    // node in the transform palette.
+    pub fn set(
+        &mut self, index: SpatialNodeIndex, fast_transform: &LayoutToWorldFastTransform,
+    ) -> bool {
+        self.grow(index);
+
+        match fast_transform.inverse() {
+            Some(inverted) => {
+                // Store the transform itself, along with metadata about it.
+                self.metadata[index.0 as usize] = TransformMetadata {
+                    transform_kind: fast_transform.kind()
+                };
+                // Write the data that will be made available to the GPU for this node.
+                self.transforms[index.0 as usize] = TransformData {
+                    transform: fast_transform.to_transform().into_owned(),
+                    inv_transform: inverted.to_transform().into_owned(),
+                };
+                true
+            }
+            None => {
+                self.invalidate(index);
+                false
+            }
+        }
     }
 
     // Get the relevant information about a given transform that is
@@ -448,14 +470,13 @@ impl TransformPalette {
         &self,
         index: SpatialNodeIndex,
     ) -> Transform {
-        let index = index.0;
-        let transform = &self.transforms[index];
-        let metadata = &self.metadata[index];
+        let data = &self.transforms[index.0 as usize];
+        let metadata = &self.metadata[index.0 as usize];
 
         Transform {
-            m: transform.transform,
+            m: &data.transform,
             transform_kind: metadata.transform_kind,
-            backface_is_visible: transform.transform.is_backface_visible(),
+            backface_is_visible: data.transform.is_backface_visible(),
         }
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -63,8 +63,8 @@ impl ScrollNodeAndClipChain {
 // the information in the clip-scroll tree. However, if we decide
 // to rasterize a picture in local space, then this will be the
 // transform relative to that picture's coordinate system.
-pub struct Transform {
-    pub m: LayoutToWorldTransform,
+pub struct Transform<'a> {
+    pub m: &'a LayoutToWorldTransform,
     pub backface_is_visible: bool,
     pub transform_kind: TransformedRectKind,
 }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1574,7 +1574,7 @@ impl PrimitiveStore {
             PrimitiveKind::TextRun => {
                 let text = &mut self.cpu_text_runs[metadata.cpu_prim_index.0];
                 // The transform only makes sense for screen space rasterization
-                let transform = prim_run_context.scroll_node.world_content_transform.into();
+                let transform = prim_run_context.scroll_node.world_content_transform.to_transform();
                 text.prepare_for_render(
                     frame_context.device_pixel_scale,
                     &transform,

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -209,7 +209,7 @@ impl SpatialNode {
         }
 
         let inv_transform = match self.world_content_transform.inverse() {
-            Some(inverted) => inverted.to_transform(),
+            Some(inverted) => inverted.to_transform().into_owned(),
             None => {
                 transform_palette.set(node_index, TransformData::invalid());
                 return;
@@ -217,7 +217,7 @@ impl SpatialNode {
         };
 
         let data = TransformData {
-            transform: self.world_content_transform.into(),
+            transform: self.world_content_transform.to_transform().into_owned(),
             inv_transform,
         };
 

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -488,6 +488,14 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         FastTransform::Transform { transform, inverse, is_2d}
     }
 
+    pub fn kind(&self) -> TransformedRectKind {
+        match *self {
+            FastTransform::Offset(_) => TransformedRectKind::AxisAligned,
+            FastTransform::Transform { ref transform, .. } if transform.preserves_2d_axis_alignment() => TransformedRectKind::AxisAligned,
+            FastTransform::Transform { .. } => TransformedRectKind::Complex,
+        }
+    }
+
     pub fn to_transform(&self) -> Cow<TypedTransform3D<f32, Src, Dst>> {
         match *self {
             FastTransform::Offset(offset) => Cow::Owned(
@@ -528,15 +536,6 @@ impl<Src, Dst> FastTransform<Src, Dst> {
                 FastTransform::Offset(*offset + *other_offset),
             FastTransform::Transform { transform, .. } =>
                 FastTransform::with_transform(transform.pre_translate(other_offset.to_3d()))
-        }
-    }
-
-    #[inline(always)]
-    pub fn preserves_2d_axis_alignment(&self) -> bool {
-        match *self {
-            FastTransform::Offset(..) => true,
-            FastTransform::Transform { ref transform, .. } =>
-                transform.preserves_2d_axis_alignment(),
         }
     }
 

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -11,6 +11,8 @@ use euclid::{HomogeneousVector};
 use num_traits::Zero;
 use plane_split::{Clipper, Plane, Polygon};
 use std::{i32, f32};
+use std::borrow::Cow;
+
 
 // Matches the definition of SK_ScalarNearlyZero in Skia.
 const NEARLY_ZERO: f32 = 1.0 / 4096.0;
@@ -486,11 +488,12 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         FastTransform::Transform { transform, inverse, is_2d}
     }
 
-    pub fn to_transform(&self) -> TypedTransform3D<f32, Src, Dst> {
+    pub fn to_transform(&self) -> Cow<TypedTransform3D<f32, Src, Dst>> {
         match *self {
-            FastTransform::Offset(offset) =>
-                TypedTransform3D::create_translation(offset.x, offset.y, 0.0),
-            FastTransform::Transform { transform, .. } => transform
+            FastTransform::Offset(offset) => Cow::Owned(
+                TypedTransform3D::create_translation(offset.x, offset.y, 0.0)
+            ),
+            FastTransform::Transform { ref transform, .. } => Cow::Borrowed(transform),
         }
     }
 
@@ -650,12 +653,6 @@ impl<Src, Dst> FastTransform<Src, Dst> {
 impl<Src, Dst> From<TypedTransform3D<f32, Src, Dst>> for FastTransform<Src, Dst> {
     fn from(transform: TypedTransform3D<f32, Src, Dst>) -> Self {
         FastTransform::with_transform(transform)
-    }
-}
-
-impl<Src, Dst> Into<TypedTransform3D<f32, Src, Dst>> for FastTransform<Src, Dst> {
-    fn into(self) -> TypedTransform3D<f32, Src, Dst> {
-        self.to_transform()
     }
 }
 


### PR DESCRIPTION
This should be harmless. Just using references and `Cow` where we did copies before. Those copies are sometimes difficult to track down in the profiler because they just make the functions heavier and not all the time manifest in separate system move calls.
cc @nical

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2942)
<!-- Reviewable:end -->
