### PR TITLE
Replace heap allocation of clip-related objects with iteration

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1788,7 +1788,7 @@ impl ClipBatcher {
     ) {
         let mut coordinate_system_id = coordinate_system_id;
         for work_item in clips.iter() {
-            let info = clip_store.get(work_item.clip_sources_index);
+            let info = &clip_store[work_item.clip_sources_index];
             let instance = ClipMaskInstance {
                 render_task_address: task_address,
                 transform_id: transforms.get_id(info.spatial_node_index),

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -16,6 +16,7 @@ use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use util::{LayoutToWorldFastTransform, MaxRect, calculate_screen_bounding_rect};
 use util::{extract_inner_rect_safe, pack_as_float, recycle_vec};
+use std::{iter, ops};
 use std::sync::Arc;
 
 #[derive(Debug, Copy, Clone)]
@@ -28,13 +29,13 @@ pub struct ClipStore {
 }
 
 impl ClipStore {
-    pub fn new() -> ClipStore {
+    pub fn new() -> Self {
         ClipStore {
             clip_sources: Vec::new(),
         }
     }
 
-    pub fn recycle(self) -> ClipStore {
+    pub fn recycle(self) -> Self {
         ClipStore {
             clip_sources: recycle_vec(self.clip_sources),
         }
@@ -45,12 +46,17 @@ impl ClipStore {
         self.clip_sources.push(clip_sources);
         index
     }
+}
 
-    pub fn get(&self, index: ClipSourcesIndex) -> &ClipSources {
+impl ops::Index<ClipSourcesIndex> for ClipStore {
+    type Output = ClipSources;
+    fn index(&self, index: ClipSourcesIndex) -> &Self::Output {
         &self.clip_sources[index.0]
     }
+}
 
-    pub fn get_mut(&mut self, index: ClipSourcesIndex) -> &mut ClipSources {
+impl ops::IndexMut<ClipSourcesIndex> for ClipStore {
+    fn index_mut(&mut self, index: ClipSourcesIndex) -> &mut Self::Output {
         &mut self.clip_sources[index.0]
     }
 }
@@ -76,7 +82,7 @@ impl ClipRegion {
         mut complex_clips: Vec<ComplexClipRegion>,
         mut image_mask: Option<ImageMask>,
         reference_frame_relative_offset: &LayoutVector2D,
-    ) -> ClipRegion {
+    ) -> Self {
         let rect = rect.translate(reference_frame_relative_offset);
 
         if let Some(ref mut image_mask) = image_mask {
@@ -97,7 +103,7 @@ impl ClipRegion {
     pub fn create_for_clip_node_with_local_clip(
         local_clip: &LocalClip,
         reference_frame_relative_offset: &LayoutVector2D
-    ) -> ClipRegion {
+    ) -> Self {
         let complex_clips = match *local_clip {
             LocalClip::Rect(_) => Vec::new(),
             LocalClip::RoundedRect(_, ref region) => vec![region.clone()],
@@ -280,6 +286,92 @@ impl ClipSource {
     }
 }
 
+
+struct BoundsAccumulator {
+    local_outer: Option<LayoutRect>,
+    local_inner: Option<LayoutRect>,
+    can_calculate_inner_rect: bool,
+    can_calculate_outer_rect: bool,
+}
+
+impl BoundsAccumulator {
+    fn new() -> Self {
+        BoundsAccumulator {
+            local_outer: Some(LayoutRect::max_rect()),
+            local_inner: Some(LayoutRect::max_rect()),
+            can_calculate_inner_rect: true,
+            can_calculate_outer_rect: false,
+        }
+    }
+
+    fn add(&mut self, source: &ClipSource) {
+        // Depending on the complexity of the clip, we may either know the outer and/or inner
+        // rect, or neither or these.  In the case of a clip-out, we currently set the mask bounds
+        // to be unknown. This is conservative, but ensures correctness. In the future we can make
+        // this a lot more clever with some proper region handling.
+        if !self.can_calculate_inner_rect {
+            return
+        }
+
+        match *source {
+            ClipSource::Image(ref mask) => {
+                if !mask.repeat {
+                    self.can_calculate_outer_rect = true;
+                    self.local_outer = self.local_outer.and_then(|r| r.intersection(&mask.rect));
+                }
+                self.local_inner = None;
+            }
+            ClipSource::Rectangle(rect, mode) => {
+                // Once we encounter a clip-out, we just assume the worst
+                // case clip mask size, for now.
+                if mode == ClipMode::ClipOut {
+                    self.can_calculate_inner_rect = false;
+                    return
+                }
+
+                self.can_calculate_outer_rect = true;
+                self.local_outer = self.local_outer.and_then(|r| r.intersection(&rect));
+                self.local_inner = self.local_inner.and_then(|r| r.intersection(&rect));
+            }
+            ClipSource::RoundedRectangle(ref rect, ref radius, mode) => {
+                // Once we encounter a clip-out, we just assume the worst
+                // case clip mask size, for now.
+                if mode == ClipMode::ClipOut {
+                    self.can_calculate_inner_rect = false;
+                    return
+                }
+
+                self.can_calculate_outer_rect = true;
+                self.local_outer = self.local_outer.and_then(|r| r.intersection(rect));
+
+                let inner_rect = extract_inner_rect_safe(rect, radius);
+                self.local_inner = self.local_inner
+                    .and_then(|r| inner_rect.and_then(|ref inner| r.intersection(inner)));
+            }
+            ClipSource::BoxShadow(..) |
+            ClipSource::LineDecoration(..) => {
+                self.can_calculate_inner_rect = false;
+            }
+        }
+    }
+
+    fn finish(self) -> (LayoutRect, Option<LayoutRect>) {
+        (
+            if self.can_calculate_inner_rect {
+                self.local_inner.unwrap_or_else(LayoutRect::zero)
+            } else {
+                LayoutRect::zero()
+            },
+            if self.can_calculate_outer_rect {
+                Some(self.local_outer.unwrap_or_else(LayoutRect::zero))
+            } else {
+                None
+            },
+        )
+    }
+}
+
+
 #[derive(Debug)]
 pub struct ClipSources {
     pub clips: Vec<(ClipSource, GpuCacheHandle)>,
@@ -291,20 +383,24 @@ pub struct ClipSources {
 }
 
 impl ClipSources {
-    pub fn new(
-        clips: Vec<ClipSource>,
-        spatial_node_index: SpatialNodeIndex,
-    ) -> Self {
-        let (local_inner_rect, local_outer_rect) = Self::calculate_inner_and_outer_rects(&clips);
+    pub fn new<I>(clip_iter: I, spatial_node_index: SpatialNodeIndex) -> Self
+    where
+        I: IntoIterator<Item = ClipSource>,
+    {
+        let mut clips = Vec::new();
+        let mut bounds_accum = BoundsAccumulator::new();
+        let mut has_image_or_line_decoration_clip = false;
+        let mut only_rectangular_clips = true;
 
-        let has_image_or_line_decoration_clip =
-            clips.iter().any(|clip| clip.is_image_or_line_decoration_clip());
-        let only_rectangular_clips =
-            !has_image_or_line_decoration_clip && clips.iter().all(|clip| clip.is_rect());
-        let clips = clips
-            .into_iter()
-            .map(|clip| (clip, GpuCacheHandle::new()))
-            .collect();
+        for clip in clip_iter {
+            bounds_accum.add(&clip);
+            has_image_or_line_decoration_clip |= clip.is_image_or_line_decoration_clip();
+            only_rectangular_clips &= clip.is_rect();
+            clips.push((clip, GpuCacheHandle::new()));
+        }
+
+        only_rectangular_clips &= !has_image_or_line_decoration_clip;
+        let (local_inner_rect, local_outer_rect) = bounds_accum.finish();
 
         ClipSources {
             clips,
@@ -317,102 +413,25 @@ impl ClipSources {
     }
 
     pub fn from_region(
-        region: ClipRegion,
+        region: &ClipRegion,
         spatial_node_index: SpatialNodeIndex,
     ) -> ClipSources {
-        let mut clips = Vec::new();
-
-        if let Some(info) = region.image_mask {
-            clips.push(ClipSource::Image(info));
-        }
-
-        clips.push(ClipSource::Rectangle(region.main, ClipMode::Clip));
-
-        for complex in region.complex_clips {
-            clips.push(ClipSource::new_rounded_rect(
+        let clip_rect = iter::once(ClipSource::Rectangle(region.main, ClipMode::Clip));
+        let clip_image = region.image_mask.map(ClipSource::Image);
+        let clips_complex = region.complex_clips
+            .iter()
+            .map(|complex| ClipSource::new_rounded_rect(
                 complex.rect,
                 complex.radii,
                 complex.mode,
             ));
-        }
 
-        ClipSources::new(clips, spatial_node_index)
+        let clips_all = clip_rect.chain(clip_image).chain(clips_complex);
+        ClipSources::new(clips_all, spatial_node_index)
     }
 
     pub fn clips(&self) -> &[(ClipSource, GpuCacheHandle)] {
         &self.clips
-    }
-
-    fn calculate_inner_and_outer_rects(clips: &Vec<ClipSource>) -> (LayoutRect, Option<LayoutRect>) {
-        if clips.is_empty() {
-            return (LayoutRect::zero(), None);
-        }
-
-        // Depending on the complexity of the clip, we may either know the outer and/or inner
-        // rect, or neither or these.  In the case of a clip-out, we currently set the mask bounds
-        // to be unknown. This is conservative, but ensures correctness. In the future we can make
-        // this a lot more clever with some proper region handling.
-        let mut local_outer = Some(LayoutRect::max_rect());
-        let mut local_inner = local_outer;
-        let mut can_calculate_inner_rect = true;
-        let mut can_calculate_outer_rect = false;
-        for source in clips {
-            match *source {
-                ClipSource::Image(ref mask) => {
-                    if !mask.repeat {
-                        can_calculate_outer_rect = true;
-                        local_outer = local_outer.and_then(|r| r.intersection(&mask.rect));
-                    }
-                    local_inner = None;
-                }
-                ClipSource::Rectangle(rect, mode) => {
-                    // Once we encounter a clip-out, we just assume the worst
-                    // case clip mask size, for now.
-                    if mode == ClipMode::ClipOut {
-                        can_calculate_inner_rect = false;
-                        break;
-                    }
-
-                    can_calculate_outer_rect = true;
-                    local_outer = local_outer.and_then(|r| r.intersection(&rect));
-                    local_inner = local_inner.and_then(|r| r.intersection(&rect));
-                }
-                ClipSource::RoundedRectangle(ref rect, ref radius, mode) => {
-                    // Once we encounter a clip-out, we just assume the worst
-                    // case clip mask size, for now.
-                    if mode == ClipMode::ClipOut {
-                        can_calculate_inner_rect = false;
-                        break;
-                    }
-
-                    can_calculate_outer_rect = true;
-                    local_outer = local_outer.and_then(|r| r.intersection(rect));
-
-                    let inner_rect = extract_inner_rect_safe(rect, radius);
-                    local_inner = local_inner
-                        .and_then(|r| inner_rect.and_then(|ref inner| r.intersection(inner)));
-                }
-                ClipSource::BoxShadow(..) |
-                ClipSource::LineDecoration(..) => {
-                    can_calculate_inner_rect = false;
-                    break;
-                }
-            }
-        }
-
-        let outer = if can_calculate_outer_rect {
-            Some(local_outer.unwrap_or_else(LayoutRect::zero))
-        } else {
-            None
-        };
-
-        let inner = if can_calculate_inner_rect {
-            local_inner.unwrap_or_else(LayoutRect::zero)
-        } else {
-            LayoutRect::zero()
-        };
-
-        (inner, outer)
     }
 
     pub fn update(

--- a/webrender/src/clip_node.rs
+++ b/webrender/src/clip_node.rs
@@ -37,7 +37,7 @@ impl ClipNode {
         clip_chains: &mut [ClipChain],
         spatial_nodes: &[SpatialNode],
     ) {
-        let clip_sources = clip_store.get_mut(self.clip_sources_index);
+        let clip_sources = &mut clip_store[self.clip_sources_index];
         clip_sources.update(gpu_cache, resource_cache, device_pixel_scale);
         let spatial_node = &spatial_nodes[clip_sources.spatial_node_index.0];
 

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -382,7 +382,7 @@ impl<'a> DisplayListFlattener<'a> {
 
         debug_assert!(info.clip_id != info.scroll_frame_id);
 
-        self.add_clip_node(info.clip_id, clip_and_scroll_ids.scroll_node_id, clip_region);
+        self.add_clip_node(info.clip_id, clip_and_scroll_ids.scroll_node_id, &clip_region);
 
         self.add_scroll_frame(
             info.scroll_frame_id,
@@ -483,7 +483,7 @@ impl<'a> DisplayListFlattener<'a> {
         let clip_chain_index = self.add_clip_node(
             info.clip_id,
             clip_and_scroll_ids.scroll_node_id,
-            ClipRegion::create_for_clip_node_with_local_clip(
+            &ClipRegion::create_for_clip_node_with_local_clip(
                 &LocalClip::from(*item.clip_rect()),
                 reference_frame_relative_offset
             ),
@@ -681,7 +681,7 @@ impl<'a> DisplayListFlattener<'a> {
                     info.image_mask,
                     &reference_frame_relative_offset,
                 );
-                self.add_clip_node(info.id, clip_and_scroll_ids.scroll_node_id, clip_region);
+                self.add_clip_node(info.id, clip_and_scroll_ids.scroll_node_id, &clip_region);
             }
             SpecificDisplayItem::ClipChain(ref info) => {
                 let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items())
@@ -1245,7 +1245,7 @@ impl<'a> DisplayListFlattener<'a> {
         &mut self,
         new_node_id: ClipId,
         parent_id: ClipId,
-        clip_region: ClipRegion,
+        clip_region: &ClipRegion,
     ) -> ClipChainIndex {
         let parent_clip_chain_index = self.id_to_index_mapper.get_clip_chain_index(&parent_id);
         let spatial_node = self.id_to_index_mapper.get_spatial_node_index(parent_id);

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -232,16 +232,14 @@ impl<'a> DisplayListFlattener<'a> {
             .get(complex_clips)
     }
 
-    //TODO: avoid collecting into a `Vec` here
     fn get_clip_chain_items(
         &self,
         pipeline_id: PipelineId,
         items: ItemRange<ClipId>,
-    ) -> Vec<ClipId> {
-        if items.is_empty() {
-            return vec![];
-        }
-        self.scene.get_display_list_for_pipeline(pipeline_id).get(items).collect()
+    ) -> impl 'a + Iterator<Item = ClipId> {
+        self.scene
+            .get_display_list_for_pipeline(pipeline_id)
+            .get(items)
     }
 
     fn flatten_root(&mut self, pipeline: &'a ScenePipeline, frame_size: &LayoutSize) {
@@ -687,8 +685,7 @@ impl<'a> DisplayListFlattener<'a> {
             }
             SpecificDisplayItem::ClipChain(ref info) => {
                 let items = self.get_clip_chain_items(pipeline_id, item.clip_chain_items())
-                    .iter()
-                    .map(|id| self.id_to_index_mapper.get_clip_node_index(*id))
+                    .map(|id| self.id_to_index_mapper.get_clip_node_index(id))
                     .collect();
                 let parent = match info.parent {
                     Some(id) => Some(

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -36,7 +36,7 @@ pub struct HitTestClipNode {
 
 impl HitTestClipNode {
     fn new(node: &ClipNode, clip_store: &ClipStore) -> Self {
-        let clips = clip_store.get(node.clip_sources_index);
+        let clips = &clip_store[node.clip_sources_index];
         let regions = clips.clips().iter().map(|source| {
             match source.0 {
                 ClipSource::Rectangle(ref rect, mode) => HitTestRegion::Rectangle(*rect, mode),

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2064,7 +2064,7 @@ impl PrimitiveStore {
                 continue;
             }
 
-            let local_clips = frame_state.clip_store.get(clip_item.clip_sources_index);
+            let local_clips = &frame_state.clip_store[clip_item.clip_sources_index];
             rect_clips_only = rect_clips_only && local_clips.only_rectangular_clips;
 
             // TODO(gw): We can easily extend the segment builder to support these clip sources in
@@ -2291,7 +2291,7 @@ impl PrimitiveStore {
         let extra_clip =  {
             let metadata = &self.cpu_metadata[prim_index.0];
             metadata.clip_sources_index.map(|clip_sources_index| {
-                let prim_clips = frame_state.clip_store.get_mut(clip_sources_index);
+                let prim_clips = &mut frame_state.clip_store[clip_sources_index];
                 prim_clips.update(
                     frame_state.gpu_cache,
                     frame_state.resource_cache,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -403,7 +403,7 @@ impl RenderTask {
         //           whether a ClipSources contains any box-shadows and skip
         //           this iteration for the majority of cases.
         for clip_item in &clips {
-            let clip_sources = clip_store.get_mut(clip_item.clip_sources_index);
+            let clip_sources = &mut clip_store[clip_item.clip_sources_index];
             for &mut (ref mut clip, _) in &mut clip_sources.clips {
                 match *clip {
                     ClipSource::BoxShadow(ref mut info) => {

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -123,7 +123,7 @@ pub struct AuxIter<'a, T> {
 impl BuiltDisplayListDescriptor {}
 
 impl BuiltDisplayList {
-    pub fn from_data(data: Vec<u8>, descriptor: BuiltDisplayListDescriptor) -> BuiltDisplayList {
+    pub fn from_data(data: Vec<u8>, descriptor: BuiltDisplayListDescriptor) -> Self {
         BuiltDisplayList { data, descriptor }
     }
 


### PR DESCRIPTION
This PR makes scene building faster by doing less heap allocations.

r? @Gankro or @gw3583 
cc @gw3583  - this is a follow-up to #2925 that I figured I'd forget about if I don't do it now ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2943)
<!-- Reviewable:end -->
