### PR TITLE
Only paint the dirty rect of non-tiled blobs.

### DIFF
--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -17,6 +17,7 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 use webrender::api::{self, DisplayListBuilder, DocumentId, PipelineId, RenderApi, Transaction};
+use webrender::api::{DeviceUintRect, DeviceUintPoint};
 
 // This example shows how to implement a very basic BlobImageHandler that can only render
 // a checkerboard pattern.
@@ -97,7 +98,10 @@ fn render_blob(
 
     Ok(api::RasterizedBlobImage {
         data: Arc::new(texels),
-        size: descriptor.size,
+        rasterized_rect: DeviceUintRect {
+            origin: DeviceUintPoint::origin(),
+            size: descriptor.size,
+        },
     })
 }
 

--- a/webrender/src/glyph_rasterizer/no_pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/no_pathfinder.rs
@@ -15,7 +15,7 @@ use platform::font::FontContext;
 use glyph_rasterizer::{FontInstance, FontContexts, GlyphKey};
 use glyph_rasterizer::{GlyphRasterizer, GlyphRasterJob, GlyphRasterJobs, GlyphRasterResult};
 use glyph_cache::{GlyphCache, CachedGlyphInfo, GlyphCacheEntry};
-use texture_cache::{TextureCache, TextureCacheHandle};
+use texture_cache::{TextureCache, TextureCacheHandle, Eviction};
 use gpu_cache::GpuCache;
 use render_task::{RenderTaskTree, RenderTaskCache};
 use tiling::SpecialRenderPasses;
@@ -188,6 +188,7 @@ impl GlyphRasterizer {
                             gpu_cache,
                             Some(glyph_key_cache.eviction_notice()),
                             UvRectKind::Rect,
+                            Eviction::Auto,
                         );
                         GlyphCacheEntry::Cached(CachedGlyphInfo {
                             texture_cache_handle,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -26,7 +26,7 @@ use print_tree::{PrintTreePrinter};
 use render_backend::FrameId;
 use resource_cache::{CacheItem, ResourceCache};
 use std::{cmp, ops, usize, f32, i32};
-use texture_cache::{TextureCache, TextureCacheHandle};
+use texture_cache::{TextureCache, TextureCacheHandle, Eviction};
 use tiling::{RenderPass, RenderTargetIndex};
 use tiling::{RenderTargetKind};
 #[cfg(feature = "pathfinder")]
@@ -1104,6 +1104,7 @@ impl RenderTaskCache {
                     gpu_cache,
                     None,
                     render_task.uv_rect_kind(),
+                    Eviction::Auto,
                 );
 
                 // Get the allocation details in the texture cache, and store

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1525,6 +1525,9 @@ impl ResourceCache {
         if what.contains(ClearCache::TEXTURE_CACHE) {
             self.texture_cache.clear();
         }
+        if what.contains(ClearCache::RASTERIZED_BLOBS) {
+            self.rasterized_blob_images.clear();
+        }
     }
 
     pub fn clear_namespace(&mut self, namespace: IdNamespace) {

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -112,6 +112,8 @@ struct CacheEntry {
     eviction_notice: Option<EvictionNotice>,
     // The type of UV rect this entry specifies.
     uv_rect_kind: UvRectKind,
+    // If true the cache entry may be evicted if unused for a number of frames.
+    eviction: Eviction,
 }
 
 impl CacheEntry {
@@ -136,6 +138,7 @@ impl CacheEntry {
             uv_rect_handle: GpuCacheHandle::new(),
             eviction_notice: None,
             uv_rect_kind,
+            eviction: Eviction::Auto,
         }
     }
 
@@ -190,6 +193,14 @@ impl TextureCacheHandle {
     pub fn new() -> Self {
         TextureCacheHandle { entry: None }
     }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum Eviction {
+    Auto,
+    Manual,
 }
 
 // An eviction notice is a shared condition useful for detecting
@@ -410,6 +421,7 @@ impl TextureCache {
         gpu_cache: &mut GpuCache,
         eviction_notice: Option<&EvictionNotice>,
         uv_rect_kind: UvRectKind,
+        eviction: Eviction,
     ) {
         // Determine if we need to allocate texture cache memory
         // for this item. We need to reallocate if any of the following
@@ -462,6 +474,8 @@ impl TextureCache {
 
         // Upload the resource rect and texture array layer.
         entry.update_gpu_cache(gpu_cache);
+
+        entry.eviction = eviction;
 
         // Create an update command, which the render thread processes
         // to upload the new image data into the correct location
@@ -581,6 +595,17 @@ impl TextureCache {
          DeviceUintRect::new(origin, entry.size))
     }
 
+    pub fn mark_unused(&mut self, handle: &TextureCacheHandle) {
+        if let Some(ref handle) = handle.entry {
+            if let Some(entry) = self.entries.get_opt_mut(handle) {
+                // Set a very low last accessed frame to make it very likely that this entry
+                // will get cleaned up next time we try to expire entries.
+                entry.last_access = FrameId(0);
+                entry.eviction = Eviction::Auto;
+            }
+        }
+    }
+
     // Expire old standalone textures.
     fn expire_old_standalone_entries(&mut self) {
         let mut eviction_candidates = Vec::new();
@@ -590,7 +615,7 @@ impl TextureCache {
         // anything not used this frame).
         for handle in self.standalone_entry_handles.drain(..) {
             let entry = self.entries.get(&handle);
-            if entry.last_access == self.frame_id {
+            if entry.eviction == Eviction::Manual || entry.last_access == self.frame_id {
                 retained_entries.push(handle);
             } else {
                 eviction_candidates.push(handle);
@@ -1205,6 +1230,7 @@ impl TextureArray {
                 texture_id: self.texture_id.unwrap(),
                 eviction_notice: None,
                 uv_rect_kind,
+                eviction: Eviction::Auto,
             }
         })
     }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -93,26 +93,26 @@ pub enum CacheEntryMarker {}
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 struct CacheEntry {
-    // Size the requested item, in device pixels.
+    /// Size the requested item, in device pixels.
     size: DeviceUintSize,
-    // Details specific to standalone or shared items.
+    /// Details specific to standalone or shared items.
     kind: EntryKind,
-    // Arbitrary user data associated with this item.
+    /// Arbitrary user data associated with this item.
     user_data: [f32; 3],
-    // The last frame this item was requested for rendering.
+    /// The last frame this item was requested for rendering.
     last_access: FrameId,
-    // Handle to the resource rect in the GPU cache.
+    /// Handle to the resource rect in the GPU cache.
     uv_rect_handle: GpuCacheHandle,
-    // Image format of the item.
+    /// Image format of the item.
     format: ImageFormat,
     filter: TextureFilter,
-    // The actual device texture ID this is part of.
+    /// The actual device texture ID this is part of.
     texture_id: CacheTextureId,
-    // Optional notice when the entry is evicted from the cache.
+    /// Optional notice when the entry is evicted from the cache.
     eviction_notice: Option<EvictionNotice>,
-    // The type of UV rect this entry specifies.
+    /// The type of UV rect this entry specifies.
     uv_rect_kind: UvRectKind,
-    // If true the cache entry may be evicted if unused for a number of frames.
+    /// If set to `Auto` the cache entry may be evicted if unused for a number of frames.
     eviction: Eviction,
 }
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -535,11 +535,12 @@ bitflags!{
     /// Mask for clearing caches in debug commands.
     #[derive(Deserialize, Serialize)]
     pub struct ClearCache: u8 {
-        const IMAGES = 0x1;
-        const GLYPHS = 0x2;
-        const GLYPH_DIMENSIONS = 0x4;
-        const RENDER_TASKS = 0x8;
-        const TEXTURE_CACHE = 0x16;
+        const IMAGES = 0b1;
+        const GLYPHS = 0b01;
+        const GLYPH_DIMENSIONS = 0b001;
+        const RENDER_TASKS = 0b0001;
+        const TEXTURE_CACHE = 0b00001;
+        const RASTERIZED_BLOBS = 0b000001;
     }
 }
 

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -245,7 +245,7 @@ pub struct BlobImageDescriptor {
 }
 
 pub struct RasterizedBlobImage {
-    pub size: DeviceUintSize,
+    pub rasterized_rect: DeviceUintRect,
     pub data: Arc<Vec<u8>>,
 }
 

--- a/wrench/src/blob.rs
+++ b/wrench/src/blob.rs
@@ -103,7 +103,7 @@ fn render_blob(
 
     Ok(RasterizedBlobImage {
         data: Arc::new(texels),
-        size: descriptor.size,
+        rasterized_rect: dirty_rect,
     })
 }
 


### PR DESCRIPTION
Unless we settle with a small tile size we should follow up with the same optimization for tiled blobs.
This is built on top of #2941.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2948)
<!-- Reviewable:end -->
