### PR TITLE
Embed PrimitiveMetadata inside Primitive struct.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -937,7 +937,7 @@ impl<'a> DisplayListFlattener<'a> {
         // If there is no root picture, create one for the main framebuffer.
         if self.sc_stack.is_empty() {
             // Should be no pictures at all if the stack is empty...
-            debug_assert!(self.prim_store.cpu_metadata.is_empty());
+            debug_assert!(self.prim_store.primitives.is_empty());
             debug_assert_eq!(transform_style, TransformStyle::Flat);
 
             // This picture stores primitive runs for items on the

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -27,7 +27,7 @@ use picture::{PictureCompositeMode, PictureId, PicturePrimitive};
 use prim_store::{BrushClipMaskKind, BrushKind, BrushPrimitive, BrushSegmentDescriptor};
 use prim_store::{EdgeAaSegmentMask, ImageSource};
 use prim_store::{BorderSource, BrushSegment, PrimitiveContainer, PrimitiveIndex, PrimitiveStore};
-use prim_store::{OpacityBinding, ScrollNodeAndClipChain, TextRunPrimitiveCpu};
+use prim_store::{OpacityBinding, ScrollNodeAndClipChain, TextRunPrimitive};
 use render_backend::{DocumentView};
 use resource_cache::{FontInstanceMap, ImageRequest};
 use scene::{Scene, ScenePipeline, StackingContextHelpers};
@@ -1902,7 +1902,7 @@ impl<'a> DisplayListFlattener<'a> {
                 font_instance.platform_options,
                 font_instance.variations.clone(),
             );
-            TextRunPrimitiveCpu::new(
+            TextRunPrimitive::new(
                 prim_font,
                 run_offset,
                 glyph_range,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -193,7 +193,7 @@ impl FrameBuilder {
     ) -> Option<RenderTaskId> {
         profile_scope!("cull");
 
-        if self.prim_store.cpu_metadata.is_empty() {
+        if self.prim_store.primitives.is_empty() {
             return None
         }
 
@@ -276,7 +276,7 @@ impl FrameBuilder {
         static SCROLLBAR_PADDING: f32 = 8.0;
 
         for scrollbar_prim in &self.scrollbar_prims {
-            let metadata = &mut self.prim_store.cpu_metadata[scrollbar_prim.prim_index.0];
+            let metadata = &mut self.prim_store.primitives[scrollbar_prim.prim_index.0].metadata;
             let scroll_frame = &clip_scroll_tree.spatial_nodes[scrollbar_prim.scroll_frame_index.0];
 
             // Invalidate what's in the cache so it will get rebuilt.

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -222,7 +222,7 @@ impl PicturePrimitive {
         });
     }
 
-    pub fn update_local_rect(
+    pub fn update_local_rect_and_set_runs(
         &mut self,
         prim_run_rect: PrimitiveRunLocalRect,
         prim_runs: Vec<PrimitiveRun>,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -225,7 +225,10 @@ impl PicturePrimitive {
     pub fn update_local_rect(
         &mut self,
         prim_run_rect: PrimitiveRunLocalRect,
+        prim_runs: Vec<PrimitiveRun>,
     ) -> LayoutRect {
+        self.runs = prim_runs;
+
         let local_content_rect = prim_run_rect.local_rect_in_actual_parent_space;
 
         self.real_local_rect = prim_run_rect.local_rect_in_original_parent_space;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1659,27 +1659,23 @@ impl PrimitiveStore {
             None => return None,
         };
 
-        let ccr = {
-            let metadata = &mut self.primitives[prim_index.0].metadata;
+        let prim = &mut self.primitives[prim_index.0];
+        prim.metadata.screen_rect = Some(ScreenRect {
+            clipped: clipped_device_rect,
+            unclipped: unclipped_device_rect,
+        });
 
-            metadata.screen_rect = Some(ScreenRect {
-                clipped: clipped_device_rect,
-                unclipped: unclipped_device_rect,
-            });
-
-            metadata.combined_local_clip_rect = if pic_context.apply_local_clip_rect {
-                clip_chain.local_clip_rect
-            } else {
-                local_clip_rect
-            };
-
-            match metadata.combined_local_clip_rect.intersection(&local_rect) {
-                Some(ccr) => ccr,
-                None => return None,
-            }
+        prim.metadata.combined_local_clip_rect = if pic_context.apply_local_clip_rect {
+            clip_chain.local_clip_rect
+        } else {
+            local_clip_rect
         };
 
-        let prim = &mut self.primitives[prim_index.0];
+        let ccr = match prim.metadata.combined_local_clip_rect.intersection(&local_rect) {
+            Some(ccr) => ccr,
+            None => return None,
+        };
+
         prim.build_prim_segments_if_needed(
             pic_state,
             frame_state,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1470,7 +1470,7 @@ impl PrimitiveStore {
             // Do some basic checks first, that can early out
             // without even knowing the local rect.
             if !prim.metadata.is_backface_visible && prim_run_context.transform.backface_is_visible {
-                if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
+                if cfg!(debug_assertions) && is_chased {
                     println!("\tculled for not having visible back faces");
                 }
                 return None;
@@ -1481,7 +1481,7 @@ impl PrimitiveStore {
                     match brush.kind {
                         BrushKind::Picture(ref mut pic) => {
                             if !pic.resolve_scene_properties(frame_context.scene_properties) {
-                                if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
+                                if cfg!(debug_assertions) && is_chased {
                                     println!("\tculled for carrying an invisible composite filter");
                                 }
                                 return None;
@@ -1559,45 +1559,41 @@ impl PrimitiveStore {
             }
         }
 
-        let (local_rect, clip_chain_id) = {
-            let metadata = &mut self.primitives[prim_index.0].metadata;
-            if metadata.local_rect.size.width <= 0.0 ||
-               metadata.local_rect.size.height <= 0.0 {
-                if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
-                    println!("\tculled for zero local rectangle");
-                }
-                return None;
-            }
-
-            metadata.screen_rect = None;
-
-            // Inflate the local rect for this primitive by the inflation factor of
-            // the picture context. This ensures that even if the primitive itself
-            // is not visible, any effects from the blur radius will be correctly
-            // taken into account.
-            let local_rect = metadata.local_rect
-                .inflate(pic_context.inflation_factor, pic_context.inflation_factor)
-                .intersection(&metadata.local_clip_rect);
-            let local_rect = match local_rect {
-                Some(local_rect) => local_rect,
-                None => {
-                    if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
-                        println!("\tculled for being out of the local clip rectangle: {:?}",
-                            metadata.local_clip_rect);
-                    }
-                    return None
-                }
-            };
-
-            (local_rect, metadata.clip_chain_id)
-        };
-
         let prim = &mut self.primitives[prim_index.0];
+        prim.metadata.screen_rect = None;
+
+        if prim.metadata.local_rect.size.width <= 0.0 ||
+           prim.metadata.local_rect.size.height <= 0.0 {
+            if cfg!(debug_assertions) && is_chased {
+                println!("\tculled for zero local rectangle");
+            }
+            return None;
+        }
+
+        // Inflate the local rect for this primitive by the inflation factor of
+        // the picture context. This ensures that even if the primitive itself
+        // is not visible, any effects from the blur radius will be correctly
+        // taken into account.
+        let local_rect = prim
+            .metadata
+            .local_rect
+            .inflate(pic_context.inflation_factor, pic_context.inflation_factor)
+            .intersection(&prim.metadata.local_clip_rect);
+        let local_rect = match local_rect {
+            Some(local_rect) => local_rect,
+            None => {
+                if cfg!(debug_assertions) && is_chased {
+                    println!("\tculled for being out of the local clip rectangle: {:?}",
+                        prim.metadata.local_clip_rect);
+                }
+                return None
+            }
+        };
 
         let clip_chain = frame_state
             .clip_store
             .build_clip_chain_instance(
-                clip_chain_id,
+                prim.metadata.clip_chain_id,
                 local_rect,
                 prim.metadata.local_clip_rect,
                 prim_run_context.spatial_node_index,
@@ -1615,7 +1611,7 @@ impl PrimitiveStore {
             }
         };
 
-        if self.chase_id == Some(prim_index) {
+        if cfg!(debug_assertions) && is_chased {
             println!("\teffective clip chain from {:?} {}",
                 clip_chain.clips_range,
                 if pic_context.apply_local_clip_rect { "(applied)" } else { "" },
@@ -1632,7 +1628,7 @@ impl PrimitiveStore {
         ) {
             Some(rect) => rect,
             None => {
-                if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
+                if cfg!(debug_assertions) && is_chased {
                     println!("\tculled for being behind the near plane of transform: {:?}",
                         prim_run_context.scroll_node.world_content_transform);
                 }
@@ -1648,7 +1644,7 @@ impl PrimitiveStore {
         ) {
             Some(rect) => rect,
             None => {
-                if cfg!(debug_assertions) && Some(prim_index) == self.chase_id {
+                if cfg!(debug_assertions) && is_chased {
                     println!("\tculled for being behind the near plane of transform: {:?}",
                         prim_run_context.scroll_node.world_content_transform);
                 }
@@ -2729,7 +2725,7 @@ impl Primitive {
                 //           sized border task.
                 let world_scale = LayoutToWorldScale::new(1.0);
                 let mut scale = world_scale * frame_context.device_pixel_scale;
-                let max_scale = BorderRenderTaskInfo::get_max_scale(&border.radius);
+                let max_scale = BorderRenderTaskInfo::get_max_scale(&border.radius, &widths);
                 scale.0 = scale.0.min(max_scale.0);
                 let scale_au = Au::from_f32_px(scale.0);
                 let needs_update = scale_au != cache_key.scale;

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1982,18 +1982,6 @@ impl PrimitiveStore {
         }
     }
 
-    fn reset_clip_task(&mut self, prim_index: PrimitiveIndex) {
-        let prim = &mut self.primitives[prim_index.0];
-        prim.metadata.clip_task_id = None;
-        if let PrimitiveDetails::Brush(ref mut brush) = prim.details {
-            if let Some(ref mut desc) = brush.segment_desc {
-                for segment in &mut desc.segments {
-                    segment.clip_task_id = BrushSegmentTaskId::Opaque;
-                }
-            }
-        }
-    }
-
     fn update_clip_task(
         &mut self,
         prim_index: PrimitiveIndex,
@@ -2008,10 +1996,10 @@ impl PrimitiveStore {
             println!("\tupdating clip task with screen rect {:?}", prim_screen_rect);
         }
         // Reset clips from previous frames since we may clip differently each frame.
-        self.reset_clip_task(prim_index);
+        let prim = &mut self.primitives[prim_index.0];
+        prim.reset_clip_task();
 
         // First try to  render this primitive's mask using optimized brush rendering.
-        let prim = &mut self.primitives[prim_index.0];
         if prim.update_clip_task_for_brush(
             prim_run_context,
             &clip_chain,
@@ -2790,5 +2778,16 @@ impl Primitive {
         }
 
         true
+    }
+
+    fn reset_clip_task(&mut self) {
+        self.metadata.clip_task_id = None;
+        if let PrimitiveDetails::Brush(ref mut brush) = self.details {
+            if let Some(ref mut desc) = brush.segment_desc {
+                for segment in &mut desc.segments {
+                    segment.clip_task_id = BrushSegmentTaskId::Opaque;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is another small step to moving primitives to be stored inside Picture structs, which will simplify some of the picture caching work.

While making that change, I also tidied up some of the prim_store code by moving several of the methods into the Primitive struct. I've done each of these as a separate commit to make it easier to review.

There's no functional changes here - just moving code around to make the picture caching work easier. There's also quite a few array indexing operations removed, which might be a small performance win.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2965)
<!-- Reviewable:end -->
