### PR TITLE
Prevent border widths to allocate huge render task surfaces.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -946,11 +946,14 @@ impl BorderRenderTaskInfo {
         instances
     }
 
-    /// Computes the maximum scale that we allow for this set of border radii.
+    /// Computes the maximum scale that we allow for this set of border parameters.
     /// capping the scale will result in rendering very large corners at a lower
     /// resolution and stretching them, so they will have the right shape, but
     /// blurrier.
-    pub fn get_max_scale(radii: &BorderRadius) -> LayoutToDeviceScale {
+    pub fn get_max_scale(
+        radii: &BorderRadius,
+        widths: &BorderWidths
+    ) -> LayoutToDeviceScale {
         let r = radii.top_left.width
             .max(radii.top_left.height)
             .max(radii.top_right.width)
@@ -958,7 +961,11 @@ impl BorderRenderTaskInfo {
             .max(radii.bottom_left.width)
             .max(radii.bottom_left.height)
             .max(radii.bottom_right.width)
-            .max(radii.bottom_right.height);
+            .max(radii.bottom_right.height)
+            .max(widths.top)
+            .max(widths.bottom)
+            .max(widths.left)
+            .max(widths.right);
 
         LayoutToDeviceScale::new(MAX_BORDER_RESOLUTION as f32 / r)
     }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1471,7 +1471,7 @@ impl PrimitiveStore {
                 //           sized border task.
                 let world_scale = LayoutToWorldScale::new(1.0);
                 let mut scale = world_scale * frame_context.device_pixel_scale;
-                let max_scale = BorderRenderTaskInfo::get_max_scale(&border.radius);
+                let max_scale = BorderRenderTaskInfo::get_max_scale(&border.radius, &widths);
                 scale.0 = scale.0.min(max_scale.0);
                 let scale_au = Au::from_f32_px(scale.0);
                 let needs_update = scale_au != cache_key.scale;


### PR DESCRIPTION
Following up from #2956 this PR makes us scale down the the intermediate render task we use to rasterize borders if the width is larger than 2k, just like we do with border radii.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2966)
<!-- Reviewable:end -->
