### PR TITLE
Fix bug where brush mask kind changes during scrolling.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -11,7 +11,7 @@ use clip_scroll_tree::{CoordinateSystemId, SpatialNodeIndex};
 use ellipse::Ellipse;
 use gpu_cache::{GpuCache, GpuCacheHandle, ToGpuBlocks};
 use gpu_types::BoxShadowStretchMode;
-use prim_store::{ClipData, ImageMaskData};
+use prim_store::{BrushClipMaskKind, ClipData, ImageMaskData};
 use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use spatial_node::SpatialNode;
@@ -352,12 +352,13 @@ pub struct ClipStore {
 
 // A clip chain instance is what gets built for a given clip
 // chain id + local primitive region + positioning node.
+#[derive(Debug)]
 pub struct ClipChainInstance {
     pub clips_range: ClipNodeRange,
     pub local_clip_rect: LayoutRect,
-    pub has_clips_from_other_coordinate_systems: bool,
     pub has_non_root_coord_system: bool,
     pub local_bounding_rect: LayoutRect,
+    pub clip_mask_kind: BrushClipMaskKind,
 }
 
 impl ClipStore {
@@ -549,11 +550,18 @@ impl ClipStore {
 
         let first_clip_node_index = self.clip_node_indices.len() as u32;
         let mut has_non_root_coord_system = false;
-        let mut has_clips_from_other_coordinate_systems = false;
+        let mut clip_mask_kind = BrushClipMaskKind::Individual;
 
         // For each potential clip node
         for node_info in self.clip_node_info.drain(..) {
             let node = &mut self.clip_nodes[node_info.node_index.0 as usize];
+
+            // TODO(gw): We can easily extend the segment builder to support these clip sources in
+            // the future, but they are rarely used.
+            // We must do this check here in case we continue early below.
+            if node.item.is_image_or_line_decoration_clip() {
+                clip_mask_kind = BrushClipMaskKind::Global;
+            }
 
             // Convert the prim rect into the clip nodes local space
             let prim_rect = node_info
@@ -600,10 +608,15 @@ impl ClipStore {
                             ClipNodeFlags::SAME_SPATIAL_NODE | ClipNodeFlags::SAME_COORD_SYSTEM
                         }
                         ClipSpaceConversion::Offset(..) => {
+                            if !node.item.is_rect() {
+                                clip_mask_kind = BrushClipMaskKind::Global;
+                            }
                             ClipNodeFlags::SAME_COORD_SYSTEM
                         }
                         ClipSpaceConversion::Transform(..) => {
-                            has_clips_from_other_coordinate_systems = true;
+                            // If this primitive is clipped by clips from a different coordinate system, then we
+                            // need to apply a clip mask for the entire primitive.
+                            clip_mask_kind = BrushClipMaskKind::Global;
                             ClipNodeFlags::empty()
                         }
                     };
@@ -626,10 +639,10 @@ impl ClipStore {
         // Return a valid clip chain instance
         Some(ClipChainInstance {
             clips_range,
-            has_clips_from_other_coordinate_systems,
             has_non_root_coord_system,
             local_clip_rect: current_local_clip_rect,
             local_bounding_rect,
+            clip_mask_kind,
         })
     }
 }


### PR DESCRIPTION
Calculate the brush clip mask kind during clip chain instance
building, instead of during segment building.

If this changes during a scroll of the same display list, detect
that and rerun the logic that assigns the clip mask kind to
each segment.

This doesn't actually re-segment, just updates the clip mask kind,
which is fine since the segments are based only on clips in the
same spatial node (so unable to change relative to each other
during scrolling).

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1483568.

Unfortunately we don't have enough scroll testing infrastructure
in wrench to add a regression test for this yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2973)
<!-- Reviewable:end -->
