### PR TITLE
Simplify determining if a batch can be merged / needs scissor.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -250,6 +250,7 @@ impl FrameBuilder {
 
         let root_render_task = RenderTask::new_picture(
             RenderTaskLocation::Fixed(frame_context.screen_rect),
+            frame_context.screen_rect.size,
             root_prim_index,
             DeviceIntPoint::zero(),
             pic_state.tasks,

--- a/webrender/src/glyph_rasterizer/pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/pathfinder.rs
@@ -301,7 +301,7 @@ fn request_render_task_from_pathfinder(glyph_key: &GlyphKey,
     let subpixel_offset = TypedPoint2D::new(glyph_subpixel_offset as f32, 0.0);
     let embolden_amount = compute_embolden_amount(size.to_f32_px());
 
-    let location = RenderTaskLocation::Dynamic(None, Some(*glyph_size));
+    let location = RenderTaskLocation::Dynamic(None, *glyph_size);
     let glyph_render_task = RenderTask::new_glyph(location,
                                                   mesh,
                                                   &glyph_origin,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -372,7 +372,8 @@ impl PicturePrimitive {
                 // relevant transforms haven't changed from frame to frame.
                 let surface = if pic_state_for_children.has_non_root_coord_system {
                     let picture_task = RenderTask::new_picture(
-                        RenderTaskLocation::Dynamic(None, Some(device_rect.size)),
+                        RenderTaskLocation::Dynamic(None, device_rect.size),
+                        prim_screen_rect.unclipped.size,
                         prim_index,
                         device_rect.origin,
                         pic_state_for_children.tasks,
@@ -428,7 +429,8 @@ impl PicturePrimitive {
                             let child_tasks = mem::replace(&mut pic_state_for_children.tasks, Vec::new());
 
                             let picture_task = RenderTask::new_picture(
-                                RenderTaskLocation::Dynamic(None, Some(device_rect.size)),
+                                RenderTaskLocation::Dynamic(None, device_rect.size),
+                                prim_screen_rect.unclipped.size,
                                 prim_index,
                                 device_rect.origin,
                                 child_tasks,
@@ -484,7 +486,8 @@ impl PicturePrimitive {
                 );
 
                 let mut picture_task = RenderTask::new_picture(
-                    RenderTaskLocation::Dynamic(None, Some(device_rect.size)),
+                    RenderTaskLocation::Dynamic(None, device_rect.size),
+                    prim_screen_rect.unclipped.size,
                     prim_index,
                     device_rect.origin,
                     pic_state_for_children.tasks,
@@ -553,7 +556,8 @@ impl PicturePrimitive {
                 );
 
                 let picture_task = RenderTask::new_picture(
-                    RenderTaskLocation::Dynamic(None, Some(prim_screen_rect.clipped.size)),
+                    RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                    prim_screen_rect.unclipped.size,
                     prim_index,
                     prim_screen_rect.clipped.origin,
                     pic_state_for_children.tasks,
@@ -588,7 +592,8 @@ impl PicturePrimitive {
                 );
 
                 let picture_task = RenderTask::new_picture(
-                    RenderTaskLocation::Dynamic(None, Some(prim_screen_rect.clipped.size)),
+                    RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                    prim_screen_rect.unclipped.size,
                     prim_index,
                     prim_screen_rect.clipped.origin,
                     pic_state_for_children.tasks,
@@ -608,7 +613,8 @@ impl PicturePrimitive {
                 );
 
                 let picture_task = RenderTask::new_picture(
-                    RenderTaskLocation::Dynamic(None, Some(prim_screen_rect.clipped.size)),
+                    RenderTaskLocation::Dynamic(None, prim_screen_rect.clipped.size),
+                    prim_screen_rect.unclipped.size,
                     prim_index,
                     prim_screen_rect.clipped.origin,
                     pic_state_for_children.tasks,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -351,7 +351,11 @@ impl RenderTarget for ColorRenderTarget {
 
                     let (target_rect, _) = task.get_target_rect();
 
-                    let mut batch_builder = AlphaBatchBuilder::new(self.screen_size, target_rect);
+                    let mut batch_builder = AlphaBatchBuilder::new(
+                        self.screen_size,
+                        target_rect,
+                        pic_task.can_merge,
+                    );
 
                     batch_builder.add_pic_to_batch(
                         pic,
@@ -845,7 +849,6 @@ impl RenderPass {
                                 None
                             }
                             RenderTaskLocation::Dynamic(ref mut origin, size) => {
-                                let size = size.expect("bug: size must be assigned by now");
                                 let alloc_size = DeviceUintSize::new(size.width as u32, size.height as u32);
                                 let (alloc_origin, target_index) =  match target_kind {
                                     RenderTargetKind::Color => color.allocate(alloc_size),


### PR DESCRIPTION
Previously, we checked if the bounding box of any child primitives
extended outside the rectangle of the allocated task rect. However,
there is a simpler way to calculate this.

If the allocated size of the render task is >= the unclipped size
of the picture bounding rect, no scissor is needed, since we know
that local clip rects will take care of ensuring nothing is
drawn outside the task boundary.

This is an optimization, but the main benefit is removing one more
piece of code that relies on knowledge of screen / device rects,
which simplifies the ongoing work to be able to rasterize in other
coordinate systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2974)
<!-- Reviewable:end -->
