### PR TITLE
Fix the yaml reader so that clip ids from complex-clip are correctly represented.

### DIFF
--- a/wrench/reftests/filters/filter-blur-clip-ref.yaml
+++ b/wrench/reftests/filters/filter-blur-clip-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+  - type: clip
+    id: 2
+    bounds: [200, 200, 100, 100]
+    complex:
+      - rect: [200, 200, 100, 100]
+  - type: stacking-context
+    clip-node: 2
+    bounds: [100, 100, 300, 300]
+    filters: blur(10)
+    items:
+    - image: "firefox.png"
+      bounds: 20 20 256 256

--- a/wrench/reftests/filters/filter-blur-clip.yaml
+++ b/wrench/reftests/filters/filter-blur-clip.yaml
@@ -1,0 +1,11 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [100, 100, 300, 300]
+      filters: blur(10)
+      complex-clip:
+        rect: [200, 200, 100, 100]
+      items:
+      - image: "firefox.png"
+        bounds: 20 20 256 256

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -1,5 +1,6 @@
 == filter-grayscale.yaml filter-grayscale-ref.yaml
 platform(linux,mac) == draw_calls(4) color_targets(5) alpha_targets(0) filter-blur.yaml filter-blur.png
+== filter-blur-clip.yaml filter-blur-clip-ref.yaml
 == isolated.yaml isolated-ref.yaml
 == invisible.yaml invisible-ref.yaml
 color_targets(1) alpha_targets(0) == opacity.yaml opacity-ref.yaml


### PR DESCRIPTION
This fixes the YAML test-case from #2934. I assume similar changes should be
made to Gecko to pass the right clip node ID around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2982)
<!-- Reviewable:end -->
