### PR TITLE
Add a low priority scene builder thread.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -599,7 +599,7 @@ impl RenderBackend {
 
                         if txn.build_frame || !txn.resource_updates.is_empty() || !txn.frame_ops.is_empty() {
                             self.update_document(
-                                txn.document_id,
+                            txn.document_id,
                                 replace(&mut txn.resource_updates, Vec::new()),
                                 replace(&mut txn.frame_ops, Vec::new()),
                                 txn.build_frame,
@@ -895,7 +895,13 @@ impl RenderBackend {
             });
         }
 
-        self.scene_tx.send(SceneBuilderRequest::Transaction(txn)).unwrap();
+        let tx = if transaction_msg.low_priority {
+            &self.low_priority_scene_tx
+        } else {
+            &self.scene_tx
+        };
+
+        tx.send(SceneBuilderRequest::Transaction(txn)).unwrap();
     }
 
     fn update_document(

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -241,7 +241,6 @@ impl Document {
         DocumentOps::nop()
     }
 
-
     fn build_frame(
         &mut self,
         resource_cache: &mut ResourceCache,
@@ -367,6 +366,7 @@ pub struct RenderBackend {
     payload_rx: Receiver<Payload>,
     result_tx: Sender<ResultMsg>,
     scene_tx: Sender<SceneBuilderRequest>,
+    low_priority_scene_tx: Sender<SceneBuilderRequest>,
     scene_rx: Receiver<SceneBuilderResult>,
 
     payload_buffer: Vec<Payload>,
@@ -393,6 +393,7 @@ impl RenderBackend {
         payload_rx: Receiver<Payload>,
         result_tx: Sender<ResultMsg>,
         scene_tx: Sender<SceneBuilderRequest>,
+        low_priority_scene_tx: Sender<SceneBuilderRequest>,
         scene_rx: Receiver<SceneBuilderResult>,
         default_device_pixel_ratio: f32,
         resource_cache: ResourceCache,
@@ -410,6 +411,7 @@ impl RenderBackend {
             payload_rx,
             result_tx,
             scene_tx,
+            low_priority_scene_tx,
             scene_rx,
             payload_buffer: Vec::new(),
             default_device_pixel_ratio,
@@ -628,7 +630,7 @@ impl RenderBackend {
             };
         }
 
-        let _ = self.scene_tx.send(SceneBuilderRequest::Stop);
+        let _ = self.low_priority_scene_tx.send(SceneBuilderRequest::Stop);
         // Ensure we read everything the scene builder is sending us from
         // inflight messages, otherwise the scene builder might panic.
         while let Ok(msg) = self.scene_rx.recv() {
@@ -665,7 +667,7 @@ impl RenderBackend {
                 self.scene_tx.send(SceneBuilderRequest::WakeUp).unwrap();
             }
             ApiMsg::FlushSceneBuilder(tx) => {
-                self.scene_tx.send(SceneBuilderRequest::Flush(tx)).unwrap();
+                self.low_priority_scene_tx.send(SceneBuilderRequest::Flush(tx)).unwrap();
             }
             ApiMsg::UpdateResources(mut updates) => {
                 self.resource_cache.pre_scene_building_update(
@@ -709,7 +711,7 @@ impl RenderBackend {
             }
             ApiMsg::DeleteDocument(document_id) => {
                 self.documents.remove(&document_id);
-                self.scene_tx.send(
+                self.low_priority_scene_tx.send(
                     SceneBuilderRequest::DeleteDocument(document_id)
                 ).unwrap();
             }
@@ -754,7 +756,7 @@ impl RenderBackend {
                         self.frame_config
                             .dual_source_blending_is_enabled = enable;
 
-                        self.scene_tx.send(SceneBuilderRequest::SetFrameBuilderConfig(
+                        self.low_priority_scene_tx.send(SceneBuilderRequest::SetFrameBuilderConfig(
                             self.frame_config.clone()
                         )).unwrap();
 
@@ -835,6 +837,7 @@ impl RenderBackend {
             blob_requests: Vec::new(),
             resource_updates: transaction_msg.resource_updates,
             frame_ops: transaction_msg.frame_ops,
+            rasterized_blobs: Vec::new(),
             set_root_pipeline: None,
             build_frame: transaction_msg.generate_frame,
             render_frame: transaction_msg.generate_frame,
@@ -1345,7 +1348,7 @@ impl RenderBackend {
         }
 
         if !scenes_to_build.is_empty() {
-            self.scene_tx.send(
+            self.low_priority_scene_tx.send(
                 SceneBuilderRequest::LoadScenes(scenes_to_build)
             ).unwrap();
         }

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -44,7 +44,7 @@ use device::query::GpuProfiler;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use record::ApiRecordingReceiver;
 use render_backend::RenderBackend;
-use scene_builder::SceneBuilder;
+use scene_builder::{SceneBuilder, LowPrioritySceneBuilder};
 use shade::Shaders;
 use render_task::{RenderTask, RenderTaskKind, RenderTaskTree};
 use resource_cache::ResourceCache;
@@ -1714,9 +1714,11 @@ impl Renderer {
         let blob_image_handler = options.blob_image_handler.take();
         let thread_listener_for_render_backend = thread_listener.clone();
         let thread_listener_for_scene_builder = thread_listener.clone();
+        let thread_listener_for_lp_scene_builder = thread_listener.clone();
         let scene_builder_hooks = options.scene_builder_hooks;
         let rb_thread_name = format!("WRRenderBackend#{}", options.renderer_id.unwrap_or(0));
         let scene_thread_name = format!("WRSceneBuilder#{}", options.renderer_id.unwrap_or(0));
+        let lp_scene_thread_name = format!("WRSceneBuilderLP#{}", options.renderer_id.unwrap_or(0));
         let glyph_rasterizer = GlyphRasterizer::new(workers)?;
 
         let (scene_builder, scene_tx, scene_rx) = SceneBuilder::new(
@@ -1734,6 +1736,26 @@ impl Renderer {
 
             if let Some(ref thread_listener) = *thread_listener_for_scene_builder {
                 thread_listener.thread_stopped(&scene_thread_name);
+            }
+        })?;
+
+        let (low_priority_scene_tx, low_priority_scene_rx) = channel();
+        let lp_builder = LowPrioritySceneBuilder {
+            rx: low_priority_scene_rx,
+            tx: scene_tx.clone(),
+        };
+
+        thread::Builder::new().name(lp_scene_thread_name.clone()).spawn(move || {
+            register_thread_with_profiler(lp_scene_thread_name.clone());
+            if let Some(ref thread_listener) = *thread_listener_for_lp_scene_builder {
+                thread_listener.thread_started(&lp_scene_thread_name);
+            }
+
+            let mut scene_builder = lp_builder;
+            scene_builder.run();
+
+            if let Some(ref thread_listener) = *thread_listener_for_lp_scene_builder {
+                thread_listener.thread_stopped(&lp_scene_thread_name);
             }
         })?;
 
@@ -1755,6 +1777,7 @@ impl Renderer {
                 payload_rx_for_backend,
                 result_tx,
                 scene_tx,
+                low_priority_scene_tx,
                 scene_rx,
                 device_pixel_ratio,
                 resource_cache,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -56,6 +56,8 @@ pub struct Transaction {
     use_scene_builder_thread: bool,
 
     generate_frame: bool,
+
+    low_priority: bool,
 }
 
 impl Transaction {
@@ -67,6 +69,7 @@ impl Transaction {
             payloads: Vec::new(),
             use_scene_builder_thread: true,
             generate_frame: false,
+            low_priority: false,
         }
     }
 
@@ -256,6 +259,7 @@ impl Transaction {
                 resource_updates: self.resource_updates,
                 use_scene_builder_thread: self.use_scene_builder_thread,
                 generate_frame: self.generate_frame,
+                low_priority: self.low_priority,
             },
             self.payloads,
         )
@@ -337,6 +341,18 @@ impl Transaction {
         self.resource_updates.push(ResourceUpdate::DeleteFontInstance(key));
     }
 
+    // A hint that this transaction can be processed at a lower priority. High-
+    // priority transactions can jump ahead of regular-priority transactions,
+    // but both high- and regular-priority transactions are processed in order
+    // relative to other transactions of the same priority.
+    pub fn set_low_priority(&mut self, low_priority: bool) {
+        self.low_priority = low_priority;
+    }
+
+    pub fn is_low_priority(&self) -> bool {
+        self.low_priority
+    }
+
     pub fn merge(&mut self, mut other: Vec<ResourceUpdate>) {
         self.resource_updates.append(&mut other);
     }
@@ -354,6 +370,7 @@ pub struct TransactionMsg {
     pub resource_updates: Vec<ResourceUpdate>,
     pub generate_frame: bool,
     pub use_scene_builder_thread: bool,
+    pub low_priority: bool,
 }
 
 impl TransactionMsg {
@@ -372,6 +389,7 @@ impl TransactionMsg {
             resource_updates: Vec::new(),
             generate_frame: false,
             use_scene_builder_thread: false,
+            low_priority: false,
         }
     }
 
@@ -382,6 +400,7 @@ impl TransactionMsg {
             resource_updates: Vec::new(),
             generate_frame: false,
             use_scene_builder_thread: false,
+            low_priority: false,
         }
     }
 }


### PR DESCRIPTION
This goes on top Kats' work from [bug 1477819](https://bugzilla.mozilla.org/show_bug.cgi?id=1477819) and replaces the pair of rasterizer thread by a single low-priority scene builder thread which coordinates with the normal scene builder thread.

The low priority scene builder is an additional thread that can be used to perform some work before forwarding the transaction to the "normal" scene builder thread.
This lets us choose to rasterize very expensive content blobs without blocking the scene builder allowing updates of the UI display list.
Since all low priority scenes request get forwarded to the regular scene builder as well, any operation that affects both threads (such as flushes or shutting down) can simply be sent to the low priority thread.

The flow between threads looks like this:

```
+------------------+     +------------------+
| LowPSceneBuilder | --> |   SceneBuilder   |
+------------------+     +------------------+
              ^           ^     |
              |           |     |
              |           |     v
         +-----------------------+      +-----------+
api ---> |     RenderBackend     | ---> |  Renderer |
         +-----------------------+      +-----------+

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2989)
<!-- Reviewable:end -->
