### PR TITLE
Enforce async scene building

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -871,8 +871,12 @@ impl RenderBackend {
 
                         // Set for any existing documents.
                         for (_, doc) in &mut self.documents {
-                            doc.frame_builder_config .dual_source_blending_is_enabled = enable;
+                            doc.frame_builder_config.dual_source_blending_is_enabled = enable;
                         }
+
+                        self.scene_tx.send(SceneBuilderRequest::SetFrameBuilderConfig(
+                            self.frame_config.clone()
+                        )).unwrap();
 
                         // We don't want to forward this message to the renderer.
                         return true;

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -29,6 +29,7 @@ pub enum SceneBuilderRequest {
     },
     WakeUp,
     Flush(MsgSender<()>),
+    SetFrameBuilderConfig(FrameBuilderConfig),
     Stop
 }
 
@@ -214,6 +215,9 @@ impl SceneBuilder {
                 // We don't need to send a WakeUp to api_tx because we only
                 // get the Stop when the RenderBackend loop is exiting.
                 return false;
+            }
+            SceneBuilderRequest::SetFrameBuilderConfig(cfg) => {
+                self.config = cfg;
             }
         }
 

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -65,7 +65,7 @@ impl Transaction {
             frame_ops: Vec::new(),
             resource_updates: Vec::new(),
             payloads: Vec::new(),
-            use_scene_builder_thread: false, // TODO: make this true by default.
+            use_scene_builder_thread: true,
             generate_frame: false,
         }
     }

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -978,6 +978,10 @@ impl RenderApi {
 
     /// Load a capture of the current frame state for debugging.
     pub fn load_capture(&self, path: PathBuf) -> Vec<CapturedDocument> {
+        // First flush the scene builder otherwise async scenes might clobber
+        // the capture we are about to load.
+        self.flush_scene_builder();
+
         let (tx, rx) = channel::msg_channel().unwrap();
         let msg = ApiMsg::DebugCommand(DebugCommand::LoadCapture(path, tx));
         self.send_message(msg);

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -486,6 +486,8 @@ impl<'a> ReftestHarness<'a> {
         reader.allow_mipmaps(allow_mipmaps);
         reader.do_frame(self.wrench);
 
+        self.wrench.api.flush_scene_builder();
+
         // wait for the frame
         self.rx.recv().unwrap();
         let stats = self.wrench.render();


### PR DESCRIPTION
Make async scene building mandatory. There are some simplifications we can get out of doing this that I want to take advantage of for the async tab switch work.
This is a first step that enforces that all transactions which invalidate the scene must go through the scene builder thread. More stuff coming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2992)
<!-- Reviewable:end -->
