### PR TITLE
Fix backface visibility in nested stacking contexts.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -732,10 +732,7 @@ impl<'a> DisplayListFlattener<'a> {
                 unreachable!("Should have returned in parent method.")
             }
             SpecificDisplayItem::PushShadow(shadow) => {
-                let mut prim_info = prim_info.clone();
-                prim_info.rect = LayoutRect::zero();
-                self
-                    .push_shadow(shadow, clip_and_scroll, &prim_info);
+                self.push_shadow(shadow, clip_and_scroll);
             }
             SpecificDisplayItem::PopAllShadows => {
                 self.pop_all_shadows();
@@ -1014,7 +1011,7 @@ impl<'a> DisplayListFlattener<'a> {
             let prim_index = self.prim_store.add_primitive(
                 &LayoutRect::zero(),
                 &max_clip,
-                is_backface_visible,
+                true,
                 clip_chain_id,
                 spatial_node_index,
                 None,
@@ -1064,7 +1061,7 @@ impl<'a> DisplayListFlattener<'a> {
             let src_prim_index = self.prim_store.add_primitive(
                 &LayoutRect::zero(),
                 &max_clip,
-                is_backface_visible,
+                true,
                 clip_chain_id,
                 spatial_node_index,
                 None,
@@ -1095,7 +1092,7 @@ impl<'a> DisplayListFlattener<'a> {
             let src_prim_index = self.prim_store.add_primitive(
                 &LayoutRect::zero(),
                 &max_clip,
-                is_backface_visible,
+                true,
                 clip_chain_id,
                 spatial_node_index,
                 None,
@@ -1153,7 +1150,7 @@ impl<'a> DisplayListFlattener<'a> {
         let sc_prim_index = self.prim_store.add_primitive(
             &LayoutRect::zero(),
             &max_clip,
-            is_backface_visible,
+            true,
             clip_chain_id,
             spatial_node_index,
             None,
@@ -1363,7 +1360,6 @@ impl<'a> DisplayListFlattener<'a> {
         &mut self,
         shadow: Shadow,
         clip_and_scroll: ScrollNodeAndClipChain,
-        info: &LayoutPrimitiveInfo,
     ) {
         let pipeline_id = self.sc_stack.last().unwrap().pipeline_id;
         let max_clip = LayoutRect::max_rect();
@@ -1397,7 +1393,7 @@ impl<'a> DisplayListFlattener<'a> {
         let shadow_prim_index = self.prim_store.add_primitive(
             &LayoutRect::zero(),
             &max_clip,
-            info.is_backface_visible,
+            true,
             clip_and_scroll.clip_chain_id,
             clip_and_scroll.spatial_node_index,
             None,

--- a/wrench/reftests/backface/backface-picture-ref.yaml
+++ b/wrench/reftests/backface/backface-picture-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+    - type: rect
+      color: red
+      bounds: 0 0 100 100

--- a/wrench/reftests/backface/backface-picture.yaml
+++ b/wrench/reftests/backface/backface-picture.yaml
@@ -1,0 +1,20 @@
+---
+root:
+  items:
+    - type: stacking-context
+      items:
+        - type: stacking-context
+          transform: rotate-y(180)
+          transform-style: preserve-3d
+          backface-visible: false
+          transform-origin: 50 50
+          items:
+            - type: stacking-context
+              transform: rotate-y(180)
+              transform-origin: 50 50
+              items:
+                - type: stacking-context
+                  items:
+                    - type: rect
+                      color: red
+                      bounds: 0 0 100 100

--- a/wrench/reftests/backface/reftest.list
+++ b/wrench/reftests/backface/reftest.list
@@ -1,2 +1,3 @@
 == backface-leaf.yaml backface-ref.yaml
 == backface-sc.yaml backface-ref.yaml
+== backface-picture.yaml backface-picture-ref.yaml


### PR DESCRIPTION
Picture primitives should not consider the backface visibility
flag - they are containers for primitives only. Instead, if all
the primitives inside a picture are backface culled, then the
entire picture will be empty and also culled.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1442916.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2997)
<!-- Reviewable:end -->
