### PR TITLE
Force all calls to project_rect to include a bounding rect.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -425,6 +425,7 @@ impl ClipStore {
         gpu_cache: &mut GpuCache,
         resource_cache: &mut ResourceCache,
         device_pixel_scale: DevicePixelScale,
+        world_rect: &WorldRect,
     ) -> Option<ClipChainInstance> {
         let mut local_clip_rect = local_prim_clip_rect;
         let spatial_nodes = &clip_scroll_tree.spatial_nodes;
@@ -550,6 +551,7 @@ impl ClipStore {
                     node.item.get_clip_result_complex(
                         transform,
                         &world_clip_rect,
+                        world_rect,
                     )
                 }
             };
@@ -869,6 +871,7 @@ impl ClipItem {
         &self,
         transform: &LayoutToWorldTransform,
         prim_world_rect: &WorldRect,
+        world_rect: &WorldRect,
     ) -> ClipResult {
         let (clip_rect, inner_rect) = match *self {
             ClipItem::Rectangle(clip_rect, ClipMode::Clip) => {
@@ -897,7 +900,11 @@ impl ClipItem {
             }
         }
 
-        let outer_clip_rect = match project_rect(transform, &clip_rect) {
+        let outer_clip_rect = match project_rect(
+            transform,
+            &clip_rect,
+            world_rect,
+        ) {
             Some(outer_clip_rect) => outer_clip_rect,
             None => return ClipResult::Partial,
         };

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -24,7 +24,7 @@ use std::f32;
 use std::sync::Arc;
 use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext};
 use tiling::{ScrollbarPrimitive, SpecialRenderPasses};
-use util;
+use util::{self, MaxRect};
 
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -108,13 +108,23 @@ impl PictureState {
     pub fn new(
         ref_spatial_node_index: SpatialNodeIndex,
         clip_scroll_tree: &ClipScrollTree,
+        world_rect: WorldRect,
     ) -> Self {
-        let map_local_to_pic = SpaceMapper::new(ref_spatial_node_index);
-
-        let mut map_pic_to_world = SpaceMapper::new(SpatialNodeIndex(0));
+        let mut map_pic_to_world = SpaceMapper::new(
+            SpatialNodeIndex(0),
+            world_rect,
+        );
         map_pic_to_world.set_target_spatial_node(
             ref_spatial_node_index,
             clip_scroll_tree,
+        );
+        let pic_bounds = map_pic_to_world.unmap(
+            &world_rect,
+        ).unwrap_or(PictureRect::max_rect());
+
+        let map_local_to_pic = SpaceMapper::new(
+            ref_spatial_node_index,
+            pic_bounds,
         );
 
         PictureState {
@@ -246,6 +256,7 @@ impl FrameBuilder {
         let mut pic_state = PictureState::new(
             root_spatial_node_index,
             &frame_context.clip_scroll_tree,
+            frame_context.world_rect,
         );
 
         let pic_context = self

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -116,14 +116,19 @@ pub struct SpaceMapper<F, T> {
     kind: CoordinateSpaceMapping<F, T>,
     pub ref_spatial_node_index: SpatialNodeIndex,
     current_target_spatial_node_index: SpatialNodeIndex,
+    bounds: TypedRect<f32, T>,
 }
 
 impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
-    pub fn new(ref_spatial_node_index: SpatialNodeIndex) -> Self {
+    pub fn new(
+        ref_spatial_node_index: SpatialNodeIndex,
+        bounds: TypedRect<f32, T>,
+    ) -> Self {
         SpaceMapper {
             kind: CoordinateSpaceMapping::Local,
             ref_spatial_node_index,
             current_target_spatial_node_index: ref_spatial_node_index,
+            bounds,
         }
     }
 
@@ -161,6 +166,21 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
         }
     }
 
+    pub fn unmap(&self, rect: &TypedRect<f32, T>) -> Option<TypedRect<f32, F>> {
+        match self.kind {
+            CoordinateSpaceMapping::Local => {
+                Some(TypedRect::from_untyped(&rect.to_untyped()))
+            }
+            CoordinateSpaceMapping::Offset(ref offset) => {
+                let offset = TypedVector2D::new(-offset.x, -offset.y);
+                Some(TypedRect::from_untyped(&rect.translate(&offset).to_untyped()))
+            }
+            CoordinateSpaceMapping::Transform(ref transform) => {
+                transform.inverse_rect_footprint(rect)
+            }
+        }
+    }
+
     pub fn map(&self, rect: &TypedRect<f32, F>) -> Option<TypedRect<f32, T>> {
         match self.kind {
             CoordinateSpaceMapping::Local => {
@@ -170,7 +190,7 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
                 Some(TypedRect::from_untyped(&rect.translate(offset).to_untyped()))
             }
             CoordinateSpaceMapping::Transform(ref transform) => {
-                match project_rect(transform, rect) {
+                match project_rect(transform, rect, &self.bounds) {
                     Some(bounds) => {
                         Some(bounds)
                     }
@@ -1601,6 +1621,7 @@ impl PrimitiveStore {
                 let mut pic_state_for_children = PictureState::new(
                     root_spatial_node_index,
                     frame_context.clip_scroll_tree,
+                    frame_context.world_rect,
                 );
 
                 // Mark whether this picture has a complex coordinate system.
@@ -1693,6 +1714,7 @@ impl PrimitiveStore {
                     frame_state.gpu_cache,
                     frame_state.resource_cache,
                     frame_context.device_pixel_scale,
+                    &frame_context.world_rect,
                 );
 
             let clip_chain = match clip_chain {
@@ -2210,6 +2232,7 @@ impl Primitive {
                     frame_state.gpu_cache,
                     frame_state.resource_cache,
                     frame_context.device_pixel_scale,
+                    &frame_context.world_rect,
                 );
 
             match segment_clip_chain {


### PR DESCRIPTION
This greatly improves the accuracy of the clipper code when
required to calculate the world rect for a primitive that
crosses the near plane.

This patch by itself doesn't fix anything specific, but when
combined with the fixes that are in progress in the
plane-split crate, it will allow correct world rect calculations
for primitives that cross the near plane in various edge cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/2999)
<!-- Reviewable:end -->
