### PR TITLE
Add requested/actual composite mode to Picture primitive.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -963,8 +963,8 @@ impl<'a> DisplayListFlattener<'a> {
 
             // If not already isolated for some other reason,
             // make this picture as isolated.
-            if parent_pic.composite_mode.is_none() {
-                parent_pic.composite_mode = Some(PictureCompositeMode::Blit);
+            if parent_pic.requested_composite_mode.is_none() {
+                parent_pic.requested_composite_mode = Some(PictureCompositeMode::Blit);
             }
         }
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -12,7 +12,7 @@ use gpu_cache::GpuCache;
 use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
-use picture::PictureSurface;
+use picture::{PictureCompositeMode, PictureSurface, RasterConfig};
 use prim_store::{PrimitiveIndex, PrimitiveRun, PrimitiveStore, Transform, SpaceMapper};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::FrameId;
@@ -301,7 +301,10 @@ impl FrameBuilder {
         );
 
         let render_task_id = frame_state.render_tasks.add(root_render_task);
-        pic.surface = Some(PictureSurface::RenderTask(render_task_id));
+        pic.raster_config = Some(RasterConfig {
+            composite_mode: PictureCompositeMode::Blit,
+            surface: Some(PictureSurface::RenderTask(render_task_id)),
+        });
         Some(render_task_id)
     }
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -547,7 +547,7 @@ impl BrushPrimitive {
     pub fn may_need_clip_mask(&self) -> bool {
         match self.kind {
             BrushKind::Picture(ref pic) => {
-                pic.composite_mode.is_some()
+                pic.raster_config.is_some()
             }
             _ => {
                 true
@@ -1485,7 +1485,7 @@ impl PrimitiveStore {
                         // If we encounter a picture that is a pass-through
                         // (i.e. no composite mode), then we can recurse into
                         // that to try and find a primitive to collapse to.
-                        if pic.composite_mode.is_none() {
+                        if pic.requested_composite_mode.is_none() {
                             return self.get_opacity_collapse_prim(run.base_prim_index);
                         }
                     }
@@ -1516,7 +1516,7 @@ impl PrimitiveStore {
         pic_prim_index: PrimitiveIndex,
     ) {
         // Only handle opacity filters for now.
-        let binding = match self.get_pic(pic_prim_index).composite_mode {
+        let binding = match self.get_pic(pic_prim_index).requested_composite_mode {
             Some(PictureCompositeMode::Filter(FilterOp::Opacity(binding, _))) => {
                 binding
             }
@@ -1564,7 +1564,7 @@ impl PrimitiveStore {
         // intermediate surface or incur an extra blend / blit. Instead,
         // the collapsed primitive will be drawn directly into the
         // parent picture.
-        self.get_pic_mut(pic_prim_index).composite_mode = None;
+        self.get_pic_mut(pic_prim_index).requested_composite_mode = None;
     }
 
     pub fn prim_count(&self) -> usize {


### PR DESCRIPTION
Previously, the composite_mode for a Picture was set during
display list flattening, and then not changed.

In the near future, we want to be able to decide during frame
build what the composite mode of a picture is. For example, if
we encounter a picture with a perspective transform, we may
decide to rasterize it in local space. Equally, if we encounter
a picture in a 3d rendering context, but detect there is no
perspective present and no plane splitting needed, we may
choose to skip drawing this to a surface and draw directly into
the parent.

This patch doesn't contain any functional changes - it just
introduces the concept of a requested and actual composite
mode, and updates surrounding code for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3000)
<!-- Reviewable:end -->
