### PR TITLE
Fix order of compositing operations with a single stacking context.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1046,36 +1046,6 @@ impl<'a> DisplayListFlattener<'a> {
             *self.picture_stack.last().unwrap()
         };
 
-        // For each filter, create a new image with that composite mode.
-        for filter in composite_ops.filters.iter().rev() {
-            let picture = PicturePrimitive::new_image(
-                self.get_next_picture_id(),
-                Some(PictureCompositeMode::Filter(*filter)),
-                false,
-                pipeline_id,
-                None,
-                true,
-            );
-
-            let src_prim = BrushPrimitive::new_picture(picture);
-            let src_prim_index = self.prim_store.add_primitive(
-                &LayoutRect::zero(),
-                &max_clip,
-                true,
-                clip_chain_id,
-                spatial_node_index,
-                None,
-                PrimitiveContainer::Brush(src_prim),
-            );
-
-            let parent_pic = self.prim_store.get_pic_mut(parent_prim_index);
-            parent_prim_index = src_prim_index;
-
-            parent_pic.add_primitive(src_prim_index);
-
-            self.picture_stack.push(src_prim_index);
-        }
-
         // Same for mix-blend-mode.
         if let Some(mix_blend_mode) = composite_ops.mix_blend_mode {
             let picture = PicturePrimitive::new_image(
@@ -1101,6 +1071,36 @@ impl<'a> DisplayListFlattener<'a> {
 
             let parent_pic = self.prim_store.get_pic_mut(parent_prim_index);
             parent_prim_index = src_prim_index;
+            parent_pic.add_primitive(src_prim_index);
+
+            self.picture_stack.push(src_prim_index);
+        }
+
+        // For each filter, create a new image with that composite mode.
+        for filter in composite_ops.filters.iter().rev() {
+            let picture = PicturePrimitive::new_image(
+                self.get_next_picture_id(),
+                Some(PictureCompositeMode::Filter(*filter)),
+                false,
+                pipeline_id,
+                None,
+                true,
+            );
+
+            let src_prim = BrushPrimitive::new_picture(picture);
+            let src_prim_index = self.prim_store.add_primitive(
+                &LayoutRect::zero(),
+                &max_clip,
+                true,
+                clip_chain_id,
+                spatial_node_index,
+                None,
+                PrimitiveContainer::Brush(src_prim),
+            );
+
+            let parent_pic = self.prim_store.get_pic_mut(parent_prim_index);
+            parent_prim_index = src_prim_index;
+
             parent_pic.add_primitive(src_prim_index);
 
             self.picture_stack.push(src_prim_index);

--- a/wrench/reftests/filters/filter-mix-blend-mode-ref.yaml
+++ b/wrench/reftests/filters/filter-mix-blend-mode-ref.yaml
@@ -1,0 +1,6 @@
+---
+root:
+  items:
+    - type: rect
+      color: [128, 128, 127, 1]
+      bounds: 100 100 100 100

--- a/wrench/reftests/filters/filter-mix-blend-mode.yaml
+++ b/wrench/reftests/filters/filter-mix-blend-mode.yaml
@@ -1,0 +1,14 @@
+---
+root:
+  items:
+    - type: rect
+      color: [128, 128, 128, 1]
+      bounds: 100 100 100 100
+    - type: stacking-context
+      bounds: [100, 100, 100, 100]
+      filters: [invert(1)]
+      mix-blend-mode: exclusion
+      items:
+      - type: rect
+        color: yellow
+        bounds: 0 0 100 100

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -35,3 +35,4 @@ platform(linux,mac) == filter-drop-shadow-on-viewport-edge.yaml filter-drop-shad
 platform(linux,mac) == blend-clipped.yaml blend-clipped.png
 == filter-segments.yaml filter-segments-ref.yaml
 == iframe-dropshadow.yaml iframe-dropshadow-ref.yaml
+== filter-mix-blend-mode.yaml filter-mix-blend-mode-ref.yaml


### PR DESCRIPTION
A rare case is that a stacking context has both a mix-blend-mode
and a filter list on it.

The CSS compositing specification says that filters should be
applied first, and then any compositing.

Fixing this will also simplify some upcoming optimizations that
make mix-blend-mode much faster in commonly used scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3001)
<!-- Reviewable:end -->
