### PR TITLE
Provide Gecko with ImageRendering property when locking NativeTexture external images

### DIFF
--- a/examples/frame_output.rs
+++ b/examples/frame_output.rs
@@ -50,7 +50,7 @@ impl webrender::OutputImageHandler for OutputHandler {
 }
 
 impl webrender::ExternalImageHandler for ExternalHandler {
-    fn lock(&mut self, _key: ExternalImageId, _channel_index: u8) -> webrender::ExternalImage {
+    fn lock(&mut self, _key: ExternalImageId, _channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
             source: webrender::ExternalImageSource::NativeTexture(self.texture_id),

--- a/examples/frame_output.rs
+++ b/examples/frame_output.rs
@@ -50,7 +50,12 @@ impl webrender::OutputImageHandler for OutputHandler {
 }
 
 impl webrender::ExternalImageHandler for ExternalHandler {
-    fn lock(&mut self, _key: ExternalImageId, _channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
+    fn lock(
+        &mut self,
+        _key: ExternalImageId,
+        _channel_index: u8,
+        _rendering: ImageRendering
+    ) -> webrender::ExternalImage {
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
             source: webrender::ExternalImageSource::NativeTexture(self.texture_id),

--- a/examples/texture_cache_stress.rs
+++ b/examples/texture_cache_stress.rs
@@ -61,7 +61,12 @@ impl ImageGenerator {
 }
 
 impl webrender::ExternalImageHandler for ImageGenerator {
-    fn lock(&mut self, _key: ExternalImageId, channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
+    fn lock(
+        &mut self,
+        _key: ExternalImageId,
+        channel_index: u8,
+        _rendering: ImageRendering
+    ) -> webrender::ExternalImage {
         self.generate_image(channel_index as u32);
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),

--- a/examples/texture_cache_stress.rs
+++ b/examples/texture_cache_stress.rs
@@ -61,7 +61,7 @@ impl ImageGenerator {
 }
 
 impl webrender::ExternalImageHandler for ImageGenerator {
-    fn lock(&mut self, _key: ExternalImageId, channel_index: u8) -> webrender::ExternalImage {
+    fn lock(&mut self, _key: ExternalImageId, channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
         self.generate_image(channel_index as u32);
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),

--- a/examples/yuv.rs
+++ b/examples/yuv.rs
@@ -60,7 +60,12 @@ impl YuvImageProvider {
 }
 
 impl webrender::ExternalImageHandler for YuvImageProvider {
-    fn lock(&mut self, key: ExternalImageId, _channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
+    fn lock(
+        &mut self,
+        key: ExternalImageId,
+        _channel_index: u8,
+        _rendering: ImageRendering
+    ) -> webrender::ExternalImage {
         let id = self.texture_ids[key.0 as usize];
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),

--- a/examples/yuv.rs
+++ b/examples/yuv.rs
@@ -60,7 +60,7 @@ impl YuvImageProvider {
 }
 
 impl webrender::ExternalImageHandler for YuvImageProvider {
-    fn lock(&mut self, key: ExternalImageId, _channel_index: u8) -> webrender::ExternalImage {
+    fn lock(&mut self, key: ExternalImageId, _channel_index: u8, _rendering: ImageRendering) -> webrender::ExternalImage {
         let id = self.texture_ids[key.0 as usize];
         webrender::ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1611,6 +1611,7 @@ pub fn resolve_image(
                     deferred_resolves.push(DeferredResolve {
                         image_properties,
                         address: gpu_cache.get_address(&cache_handle),
+                        rendering: request.rendering,
                     });
 
                     cache_item

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -211,12 +211,15 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
 /// images that are visible, a DeferredResolve is created
 /// that is stored in the frame. This allows the render
 /// thread to iterate this list and update any changed
-/// texture data and update the UV rect.
+/// texture data and update the UV rect. Any filtering
+/// is handled externally for NativeTexture external
+/// images.
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct DeferredResolve {
     pub address: GpuCacheAddress,
     pub image_properties: ImageProperties,
+    pub rendering: ImageRendering,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4306,7 +4306,7 @@ struct DummyExternalImageHandler {
 
 #[cfg(feature = "replay")]
 impl ExternalImageHandler for DummyExternalImageHandler {
-    fn lock(&mut self, key: ExternalImageId, channel_index: u8) -> ExternalImage {
+    fn lock(&mut self, key: ExternalImageId, channel_index: u8, rendering: ImageRendering) -> ExternalImage {
         let (ref captured_data, ref uv) = self.data[&(key, channel_index)];
         ExternalImage {
             uv: *uv,

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4306,7 +4306,7 @@ struct DummyExternalImageHandler {
 
 #[cfg(feature = "replay")]
 impl ExternalImageHandler for DummyExternalImageHandler {
-    fn lock(&mut self, key: ExternalImageId, channel_index: u8, rendering: ImageRendering) -> ExternalImage {
+    fn lock(&mut self, key: ExternalImageId, channel_index: u8, _rendering: ImageRendering) -> ExternalImage {
         let (ref captured_data, ref uv) = self.data[&(key, channel_index)];
         ExternalImage {
             uv: *uv,


### PR DESCRIPTION
fixes #2993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3009)
<!-- Reviewable:end -->
