### PR TITLE
Consistently use unsigned integer division in shaders

### DIFF
--- a/webrender/res/prim_shared.glsl
+++ b/webrender/res/prim_shared.glsl
@@ -50,8 +50,8 @@ uniform HIGHP_SAMPLER_FLOAT isampler2D sPrimitiveHeadersI;
 // Instanced attributes
 in ivec4 aData;
 
-#define VECS_PER_PRIM_HEADER_F 2
-#define VECS_PER_PRIM_HEADER_I 2
+#define VECS_PER_PRIM_HEADER_F 2U
+#define VECS_PER_PRIM_HEADER_I 2U
 
 struct PrimitiveHeader {
     RectWithSize local_rect;

--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -16,6 +16,7 @@ varying vec4 vUvClip;
 #ifdef WR_VERTEX_SHADER
 
 #define VECS_PER_TEXT_RUN           3
+#define GLYPHS_PER_GPU_BLOCK        2U
 
 struct Glyph {
     vec2 offset;
@@ -26,12 +27,13 @@ Glyph fetch_glyph(int specific_prim_address,
     // Two glyphs are packed in each texel in the GPU cache.
     int glyph_address = specific_prim_address +
                         VECS_PER_TEXT_RUN +
-                        glyph_index / 2;
+                        int(uint(glyph_index) / GLYPHS_PER_GPU_BLOCK);
     vec4 data = fetch_from_resource_cache_1(glyph_address);
     // Select XY or ZW based on glyph index.
     // We use "!= 0" instead of "== 1" here in order to work around a driver
     // bug with equality comparisons on integers.
-    vec2 glyph = mix(data.xy, data.zw, bvec2(glyph_index % 2 != 0));
+    vec2 glyph = mix(data.xy, data.zw,
+                     bvec2(uint(glyph_index) % GLYPHS_PER_GPU_BLOCK != 0U));
 
     return Glyph(glyph);
 }

--- a/webrender/res/render_task.glsl
+++ b/webrender/res/render_task.glsl
@@ -4,7 +4,7 @@
 
 
 #ifdef WR_VERTEX_SHADER
-#define VECS_PER_RENDER_TASK        2
+#define VECS_PER_RENDER_TASK        2U
 
 uniform HIGHP_SAMPLER_FLOAT sampler2D sRenderTasks;
 

--- a/webrender/res/resource_cache.glsl
+++ b/webrender/res/resource_cache.glsl
@@ -14,8 +14,8 @@ uniform HIGHP_SAMPLER_FLOAT sampler2D sResourceCache;
 //           instead of an int, and encode the UV directly
 //           in the vertices.
 ivec2 get_resource_cache_uv(int address) {
-    return ivec2(address % WR_MAX_VERTEX_TEXTURE_WIDTH,
-                 address / WR_MAX_VERTEX_TEXTURE_WIDTH);
+    return ivec2(uint(address) % WR_MAX_VERTEX_TEXTURE_WIDTH,
+                 uint(address) / WR_MAX_VERTEX_TEXTURE_WIDTH);
 }
 
 vec4[2] fetch_from_resource_cache_2_direct(ivec2 address) {

--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -40,7 +40,7 @@
     // https://github.com/servo/webrender/pull/623
     // https://github.com/servo/servo/issues/13953
     // Do the division with unsigned ints because that's more efficient with D3D
-    #define get_fetch_uv(i, vpi)  ivec2(int(uint(vpi) * (uint(i) % uint(WR_MAX_VERTEX_TEXTURE_WIDTH/vpi))), int(uint(i) / uint(WR_MAX_VERTEX_TEXTURE_WIDTH/vpi)))
+    #define get_fetch_uv(i, vpi)  ivec2(int(vpi * (uint(i) % (WR_MAX_VERTEX_TEXTURE_WIDTH/vpi))), int(uint(i) / (WR_MAX_VERTEX_TEXTURE_WIDTH/vpi)))
 #endif
 
 //======================================================================================

--- a/webrender/res/transform.glsl
+++ b/webrender/res/transform.glsl
@@ -6,7 +6,7 @@ flat varying vec4 vTransformBounds;
 
 #ifdef WR_VERTEX_SHADER
 
-#define VECS_PER_TRANSFORM   8
+#define VECS_PER_TRANSFORM   8U
 uniform HIGHP_SAMPLER_FLOAT sampler2D sTransformPalette;
 
 void init_transform_vs(vec4 local_bounds) {

--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -352,7 +352,7 @@ fn create_prim_shader(
     vertex_format: VertexArrayKind,
 ) -> Result<Program, ShaderError> {
     let mut prefix = format!(
-        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}\n",
+        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}U\n",
         MAX_VERTEX_TEXTURE_WIDTH
     );
 
@@ -398,7 +398,7 @@ fn create_prim_shader(
 
 fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program, ShaderError> {
     let prefix = format!(
-        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}\n
+        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}U\n
         #define WR_FEATURE_TRANSFORM\n",
         MAX_VERTEX_TEXTURE_WIDTH
     );

--- a/webrender/tests/angle_shader_validation.rs
+++ b/webrender/tests/angle_shader_validation.rs
@@ -16,7 +16,7 @@ struct Shader {
     features: &'static [&'static str],
 }
 
-const SHADER_PREFIX: &str = "#define WR_MAX_VERTEX_TEXTURE_WIDTH 1024\n";
+const SHADER_PREFIX: &str = "#define WR_MAX_VERTEX_TEXTURE_WIDTH 1024U\n";
 
 const BRUSH_FEATURES: &[&str] = &["", "ALPHA_PASS"];
 const CLIP_FEATURES: &[&str] = &["TRANSFORM"];


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1443747

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3014)
<!-- Reviewable:end -->
