### PR TITLE
Add external event notifications in transactions.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -9,6 +9,7 @@ use api::{DeviceIntPoint, DevicePixelScale, DeviceUintPoint, DeviceUintRect, Dev
 use api::{DocumentId, DocumentLayer, ExternalScrollId, FrameMsg, HitTestFlags, HitTestResult};
 use api::{IdNamespace, LayoutPoint, PipelineId, RenderNotifier, SceneMsg, ScrollClamping};
 use api::{ScrollLocation, ScrollNodeState, TransactionMsg, ResourceUpdate, ImageKey};
+use api::ExternalEvent;
 use api::channel::{MsgReceiver, Payload};
 #[cfg(feature = "capture")]
 use api::CaptureBits;

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -4,7 +4,7 @@
 
 use api::{AsyncBlobImageRasterizer, BlobImageRequest, BlobImageParams, BlobImageResult};
 use api::{DocumentId, PipelineId, ApiMsg, FrameMsg, ResourceUpdate, Epoch};
-use api::{BuiltDisplayList, ColorF, LayoutSize};
+use api::{BuiltDisplayList, ColorF, LayoutSize, ExternalEvent};
 use api::channel::MsgSender;
 use frame_builder::{FrameBuilderConfig, FrameBuilder};
 use clip_scroll_tree::ClipScrollTree;
@@ -30,6 +30,7 @@ pub struct Transaction {
     pub rasterized_blobs: Vec<(BlobImageRequest, BlobImageResult)>,
     pub resource_updates: Vec<ResourceUpdate>,
     pub frame_ops: Vec<FrameMsg>,
+    pub notifications: Vec<ExternalEvent>,
     pub set_root_pipeline: Option<PipelineId>,
     pub build_frame: bool,
     pub render_frame: bool,
@@ -61,6 +62,7 @@ pub struct BuiltTransaction {
     pub blob_rasterizer: Option<Box<AsyncBlobImageRasterizer>>,
     pub frame_ops: Vec<FrameMsg>,
     pub removed_pipelines: Vec<PipelineId>,
+    pub notifications: Vec<ExternalEvent>,
     pub scene_build_start_time: u64,
     pub scene_build_end_time: u64,
     pub build_frame: bool,
@@ -251,6 +253,7 @@ impl SceneBuilder {
                 blob_rasterizer: None,
                 frame_ops: Vec::new(),
                 removed_pipelines: Vec::new(),
+                notifications: Vec::new(),
                 scene_build_start_time,
                 scene_build_end_time: precise_time_ns(),
             });
@@ -332,6 +335,7 @@ impl SceneBuilder {
             blob_rasterizer: replace(&mut txn.blob_rasterizer, None),
             frame_ops: replace(&mut txn.frame_ops, Vec::new()),
             removed_pipelines: replace(&mut txn.removed_pipelines, Vec::new()),
+            notifications: replace(&mut txn.notifications, Vec::new()),
             scene_build_start_time,
             scene_build_end_time: precise_time_ns(),
         })

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -4,7 +4,7 @@
 
 use api::{AsyncBlobImageRasterizer, BlobImageRequest, BlobImageParams, BlobImageResult};
 use api::{DocumentId, PipelineId, ApiMsg, FrameMsg, ResourceUpdate, Epoch};
-use api::{BuiltDisplayList, ColorF, LayoutSize, ExternalEvent};
+use api::{BuiltDisplayList, ColorF, LayoutSize, NotificationRequest, Checkpoint};
 use api::channel::MsgSender;
 use frame_builder::{FrameBuilderConfig, FrameBuilder};
 use clip_scroll_tree::ClipScrollTree;
@@ -17,6 +17,7 @@ use scene::Scene;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::mem::replace;
 use time::precise_time_ns;
+use util::drain_filter;
 
 /// Represents the work associated to a transaction before scene building.
 pub struct Transaction {
@@ -30,7 +31,7 @@ pub struct Transaction {
     pub rasterized_blobs: Vec<(BlobImageRequest, BlobImageResult)>,
     pub resource_updates: Vec<ResourceUpdate>,
     pub frame_ops: Vec<FrameMsg>,
-    pub notifications: Vec<ExternalEvent>,
+    pub notifications: Vec<NotificationRequest>,
     pub set_root_pipeline: Option<PipelineId>,
     pub build_frame: bool,
     pub render_frame: bool,
@@ -62,7 +63,7 @@ pub struct BuiltTransaction {
     pub blob_rasterizer: Option<Box<AsyncBlobImageRasterizer>>,
     pub frame_ops: Vec<FrameMsg>,
     pub removed_pipelines: Vec<PipelineId>,
-    pub notifications: Vec<ExternalEvent>,
+    pub notifications: Vec<NotificationRequest>,
     pub scene_build_start_time: u64,
     pub scene_build_end_time: u64,
     pub build_frame: bool,
@@ -324,6 +325,12 @@ impl SceneBuilder {
             |rasterizer| rasterizer.rasterize(&blob_requests),
         );
         rasterized_blobs.append(&mut txn.rasterized_blobs);
+
+        drain_filter(
+            &mut txn.notifications,
+            |n| { n.when() == Checkpoint::SceneBuilt },
+            |n| { n.notify(); },
+        );
 
         Box::new(BuiltTransaction {
             document_id: txn.document_id,

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -508,3 +508,63 @@ pub fn world_rect_to_device_pixels(
     let device_rect = rect * device_pixel_scale;
     device_rect.round_out()
 }
+
+/// Run the first callback over all elements in the array. If the callback returns true,
+/// the element is removed from the array and moved to a second callback.
+///
+/// This is a simple implementation waiting for Vec::drain_filter to be stable.
+/// When that happens, code like:
+///
+/// let filter = |op| {
+///     match *op {
+///         Enum::Foo | Enum::Bar => true,
+///         Enum::Baz => false,
+///     }
+/// };
+/// drain_filter(
+///     &mut ops,
+///     filter,
+///     |op| {
+///         match op {
+///             Enum::Foo => { foo(); }
+///             Enum::Bar => { bar(); }
+///             Enum::Baz => { unreachable!(); }
+///         }
+///     },
+/// );
+///
+/// Can be rewritten as:
+///
+/// let filter = |op| {
+///     match *op {
+///         Enum::Foo | Enum::Bar => true,
+///         Enum::Baz => false,
+///     }
+/// };
+/// for op in ops.drain_filter(filter) {
+///     match op {
+///         Enum::Foo => { foo(); }
+///         Enum::Bar => { bar(); }
+///         Enum::Baz => { unreachable!(); }
+///     }
+/// }
+///
+/// See https://doc.rust-lang.org/std/vec/struct.Vec.html#method.drain_filter
+pub fn drain_filter<T, Filter, Action>(
+    vec: &mut Vec<T>,
+    mut filter: Filter,
+    mut action: Action,
+)
+where
+    Filter: FnMut(&mut T) -> bool,
+    Action: FnMut(T)
+{
+    let mut i = 0;
+    while i != vec.len() {
+        if filter(&mut vec[i]) {
+            action(vec.remove(i));
+        } else {
+            i += 1;
+        }
+    }
+}

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -48,6 +48,8 @@ pub struct Transaction {
     // Additional display list data.
     payloads: Vec<Payload>,
 
+    notifications: Vec<ExternalEvent>,
+
     // Resource updates are applied after scene building.
     pub resource_updates: Vec<ResourceUpdate>,
 
@@ -67,6 +69,7 @@ impl Transaction {
             frame_ops: Vec::new(),
             resource_updates: Vec::new(),
             payloads: Vec::new(),
+            notifications: Vec::new(),
             use_scene_builder_thread: true,
             generate_frame: false,
             low_priority: false,
@@ -88,7 +91,8 @@ impl Transaction {
         !self.generate_frame &&
             self.scene_ops.is_empty() &&
             self.frame_ops.is_empty() &&
-            self.resource_updates.is_empty()
+            self.resource_updates.is_empty() &&
+            self.notifications.is_empty()
     }
 
     pub fn update_epoch(&mut self, pipeline_id: PipelineId, epoch: Epoch) {
@@ -169,6 +173,18 @@ impl Transaction {
 
     pub fn update_resources(&mut self, resources: Vec<ResourceUpdate>) {
         self.merge(resources);
+    }
+
+    // Note: Gecko uses this to get notified when a transaction that contains
+    // potentially long blob rasterization or scene build is ready to be rendered.
+    // so that the tab-switching integration can react adequately when tab
+    // switching takes too long. For this use case what matters is that the
+    // notification doesn't fire before scene building and blob rasterization.
+
+    /// Trigger the external event notification when the transaction gets passed
+    /// the frame building stage.
+    pub fn notify(&mut self, event: ExternalEvent) {
+        self.notifications.push(event);
     }
 
     pub fn set_window_parameters(
@@ -257,6 +273,7 @@ impl Transaction {
                 scene_ops: self.scene_ops,
                 frame_ops: self.frame_ops,
                 resource_updates: self.resource_updates,
+                notifications: self.notifications,
                 use_scene_builder_thread: self.use_scene_builder_thread,
                 generate_frame: self.generate_frame,
                 low_priority: self.low_priority,
@@ -368,6 +385,7 @@ pub struct TransactionMsg {
     pub scene_ops: Vec<SceneMsg>,
     pub frame_ops: Vec<FrameMsg>,
     pub resource_updates: Vec<ResourceUpdate>,
+    pub notifications: Vec<ExternalEvent>,
     pub generate_frame: bool,
     pub use_scene_builder_thread: bool,
     pub low_priority: bool,
@@ -378,7 +396,8 @@ impl TransactionMsg {
         !self.generate_frame &&
             self.scene_ops.is_empty() &&
             self.frame_ops.is_empty() &&
-            self.resource_updates.is_empty()
+            self.resource_updates.is_empty() &&
+            self.notifications.is_empty()
     }
 
     // TODO: We only need this for a few RenderApi methods which we should remove.
@@ -387,6 +406,7 @@ impl TransactionMsg {
             scene_ops: Vec::new(),
             frame_ops: vec![msg],
             resource_updates: Vec::new(),
+            notifications: Vec::new(),
             generate_frame: false,
             use_scene_builder_thread: false,
             low_priority: false,
@@ -398,6 +418,7 @@ impl TransactionMsg {
             scene_ops: vec![msg],
             frame_ops: Vec::new(),
             resource_updates: Vec::new(),
+            notifications: Vec::new(),
             generate_frame: false,
             use_scene_builder_thread: false,
             low_priority: false,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -10,6 +10,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::u32;
 use {BuiltDisplayList, BuiltDisplayListDescriptor, ColorF, DeviceIntPoint, DeviceUintRect};
 use {DeviceUintSize, ExternalScrollId, FontInstanceKey, FontInstanceOptions};
@@ -48,7 +49,7 @@ pub struct Transaction {
     // Additional display list data.
     payloads: Vec<Payload>,
 
-    notifications: Vec<ExternalEvent>,
+    notifications: Vec<NotificationRequest>,
 
     // Resource updates are applied after scene building.
     pub resource_updates: Vec<ResourceUpdate>,
@@ -178,12 +179,15 @@ impl Transaction {
     // Note: Gecko uses this to get notified when a transaction that contains
     // potentially long blob rasterization or scene build is ready to be rendered.
     // so that the tab-switching integration can react adequately when tab
-    // switching takes too long. For this use case what matters is that the
+    // switching takes too long. For this use case when matters is that the
     // notification doesn't fire before scene building and blob rasterization.
 
-    /// Trigger the external event notification when the transaction gets passed
-    /// the frame building stage.
-    pub fn notify(&mut self, event: ExternalEvent) {
+    /// Trigger a notification at a certain stage of the rendering pipeline.
+    ///
+    /// Not that notification requests are skipped during serialization, so is is
+    /// best to use them for synchronization purposes and not for things that could
+    /// affect the WebRender's state.
+    pub fn notify(&mut self, event: NotificationRequest) {
         self.notifications.push(event);
     }
 
@@ -235,7 +239,7 @@ impl Transaction {
     /// in `webrender::Renderer`, [new_frame_ready()][notifier] gets called.
     /// Note that the notifier is called even if the frame generation was a
     /// no-op; the arguments passed to `new_frame_ready` will provide information
-    /// as to what happened.
+    /// as to when happened.
     ///
     /// [notifier]: trait.RenderNotifier.html#tymethod.new_frame_ready
     pub fn generate_frame(&mut self) {
@@ -385,10 +389,12 @@ pub struct TransactionMsg {
     pub scene_ops: Vec<SceneMsg>,
     pub frame_ops: Vec<FrameMsg>,
     pub resource_updates: Vec<ResourceUpdate>,
-    pub notifications: Vec<ExternalEvent>,
     pub generate_frame: bool,
     pub use_scene_builder_thread: bool,
     pub low_priority: bool,
+
+    #[serde(skip)]
+    pub notifications: Vec<NotificationRequest>,
 }
 
 impl TransactionMsg {
@@ -1160,4 +1166,49 @@ pub trait RenderNotifier: Send {
         unimplemented!()
     }
     fn shut_down(&self) {}
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Checkpoint {
+    SceneBuilt,
+    FrameBuilt,
+    /// NotificationRequests get notified with this if they get dropped without having been
+    /// notified. This provides the guarantee that if a request is created it will get notified.
+    TransactionDropped,
+}
+
+pub trait NotificationHandler : Send + Sync {
+    fn notify(&self, when: Checkpoint);
+}
+
+#[derive(Clone)]
+pub struct NotificationRequest {
+    handler: Arc<NotificationHandler>,
+    when: Checkpoint,
+    done: bool,
+}
+
+impl NotificationRequest {
+    pub fn new(when: Checkpoint, handler: Arc<NotificationHandler>) -> Self {
+        NotificationRequest {
+            handler,
+            when,
+            done: false,
+        }
+    }
+
+    pub fn when(&self) -> Checkpoint { self.when }
+
+    pub fn notify(mut self) {
+        self.handler.notify(self.when);
+        self.done = true;
+    }
+}
+
+impl Drop for NotificationRequest {
+    fn drop(&mut self) {
+        if !self.done {
+            self.handler.notify(Checkpoint::TransactionDropped);
+        }
+    }
 }


### PR DESCRIPTION
This allows gecko to attach a callback to the transaction and run it after the scene is built to notify the tab switcher that the work is done.

The first commit adds a drain_filter utility modeled after currently unstable Vec::drain_filter. The idea is to be able to get a vector of operations, and each stage of the pipeline can decide to move operations out of the the array and handle them or let them for the next stages to consume.
Hopefully we can use this to merge back the frame_ops, scene_ops and the other vectors in the `Transaction` struct.
This was previously inconvenient because of how some operations need to move elements out of the vector but while we need to keep the array alive at the same time, and drain_filter makes that less painful.

This PR is based on top of #2989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3020)
<!-- Reviewable:end -->
