### PR TITLE
Ensure transactions that request a frame always get forwarded to the renderer.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -908,6 +908,7 @@ impl RenderBackend {
         profile_counters: &mut BackendProfileCounters,
         has_built_scene: bool,
     ) {
+        let requested_frame = render_frame;
         self.resource_cache.post_scene_building_update(
             resource_updates,
             &mut profile_counters.resources,
@@ -1016,7 +1017,10 @@ impl RenderBackend {
             self.result_tx.send(msg).unwrap();
         }
 
-        if render_frame {
+        // Always forward the transaction to the renderer if a frame was requested,
+        // otherwise gecko can get into a state where it waits (forever) for the
+        // transaction to complete before sending new work.
+        if requested_frame {
             self.notifier.new_frame_ready(document_id, scroll, render_frame, frame_build_time);
         }
     }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -597,18 +597,16 @@ impl RenderBackend {
                             self.resource_cache.set_blob_rasterizer(rasterizer);
                         }
 
-                        if txn.build_frame || !txn.resource_updates.is_empty() || !txn.frame_ops.is_empty() {
-                            self.update_document(
+                        self.update_document(
                             txn.document_id,
-                                replace(&mut txn.resource_updates, Vec::new()),
-                                replace(&mut txn.frame_ops, Vec::new()),
-                                txn.build_frame,
-                                txn.render_frame,
-                                &mut frame_counter,
-                                &mut profile_counters,
-                                has_built_scene,
-                            );
-                        }
+                            replace(&mut txn.resource_updates, Vec::new()),
+                            replace(&mut txn.frame_ops, Vec::new()),
+                            txn.build_frame,
+                            txn.render_frame,
+                            &mut frame_counter,
+                            &mut profile_counters,
+                            has_built_scene,
+                        );
                     },
                     SceneBuilderResult::FlushComplete(tx) => {
                         tx.send(()).ok();


### PR DESCRIPTION
Gecko depends on transactions that request frames to be passed all the way to the renderer, even if the frame can't be built or doesn't need to be built (nothing visibly changed). If one of these transaction is dropped before getting to the renderer, Gecko might wait for the notification that this transaction was rendered forever and not send new frames, and nothing ever gets rendered again.
This type of race tends to manifest itself on windows a lot more than on other platforms, probably because of the way the GPU process affects timings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3036)
<!-- Reviewable:end -->
