### PR TITLE
Remove render_on_scroll.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -97,12 +97,6 @@ struct Document {
     // A set of pipelines that the caller has requested be
     // made available as output textures.
     output_pipelines: FastHashSet<PipelineId>,
-    // A helper switch to prevent any frames rendering triggered by scrolling
-    // messages between `SetDisplayList` and `GenerateFrame`.
-    // If we allow them, then a reftest that scrolls a few layers before generating
-    // the first frame would produce inconsistent rendering results, because
-    // scroll events are not necessarily received in deterministic order.
-    render_on_scroll: Option<bool>,
 
     /// A data structure to allow hit testing against rendered frames. This is updated
     /// every time we produce a fully rendered frame.
@@ -117,14 +111,8 @@ impl Document {
     pub fn new(
         window_size: DeviceUintSize,
         layer: DocumentLayer,
-        enable_render_on_scroll: bool,
         default_device_pixel_ratio: f32,
     ) -> Self {
-        let render_on_scroll = if enable_render_on_scroll {
-            Some(false)
-        } else {
-            None
-        };
         Document {
             scene: Scene::new(),
             removed_pipelines: Vec::new(),
@@ -141,7 +129,6 @@ impl Document {
             frame_id: FrameId(0),
             frame_builder: None,
             output_pipelines: FastHashSet::default(),
-            render_on_scroll,
             hit_tester: None,
             dynamic_properties: SceneProperties::new(),
         }
@@ -173,7 +160,6 @@ impl Document {
             FrameMsg::Scroll(delta, cursor) => {
                 profile_scope!("Scroll");
 
-                let mut should_render = true;
                 let node_index = match self.hit_tester {
                     Some(ref hit_tester) => {
                         // Ideally we would call self.scroll_nearest_scrolling_ancestor here, but
@@ -182,20 +168,18 @@ impl Document {
                         hit_tester.find_node_under_point(test)
                     }
                     None => {
-                        should_render = false;
                         None
                     }
                 };
 
-                let should_render =
-                    should_render &&
-                    self.scroll_nearest_scrolling_ancestor(delta, node_index) &&
-                    self.render_on_scroll == Some(true);
+                if self.hit_tester.is_some() {
+                    let _scrolled = self.scroll_nearest_scrolling_ancestor(delta, node_index);
+                }
 
                 return DocumentOps {
+                    // TODO: Does it make sense to track this as a scrolling even if we
+                    // ended up not scrolling anything?
                     scroll: true,
-                    build_frame: should_render,
-                    render_frame: should_render,
                     ..DocumentOps::nop()
                 };
             }
@@ -216,13 +200,10 @@ impl Document {
             FrameMsg::ScrollNodeWithId(origin, id, clamp) => {
                 profile_scope!("ScrollNodeWithScrollId");
 
-                let should_render = self.scroll_node(origin, id, clamp)
-                    && self.render_on_scroll == Some(true);
+                let _scrolled = self.scroll_node(origin, id, clamp);
 
                 return DocumentOps {
                     scroll: true,
-                    build_frame: should_render,
-                    render_frame: should_render,
                     ..DocumentOps::nop()
                 };
             }
@@ -350,7 +331,6 @@ static NEXT_NAMESPACE_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 struct PlainRenderBackend {
     default_device_pixel_ratio: f32,
-    enable_render_on_scroll: bool,
     frame_config: FrameBuilderConfig,
     documents: FastHashMap<DocumentId, DocumentView>,
     resources: PlainResources,
@@ -384,7 +364,6 @@ pub struct RenderBackend {
     sampler: Option<Box<AsyncPropertySampler + Send>>,
 
     last_scene_id: u64,
-    enable_render_on_scroll: bool,
 }
 
 impl RenderBackend {
@@ -401,7 +380,6 @@ impl RenderBackend {
         frame_config: FrameBuilderConfig,
         recorder: Option<Box<ApiRecordingReceiver>>,
         sampler: Option<Box<AsyncPropertySampler + Send>>,
-        enable_render_on_scroll: bool,
     ) -> RenderBackend {
         // The namespace_id should start from 1.
         NEXT_NAMESPACE_ID.fetch_add(1, Ordering::Relaxed);
@@ -423,7 +401,6 @@ impl RenderBackend {
             recorder,
             sampler,
             last_scene_id: 0,
-            enable_render_on_scroll,
         }
     }
 
@@ -506,10 +483,6 @@ impl RenderBackend {
                     viewport_size,
                     content_size,
                 });
-
-                if let Some(ref mut ros) = doc.render_on_scroll {
-                    *ros = false; //wait for `GenerateFrame`
-                }
 
                 // Note: this isn't quite right as auxiliary values will be
                 // pulled out somewhere in the prim_store, but aux values are
@@ -704,7 +677,6 @@ impl RenderBackend {
                 let document = Document::new(
                     initial_size,
                     layer,
-                    self.enable_render_on_scroll,
                     self.default_device_pixel_ratio,
                 );
                 self.documents.insert(document_id, document);
@@ -946,12 +918,6 @@ impl RenderBackend {
 
         if doc.dynamic_properties.flush_pending_updates() {
             build_frame = true;
-        }
-
-        if render_frame {
-            if let Some(ref mut ros) = doc.render_on_scroll {
-                *ros = true;
-            }
         }
 
         if !doc.can_render() {
@@ -1214,7 +1180,6 @@ impl RenderBackend {
         info!("\tbackend");
         let backend = PlainRenderBackend {
             default_device_pixel_ratio: self.default_device_pixel_ratio,
-            enable_render_on_scroll: self.enable_render_on_scroll,
             frame_config: self.frame_config.clone(),
             documents: self.documents
                 .iter()
@@ -1279,7 +1244,6 @@ impl RenderBackend {
         self.documents.clear();
         self.default_device_pixel_ratio = backend.default_device_pixel_ratio;
         self.frame_config = backend.frame_config;
-        self.enable_render_on_scroll = backend.enable_render_on_scroll;
 
         let mut scenes_to_build = Vec::new();
 
@@ -1298,7 +1262,6 @@ impl RenderBackend {
                 frame_id: FrameId(0),
                 frame_builder: Some(FrameBuilder::empty()),
                 output_pipelines: FastHashSet::default(),
-                render_on_scroll: None,
                 dynamic_properties: SceneProperties::new(),
                 hit_tester: None,
             };

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1710,7 +1710,6 @@ impl Renderer {
                 Arc::new(worker.unwrap())
             });
         let sampler = options.sampler;
-        let enable_render_on_scroll = options.enable_render_on_scroll;
 
         let blob_image_handler = options.blob_image_handler.take();
         let thread_listener_for_render_backend = thread_listener.clone();
@@ -1792,7 +1791,6 @@ impl Renderer {
                 config,
                 recorder,
                 sampler,
-                enable_render_on_scroll,
             );
             backend.run(backend_profile_counters);
             if let Some(ref thread_listener) = *thread_listener_for_render_backend {
@@ -4240,7 +4238,6 @@ pub struct RendererOptions {
     pub blob_image_handler: Option<Box<BlobImageHandler>>,
     pub recorder: Option<Box<ApiRecordingReceiver>>,
     pub thread_listener: Option<Box<ThreadListener + Send + Sync>>,
-    pub enable_render_on_scroll: bool,
     pub cached_programs: Option<Rc<ProgramCache>>,
     pub debug_flags: DebugFlags,
     pub renderer_id: Option<u64>,
@@ -4276,7 +4273,6 @@ impl Default for RendererOptions {
             blob_image_handler: None,
             recorder: None,
             thread_listener: None,
-            enable_render_on_scroll: true,
             renderer_id: None,
             cached_programs: None,
             disable_dual_source_blending: false,


### PR DESCRIPTION
It was used by tests before we had transactions but it isn't useful anymore.

This commit should not change the current behavior. Turns out we weren't taking advantage of the knowledge of whether something actually scrolled for anything other than the render_on_scroll mechanism.
This is useful information, though, that should help with deciding if/when we need to re-build the frame, so I left it visible in unused `_scrolled` variables. We should take advantage of these in followup work to remove redundant frame building.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3037)
<!-- Reviewable:end -->
