### PR TITLE
Basic recording support for loaded captures

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -243,7 +243,6 @@ pub fn main_wrapper<E: Example>(
                     2.0
                 ),
                 winit::VirtualKeyCode::M => api.notify_memory_pressure(),
-                #[cfg(feature = "capture")]
                 winit::VirtualKeyCode::C => {
                     let path: PathBuf = "../captures/example".into();
                     //TODO: switch between SCENE/FRAME capture types

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -783,7 +783,31 @@ impl RenderBackend {
                                 window_size: doc.view.window_size,
                             };
                             tx.send(captured).unwrap();
+
+                            // notify the active recorder
+                            if let Some(ref mut r) = self.recorder {
+                                let pipeline_id = doc.scene.root_pipeline_id.unwrap();
+                                let epoch =  doc.scene.pipeline_epochs[&pipeline_id];
+                                let pipeline = &doc.scene.pipelines[&pipeline_id];
+                                let scene_msg = SceneMsg::SetDisplayList {
+                                    list_descriptor: pipeline.display_list.descriptor().clone(),
+                                    epoch,
+                                    pipeline_id,
+                                    background: pipeline.background_color,
+                                    viewport_size: pipeline.viewport_size,
+                                    content_size: pipeline.content_size,
+                                    preserve_frame_state: false,
+                                };
+                                let txn = TransactionMsg::scene_message(scene_msg);
+                                r.write_msg(*frame_counter, &ApiMsg::UpdateDocument(*id, txn));
+                                r.write_payload(*frame_counter, &Payload::construct_data(
+                                    epoch,
+                                    pipeline_id,
+                                    pipeline.display_list.data(),
+                                ));
+                            }
                         }
+
                         // Note: we can't pass `LoadCapture` here since it needs to arrive
                         // before the `PublishDocument` messages sent by `load_capture`.
                         return true;

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -382,7 +382,7 @@ impl TransactionMsg {
     }
 
     // TODO: We only need this for a few RenderApi methods which we should remove.
-    fn frame_message(msg: FrameMsg) -> Self {
+    pub fn frame_message(msg: FrameMsg) -> Self {
         TransactionMsg {
             scene_ops: Vec::new(),
             frame_ops: vec![msg],
@@ -393,7 +393,7 @@ impl TransactionMsg {
         }
     }
 
-    fn scene_message(msg: SceneMsg) -> Self {
+    pub fn scene_message(msg: SceneMsg) -> Self {
         TransactionMsg {
             scene_ops: vec![msg],
             frame_ops: Vec::new(),

--- a/webrender_api/src/channel.rs
+++ b/webrender_api/src/channel.rs
@@ -24,21 +24,26 @@ pub struct Payload {
 impl Payload {
     /// Convert the payload to a raw byte vector, in order for it to be
     /// efficiently shared via shmem, for example.
+    /// This is a helper static method working on a slice.
+    pub fn construct_data(epoch: Epoch, pipeline_id: PipelineId, dl_data: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(
+            mem::size_of::<u32>() + 2 * mem::size_of::<u32>() + mem::size_of::<u64>() + dl_data.len(),
+        );
+        data.write_u32::<LittleEndian>(epoch.0).unwrap();
+        data.write_u32::<LittleEndian>(pipeline_id.0).unwrap();
+        data.write_u32::<LittleEndian>(pipeline_id.1).unwrap();
+        data.write_u64::<LittleEndian>(dl_data.len() as u64)
+            .unwrap();
+        data.extend_from_slice(dl_data);
+        data
+    }
+    /// Convert the payload to a raw byte vector, in order for it to be
+    /// efficiently shared via shmem, for example.
     ///
     /// TODO(emilio, #1049): Consider moving the IPC boundary to the
     /// constellation in Servo and remove this complexity from WR.
     pub fn to_data(&self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(
-            mem::size_of::<u32>() + 2 * mem::size_of::<u32>() + mem::size_of::<u64>() +
-                self.display_list_data.len(),
-        );
-        data.write_u32::<LittleEndian>(self.epoch.0).unwrap();
-        data.write_u32::<LittleEndian>(self.pipeline_id.0).unwrap();
-        data.write_u32::<LittleEndian>(self.pipeline_id.1).unwrap();
-        data.write_u64::<LittleEndian>(self.display_list_data.len() as u64)
-            .unwrap();
-        data.extend_from_slice(&self.display_list_data);
-        data
+        Self::construct_data(self.epoch, self.pipeline_id, &self.display_list_data)
     }
 
     /// Deserializes the given payload from a raw byte vector.


### PR DESCRIPTION
Fixes #2583 (more follow-up is expected though for correctness)

This change makes the capture infrastructure play better with the display-list-based recording. It produces a fake `SetDisplayList` message to be recorded based on the (already) loaded scene. Result isn't always consumable by the YAML reader (there are correctness issues, and I bet the YAML reading-writing loop isn't sinless either, given that it was never tested on big scenes, typically produced by capturing from Gecko). Here is the `basic` example replayed from YAML:
![wrench-yaml-from-capture](https://user-images.githubusercontent.com/107301/45302345-10f60500-b4e1-11e8-9e94-aa4c82b2cb7d.png)

YAML is at least always generated, and it gives an easier workflow for developers trying to reproduce a captured bug in a YAML reftest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3038)
<!-- Reviewable:end -->
