### PR TITLE
Check preserve-3d when computing stacking-context backface-visibility

### DIFF
--- a/wrench/reftests/transforms/complex-preserve-3d.yaml
+++ b/wrench/reftests/transforms/complex-preserve-3d.yaml
@@ -1,0 +1,24 @@
+# the root sc should dominate backface-visibility and hide the rect
+
+---
+root:
+  items:
+    -
+      bounds: [300, 300, 300, 300]
+      clip-rect: [300, 300, 300, 300]
+      type: "stacking-context"
+      transform: rotate-y(180)
+      transform-style: flat
+      backface-visible: false
+      items:
+        -
+          type: "stacking-context"
+          transform-style: preserve-3d
+          backface-visible: true
+          items:
+            -
+              bounds: [350, 350, 150, 150]
+              clip-rect: [350, 350, 150, 150]
+              type: rect
+              color: 255 255 0 0.4000
+              backface-visible: true

--- a/wrench/reftests/transforms/reftest.list
+++ b/wrench/reftests/transforms/reftest.list
@@ -23,3 +23,4 @@ platform(linux,mac) == perspective-mask.yaml perspective-mask.png
 rotate-clip.yaml rotate-clip-ref.yaml
 clip-translate.yaml clip-translate-ref.yaml
 platform(linux,mac) == perspective-clip.yaml perspective-clip.png
+== complex-preserve-3d.yaml blank.yaml


### PR DESCRIPTION
this appears to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1489937

try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=386d8adb469cb458af4b5359de63c9a067345e22

(that some other should-be-fine commits snuck onto)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3040)
<!-- Reviewable:end -->
