### PR TITLE
Avoid allocating clip tasks for clip rects in same coordinate system.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2245,7 +2245,7 @@ impl Primitive {
 
             match segment_clip_chain {
                 Some(segment_clip_chain) => {
-                    if segment_clip_chain.clips_range.count == 0 ||
+                    if !segment_clip_chain.needs_mask ||
                        (!segment.may_need_clip_mask && !segment_clip_chain.has_non_local_clips) {
                         segment.clip_task_id = BrushSegmentTaskId::Opaque;
                         continue;
@@ -2794,7 +2794,7 @@ impl Primitive {
             return;
         }
 
-        if clip_chain.clips_range.count > 0 {
+        if clip_chain.needs_mask {
             if let Some((device_rect, _, _)) = get_raster_rects(
                 clip_chain.pic_clip_rect,
                 &pic_state.map_pic_to_raster,


### PR DESCRIPTION
If a clip chain only ends up with clip rects that are from the
same coordinate system, there is no need to allocate a clip mask,
as the clip can be implemented via the local clip rect in the
primitive vertex shader.

This is an important optimization for reducing clip task
allocations on common pages (although they won't actually be
drawn into the clip mask anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3041)
<!-- Reviewable:end -->
