### PR TITLE
Track the validity of the frame and hit tester to avoid redundant work.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -956,8 +956,9 @@ impl RenderBackend {
             render_frame = false;
         }
 
-        // If we don't generate a frame it makes no sense to render.
-        debug_assert!(build_frame || !render_frame);
+        if doc.frame_is_valid {
+            build_frame = false;
+        }
 
         let mut frame_build_time = None;
         if build_frame && doc.has_pixels() {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1002,7 +1002,7 @@ impl RenderBackend {
             );
             self.result_tx.send(msg).unwrap();
             profile_counters.reset();
-        } else if build_frame {
+        } else if requested_frame {
             // WR-internal optimization to avoid doing a bunch of render work if
             // there's no pixels. We still want to pretend to render and request
             // a render to make sure that the callbacks (particularly the


### PR DESCRIPTION
This lays the ground work for keeping track of the validity of the current frame and hit tester to allow only re-building them when something invalidates them.

This initial commit only skips redundant frame builds (typically when a scene is built and the vsync triggered transactions that follows doesn't scroll or use async animations). But after we separate building the frame and the hit tester, we'll be able to improve upon this by lazily building the frame and avoid double frame builds during scrolling and animations as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3043)
<!-- Reviewable:end -->
