### PR TITLE
Handle scale + offset as same coordinate system.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -17,7 +17,7 @@ use prim_store::{ClipData, ImageMaskData, SpaceMapper};
 use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use std::{cmp, u32};
-use util::{extract_inner_rect_safe, pack_as_float, project_rect, recycle_vec};
+use util::{extract_inner_rect_safe, pack_as_float, project_rect, recycle_vec, ScaleOffset};
 
 /*
 
@@ -200,7 +200,7 @@ pub struct ClipNodeRange {
 #[derive(Debug)]
 enum ClipSpaceConversion {
     Local,
-    Offset(LayoutVector2D),
+    ScaleOffset(ScaleOffset),
     Transform(LayoutToWorldTransform),
 }
 
@@ -538,9 +538,9 @@ impl ClipStore {
                 ClipSpaceConversion::Local => {
                     node.item.get_clip_result(&local_bounding_rect)
                 }
-                ClipSpaceConversion::Offset(offset) => {
+                ClipSpaceConversion::ScaleOffset(ref scale_offset) => {
                     has_non_local_clips = true;
-                    node.item.get_clip_result(&local_bounding_rect.translate(&-offset))
+                    node.item.get_clip_result(&scale_offset.unmap(&local_bounding_rect))
                 }
                 ClipSpaceConversion::Transform(ref transform) => {
                     has_non_local_clips = true;
@@ -576,7 +576,7 @@ impl ClipStore {
                         ClipSpaceConversion::Local => {
                             ClipNodeFlags::SAME_SPATIAL_NODE | ClipNodeFlags::SAME_COORD_SYSTEM
                         }
-                        ClipSpaceConversion::Offset(..) => {
+                        ClipSpaceConversion::ScaleOffset(..) => {
                             ClipNodeFlags::SAME_COORD_SYSTEM
                         }
                         ClipSpaceConversion::Transform(..) => {
@@ -1156,9 +1156,12 @@ fn add_clip_node_to_current_chain(
     let conversion = if spatial_node_index == clip_node.spatial_node_index {
         Some(ClipSpaceConversion::Local)
     } else if ref_spatial_node.coordinate_system_id == clip_spatial_node.coordinate_system_id {
-        let offset = clip_spatial_node.coordinate_system_relative_offset -
-                     ref_spatial_node.coordinate_system_relative_offset;
-        Some(ClipSpaceConversion::Offset(offset))
+        let scale_offset = ref_spatial_node
+            .coordinate_system_relative_scale_offset
+            .subtract(
+                &clip_spatial_node.coordinate_system_relative_scale_offset
+            );
+        Some(ClipSpaceConversion::ScaleOffset(scale_offset))
     } else {
         let xf = clip_scroll_tree.get_relative_transform(
             clip_node.spatial_node_index,
@@ -1181,8 +1184,8 @@ fn add_clip_node_to_current_chain(
                         None => return false,
                     };
                 }
-                ClipSpaceConversion::Offset(ref offset) => {
-                    let clip_rect = clip_rect.translate(offset);
+                ClipSpaceConversion::ScaleOffset(ref scale_offset) => {
+                    let clip_rect = scale_offset.map(&clip_rect);
                     *local_clip_rect = match local_clip_rect.intersection(&clip_rect) {
                         Some(rect) => rect,
                         None => return false,

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -540,7 +540,7 @@ impl ClipStore {
                 }
                 ClipSpaceConversion::ScaleOffset(ref scale_offset) => {
                     has_non_local_clips = true;
-                    node.item.get_clip_result(&scale_offset.unmap(&local_bounding_rect))
+                    node.item.get_clip_result(&scale_offset.unmap_rect(&local_bounding_rect))
                 }
                 ClipSpaceConversion::Transform(ref transform) => {
                     has_non_local_clips = true;
@@ -1158,7 +1158,7 @@ fn add_clip_node_to_current_chain(
     } else if ref_spatial_node.coordinate_system_id == clip_spatial_node.coordinate_system_id {
         let scale_offset = ref_spatial_node
             .coordinate_system_relative_scale_offset
-            .subtract(
+            .difference(
                 &clip_spatial_node.coordinate_system_relative_scale_offset
             );
         Some(ClipSpaceConversion::ScaleOffset(scale_offset))
@@ -1185,7 +1185,7 @@ fn add_clip_node_to_current_chain(
                     };
                 }
                 ClipSpaceConversion::ScaleOffset(ref scale_offset) => {
-                    let clip_rect = scale_offset.map(&clip_rect);
+                    let clip_rect = scale_offset.map_rect(&clip_rect);
                     *local_clip_rect = match local_clip_rect.intersection(&clip_rect) {
                         Some(rect) => rect,
                         None => return false,

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -134,7 +134,8 @@ impl ClipScrollTree {
         nodes.reverse();
 
         let mut transform = parent.coordinate_system_relative_scale_offset
-                                  .to_inverse_transform();
+                                  .inverse()
+                                  .to_transform();
 
         for node in nodes {
             let coord_system = &self.coord_systems[node.0 as usize];

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ExternalScrollId, LayoutPoint, LayoutRect, LayoutVector2D, LayoutVector3D};
+use api::{ExternalScrollId, LayoutPoint, LayoutRect, LayoutVector2D};
 use api::{PipelineId, ScrollClamping, ScrollNodeState, ScrollLocation};
 use api::{LayoutSize, LayoutTransform, PropertyBinding, ScrollSensitivity, WorldPoint};
 use gpu_types::TransformPalette;
@@ -11,7 +11,7 @@ use print_tree::{PrintTree, PrintTreePrinter};
 use scene::SceneProperties;
 use smallvec::SmallVec;
 use spatial_node::{ScrollFrameInfo, SpatialNode, SpatialNodeType, StickyFrameInfo};
-use util::LayoutToWorldFastTransform;
+use util::{LayoutToWorldFastTransform, ScaleOffset};
 
 pub type ScrollStates = FastHashMap<ExternalScrollId, ScrollFrameInfo>;
 
@@ -28,7 +28,6 @@ pub struct CoordinateSystemId(pub u32);
 /// transforms.
 #[derive(Debug)]
 pub struct CoordinateSystem {
-    pub offset: LayoutVector3D,
     pub transform: LayoutTransform,
     pub parent: Option<CoordinateSystemId>,
 }
@@ -36,7 +35,6 @@ pub struct CoordinateSystem {
 impl CoordinateSystem {
     fn root() -> Self {
         CoordinateSystem {
-            offset: LayoutVector3D::zero(),
             transform: LayoutTransform::identity(),
             parent: None,
         }
@@ -87,8 +85,8 @@ pub struct TransformUpdateState {
     /// coordinate systems which are relatively axis aligned.
     pub current_coordinate_system_id: CoordinateSystemId,
 
-    /// Offset from the coordinate system that started this compatible coordinate system.
-    pub coordinate_system_relative_offset: LayoutVector2D,
+    /// Scale and offset from the coordinate system that started this compatible coordinate system.
+    pub coordinate_system_relative_scale_offset: ScaleOffset,
 
     /// True if this node is transformed by an invertible transform.  If not, display items
     /// transformed by this node will not be displayed and display items not transformed by this
@@ -135,24 +133,16 @@ impl ClipScrollTree {
 
         nodes.reverse();
 
-        let mut transform = LayoutTransform::create_translation(
-            -parent.coordinate_system_relative_offset.x,
-            -parent.coordinate_system_relative_offset.y,
-            0.0,
-        );
+        let mut transform = parent.coordinate_system_relative_scale_offset
+                                  .to_inverse_transform();
 
         for node in nodes {
             let coord_system = &self.coord_systems[node.0 as usize];
-            transform = transform.pre_translate(coord_system.offset)
-                                 .pre_mul(&coord_system.transform);
+            transform = transform.pre_mul(&coord_system.transform);
         }
 
-        let transform = transform.pre_translate(
-            LayoutVector3D::new(
-                child.coordinate_system_relative_offset.x,
-                child.coordinate_system_relative_offset.y,
-                0.0,
-            )
+        let transform = transform.pre_mul(
+            &child.coordinate_system_relative_scale_offset.to_transform(),
         );
 
         if inverse {
@@ -274,7 +264,7 @@ impl ClipScrollTree {
             nearest_scrolling_ancestor_offset: LayoutVector2D::zero(),
             nearest_scrolling_ancestor_viewport: LayoutRect::zero(),
             current_coordinate_system_id: CoordinateSystemId::root(),
-            coordinate_system_relative_offset: LayoutVector2D::zero(),
+            coordinate_system_relative_scale_offset: ScaleOffset::identity(),
             invertible: true,
         };
 

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -12,7 +12,7 @@ use app_units::Au;
 use border::{BorderCacheKey, BorderRenderTaskInfo};
 use clip_scroll_tree::{ClipScrollTree, CoordinateSystemId, SpatialNodeIndex};
 use clip::{ClipNodeFlags, ClipChainId, ClipChainInstance, ClipItem, ClipNodeCollector};
-use euclid::{TypedVector2D, TypedTransform3D, TypedRect};
+use euclid::{TypedTransform3D, TypedRect};
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureContext, PictureState};
 use frame_builder::PrimitiveContext;
 use glyph_rasterizer::{FontInstance, FontTransform, GlyphKey, FONT_SIZE_LIMIT};
@@ -30,7 +30,7 @@ use resource_cache::{ImageProperties, ImageRequest, ResourceCache};
 use scene::SceneProperties;
 use segment::SegmentBuilder;
 use std::{cmp, fmt, mem, usize};
-use util::{MatrixHelpers, pack_as_float, recycle_vec, project_rect, raster_rect_to_device_pixels};
+use util::{ScaleOffset, MatrixHelpers, pack_as_float, recycle_vec, project_rect, raster_rect_to_device_pixels};
 
 
 const MIN_BRUSH_SPLIT_AREA: f32 = 256.0 * 256.0;
@@ -95,7 +95,7 @@ impl PrimitiveOpacity {
 #[derive(Debug)]
 pub enum CoordinateSpaceMapping<F, T> {
     Local,
-    Offset(TypedVector2D<f32, F>),
+    ScaleOffset(ScaleOffset),
     Transform(TypedTransform3D<f32, F, T>),
 }
 
@@ -145,13 +145,12 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
             self.kind = if self.ref_spatial_node_index == target_node_index {
                 CoordinateSpaceMapping::Local
             } else if ref_spatial_node.coordinate_system_id == target_spatial_node.coordinate_system_id {
-                let offset = TypedVector2D::new(
-                    target_spatial_node.coordinate_system_relative_offset.x -
-                        ref_spatial_node.coordinate_system_relative_offset.x,
-                    target_spatial_node.coordinate_system_relative_offset.y -
-                        ref_spatial_node.coordinate_system_relative_offset.y,
-                );
-                CoordinateSpaceMapping::Offset(offset)
+                CoordinateSpaceMapping::ScaleOffset(
+                    ref_spatial_node.coordinate_system_relative_scale_offset
+                        .subtract(
+                            &target_spatial_node.coordinate_system_relative_scale_offset
+                        )
+                )
             } else {
                 let transform = clip_scroll_tree.get_relative_transform(
                     target_node_index,
@@ -170,8 +169,8 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
             CoordinateSpaceMapping::Local => {
                 TypedTransform3D::identity()
             }
-            CoordinateSpaceMapping::Offset(offset) => {
-                TypedTransform3D::create_translation(offset.x, offset.y, 0.0)
+            CoordinateSpaceMapping::ScaleOffset(ref scale_offset) => {
+                scale_offset.to_transform()
             }
             CoordinateSpaceMapping::Transform(transform) => {
                 transform
@@ -184,9 +183,8 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
             CoordinateSpaceMapping::Local => {
                 Some(TypedRect::from_untyped(&rect.to_untyped()))
             }
-            CoordinateSpaceMapping::Offset(ref offset) => {
-                let offset = TypedVector2D::new(-offset.x, -offset.y);
-                Some(TypedRect::from_untyped(&rect.translate(&offset).to_untyped()))
+            CoordinateSpaceMapping::ScaleOffset(ref scale_offset) => {
+                Some(scale_offset.unmap(rect))
             }
             CoordinateSpaceMapping::Transform(ref transform) => {
                 transform.inverse_rect_footprint(rect)
@@ -199,8 +197,8 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
             CoordinateSpaceMapping::Local => {
                 Some(TypedRect::from_untyped(&rect.to_untyped()))
             }
-            CoordinateSpaceMapping::Offset(ref offset) => {
-                Some(TypedRect::from_untyped(&rect.translate(offset).to_untyped()))
+            CoordinateSpaceMapping::ScaleOffset(ref scale_offset) => {
+                Some(scale_offset.map(rect))
             }
             CoordinateSpaceMapping::Transform(ref transform) => {
                 match project_rect(transform, rect, &self.bounds) {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -147,7 +147,7 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
             } else if ref_spatial_node.coordinate_system_id == target_spatial_node.coordinate_system_id {
                 CoordinateSpaceMapping::ScaleOffset(
                     ref_spatial_node.coordinate_system_relative_scale_offset
-                        .subtract(
+                        .difference(
                             &target_spatial_node.coordinate_system_relative_scale_offset
                         )
                 )
@@ -184,7 +184,7 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
                 Some(TypedRect::from_untyped(&rect.to_untyped()))
             }
             CoordinateSpaceMapping::ScaleOffset(ref scale_offset) => {
-                Some(scale_offset.unmap(rect))
+                Some(scale_offset.unmap_rect(rect))
             }
             CoordinateSpaceMapping::Transform(ref transform) => {
                 transform.inverse_rect_footprint(rect)
@@ -198,7 +198,7 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
                 Some(TypedRect::from_untyped(&rect.to_untyped()))
             }
             CoordinateSpaceMapping::ScaleOffset(ref scale_offset) => {
-                Some(scale_offset.map(rect))
+                Some(scale_offset.map_rect(rect))
             }
             CoordinateSpaceMapping::Transform(ref transform) => {
                 match project_rect(transform, rect, &self.bounds) {

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -5,12 +5,12 @@
 
 use api::{ExternalScrollId, LayoutPixel, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform};
 use api::{LayoutVector2D, PipelineId, PropertyBinding, ScrollClamping, ScrollLocation};
-use api::{ScrollSensitivity, StickyOffsetBounds, LayoutVector3D};
+use api::{ScrollSensitivity, StickyOffsetBounds};
 use clip_scroll_tree::{CoordinateSystem, CoordinateSystemId, SpatialNodeIndex, TransformUpdateState};
 use euclid::SideOffsets2D;
 use gpu_types::TransformPalette;
 use scene::SceneProperties;
-use util::{LayoutFastTransform, LayoutToWorldFastTransform, MatrixHelpers, TransformedRectKind};
+use util::{LayoutFastTransform, LayoutToWorldFastTransform, ScaleOffset, TransformedRectKind};
 
 #[derive(Clone, Debug)]
 pub enum SpatialNodeType {
@@ -66,7 +66,7 @@ pub struct SpatialNode {
     /// The transformation from the coordinate system which established our compatible coordinate
     /// system (same coordinate system id) and us. This can change via scroll offsets and via new
     /// reference frame transforms.
-    pub coordinate_system_relative_offset: LayoutVector2D,
+    pub coordinate_system_relative_scale_offset: ScaleOffset,
 }
 
 impl SpatialNode {
@@ -85,7 +85,7 @@ impl SpatialNode {
             node_type,
             invertible: true,
             coordinate_system_id: CoordinateSystemId(0),
-            coordinate_system_relative_offset: LayoutVector2D::zero(),
+            coordinate_system_relative_scale_offset: ScaleOffset::identity(),
         }
     }
 
@@ -275,27 +275,28 @@ impl SpatialNode {
 
                 // Try to update our compatible coordinate system transform. If we cannot, start a new
                 // incompatible coordinate system.
-                if relative_transform.is_simple_2d_translation() {
-                    self.coordinate_system_relative_offset =
-                        state.coordinate_system_relative_offset +
-                        LayoutVector2D::new(relative_transform.m41, relative_transform.m42);
-                } else {
-                    // If we break 2D axis alignment or have a perspective component, we need to start a
-                    // new incompatible coordinate system with which we cannot share clips without masking.
-                    self.coordinate_system_relative_offset = LayoutVector2D::zero();
+                match ScaleOffset::from_transform(&relative_transform) {
+                    Some(ref scale_offset) => {
+                        self.coordinate_system_relative_scale_offset =
+                            state.coordinate_system_relative_scale_offset.accumulate(scale_offset);
+                    }
+                    None => {
+                        // If we break 2D axis alignment or have a perspective component, we need to start a
+                        // new incompatible coordinate system with which we cannot share clips without masking.
+                        self.coordinate_system_relative_scale_offset = ScaleOffset::identity();
 
-                    // Push that new coordinate system and record the new id.
-                    let coord_system = CoordinateSystem {
-                        offset: LayoutVector3D::new(
-                            state.coordinate_system_relative_offset.x,
-                            state.coordinate_system_relative_offset.y,
-                            0.0,
-                        ),
-                        transform: relative_transform,
-                        parent: Some(state.current_coordinate_system_id),
-                    };
-                    state.current_coordinate_system_id = CoordinateSystemId(coord_systems.len() as u32);
-                    coord_systems.push(coord_system);
+                        let transform = state.coordinate_system_relative_scale_offset
+                                             .to_transform()
+                                             .pre_mul(&relative_transform);
+
+                        // Push that new coordinate system and record the new id.
+                        let coord_system = CoordinateSystem {
+                            transform,
+                            parent: Some(state.current_coordinate_system_id),
+                        };
+                        state.current_coordinate_system_id = CoordinateSystemId(coord_systems.len() as u32);
+                        coord_systems.push(coord_system);
+                    }
                 }
 
                 self.coordinate_system_id = state.current_coordinate_system_id;
@@ -327,8 +328,8 @@ impl SpatialNode {
                 };
 
                 let added_offset = state.parent_accumulated_scroll_offset + sticky_offset + scroll_offset;
-                self.coordinate_system_relative_offset =
-                    state.coordinate_system_relative_offset + added_offset;
+                self.coordinate_system_relative_scale_offset =
+                    state.coordinate_system_relative_scale_offset.offset(added_offset.to_untyped());
 
                 if let SpatialNodeType::StickyFrame(ref mut info) = self.node_type {
                     info.current_offset = sticky_offset;
@@ -475,7 +476,7 @@ impl SpatialNode {
             SpatialNodeType::ReferenceFrame(ref info) => {
                 state.parent_reference_frame_transform = self.world_viewport_transform;
                 state.parent_accumulated_scroll_offset = LayoutVector2D::zero();
-                state.coordinate_system_relative_offset = self.coordinate_system_relative_offset;
+                state.coordinate_system_relative_scale_offset = self.coordinate_system_relative_scale_offset;
                 let translation = -info.origin_in_parent_reference_frame;
                 state.nearest_scrolling_ancestor_viewport =
                     state.nearest_scrolling_ancestor_viewport


### PR DESCRIPTION
Apart from simple translations, the most common transform that
is encountered in WR is a scale + offset combination. This is
used especially heavily on animations, and hi-dpi screens.

Previously, WR would consider this a different coordinate
system, which means falling back to clip masks for many
cases (e.g. a rectangle in root coordinate system that has
a partial overlap with a primitive in a scaled coord system).

However, these scale + offset transforms still result in an
axis-aligned rectangle between the two coordinate systems. Thus,
we can actually consider them to be the same coordinate system.

The outcome of this is that we can apply clip rectangles as
local clip rects in the vertex shader. This greatly reduces
the number of clip masks that we allocate in such situations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3046)
<!-- Reviewable:end -->
