### PR TITLE
Gracefully avoid generating empty border segments

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -529,7 +529,8 @@ impl BrushSegment {
         edge_flags: EdgeAaSegmentMask,
         extra_data: [f32; 4],
         brush_flags: BrushFlags,
-    ) -> BrushSegment {
+    ) -> Self {
+        debug_assert!(rect.size.width > 0.0 && rect.size.height > 0.0);
         BrushSegment {
             local_rect: rect,
             clip_task_id: BrushSegmentTaskId::Opaque,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -38,8 +38,8 @@ pub const MAX_BLUR_STD_DEVIATION: f32 = 4.0;
 pub const MIN_DOWNSCALING_RT_SIZE: i32 = 128;
 
 fn render_task_sanity_check(size: &DeviceIntSize) {
-    if size.width > RENDER_TASK_SIZE_SANITY_CHECK ||
-        size.height > RENDER_TASK_SIZE_SANITY_CHECK {
+    if size.width < 0 || size.width > RENDER_TASK_SIZE_SANITY_CHECK ||
+        size.height < 0 || size.height > RENDER_TASK_SIZE_SANITY_CHECK {
         error!("Attempting to create a render task of size {}x{}", size.width, size.height);
         panic!();
     }


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1489644
Also related to https://github.com/servo/webrender/issues/2715#issuecomment-419948326

The change makes us avoid doing meaningless work and then stumbling upon unexpected data. Good for both performance, stability, and the health of the users ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3049)
<!-- Reviewable:end -->
