### PR TITLE
Don't cache pictures if they contain an external image

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -24,7 +24,7 @@ use prim_store::{BorderSource, Primitive, PrimitiveDetails};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskTree};
 use renderer::{BlendMode, ImageBufferKind, ShaderColorMode};
 use renderer::BLOCKS_PER_UV_RECT;
-use resource_cache::{CacheItem, GlyphFetchResult, ImageRequest, ResourceCache};
+use resource_cache::{CacheItem, GlyphFetchResult, ImageRequest, ResourceCache, ImageProperties};
 use scene::FilterOpHelpers;
 use std::{f32, i32};
 use tiling::{RenderTargetContext};
@@ -1602,6 +1602,30 @@ impl Primitive {
                     }
                 }
             }
+        }
+    }
+
+    pub fn is_cacheable(
+        &self,
+        resource_cache: &ResourceCache
+    ) -> bool {
+        let image_key = match self.details {
+            PrimitiveDetails::Brush(BrushPrimitive { kind: BrushKind::Image{ request, ..  }, .. }) => {
+                request.key
+            }
+            PrimitiveDetails::Brush(BrushPrimitive { kind: BrushKind::YuvImage{ yuv_key, .. }, .. }) => {
+                yuv_key[0]
+            }
+            PrimitiveDetails::Brush(_) |
+            PrimitiveDetails::TextRun(..) => {
+                return true
+            }
+        };
+        match resource_cache.get_image_properties(image_key) {
+            Some(ImageProperties { external_image: Some(_), .. }) => {
+                false
+            }
+            _ => true
         }
     }
 }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -100,6 +100,7 @@ pub struct PictureContext {
 pub struct PictureState {
     pub tasks: Vec<RenderTaskId>,
     pub has_non_root_coord_system: bool,
+    pub is_cacheable: bool,
     pub local_rect_changed: bool,
     pub map_local_to_pic: SpaceMapper<LayoutPixel, PicturePixel>,
     pub map_pic_to_world: SpaceMapper<PicturePixel, WorldPixel>,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -291,6 +291,7 @@ impl PicturePrimitive {
         let state = PictureState {
             tasks: Vec::new(),
             has_non_root_coord_system: false,
+            is_cacheable: true,
             local_rect_changed: false,
             raster_spatial_node_index,
             surface_spatial_node_index,
@@ -472,7 +473,8 @@ impl PicturePrimitive {
                         // anyway. In the future we should relax this a bit, so that we can
                         // cache tasks with complex coordinate systems if we detect the
                         // relevant transforms haven't changed from frame to frame.
-                        let surface = if pic_state_for_children.has_non_root_coord_system {
+                        let surface = if pic_state_for_children.has_non_root_coord_system ||
+                                         !pic_state_for_children.is_cacheable {
                             let picture_task = RenderTask::new_picture(
                                 RenderTaskLocation::Dynamic(None, device_rect.size),
                                 unclipped.size,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1653,6 +1653,10 @@ impl PrimitiveStore {
                     Some(pic_rect)
                 };
 
+                if !pic_state_for_children.is_cacheable {
+                  pic_state.is_cacheable = false;
+                }
+
                 // Restore the dependencies (borrow check dance)
                 let prim = &mut self.primitives[prim_index.0];
                 let (new_local_rect, clip_node_collector) = prim
@@ -1678,6 +1682,10 @@ impl PrimitiveStore {
         };
 
         let prim = &mut self.primitives[prim_index.0];
+
+        if !prim.is_cacheable(frame_state.resource_cache) {
+            pic_state.is_cacheable = false;
+        }
 
         if is_passthrough {
             prim.metadata.clipped_world_rect = Some(pic_state.map_pic_to_world.bounds);


### PR DESCRIPTION
Fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1482727

Videos can be updated externally without a scene build, so we can't cache Pictures that contain them.

This detects when a picture contains an external image, and disables caching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3050)
<!-- Reviewable:end -->
