### PR TITLE
Speed up updating the hit-test tree

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -291,7 +291,9 @@ impl ClipScrollTree {
         // TODO(gw): This is an ugly borrow check workaround to clone these.
         //           Restructure this to avoid the clones!
         let mut state = state.clone();
-        let node_children = {
+        let mut node_children: SmallVec<[SpatialNodeIndex; 4]> = SmallVec::new();
+
+        {
             let node = match self.spatial_nodes.get_mut(node_index.0) {
                 Some(node) => node,
                 None => return,
@@ -307,8 +309,8 @@ impl ClipScrollTree {
             }
 
             node.prepare_state_for_children(&mut state);
-            node.children.clone()
-        };
+            node_children.extend_from_slice(&node.children);
+        }
 
         for child_node_index in node_children {
             self.update_node(

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -340,9 +340,11 @@ impl FrameBuilder {
         resource_cache.begin_frame(frame_id);
         gpu_cache.begin_frame();
 
-        let mut transform_palette = clip_scroll_tree.update_tree(
+        let mut transform_palette = TransformPalette::new();
+        clip_scroll_tree.update_tree(
             pan,
             scene_properties,
+            Some(&mut transform_palette),
         );
 
         self.update_scroll_bars(clip_scroll_tree, gpu_cache);

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -415,12 +415,17 @@ pub struct TransformPalette {
 }
 
 impl TransformPalette {
-    pub fn new(spatial_node_count: usize) -> Self {
+    pub fn new() -> Self {
         TransformPalette {
-            transforms: vec![TransformData::invalid(); spatial_node_count],
-            metadata: vec![TransformMetadata::invalid(); spatial_node_count],
+            transforms: Vec::new(),
+            metadata: Vec::new(),
             map: FastHashMap::default(),
         }
+    }
+
+    pub fn reserve(&mut self, count: usize) {
+        self.transforms = vec![TransformData::invalid(); count];
+        self.metadata = vec![TransformMetadata::invalid(); count];
     }
 
     pub fn set_world_transform(

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -284,10 +284,10 @@ impl Document {
             let accumulated_scale_factor = self.view.accumulated_scale_factor();
             let pan = self.view.pan.to_f32() / accumulated_scale_factor;
 
-            // TODO: do we need to do something with the transform palette?
-            let _palette = self.clip_scroll_tree.update_tree(
+            self.clip_scroll_tree.update_tree(
                 pan,
                 &self.dynamic_properties,
+                None,
             );
 
             self.hit_tester = Some(frame_builder.create_hit_tester(&self.clip_scroll_tree));

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -348,14 +348,12 @@ impl Document {
 
 struct DocumentOps {
     scroll: bool,
-    build_frame: bool,
 }
 
 impl DocumentOps {
     fn nop() -> Self {
         DocumentOps {
             scroll: false,
-            build_frame: false,
         }
     }
 }
@@ -612,7 +610,6 @@ impl RenderBackend {
                             replace(&mut txn.resource_updates, Vec::new()),
                             replace(&mut txn.frame_ops, Vec::new()),
                             replace(&mut txn.notifications, Vec::new()),
-                            txn.build_frame,
                             txn.render_frame,
                             &mut frame_counter,
                             &mut profile_counters,
@@ -865,7 +862,6 @@ impl RenderBackend {
             rasterized_blobs: Vec::new(),
             notifications: transaction_msg.notifications,
             set_root_pipeline: None,
-            build_frame: transaction_msg.generate_frame,
             render_frame: transaction_msg.generate_frame,
         });
 
@@ -900,7 +896,6 @@ impl RenderBackend {
                 replace(&mut txn.resource_updates, Vec::new()),
                 replace(&mut txn.frame_ops, Vec::new()),
                 replace(&mut txn.notifications, Vec::new()),
-                txn.build_frame,
                 txn.render_frame,
                 frame_counter,
                 profile_counters,
@@ -937,7 +932,6 @@ impl RenderBackend {
         resource_updates: Vec<ResourceUpdate>,
         mut frame_ops: Vec<FrameMsg>,
         mut notifications: Vec<NotificationRequest>,
-        mut build_frame: bool,
         mut render_frame: bool,
         frame_counter: &mut u32,
         profile_counters: &mut BackendProfileCounters,
@@ -950,7 +944,7 @@ impl RenderBackend {
         // fiddle with things after a potentially long scene build, but just
         // before rendering. This is useful for rendering with the latest
         // async transforms.
-        if build_frame {
+        if requested_frame {
             if let Some(ref sampler) = self.sampler {
                 frame_ops.append(&mut sampler.sample());
             }
@@ -964,7 +958,6 @@ impl RenderBackend {
         for frame_msg in frame_ops {
             let _timer = profile_counters.total_time.timer();
             let op = doc.process_frame_msg(frame_msg);
-            build_frame |= op.build_frame;
             scroll |= op.scroll;
         }
 
@@ -979,30 +972,23 @@ impl RenderBackend {
             &mut profile_counters.resources,
         );
 
-        // After applying the new scene we need to
-        // rebuild the hit-tester, so we trigger a frame generation
-        // step.
-        //
-        // TODO: We could avoid some the cost of building the frame by only
-        // building the information required for hit-testing (See #2807).
-        build_frame |= has_built_scene;
-
         if doc.dynamic_properties.flush_pending_updates() {
             doc.frame_is_valid = false;
             doc.hit_tester_is_valid = false;
-            build_frame = true;
         }
 
         if !doc.can_render() {
             // TODO: this happens if we are building the first scene asynchronously and
             // scroll at the same time. we should keep track of the fact that we skipped
             // composition here and do it as soon as we receive the scene.
-            build_frame = false;
             render_frame = false;
         }
 
-        if doc.frame_is_valid {
-            build_frame = false;
+        // Avoid re-building the frame if the current built frame is still valid.
+        let build_frame = render_frame && !doc.frame_is_valid;
+
+        if !doc.hit_tester_is_valid && !build_frame {
+            doc.rebuild_hit_tester();
         }
 
         let mut frame_build_time = None;

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -279,6 +279,21 @@ impl Document {
         }
     }
 
+    fn rebuild_hit_tester(&mut self) {
+        if let Some(ref mut frame_builder) = self.frame_builder {
+            let accumulated_scale_factor = self.view.accumulated_scale_factor();
+            let pan = self.view.pan.to_f32() / accumulated_scale_factor;
+
+            // TODO: do we need to do something with the transform palette?
+            let _palette = self.clip_scroll_tree.update_tree(
+                pan,
+                &self.dynamic_properties,
+            );
+
+            self.hit_tester = Some(frame_builder.create_hit_tester(&self.clip_scroll_tree));
+        }
+    }
+
     pub fn updated_pipeline_info(&mut self) -> PipelineInfo {
         let removed_pipelines = replace(&mut self.removed_pipelines, Vec::new());
         PipelineInfo {

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -33,7 +33,6 @@ pub struct Transaction {
     pub frame_ops: Vec<FrameMsg>,
     pub notifications: Vec<NotificationRequest>,
     pub set_root_pipeline: Option<PipelineId>,
-    pub build_frame: bool,
     pub render_frame: bool,
 }
 
@@ -66,7 +65,6 @@ pub struct BuiltTransaction {
     pub notifications: Vec<NotificationRequest>,
     pub scene_build_start_time: u64,
     pub scene_build_end_time: u64,
-    pub build_frame: bool,
     pub render_frame: bool,
 }
 
@@ -246,7 +244,6 @@ impl SceneBuilder {
 
             let txn = Box::new(BuiltTransaction {
                 document_id: item.document_id,
-                build_frame: true,
                 render_frame: item.build_frame,
                 built_scene,
                 resource_updates: Vec::new(),
@@ -334,7 +331,6 @@ impl SceneBuilder {
 
         Box::new(BuiltTransaction {
             document_id: txn.document_id,
-            build_frame: txn.build_frame || built_scene.is_some(),
             render_frame: txn.render_frame,
             built_scene,
             rasterized_blobs,


### PR DESCRIPTION
The first two commits take advantage of what was put in place in #3043 to avoid building the frame when all we need is the hit tester.
The next two commits pick some low hanging optimization fruits in the hit tester to paper over a few minor talos regressions from the first commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3052)
<!-- Reviewable:end -->
