### PR TITLE
border: Avoid generating empty segments.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -597,6 +597,11 @@ fn get_edge_info(
         return EdgeInfo::new(0.0, 0.0, 0.0);
     }
 
+    // No point on this. This can happen with huge radii, for example.
+    if avail_size <= 0.0 {
+        return EdgeInfo::new(0.0, 0.0, 0.0);
+    }
+
     match style {
         BorderStyle::Dashed => {
             // Basically, two times the dash size.
@@ -1124,11 +1129,11 @@ fn add_corner_segment(
         return;
     }
 
-    if widths.width <= 0.0 && widths.height <= 0.0 {
+    if side0.style.is_hidden() && side1.style.is_hidden() {
         return;
     }
 
-    if side0.style.is_hidden() && side1.style.is_hidden() {
+    if image_rect.size.width <= 0. || image_rect.size.height <= 0. {
         return;
     }
 
@@ -1163,6 +1168,10 @@ fn add_edge_segment(
     }
 
     if side.style.is_hidden() {
+        return;
+    }
+
+    if image_rect.size.width <= 0. || image_rect.size.height <= 0. {
         return;
     }
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -38,8 +38,8 @@ pub const MAX_BLUR_STD_DEVIATION: f32 = 4.0;
 pub const MIN_DOWNSCALING_RT_SIZE: i32 = 128;
 
 fn render_task_sanity_check(size: &DeviceIntSize) {
-    if size.width > RENDER_TASK_SIZE_SANITY_CHECK ||
-        size.height > RENDER_TASK_SIZE_SANITY_CHECK {
+    if size.width < 0 || size.width > RENDER_TASK_SIZE_SANITY_CHECK ||
+        size.height < 0 || size.height > RENDER_TASK_SIZE_SANITY_CHECK {
         error!("Attempting to create a render task of size {}x{}", size.width, size.height);
         panic!();
     }


### PR DESCRIPTION
This is a bit less invasive and should do the job.

I've confirmed that all the negative sizes came from edges, when a huge radii
with radius > rect.size - cw_border.width - ccw_border.width caused avail_width to be negative.

Still we're creating a gazillion empty borders which are useless, so prevent
that too by checking in add_edge_segment and add_corner_segment.

I've confirmed that this passes the reftests that are failing in #3049, but waiting for try just to double-check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3056)
<!-- Reviewable:end -->
