### PR TITLE
Tidy up the scene flattening interface.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -19,7 +19,7 @@ use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use std::{cmp, u32};
 use std::os::raw::c_void;
-use util::{extract_inner_rect_safe, pack_as_float, project_rect, recycle_vec, ScaleOffset};
+use util::{extract_inner_rect_safe, pack_as_float, project_rect, ScaleOffset};
 
 /*
 
@@ -346,16 +346,6 @@ impl ClipStore {
             clip_node_indices: Vec::new(),
             clip_node_info: Vec::new(),
             clip_node_collectors: Vec::new(),
-        }
-    }
-
-    pub fn recycle(self) -> Self {
-        ClipStore {
-            clip_nodes: recycle_vec(self.clip_nodes),
-            clip_chain_nodes: recycle_vec(self.clip_chain_nodes),
-            clip_node_indices: recycle_vec(self.clip_node_indices),
-            clip_node_info: recycle_vec(self.clip_node_info),
-            clip_node_collectors: recycle_vec(self.clip_node_collectors),
         }
     }
 

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -58,7 +58,6 @@ pub struct FrameBuilder {
     background_color: Option<ColorF>,
     window_size: DeviceUintSize,
     scene_id: u64,
-    pub next_picture_id: u64,
     pub prim_store: PrimitiveStore,
     pub clip_store: ClipStore,
     pub hit_testing_runs: Vec<HitTestingRun>,
@@ -128,6 +127,7 @@ impl<'a> PrimitiveContext<'a> {
 }
 
 impl FrameBuilder {
+    #[cfg(feature = "replay")]
     pub fn empty() -> Self {
         FrameBuilder {
             hit_testing_runs: Vec::new(),
@@ -138,7 +138,6 @@ impl FrameBuilder {
             window_size: DeviceUintSize::zero(),
             background_color: None,
             scene_id: 0,
-            next_picture_id: 0,
             config: FrameBuilderConfig {
                 enable_scrollbars: false,
                 default_font_render_mode: FontRenderMode::Mono,
@@ -166,7 +165,6 @@ impl FrameBuilder {
             window_size,
             scene_id,
             config: flattener.config,
-            next_picture_id: flattener.next_picture_id,
         }
     }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -78,6 +78,29 @@ pub enum PictureSurface {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PictureId(pub u64);
 
+// TODO(gw): Having to generate globally unique picture
+//           ids for caching is not ideal. We should be
+//           able to completely remove this once we cache
+//           pictures based on their content, rather than
+//           the current cache key structure.
+pub struct PictureIdGenerator {
+    next: u64,
+}
+
+impl PictureIdGenerator {
+    pub fn new() -> Self {
+        PictureIdGenerator {
+            next: 0,
+        }
+    }
+
+    pub fn next(&mut self) -> PictureId {
+        let id = PictureId(self.next);
+        self.next += 1;
+        id
+    }
+}
+
 // Cache key that determines whether a pre-existing
 // picture in the texture cache matches the content
 // of the current picture.

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -30,7 +30,7 @@ use resource_cache::{ImageProperties, ImageRequest, ResourceCache};
 use scene::SceneProperties;
 use segment::SegmentBuilder;
 use std::{cmp, fmt, mem, usize};
-use util::{ScaleOffset, MatrixHelpers, pack_as_float, recycle_vec, project_rect, raster_rect_to_device_pixels};
+use util::{ScaleOffset, MatrixHelpers, pack_as_float, project_rect, raster_rect_to_device_pixels};
 
 
 const MIN_BRUSH_SPLIT_AREA: f32 = 256.0 * 256.0;
@@ -1383,13 +1383,6 @@ impl PrimitiveStore {
         PrimitiveStore {
             primitives: Vec::new(),
             chase_id: None,
-        }
-    }
-
-    pub fn recycle(self) -> Self {
-        PrimitiveStore {
-            primitives: recycle_vec(self.primitives),
-            chase_id: self.chase_id,
         }
     }
 

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -10,6 +10,7 @@ use frame_builder::{FrameBuilderConfig, FrameBuilder};
 use clip_scroll_tree::ClipScrollTree;
 use display_list_flattener::DisplayListFlattener;
 use internal_types::{FastHashMap, FastHashSet};
+use picture::PictureIdGenerator;
 use resource_cache::FontInstanceMap;
 use render_backend::DocumentView;
 use renderer::{PipelineInfo, SceneBuilderHooks};
@@ -139,6 +140,7 @@ pub struct SceneBuilder {
     api_tx: MsgSender<ApiMsg>,
     config: FrameBuilderConfig,
     hooks: Option<Box<SceneBuilderHooks + Send>>,
+    picture_id_generator: PictureIdGenerator,
 }
 
 impl SceneBuilder {
@@ -157,6 +159,7 @@ impl SceneBuilder {
                 api_tx,
                 config,
                 hooks,
+                picture_id_generator: PictureIdGenerator::new(),
             },
             in_tx,
             out_rx,
@@ -224,7 +227,6 @@ impl SceneBuilder {
                 let mut new_scene = Scene::new();
 
                 let frame_builder = DisplayListFlattener::create_frame_builder(
-                    FrameBuilder::empty(),
                     &item.scene,
                     &mut clip_scroll_tree,
                     item.font_instances,
@@ -233,6 +235,7 @@ impl SceneBuilder {
                     &self.config,
                     &mut new_scene,
                     item.scene_id,
+                    &mut self.picture_id_generator,
                 );
 
                 built_scene = Some(BuiltScene {
@@ -300,7 +303,6 @@ impl SceneBuilder {
                 let mut new_scene = Scene::new();
 
                 let frame_builder = DisplayListFlattener::create_frame_builder(
-                    FrameBuilder::empty(),
                     &scene,
                     &mut clip_scroll_tree,
                     request.font_instances,
@@ -309,6 +311,7 @@ impl SceneBuilder {
                     &self.config,
                     &mut new_scene,
                     request.scene_id,
+                    &mut self.picture_id_generator,
                 );
 
                 built_scene = Some(BuiltScene {

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -376,22 +376,6 @@ pub fn extract_inner_rect_safe<U>(
     extract_inner_rect_impl(rect, radii, 1.0)
 }
 
-/// Consumes the old vector and returns a new one that may reuse the old vector's allocated
-/// memory.
-pub fn recycle_vec<T>(mut old_vec: Vec<T>) -> Vec<T> {
-    if old_vec.capacity() > 2 * old_vec.len() {
-        // Avoid reusing the buffer if it is a lot larger than it needs to be. This prevents
-        // a frame with exceptionally large allocations to cause subsequent frames to retain
-        // more memory than they need.
-        return Vec::with_capacity(old_vec.len());
-    }
-
-    old_vec.clear();
-
-    old_vec
-}
-
-
 #[cfg(test)]
 pub mod test {
     use super::*;


### PR DESCRIPTION
Now that display list flattening is always done by the scene
building thread, there is never a valid old frame builder
that can be recycled. Update the interface to make this
clearer.

Also slightly tidy up how picture ids are generated. This is
a temporary hack only - they won't be needed once we are
caching pictures based on their content.

This also removes the last current use or recycle_vec and
associated methods. I've removed them for now to avoid
warnings, but hopefully in the future we can find a way
to use these again in some places to avoid so many allocations
per frame!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3059)
<!-- Reviewable:end -->
