### PR TITLE
Only use serde when feature="serialize | deserialize" are active

### DIFF
--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -9,8 +9,8 @@ description = "Public API for WebRender"
 [features]
 nightly = ["euclid/unstable", "serde/unstable"]
 ipc = ["ipc-channel"]
-serialize = []
-deserialize = []
+serialize = ["serde", "serde_derive", "serde_bytes", "euclid/serde"]
+deserialize = ["serde", "serde_derive", "serde_bytes", "euclid/serde"]
 
 [dependencies]
 app_units = "0.7"
@@ -18,10 +18,10 @@ bincode = "1.0"
 bitflags = "1.0"
 byteorder = "1.2.1"
 ipc-channel = {version = "0.11.0", optional = true}
-euclid = { version = "0.19", features = ["serde"] }
-serde = { version = "=1.0.66", features = ["rc"] }
-serde_derive = { version = "=1.0.66", features = ["deserialize_in_place"] }
-serde_bytes = "0.10"
+euclid = { version = "0.19", default-features = false }
+serde = { version = "=1.0.66", features = ["rc"], optional = true }
+serde_derive = { version = "=1.0.66", features = ["deserialize_in_place"], optional = true  }
+serde_bytes = { version = "0.10", optional = true }
 time = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Since #[derive(Serialize, Deserialize)] are already behind these feature flags, there isn't much to do, it's simply unnecessary to require serde when neither serialize or deserialize features are active.

Together with https://github.com/servo/app_units/pull/44, this will eliminate serde from webrender entirely in `--no-default-features` builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3060)
<!-- Reviewable:end -->
