### PR TITLE
Prep work for retaining clip nodes in GPU cache between display lists.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1777,10 +1777,10 @@ impl ClipBatcher {
         transforms: &mut TransformPalette,
     ) {
         for i in 0 .. clip_node_range.count {
-            let (clip_node, flags) = clip_store.get_node_from_range(&clip_node_range, i);
+            let (clip_node, flags, spatial_node_index) = clip_store.get_node_from_range(&clip_node_range, i);
 
             let clip_transform_id = transforms.get_id(
-                clip_node.spatial_node_index,
+                spatial_node_index,
                 ROOT_SPATIAL_NODE_INDEX,
                 clip_scroll_tree,
             );

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -107,7 +107,6 @@ enum ClipResult {
 // that control where the GPU data for this clip source
 // can be found.
 pub struct ClipNode {
-    pub spatial_node_index: SpatialNodeIndex,
     pub item: ClipItem,
     pub gpu_cache_handle: GpuCacheHandle,
 }
@@ -123,7 +122,7 @@ bitflags! {
 // Identifier for a clip chain. Clip chains are stored
 // in a contiguous array in the clip store. They are
 // identified by a simple index into that array.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct ClipChainId(pub u32);
 
 // The root of each clip chain is the NONE id. The
@@ -139,6 +138,7 @@ impl ClipChainId {
 #[derive(Clone)]
 pub struct ClipChainNode {
     pub clip_node_index: ClipNodeIndex,
+    pub spatial_node_index: SpatialNodeIndex,
     pub parent_clip_chain_id: ClipChainId,
 }
 
@@ -157,21 +157,29 @@ pub struct ClipNodeIndex(pub u32);
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct ClipNodeInstance(pub u32);
+pub struct ClipNodeInstance {
+    index_and_flags: u32,
+    spatial_node_index: u32,
+}
 
 impl ClipNodeInstance {
-    fn new(index: ClipNodeIndex, flags: ClipNodeFlags) -> ClipNodeInstance {
-        ClipNodeInstance(
-            (index.0 & 0x00ffffff) | ((flags.bits() as u32) << 24)
-        )
+    fn new(
+        index: ClipNodeIndex,
+        flags: ClipNodeFlags,
+        spatial_node_index: SpatialNodeIndex,
+    ) -> ClipNodeInstance {
+        ClipNodeInstance {
+            index_and_flags: (index.0 & 0x00ffffff) | ((flags.bits() as u32) << 24),
+            spatial_node_index: spatial_node_index.0 as u32,
+        }
     }
 
     fn flags(&self) -> ClipNodeFlags {
-        ClipNodeFlags::from_bits_truncate((self.0 >> 24) as u8)
+        ClipNodeFlags::from_bits_truncate((self.index_and_flags >> 24) as u8)
     }
 
     fn index(&self) -> usize {
-        (self.0 & 0x00ffffff) as usize
+        (self.index_and_flags & 0x00ffffff) as usize
     }
 }
 
@@ -202,6 +210,7 @@ enum ClipSpaceConversion {
 struct ClipNodeInfo {
     conversion: ClipSpaceConversion,
     node_index: ClipNodeIndex,
+    spatial_node_index: SpatialNodeIndex,
     has_non_root_coord_system: bool,
 }
 
@@ -344,42 +353,16 @@ impl ClipStore {
         &self.clip_chain_nodes[clip_chain_id.0 as usize]
     }
 
-/*
-    pub fn add_clip_items(
-        &mut self,
-        clip_items: Vec<ClipItem>,
-        spatial_node_index: SpatialNodeIndex,
-    ) -> ClipItemRange {
-        debug_assert!(!clip_items.is_empty());
-
-        let range = ClipItemRange {
-            index: ClipNodeIndex(self.clip_nodes.len() as u32),
-            count: clip_items.len() as u32,
-        };
-
-        let nodes = clip_items
-            .into_iter()
-            .map(|item| {
-                ClipNode {
-                    item,
-                    spatial_node_index,
-                    gpu_cache_handle: GpuCacheHandle::new(),
-                }
-            });
-
-        self.clip_nodes.extend(nodes);
-        range
-    }
-*/
-
     pub fn add_clip_chain_node_index(
         &mut self,
         clip_node_index: ClipNodeIndex,
+        spatial_node_index: SpatialNodeIndex,
         parent_clip_chain_id: ClipChainId,
     ) -> ClipChainId {
         let id = ClipChainId(self.clip_chain_nodes.len() as u32);
         self.clip_chain_nodes.push(ClipChainNode {
             clip_node_index,
+            spatial_node_index,
             parent_clip_chain_id,
         });
         id
@@ -394,12 +377,12 @@ impl ClipStore {
         let clip_node_index = ClipNodeIndex(self.clip_nodes.len() as u32);
         self.clip_nodes.push(ClipNode {
             item,
-            spatial_node_index,
             gpu_cache_handle: GpuCacheHandle::new(),
         });
 
         self.add_clip_chain_node_index(
             clip_node_index,
+            spatial_node_index,
             parent_clip_chain_id,
         )
     }
@@ -408,9 +391,13 @@ impl ClipStore {
         &self,
         node_range: &ClipNodeRange,
         index: u32,
-    ) -> (&ClipNode, ClipNodeFlags) {
+    ) -> (&ClipNode, ClipNodeFlags, SpatialNodeIndex) {
         let instance = self.clip_node_indices[(node_range.first + index) as usize];
-        (&self.clip_nodes[instance.index()], instance.flags())
+        (
+            &self.clip_nodes[instance.index()],
+            instance.flags(),
+            SpatialNodeIndex(instance.spatial_node_index as usize),
+        )
     }
 
     pub fn get_node_from_range_mut(
@@ -469,19 +456,19 @@ impl ClipStore {
         // for each clip chain node
         while current_clip_chain_id != ClipChainId::NONE {
             let clip_chain_node = &self.clip_chain_nodes[current_clip_chain_id.0 as usize];
-            let clip_node = &self.clip_nodes[clip_chain_node.clip_node_index.0 as usize];
 
             // Check if any clip node index should actually be
             // handled during compositing of a rasterization root.
             match self.clip_node_collectors.iter_mut().find(|c| {
-                clip_node.spatial_node_index < c.raster_root
+                clip_chain_node.spatial_node_index < c.raster_root
             }) {
                 Some(collector) => {
-                    collector.insert(clip_chain_node.clip_node_index);
+                    collector.insert(current_clip_chain_id);
                 }
                 None => {
                     if !add_clip_node_to_current_chain(
                         clip_chain_node.clip_node_index,
+                        clip_chain_node.spatial_node_index,
                         spatial_node_index,
                         &mut local_clip_rect,
                         &mut self.clip_node_info,
@@ -499,9 +486,15 @@ impl ClipStore {
         // Add any collected clips from primitives that should be
         // handled as part of this rasterization root.
         if let Some(clip_node_collector) = clip_node_collector {
-            for clip_node_index in &clip_node_collector.clips {
+            for clip_chain_id in &clip_node_collector.clips {
+                let (clip_node_index, clip_spatial_node_index) = {
+                    let clip_chain_node = &self.clip_chain_nodes[clip_chain_id.0 as usize];
+                    (clip_chain_node.clip_node_index, clip_chain_node.spatial_node_index)
+                };
+
                 if !add_clip_node_to_current_chain(
-                    *clip_node_index,
+                    clip_node_index,
+                    clip_spatial_node_index,
                     spatial_node_index,
                     &mut local_clip_rect,
                     &mut self.clip_node_info,
@@ -603,8 +596,12 @@ impl ClipStore {
                     };
 
                     // Store this in the index buffer for this clip chain instance.
-                    self.clip_node_indices
-                        .push(ClipNodeInstance::new(node_info.node_index, flags));
+                    let instance = ClipNodeInstance::new(
+                        node_info.node_index,
+                        flags,
+                        node_info.spatial_node_index,
+                    );
+                    self.clip_node_indices.push(instance);
 
                     has_non_root_coord_system |= node_info.has_non_root_coord_system;
                 }
@@ -1125,7 +1122,7 @@ pub fn project_inner_rect(
 #[derive(Debug)]
 pub struct ClipNodeCollector {
     raster_root: SpatialNodeIndex,
-    clips: FastHashSet<ClipNodeIndex>,
+    clips: FastHashSet<ClipChainId>,
 }
 
 impl ClipNodeCollector {
@@ -1140,9 +1137,9 @@ impl ClipNodeCollector {
 
     pub fn insert(
         &mut self,
-        clip_node_index: ClipNodeIndex,
+        clip_chain_id: ClipChainId,
     ) {
-        self.clips.insert(clip_node_index);
+        self.clips.insert(clip_chain_id);
     }
 }
 
@@ -1151,6 +1148,7 @@ impl ClipNodeCollector {
 // results in the entire primitive being culled out.
 fn add_clip_node_to_current_chain(
     clip_node_index: ClipNodeIndex,
+    clip_spatial_node_index: SpatialNodeIndex,
     spatial_node_index: SpatialNodeIndex,
     local_clip_rect: &mut LayoutRect,
     clip_node_info: &mut Vec<ClipNodeInfo>,
@@ -1158,12 +1156,12 @@ fn add_clip_node_to_current_chain(
     clip_scroll_tree: &ClipScrollTree,
 ) -> bool {
     let clip_node = &clip_nodes[clip_node_index.0 as usize];
-    let clip_spatial_node = &clip_scroll_tree.spatial_nodes[clip_node.spatial_node_index.0 as usize];
+    let clip_spatial_node = &clip_scroll_tree.spatial_nodes[clip_spatial_node_index.0];
     let ref_spatial_node = &clip_scroll_tree.spatial_nodes[spatial_node_index.0];
 
     // Determine the most efficient way to convert between coordinate
     // systems of the primitive and clip node.
-    let conversion = if spatial_node_index == clip_node.spatial_node_index {
+    let conversion = if spatial_node_index == clip_spatial_node_index {
         Some(ClipSpaceConversion::Local)
     } else if ref_spatial_node.coordinate_system_id == clip_spatial_node.coordinate_system_id {
         let scale_offset = ref_spatial_node
@@ -1174,7 +1172,7 @@ fn add_clip_node_to_current_chain(
         Some(ClipSpaceConversion::ScaleOffset(scale_offset))
     } else {
         let xf = clip_scroll_tree.get_relative_transform(
-            clip_node.spatial_node_index,
+            clip_spatial_node_index,
             ROOT_SPATIAL_NODE_INDEX,
         );
 
@@ -1217,6 +1215,7 @@ fn add_clip_node_to_current_chain(
         clip_node_info.push(ClipNodeInfo {
             conversion,
             node_index: clip_node_index,
+            spatial_node_index: clip_spatial_node_index,
             has_non_root_coord_system: clip_spatial_node.coordinate_system_id != CoordinateSystemId::root(),
         })
     }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -684,16 +684,21 @@ impl<'a> DisplayListFlattener<'a> {
                         .id_to_index_mapper
                         .get_clip_chain_id(&item);
                     // Get the id of the clip sources entry for that clip chain node.
-                    let clip_node_index = self
-                        .clip_store
-                        .get_clip_chain(item_clip_chain_id)
-                        .clip_node_index;
+                    let (clip_node_index, spatial_node_index) = {
+                        let clip_chain = self
+                            .clip_store
+                            .get_clip_chain(item_clip_chain_id);
+
+                        (clip_chain.clip_node_index, clip_chain.spatial_node_index)
+                    };
+
                     // Add a new clip chain node, which references the same clip sources, and
                     // parent it to the current parent.
                     clip_chain_id = self
                         .clip_store
                         .add_clip_chain_node_index(
                             clip_node_index,
+                            spatial_node_index,
                             parent_clip_chain_id,
                         );
                     // For the next clip node, use this new clip chain node as the parent,

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -27,9 +27,6 @@ pub struct HitTestSpatialNode {
 }
 
 pub struct HitTestClipNode {
-    /// The positioning node for this clip node.
-    spatial_node: SpatialNodeIndex,
-
     /// A particular point must be inside all of these regions to be considered clipped in
     /// for the purposes of a hit test.
     region: HitTestRegion,
@@ -47,7 +44,6 @@ impl HitTestClipNode {
         };
 
         HitTestClipNode {
-            spatial_node: node.spatial_node_index,
             region,
         }
     }
@@ -179,7 +175,12 @@ impl HitTester {
             return false;
         }
 
-        if !self.is_point_clipped_in_for_clip_node(point, descriptor.clip_node_index, test) {
+        if !self.is_point_clipped_in_for_clip_node(
+            point,
+            descriptor.clip_node_index,
+            descriptor.spatial_node_index,
+            test,
+        ) {
             test.set_in_clip_chain_cache(clip_chain_id, ClippedIn::NotClippedIn);
             return false;
         }
@@ -192,6 +193,7 @@ impl HitTester {
         &self,
         point: WorldPoint,
         node_index: ClipNodeIndex,
+        spatial_node_index: SpatialNodeIndex,
         test: &mut HitTest
     ) -> bool {
         if let Some(clipped_in) = test.node_cache.get(&node_index) {
@@ -200,7 +202,7 @@ impl HitTester {
 
         let node = &self.clip_nodes[node_index.0 as usize];
         let transform = self
-            .spatial_nodes[node.spatial_node.0 as usize]
+            .spatial_nodes[spatial_node_index.0]
             .world_viewport_transform;
         let transformed_point = match transform
             .inverse()

--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -179,12 +179,9 @@ impl HitTester {
             return false;
         }
 
-        for i in 0 .. descriptor.clip_item_range.count {
-            let clip_node_index = ClipNodeIndex(descriptor.clip_item_range.index.0 + i);
-            if !self.is_point_clipped_in_for_clip_node(point, clip_node_index, test) {
-                test.set_in_clip_chain_cache(clip_chain_id, ClippedIn::NotClippedIn);
-                return false;
-            }
+        if !self.is_point_clipped_in_for_clip_node(point, descriptor.clip_node_index, test) {
+            test.set_in_clip_chain_cache(clip_chain_id, ClippedIn::NotClippedIn);
+            return false;
         }
 
         test.set_in_clip_chain_cache(clip_chain_id, ClippedIn::ClippedIn);

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2073,7 +2073,9 @@ fn write_brush_segment_description(
     // Segment the primitive on all the local-space clip sources that we can.
     let mut local_clip_count = 0;
     for i in 0 .. clip_chain.clips_range.count {
-        let (clip_node, flags) = frame_state.clip_store.get_node_from_range(&clip_chain.clips_range, i);
+        let (clip_node, flags, _) = frame_state
+            .clip_store
+            .get_node_from_range(&clip_chain.clips_range, i);
 
         // If this clip item is positioned by another positioning node, its relative position
         // could change during scrolling. This means that we would need to resegment. Instead


### PR DESCRIPTION
This will also allow us to quickly check clip nodes for equality (part of picture caching work) in the future.

Commit notes:

```
Remove clip item range.

Instead, there is a single clip node index stored in each clip
chain node. This makes the clip chain nodes slightly longer in
some use cases (most clip nodes only contain a single clip).
```

```
Store the spatial node index in the clip chain node.

This means the ClipNode is independent of positioning, which
makes it simple to retain in the GPU cache between frames and
display lists.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3064)
<!-- Reviewable:end -->
