### PR TITLE
Add debug commands to simulate slow scene building.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -817,6 +817,16 @@ impl RenderBackend {
                         self.resource_cache.clear(mask);
                         return true;
                     }
+                    DebugCommand::SimulateLongSceneBuild(time_ms) => {
+                        self.scene_tx.send(SceneBuilderRequest::SimulateLongSceneBuild(time_ms)).unwrap();
+                        return true;
+                    }
+                    DebugCommand::SimulateLongLowPrioritySceneBuild(time_ms) => {
+                        self.low_priority_scene_tx.send(
+                            SceneBuilderRequest::SimulateLongLowPrioritySceneBuild(time_ms)
+                        ).unwrap();
+                        return true;
+                    }
                     _ => ResultMsg::DebugCommand(option),
                 };
                 self.result_tx.send(msg).unwrap();

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1710,6 +1710,7 @@ impl Renderer {
             let lp_builder = LowPrioritySceneBuilder {
                 rx: low_priority_scene_rx,
                 tx: scene_tx.clone(),
+                simulate_slow_ms: 0,
             };
 
             thread::Builder::new().name(lp_scene_thread_name.clone()).spawn(move || {
@@ -2186,7 +2187,9 @@ impl Renderer {
             DebugCommand::LoadCapture(..) => {
                 panic!("Capture commands are not welcome here! Did you build with 'capture' feature?")
             }
-            DebugCommand::ClearCaches(_) => {}
+            DebugCommand::ClearCaches(_)
+            | DebugCommand::SimulateLongSceneBuild(_)
+            | DebugCommand::SimulateLongLowPrioritySceneBuild(_) => {}
             DebugCommand::InvalidateGpuCache => {
                 match self.gpu_cache_texture.bus {
                     CacheBus::PixelBuffer { ref mut rows, .. } => {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -638,6 +638,12 @@ pub enum DebugCommand {
     ClearCaches(ClearCache),
     /// Invalidate GPU cache, forcing the update from the CPU mirror.
     InvalidateGpuCache,
+    /// Causes the scene builder to pause for a given amount of miliseconds each time it
+    /// processes a transaction.
+    SimulateLongSceneBuild(u32),
+    /// Causes the low priority scene builder to pause for a given amount of miliseconds
+    /// each time it processes a transaction.
+    SimulateLongLowPrioritySceneBuild(u32),
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
I found a race condition that was only reliably reproducible by artificially slowing down scene building. Adding this to the debug commands to make it easier in the future. It would be useful to follow up with debug options to simulate slow frame builds and slow rendering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3066)
<!-- Reviewable:end -->
