### PR TITLE
GPU cache debug visualization

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -232,6 +232,15 @@ pub fn main_wrapper<E: Example>(
                 winit::VirtualKeyCode::Q => renderer.toggle_debug_flags(
                     webrender::DebugFlags::GPU_TIME_QUERIES | webrender::DebugFlags::GPU_SAMPLE_QUERIES
                 ),
+                winit::VirtualKeyCode::F => renderer.toggle_debug_flags(
+                    webrender::DebugFlags::NEW_FRAME_INDICATOR | webrender::DebugFlags::NEW_SCENE_INDICATOR
+                ),
+                winit::VirtualKeyCode::G => api.send_debug_cmd(
+                    // go through the API so that we reach the render backend
+                    DebugCommand::EnableGpuCacheDebug(
+                        !renderer.get_debug_flags().contains(webrender::DebugFlags::GPU_CACHE_DBG)
+                    ),
+                ),
                 winit::VirtualKeyCode::Key1 => txn.set_window_parameters(
                     framebuffer_size,
                     DeviceUintRect::new(DeviceUintPoint::zero(), framebuffer_size),

--- a/webrender/src/gpu_cache.rs
+++ b/webrender/src/gpu_cache.rs
@@ -232,6 +232,13 @@ pub enum GpuCacheUpdate {
     },
 }
 
+pub struct GpuDebugChunk {
+    pub address: GpuCacheAddress,
+    pub fresh: bool,
+    pub tag: u8,
+    pub size: u16,
+}
+
 #[must_use]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
@@ -246,6 +253,9 @@ pub struct GpuCacheUpdateList {
     /// A flat list of GPU blocks that are pending upload
     /// to GPU memory.
     pub blocks: Vec<GpuBlockData>,
+    /// Whole state GPU block metadata for debugging.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub debug_chunks: Vec<GpuDebugChunk>,
 }
 
 // Holds the free lists of fixed size blocks. Mostly
@@ -535,6 +545,9 @@ pub struct GpuCache {
     /// Number of blocks requested this frame that don't
     /// need to be re-uploaded.
     saved_block_count: usize,
+    /// True if the Renderer expects to receive the metadata
+    /// about GPU blocks with on each update.
+    in_debug: bool,
 }
 
 impl GpuCache {
@@ -543,6 +556,7 @@ impl GpuCache {
             frame_id: FrameId::new(0),
             texture: Texture::new(),
             saved_block_count: 0,
+            in_debug: false,
         }
     }
 
@@ -643,9 +657,29 @@ impl GpuCache {
         GpuCacheUpdateList {
             frame_id: self.frame_id,
             height: self.texture.height,
+            debug_chunks: if self.in_debug {
+                self.texture.updates
+                    .iter()
+                    .map(|update| match *update {
+                        GpuCacheUpdate::Copy { address, block_index, block_count } => GpuDebugChunk {
+                            address,
+                            fresh: self.frame_id == self.texture.blocks[block_index].last_access_time,
+                            tag: 0, //TODO
+                            size: block_count.min(0xFFFF) as u16,
+                        }
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            },
             updates: mem::replace(&mut self.texture.updates, Vec::new()),
             blocks: mem::replace(&mut self.texture.pending_blocks, Vec::new()),
         }
+    }
+
+    /// Enable GPU block debugging.
+    pub fn set_debug(&mut self, enable: bool) {
+        self.in_debug = enable;
     }
 
     /// Get the actual GPU address in the texture for a given slot ID.

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -757,6 +757,10 @@ impl RenderBackend {
                         // We don't want to forward this message to the renderer.
                         return true;
                     }
+                    DebugCommand::EnableGpuCacheDebug(enable) => {
+                        self.gpu_cache.set_debug(enable);
+                        ResultMsg::DebugCommand(option)
+                    }
                     DebugCommand::FetchDocuments => {
                         let json = self.get_docs_for_debugger();
                         ResultMsg::DebugOutput(DebugOutput::FetchDocuments(json))

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -27,11 +27,15 @@ use device::{ExternalTexture, FBOId, TextureSlot};
 use device::{FileWatcherHandler, ShaderError, TextureFilter,
              VertexUsageHint, VAO, VBO, CustomVAO};
 use device::{ProgramCache, ReadPixelsFormat};
-use euclid::{rect, Transform3D};
+#[cfg(feature = "debug_renderer")]
+use euclid::rect;
+use euclid::Transform3D;
 use frame_builder::{ChasePrimitive, FrameBuilderConfig};
 use gleam::gl;
 use glyph_rasterizer::{GlyphFormat, GlyphRasterizer};
 use gpu_cache::{GpuBlockData, GpuCacheUpdate, GpuCacheUpdateList};
+#[cfg(feature = "debug_renderer")]
+use gpu_cache::GpuDebugChunk;
 #[cfg(feature = "pathfinder")]
 use gpu_glyph_renderer::GpuGlyphRenderer;
 use internal_types::{SourceTexture, ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE, ResourceCacheError};
@@ -227,6 +231,7 @@ bitflags! {
         const NEW_FRAME_INDICATOR   = 1 << 9;
         const NEW_SCENE_INDICATOR   = 1 << 10;
         const SHOW_OVERDRAW         = 1 << 11;
+        const GPU_CACHE_DBG         = 1 << 12;
     }
 }
 
@@ -242,7 +247,6 @@ fn flag_changed(before: DebugFlags, after: DebugFlags, select: DebugFlags) -> Op
 #[derive(Copy, Clone, Debug)]
 pub enum ShaderColorMode {
     FromRenderPassMode = 0,
-
     Alpha = 1,
     SubpixelConstantTextColor = 2,
     SubpixelWithBgColorPass0 = 3,
@@ -1359,6 +1363,8 @@ pub struct Renderer {
     transforms_texture: VertexDataTexture,
     render_task_texture: VertexDataTexture,
     gpu_cache_texture: CacheTexture,
+    #[cfg(feature = "debug_renderer")]
+    gpu_cache_debug_chunks: Vec<GpuDebugChunk>,
 
     gpu_cache_frame_id: FrameId,
     gpu_cache_overflow: bool,
@@ -1816,6 +1822,8 @@ impl Renderer {
             cpu_profiles: VecDeque::new(),
             gpu_profiles: VecDeque::new(),
             gpu_cache_texture,
+            #[cfg(feature = "debug_renderer")]
+            gpu_cache_debug_chunks: Vec::new(),
             gpu_cache_frame_id: FrameId::new(0),
             gpu_cache_overflow: false,
             texture_cache_upload_pbo,
@@ -1914,7 +1922,11 @@ impl Renderer {
                     self.pending_texture_updates.push(texture_update_list);
                     self.backend_profile_counters = profile_counters;
                 }
-                ResultMsg::UpdateGpuCache(list) => {
+                ResultMsg::UpdateGpuCache(mut list) => {
+                    #[cfg(feature = "debug_renderer")]
+                    {
+                        self.gpu_cache_debug_chunks = mem::replace(&mut list.debug_chunks, Vec::new());
+                    }
                     self.pending_gpu_cache_updates.push(list);
                 }
                 ResultMsg::UpdateResources {
@@ -2149,6 +2161,9 @@ impl Renderer {
             }
             DebugCommand::EnableRenderTargetDebug(enable) => {
                 self.set_debug_flag(DebugFlags::RENDER_TARGET_DBG, enable);
+            }
+            DebugCommand::EnableGpuCacheDebug(enable) => {
+                self.set_debug_flag(DebugFlags::GPU_CACHE_DBG, enable);
             }
             DebugCommand::EnableGpuTimeQueries(enable) => {
                 self.set_debug_flag(DebugFlags::GPU_TIME_QUERIES, enable);
@@ -2477,6 +2492,7 @@ impl Renderer {
                 height: gpu_cache_height,
                 blocks: vec![[1f32; 4].into()],
                 updates: Vec::new(),
+                debug_chunks: Vec::new(),
             });
         }
 
@@ -3457,6 +3473,7 @@ impl Renderer {
             height: self.gpu_cache_texture.get_height(),
             blocks: Vec::new(),
             updates: Vec::new(),
+            debug_chunks: Vec::new(),
         };
 
         for deferred_resolve in deferred_resolves {
@@ -3787,13 +3804,16 @@ impl Renderer {
         }
 
         self.texture_resolver.end_frame();
-        if let Some(framebuffer_size) = framebuffer_size {
-            self.draw_render_target_debug(framebuffer_size);
-            self.draw_texture_cache_debug(framebuffer_size);
-        }
 
         #[cfg(feature = "debug_renderer")]
-        self.draw_epoch_debug();
+        {
+            if let Some(framebuffer_size) = framebuffer_size {
+                self.draw_render_target_debug(framebuffer_size);
+                self.draw_texture_cache_debug(framebuffer_size);
+                self.draw_gpu_cache_debug(framebuffer_size);
+            }
+            self.draw_epoch_debug();
+        }
 
         // Garbage collect any frame outputs that weren't used this frame.
         let device = &mut self.device;
@@ -3852,6 +3872,7 @@ impl Renderer {
         write_profile(filename);
     }
 
+    #[cfg(feature = "debug_renderer")]
     fn draw_render_target_debug(&mut self, framebuffer_size: DeviceUintSize) {
         if !self.debug_flags.contains(DebugFlags::RENDER_TARGET_DBG) {
             return;
@@ -3890,6 +3911,7 @@ impl Renderer {
         }
     }
 
+    #[cfg(feature = "debug_renderer")]
     fn draw_texture_cache_debug(&mut self, framebuffer_size: DeviceUintSize) {
         if !self.debug_flags.contains(DebugFlags::TEXTURE_CACHE_DBG) {
             return;
@@ -3949,7 +3971,7 @@ impl Renderer {
 
         let debug_renderer = match self.debug.get_mut(&mut self.device) {
             Some(render) => render,
-            None => { return; }
+            None => return,
         };
 
         let dy = debug_renderer.line_height();
@@ -3976,6 +3998,44 @@ impl Renderer {
             ColorU::new(25, 25, 25, 200),
             ColorU::new(51, 51, 51, 200),
         );
+    }
+
+    #[cfg(feature = "debug_renderer")]
+    fn draw_gpu_cache_debug(&mut self, framebuffer_size: DeviceUintSize) {
+        if !self.debug_flags.contains(DebugFlags::GPU_CACHE_DBG) {
+            return;
+        }
+
+        let debug_renderer = match self.debug.get_mut(&mut self.device) {
+            Some(render) => render,
+            None => return,
+        };
+
+        let (x_off, y_off) = (30f32, 30f32);
+        //let x_end = framebuffer_size.width as f32 - x_off;
+        let y_end = framebuffer_size.height as f32 - y_off;
+        debug_renderer.add_quad(
+            x_off,
+            y_off,
+            x_off + MAX_VERTEX_TEXTURE_WIDTH as f32,
+            y_end,
+            ColorU::new(80, 80, 80, 80),
+            ColorU::new(80, 80, 80, 80),
+        );
+
+        for chunk in &self.gpu_cache_debug_chunks {
+            let color = match chunk.tag {
+                _ => ColorU::new(250, 0, 0, 200),
+            };
+            debug_renderer.add_quad(
+                x_off + chunk.address.u as f32,
+                y_off + chunk.address.v as f32,
+                x_off + chunk.address.u as f32 + chunk.size as f32,
+                y_off + chunk.address.v as f32 + 1.0,
+                color,
+                color,
+            );
+        }
     }
 
     /// Pass-through to `Device::read_pixels_into`, used by Gecko's WR bindings.

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -608,6 +608,8 @@ pub enum DebugCommand {
     EnableTextureCacheDebug(bool),
     /// Display intermediate render targets on screen.
     EnableRenderTargetDebug(bool),
+    /// Display the contents of GPU cache.
+    EnableGpuCacheDebug(bool),
     /// Display GPU timing results.
     EnableGpuTimeQueries(bool),
     /// Display GPU overdraw results

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -622,6 +622,18 @@ fn render<'a>(
                         wrench.renderer.toggle_debug_flags(DebugFlags::SHOW_OVERDRAW);
                         do_render = true;
                     }
+                    VirtualKeyCode::G => {
+                        // go through the API so that we reach the render backend
+                        wrench.api.send_debug_cmd(DebugCommand::EnableGpuCacheDebug(
+                            !wrench.renderer.get_debug_flags().contains(webrender::DebugFlags::GPU_CACHE_DBG)
+                        ));
+                        // force scene rebuild to see the full set of used GPU cache entries
+                        let mut txn = Transaction::new();
+                        txn.set_root_pipeline(wrench.root_pipeline_id);
+                        wrench.api.send_transaction(wrench.document_id, txn);
+
+                        do_frame = true;
+                    }
                     VirtualKeyCode::R => {
                         wrench.set_page_zoom(ZoomFactor::new(1.0));
                         do_frame = true;

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -553,6 +553,7 @@ impl Wrench {
             "I - Toggle showing texture caches",
             "B - Toggle showing alpha primitive rects",
             "V - Toggle showing overdraw",
+            "G - Toggle showing gpu cache updates",
             "S - Toggle compact profiler",
             "Q - Toggle GPU queries for time and samples",
             "M - Trigger memory pressure event",


### PR DESCRIPTION
This is a barebones visualization path for GPU cache updates. The idea is to assign different tags/colors for different types of the GPU cache blocks, so that we can see how bad the updates are fragmented upon scrolling and/or scene updates.

![wr-gpu-cache-debug](https://user-images.githubusercontent.com/107301/45647892-0c0ef380-ba95-11e8-8f4b-a9d8c00c51df.png)

r? @gw3583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3069)
<!-- Reviewable:end -->
