### PR TITLE
Don't move pending_properties to current_properties in flush_pending_…

### DIFF
--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -58,8 +58,8 @@ impl SceneProperties {
     pub fn flush_pending_updates(&mut self) -> bool {
         let mut properties_changed = false;
 
-        if let Some(pending_properties) = self.pending_properties.take() {
-            if pending_properties != self.current_properties {
+        if let Some(ref pending_properties) = self.pending_properties {
+            if *pending_properties != self.current_properties {
                 self.transform_properties.clear();
                 self.float_properties.clear();
 
@@ -73,7 +73,7 @@ impl SceneProperties {
                         .insert(property.key.id, property.value);
                 }
 
-                self.current_properties = pending_properties;
+                self.current_properties = pending_properties.clone();
                 properties_changed = true;
             }
         }


### PR DESCRIPTION
…updates

Basically add_properties is called along with set_properties, but sometimes
add_properties is called without set_properties, once it happens in a single
transaction, the DynamicProperties which was previously set by set_properties
will not be incorporated into the dynamic properties because it was cleared
in the previous transaction, thus a flicker will happen.  E.g. a transform
animation value set by set_properties isn't rendered.

To avoid the flicker this change stops moving pending_properties in
flush_pending_updates and thus only set_properties clears the
penrind_properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3090)
<!-- Reviewable:end -->
