### PR TITLE
Construct split planes with help of the inversed transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plane-split"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1496,7 +1496,7 @@ dependencies = [
  "pathfinder_gfx_utils 0.2.0 (git+https://github.com/pcwalton/pathfinder?branch=webrender)",
  "pathfinder_partitioner 0.2.0 (git+https://github.com/pcwalton/pathfinder?branch=webrender)",
  "pathfinder_path_utils 0.2.0 (git+https://github.com/pcwalton/pathfinder?branch=webrender)",
- "plane-split 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plane-split 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1803,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pathfinder_path_utils 0.2.0 (git+https://github.com/pcwalton/pathfinder?branch=webrender)" = "<none>"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
-"checksum plane-split 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64d766f38b15fe1337bdddfc869ef5c50437323f857aaaadc6490197db80a1b8"
+"checksum plane-split 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cd1ab9bf7197c31ac8004a487cd1ddc5cf420029fb53023fdcab0540b5fa1410"
 "checksum png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f54b9600d584d3b8a739e1662a595fab051329eff43f20e7d8cc22872962145b"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -32,7 +32,7 @@ image = { optional = true, version = "0.19" }
 lazy_static = "1"
 log = "0.4"
 num-traits = "0.2"
-plane-split = "0.13"
+plane-split = "0.13.1"
 png = { optional = true, version = "0.12" }
 rayon = "1"
 ron = { optional = true, version = "0.1.7" }

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -703,9 +703,11 @@ impl AlphaBatchBuilder {
                             if let Some(local_rect) = local_rect {
                                 match transform.transform_kind() {
                                     TransformedRectKind::AxisAligned => {
-                                        let polygon = Polygon::from_transformed_rect(
+                                        let inv_transform = transforms.get_world_inv_transform(prim_metadata.spatial_node_index);
+                                        let polygon = Polygon::from_transformed_rect_with_inverse(
                                             local_rect.cast(),
-                                            transform.cast(),
+                                            &transform.cast(),
+                                            &inv_transform.cast(),
                                             prim_index.0,
                                         ).unwrap();
                                         splitter.add(polygon);

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform, LayoutTransform};
-use api::{PremultipliedColorF, LayoutToPictureTransform, PictureToLayoutTransform, PicturePixel, WorldPixel};
+use api::{
+    DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform, LayoutTransform,
+    PremultipliedColorF, LayoutToPictureTransform, PictureToLayoutTransform, PicturePixel,
+    WorldPixel, WorldToLayoutTransform,
+};
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
 use internal_types::FastHashMap;
@@ -485,6 +488,15 @@ impl TransformPalette {
         self.transforms[index.0]
             .transform
             .with_destination::<WorldPixel>()
+    }
+
+    pub fn get_world_inv_transform(
+        &self,
+        index: SpatialNodeIndex,
+    ) -> WorldToLayoutTransform {
+        self.transforms[index.0]
+            .inv_transform
+            .with_source::<WorldPixel>()
     }
 
     // Get a transform palette id for the given spatial node.


### PR DESCRIPTION
Fixes #3070
Try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=5eb3a20402b513ccfa2d526b14f32ed707821e92

Meat of the fix is within `plane-split` 0.13.1 update, which we use in this PR in order to construct consistently transformed polygons for splitting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3093)
<!-- Reviewable:end -->
