### PR TITLE
Don't normalize outset / inset borders to solid.

### DIFF
--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -283,9 +283,7 @@ impl NormalBorder {
         fn renders_small_border_solid(style: BorderStyle) -> bool {
             match style {
                 BorderStyle::Groove |
-                BorderStyle::Ridge |
-                BorderStyle::Inset |
-                BorderStyle::Outset => true,
+                BorderStyle::Ridge => true,
                 _ => false,
             }
         }

--- a/wrench/reftests/border/reftest.list
+++ b/wrench/reftests/border/reftest.list
@@ -24,3 +24,4 @@ platform(linux,mac) == dotted-corner-small-radius.yaml dotted-corner-small-radiu
 platform(linux,mac) == small-dotted-border.yaml small-dotted-border.png
 == discontinued-dash.yaml discontinued-dash.png
 == border-dashed-dotted-caching.yaml border-dashed-dotted-caching.png
+!= small-inset-outset.yaml small-inset-outset-notref.yaml

--- a/wrench/reftests/border/small-inset-outset-notref.yaml
+++ b/wrench/reftests/border/small-inset-outset-notref.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 500, 500]
+      items:
+        - type: border
+          bounds: [ 0, 0, 200, 200 ]
+          width: 1
+          border-type: normal
+          style: solid
+          color: black

--- a/wrench/reftests/border/small-inset-outset.yaml
+++ b/wrench/reftests/border/small-inset-outset.yaml
@@ -1,0 +1,12 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 500, 500]
+      items:
+        - type: border
+          bounds: [ 0, 0, 200, 200 ]
+          width: 1
+          border-type: normal
+          style: inset
+          color: black


### PR DESCRIPTION
inset / outset don't render two lines, so they don't need the same restriction as `groove` / `ridge`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3109)
<!-- Reviewable:end -->
