### PR TITLE
Introduce PrimitiveInstance in picture runs.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -18,7 +18,7 @@ use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use picture::{PictureCompositeMode, PicturePrimitive, PictureSurface};
 use plane_split::{BspSplitter, Clipper, Polygon, Splitter};
 use prim_store::{BrushKind, BrushPrimitive, BrushSegmentTaskId, DeferredResolve};
-use prim_store::{EdgeAaSegmentMask, ImageSource, PrimitiveIndex};
+use prim_store::{EdgeAaSegmentMask, ImageSource};
 use prim_store::{PrimitiveMetadata, VisibleGradientTile, PrimitiveInstance};
 use prim_store::{BorderSource, Primitive, PrimitiveDetails};
 use render_task::{RenderTaskAddress, RenderTaskId, RenderTaskTree};
@@ -450,7 +450,7 @@ impl AlphaBatchBuilder {
         let mut splitter = BspSplitter::new();
 
         // Add each run in this picture to the batch.
-        for prim_instance in &pic.prim_instances {
+        for (plane_split_anchor, prim_instance) in pic.prim_instances.iter().enumerate() {
             self.add_prim_to_batch(
                 prim_instance,
                 ctx,
@@ -463,13 +463,15 @@ impl AlphaBatchBuilder {
                 prim_headers,
                 transforms,
                 root_spatial_node_index,
+                plane_split_anchor,
             );
         }
 
         // Flush the accumulated plane splits onto the task tree.
         // Z axis is directed at the screen, `sort` is ascending, and we need back-to-front order.
         for poly in splitter.sort(vec3(0.0, 0.0, 1.0)) {
-            let prim_index = PrimitiveIndex(poly.anchor);
+            let prim_instance = &pic.prim_instances[poly.anchor];
+            let prim_index = prim_instance.prim_index;
             let pic_metadata = &ctx.prim_store.primitives[prim_index.0].metadata;
             if cfg!(debug_assertions) && ctx.prim_store.chase_id == Some(prim_index) {
                 println!("\t\tsplit polygon {:?}", poly.points);
@@ -487,7 +489,7 @@ impl AlphaBatchBuilder {
 
             let prim_header = PrimitiveHeader {
                 local_rect: pic_metadata.local_rect,
-                local_clip_rect: pic_metadata.combined_local_clip_rect,
+                local_clip_rect: prim_instance.combined_local_clip_rect,
                 task_address,
                 specific_prim_address: GpuCacheAddress::invalid(),
                 clip_task_address,
@@ -568,6 +570,7 @@ impl AlphaBatchBuilder {
         prim_headers: &mut PrimitiveHeaders,
         transforms: &mut TransformPalette,
         root_spatial_node_index: SpatialNodeIndex,
+        plane_split_anchor: usize,
     ) {
         let prim = &ctx.prim_store.primitives[prim_instance.prim_index.0];
         let prim_metadata = &prim.metadata;
@@ -631,7 +634,7 @@ impl AlphaBatchBuilder {
 
         let prim_header = PrimitiveHeader {
             local_rect: prim_metadata.local_rect,
-            local_clip_rect: prim_metadata.combined_local_clip_rect,
+            local_clip_rect: prim_instance.combined_local_clip_rect,
             task_address,
             specific_prim_address: prim_cache_address,
             clip_task_address,
@@ -662,7 +665,7 @@ impl AlphaBatchBuilder {
                             // since we determine the UVs by doing a bilerp with a factor
                             // from the original local rect.
                             let local_rect = prim_metadata.local_rect
-                                                          .intersection(&prim_metadata.combined_local_clip_rect);
+                                                          .intersection(&prim_instance.combined_local_clip_rect);
 
                             if let Some(local_rect) = local_rect {
                                 match transform.transform_kind() {
@@ -672,7 +675,7 @@ impl AlphaBatchBuilder {
                                             local_rect.cast(),
                                             &transform.cast(),
                                             &inv_transform.cast(),
-                                            prim_instance.prim_index.0,
+                                            plane_split_anchor,
                                         ).unwrap();
                                         splitter.add(polygon);
                                     }
@@ -682,7 +685,7 @@ impl AlphaBatchBuilder {
                                         let results = clipper.clip_transformed(
                                             Polygon::from_rect(
                                                 local_rect.cast(),
-                                                prim_instance.prim_index.0,
+                                                plane_split_anchor,
                                             ),
                                             &matrix,
                                             Some(bounding_rect.to_f64()),

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -450,11 +450,9 @@ impl AlphaBatchBuilder {
         let mut splitter = BspSplitter::new();
 
         // Add each run in this picture to the batch.
-        for prim_index in &pic.prim_indices {
-            let prim_index = *prim_index;
-
+        for prim_instance in &pic.prim_instances {
             self.add_prim_to_batch(
-                prim_index,
+                prim_instance.prim_index,
                 ctx,
                 gpu_cache,
                 render_tasks,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -13,7 +13,7 @@ use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
 use picture::{PictureCompositeMode, PictureSurface, RasterConfig};
-use prim_store::{PrimitiveIndex, PrimitiveRun, PrimitiveStore, SpaceMapper};
+use prim_store::{PrimitiveIndex, PrimitiveStore, SpaceMapper};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::FrameId;
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
@@ -89,7 +89,7 @@ pub struct FrameBuildingState<'a> {
 
 pub struct PictureContext {
     pub pipeline_id: PipelineId,
-    pub prim_runs: Vec<PrimitiveRun>,
+    pub prim_indices: Vec<PrimitiveIndex>,
     pub apply_local_clip_rect: bool,
     pub inflation_factor: f32,
     pub allow_subpixel_aa: bool,
@@ -247,7 +247,7 @@ impl FrameBuilder {
 
         let mut pic_rect = PictureRect::zero();
 
-        self.prim_store.prepare_prim_runs(
+        self.prim_store.prepare_primitives(
             &pic_context,
             &mut pic_state,
             &frame_context,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -13,7 +13,7 @@ use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
 use picture::{PictureCompositeMode, PictureSurface, RasterConfig};
-use prim_store::{PrimitiveIndex, PrimitiveStore, SpaceMapper};
+use prim_store::{PrimitiveIndex, PrimitiveInstance, PrimitiveStore, SpaceMapper};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::FrameId;
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
@@ -89,7 +89,7 @@ pub struct FrameBuildingState<'a> {
 
 pub struct PictureContext {
     pub pipeline_id: PipelineId,
-    pub prim_indices: Vec<PrimitiveIndex>,
+    pub prim_instances: Vec<PrimitiveInstance>,
     pub apply_local_clip_rect: bool,
     pub inflation_factor: f32,
     pub allow_subpixel_aa: bool,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -13,7 +13,7 @@ use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap};
 use picture::{PictureCompositeMode, PictureSurface, RasterConfig};
-use prim_store::{PrimitiveIndex, PrimitiveInstance, PrimitiveStore, SpaceMapper};
+use prim_store::{PrimitiveIndex, PrimitiveStore, SpaceMapper};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::FrameId;
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
@@ -89,7 +89,6 @@ pub struct FrameBuildingState<'a> {
 
 pub struct PictureContext {
     pub pipeline_id: PipelineId,
-    pub prim_instances: Vec<PrimitiveInstance>,
     pub apply_local_clip_rect: bool,
     pub inflation_factor: f32,
     pub allow_subpixel_aa: bool,
@@ -231,7 +230,7 @@ impl FrameBuilder {
             root_spatial_node_index,
         );
 
-        let (pic_context, mut pic_state) = self
+        let (pic_context, mut pic_state, mut instances) = self
             .prim_store
             .get_pic_mut(root_prim_index)
             .take_context(
@@ -248,6 +247,7 @@ impl FrameBuilder {
         let mut pic_rect = PictureRect::zero();
 
         self.prim_store.prepare_primitives(
+            &mut instances,
             &pic_context,
             &mut pic_state,
             &frame_context,
@@ -259,6 +259,7 @@ impl FrameBuilder {
             .prim_store
             .get_pic_mut(root_prim_index);
         pic.restore_context(
+            instances,
             pic_context,
             pic_state,
             Some(pic_rect),

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -140,7 +140,7 @@ pub struct ClipMaskBorderCornerDotDash {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct PrimitiveInstance {
+pub struct PrimitiveInstanceData {
     data: [i32; 4],
 }
 
@@ -251,8 +251,8 @@ impl GlyphInstance {
     // TODO(gw): Some of these fields can be moved to the primitive
     //           header since they are constant, and some can be
     //           compressed to a smaller size.
-    pub fn build(&self, data0: i32, data1: i32, data2: i32) -> PrimitiveInstance {
-        PrimitiveInstance {
+    pub fn build(&self, data0: i32, data1: i32, data2: i32) -> PrimitiveInstanceData {
+        PrimitiveInstanceData {
             data: [
                 self.prim_header_index.0 as i32,
                 data0,
@@ -283,9 +283,9 @@ impl SplitCompositeInstance {
     }
 }
 
-impl From<SplitCompositeInstance> for PrimitiveInstance {
+impl From<SplitCompositeInstance> for PrimitiveInstanceData {
     fn from(instance: SplitCompositeInstance) -> Self {
-        PrimitiveInstance {
+        PrimitiveInstanceData {
             data: [
                 instance.prim_header_index.0,
                 instance.polygons_address.as_int(),
@@ -324,9 +324,9 @@ pub struct BrushInstance {
     pub brush_flags: BrushFlags,
 }
 
-impl From<BrushInstance> for PrimitiveInstance {
+impl From<BrushInstance> for PrimitiveInstanceData {
     fn from(instance: BrushInstance) -> Self {
-        PrimitiveInstance {
+        PrimitiveInstanceData {
             data: [
                 instance.prim_header_index.0,
                 instance.clip_task_address.0 as i32,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -376,6 +376,7 @@ impl PicturePrimitive {
     ) {
         self.prim_instances.push(PrimitiveInstance {
             prim_index,
+            combined_local_clip_rect: LayoutRect::zero(),
         });
     }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -14,7 +14,7 @@ use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState};
 use frame_builder::{PictureContext, PrimitiveContext};
 use gpu_cache::{GpuCacheHandle};
 use gpu_types::UvRectKind;
-use prim_store::{PrimitiveIndex, PrimitiveRun, SpaceMapper};
+use prim_store::{PrimitiveIndex, SpaceMapper};
 use prim_store::{PrimitiveMetadata, get_raster_rects};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
@@ -157,7 +157,7 @@ pub struct PictureCacheKey {
 #[derive(Debug)]
 pub struct PicturePrimitive {
     // List of primitive runs that make up this picture.
-    pub runs: Vec<PrimitiveRun>,
+    pub prim_indices: Vec<PrimitiveIndex>,
     pub state: Option<PictureState>,
 
     // The pipeline that the primitives on this picture belong to.
@@ -224,7 +224,7 @@ impl PicturePrimitive {
         requested_raster_space: RasterSpace,
     ) -> Self {
         PicturePrimitive {
-            runs: Vec::new(),
+            prim_indices: Vec::new(),
             state: None,
             secondary_render_task_id: None,
             requested_composite_mode,
@@ -357,7 +357,7 @@ impl PicturePrimitive {
 
         let context = PictureContext {
             pipeline_id: self.pipeline_id,
-            prim_runs: mem::replace(&mut self.runs, Vec::new()),
+            prim_indices: mem::replace(&mut self.prim_indices, Vec::new()),
             apply_local_clip_rect: self.apply_local_clip_rect,
             inflation_factor,
             allow_subpixel_aa,
@@ -373,17 +373,7 @@ impl PicturePrimitive {
         &mut self,
         prim_index: PrimitiveIndex,
     ) {
-        if let Some(ref mut run) = self.runs.last_mut() {
-            if run.base_prim_index.0 + run.count == prim_index.0 {
-                run.count += 1;
-                return;
-            }
-        }
-
-        self.runs.push(PrimitiveRun {
-            base_prim_index: prim_index,
-            count: 1,
-        });
+        self.prim_indices.push(prim_index);
     }
 
     pub fn restore_context(
@@ -393,7 +383,7 @@ impl PicturePrimitive {
         local_rect: Option<PictureRect>,
         frame_state: &mut FrameBuildingState,
     ) -> (LayoutRect, Option<ClipNodeCollector>) {
-        self.runs = context.prim_runs;
+        self.prim_indices = context.prim_indices;
         self.state = Some(state);
 
         let local_rect = match local_rect {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -231,7 +231,7 @@ impl GpuCacheHandle {
 impl GpuCacheAddress {
     pub fn as_int(&self) -> i32 {
         // TODO(gw): Temporarily encode GPU Cache addresses as a single int.
-        //           In the future, we can change the PrimitiveInstance struct
+        //           In the future, we can change the PrimitiveInstanceData struct
         //           to use 2x u16 for the vertex attribute instead of an i32.
         self.v as i32 * MAX_VERTEX_TEXTURE_WIDTH as i32 + self.u as i32
     }

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1620,7 +1620,7 @@ impl PrimitiveStore {
         };
 
         let (is_passthrough, clip_node_collector) = match pic_info {
-            Some((pic_context_for_children, mut pic_state_for_children)) => {
+            Some((pic_context_for_children, mut pic_state_for_children, mut prim_instances)) => {
                 // Mark whether this picture has a complex coordinate system.
                 let is_passthrough = pic_context_for_children.is_passthrough;
                 pic_state_for_children.has_non_root_coord_system |=
@@ -1628,6 +1628,7 @@ impl PrimitiveStore {
 
                 let mut pic_rect = PictureRect::zero();
                 self.prepare_primitives(
+                    &mut prim_instances,
                     &pic_context_for_children,
                     &mut pic_state_for_children,
                     frame_context,
@@ -1651,6 +1652,7 @@ impl PrimitiveStore {
                 let (new_local_rect, clip_node_collector) = prim
                     .as_pic_mut()
                     .restore_context(
+                        prim_instances,
                         pic_context_for_children,
                         pic_state_for_children,
                         pic_rect,
@@ -1822,6 +1824,7 @@ impl PrimitiveStore {
 
     pub fn prepare_primitives(
         &mut self,
+        prim_instances: &mut Vec<PrimitiveInstance>,
         pic_context: &PictureContext,
         pic_state: &mut PictureState,
         frame_context: &FrameBuildingContext,
@@ -1834,7 +1837,7 @@ impl PrimitiveStore {
             .expect("No display list?")
             .display_list;
 
-        for prim_instance in &pic_context.prim_instances {
+        for prim_instance in prim_instances {
             let prim_index = prim_instance.prim_index;
             let is_chased = Some(prim_index) == self.chase_id;
 


### PR DESCRIPTION
The goal of this work is to start separating the data stored in the Primitive struct into instance and template data.

The idea is that Pictures will store PrimitiveInstance structures, instead of just primitive indices. These instance structures will eventually contain information relevant to this specific instance of a primitive (for example, the combined local clip rect, the clip task ID etc), and the ID of the interned template data. 

What remains in the Primitive structure will then be treated as primitive template data. It will be hashed and interned, in the same way that clip nodes are. This will mean:

- We can quickly compare if the primitive in a picture is the same (by comparing the interned primitive ID, and a small amount of per-instance data). This can also be done during scene building, rather than frame building, for most primitive types.
- The GPU cache handles (and contents) for primitive templates are persisted between display lists, significantly reducing the amount of GPU cache updates.
- Pages that contain many duplicated primitive template structures will be more efficient, since they'll be de-duplicated by the interning process in the scene builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3110)
<!-- Reviewable:end -->
