### PR TITLE
Store a queue of rasterized blobs instead for non-tiled images (take two)

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -979,7 +979,7 @@ impl ResourceCache {
             let request: BlobImageRequest = request.into();
             let missing = match (self.rasterized_blob_images.get(&request.key), request.tile) {
                 (Some(RasterizedBlob::Tiled(tiles)), Some(tile)) => !tiles.contains_key(&tile),
-                (Some(RasterizedBlob::NonTiled(..)), None) => false,
+                (Some(RasterizedBlob::NonTiled(ref queue)), None) => queue.is_empty(),
                 _ => true,
             };
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -33,6 +33,7 @@ use profiler::{ResourceProfileCounters, TextureCacheProfileCounters};
 use render_backend::FrameId;
 use render_task::{RenderTaskCache, RenderTaskCacheKey, RenderTaskId};
 use render_task::{RenderTaskCacheEntry, RenderTaskCacheEntryHandle, RenderTaskTree};
+use smallvec::SmallVec;
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::collections::hash_map::IterMut;
 use std::{cmp, mem};
@@ -102,7 +103,7 @@ enum State {
 /// Post scene building state.
 enum RasterizedBlob {
     Tiled(FastHashMap<TileOffset, RasterizedBlobImage>),
-    NonTiled(RasterizedBlobImage),
+    NonTiled(Vec<RasterizedBlobImage>),
 }
 
 /// Pre scene building state.
@@ -626,7 +627,16 @@ impl ResourceCache {
                     tiles.insert(tile, data);
                 }
             } else {
-                *image = RasterizedBlob::NonTiled(data);
+                if let RasterizedBlob::NonTiled(ref mut queue) = *image {
+                    // If our new rasterized rect overwrites items in the queue, discard them.
+                    queue.retain(|img| {
+                        !data.rasterized_rect.contains_rect(&img.rasterized_rect)
+                    });
+
+                    queue.push(data);
+                } else {
+                    *image = RasterizedBlob::NonTiled(vec![data]);
+                }
             }
         }
     }
@@ -1103,11 +1113,30 @@ impl ResourceCache {
                     );
                 });
             } else {
-                let needs_upload = match self.cached_images.try_get(&key) {
+                let mut needs_upload = match self.cached_images.try_get(&key) {
                     Some(&ImageResult::UntiledAuto(ref entry)) => {
                         self.texture_cache.needs_upload(&entry.texture_cache_handle)
                     }
                     _ => true,
+                };
+
+                // If the queue of ratserized updates is growing it probably means that
+                // the texture is not getting uploaded because the display item is off-screen.
+                // In that case we are better off
+                // - Either not kicking rasterization for that image (avoid wasted cpu work
+                //   but will jank next time the item is visible because of lazy rasterization.
+                // - Clobber the update queue by pushing an update with a larger dirty rect
+                //   to prevent it from accumulating.
+                //
+                // We do the latter here but it's not ideal and might want to revisit and do
+                // the former instead.
+                match self.rasterized_blob_images.get_mut(&key) {
+                    Some(RasterizedBlob::NonTiled(ref queue)) => {
+                        if queue.len() > 2 {
+                            needs_upload = true;
+                        }
+                    }
+                    _ => {},
                 };
 
                 let dirty_rect = if needs_upload {
@@ -1432,28 +1461,32 @@ impl ResourceCache {
             let image_template = self.resources.image_templates.get_mut(request.key).unwrap();
             debug_assert!(image_template.data.uses_texture_cache());
 
-            let mut blob_rasterized_rect = None;
-            let image_data = match image_template.data {
+            let mut updates: SmallVec<[(ImageData, Option<DeviceUintRect>); 1]> = SmallVec::new();
+
+            match image_template.data {
                 ImageData::Raw(..) | ImageData::External(..) => {
                     // Safe to clone here since the Raw image data is an
                     // Arc, and the external image data is small.
-                    image_template.data.clone()
+                    updates.push((image_template.data.clone(), None));
                 }
                 ImageData::Blob(..) => {
 
-
-                    let blob_image = self.rasterized_blob_images.get(&request.key).unwrap();
+                    let blob_image = self.rasterized_blob_images.get_mut(&request.key).unwrap();
                     match (blob_image, request.tile) {
                         (RasterizedBlob::Tiled(ref tiles), Some(tile)) => {
                             let img = &tiles[&tile];
-                            blob_rasterized_rect = Some(img.rasterized_rect);
-
-                            ImageData::Raw(Arc::clone(&img.data))
+                            updates.push((
+                                ImageData::Raw(Arc::clone(&img.data)),
+                                Some(img.rasterized_rect)
+                            ));
                         }
-                        (RasterizedBlob::NonTiled(ref img), None) => {
-                            blob_rasterized_rect = Some(img.rasterized_rect);
-
-                            ImageData::Raw(Arc::clone(&img.data))
+                        (RasterizedBlob::NonTiled(ref mut queue), None) => {
+                            for img in queue.drain(..) {
+                                updates.push((
+                                    ImageData::Raw(Arc::clone(&img.data)),
+                                    Some(img.rasterized_rect)
+                                ));
+                            }
                         }
                         _ =>  {
                             debug_assert!(false, "invalid blob image request during frame building");
@@ -1463,100 +1496,102 @@ impl ResourceCache {
                 }
             };
 
-            let entry = match *self.cached_images.get_mut(&request.key) {
-                ImageResult::UntiledAuto(ref mut entry) => entry,
-                ImageResult::Multi(ref mut entries) => entries.get_mut(&request.into()),
-                ImageResult::Err(_) => panic!("Update requested for invalid entry")
-            };
-
-            match (blob_rasterized_rect, entry.dirty_rect) {
-                (Some(rasterized), Some(dirty)) => {
-                    debug_assert!(request.tile.is_some() || rasterized.contains_rect(&dirty));
-                }
-                _ => {}
-            }
-
-            let mut descriptor = image_template.descriptor.clone();
-            let local_dirty_rect;
-
-            if let Some(tile) = request.tile {
-                let tile_size = image_template.tiling.unwrap();
-                let clipped_tile_size = compute_tile_size(&descriptor, tile_size, tile);
-
-                local_dirty_rect = if let Some(rect) = entry.dirty_rect.take() {
-                    // We should either have a dirty rect, or we are re-uploading where the dirty
-                    // rect is ignored anyway.
-                    let intersection = intersect_for_tile(rect, clipped_tile_size, tile_size, tile);
-                    debug_assert!(intersection.is_some() ||
-                                  self.texture_cache.needs_upload(&entry.texture_cache_handle));
-                    intersection
-                } else {
-                    None
+            for (image_data, blob_rasterized_rect) in updates {
+                let entry = match *self.cached_images.get_mut(&request.key) {
+                    ImageResult::UntiledAuto(ref mut entry) => entry,
+                    ImageResult::Multi(ref mut entries) => entries.get_mut(&request.into()),
+                    ImageResult::Err(_) => panic!("Update requested for invalid entry")
                 };
 
-                // The tiled image could be stored on the CPU as one large image or be
-                // already broken up into tiles. This affects the way we compute the stride
-                // and offset.
-                let tiled_on_cpu = image_template.data.is_blob();
-                if !tiled_on_cpu {
-                    let bpp = descriptor.format.bytes_per_pixel();
-                    let stride = descriptor.compute_stride();
-                    descriptor.stride = Some(stride);
-                    descriptor.offset +=
-                        tile.y as u32 * tile_size as u32 * stride +
-                        tile.x as u32 * tile_size as u32 * bpp;
-                }
+                let mut descriptor = image_template.descriptor.clone();
+                let mut local_dirty_rect;
 
-                descriptor.size = clipped_tile_size;
-            } else {
-                local_dirty_rect = entry.dirty_rect.take();
-            }
+                if let Some(tile) = request.tile {
+                    let tile_size = image_template.tiling.unwrap();
+                    let clipped_tile_size = compute_tile_size(&descriptor, tile_size, tile);
 
-            let filter = match request.rendering {
-                ImageRendering::Pixelated => {
-                    TextureFilter::Nearest
-                }
-                ImageRendering::Auto | ImageRendering::CrispEdges => {
-                    // If the texture uses linear filtering, enable mipmaps and
-                    // trilinear filtering, for better image quality. We only
-                    // support this for now on textures that are not placed
-                    // into the shared cache. This accounts for any image
-                    // that is > 512 in either dimension, so it should cover
-                    // the most important use cases. We may want to support
-                    // mip-maps on shared cache items in the future.
-                    if descriptor.allow_mipmaps &&
-                       descriptor.size.width > 512 &&
-                       descriptor.size.height > 512 &&
-                       !self.texture_cache.is_allowed_in_shared_cache(
-                        TextureFilter::Linear,
-                        &descriptor,
-                    ) {
-                        TextureFilter::Trilinear
+                    local_dirty_rect = if let Some(rect) = entry.dirty_rect.take() {
+                        // We should either have a dirty rect, or we are re-uploading where the dirty
+                        // rect is ignored anyway.
+                        let intersection = intersect_for_tile(rect, clipped_tile_size, tile_size, tile);
+                        debug_assert!(intersection.is_some() ||
+                                      self.texture_cache.needs_upload(&entry.texture_cache_handle));
+                        intersection
                     } else {
-                        TextureFilter::Linear
+                        None
+                    };
+
+                    // The tiled image could be stored on the CPU as one large image or be
+                    // already broken up into tiles. This affects the way we compute the stride
+                    // and offset.
+                    let tiled_on_cpu = image_template.data.is_blob();
+                    if !tiled_on_cpu {
+                        let bpp = descriptor.format.bytes_per_pixel();
+                        let stride = descriptor.compute_stride();
+                        descriptor.stride = Some(stride);
+                        descriptor.offset +=
+                            tile.y as u32 * tile_size as u32 * stride +
+                            tile.x as u32 * tile_size as u32 * bpp;
                     }
+
+                    descriptor.size = clipped_tile_size;
+                } else {
+                    local_dirty_rect = entry.dirty_rect.take();
                 }
-            };
 
-            let eviction = if image_template.data.is_blob() {
-                Eviction::Manual
-            } else {
-                Eviction::Auto
-            };
+                // If we are uploading the dirty region of a blob image we might have several
+                // rects to upload so we use each of these rasterized rects rather than the
+                // overall dirty rect of the image.
+                if blob_rasterized_rect.is_some() {
+                    local_dirty_rect = blob_rasterized_rect;
+                }
 
-            //Note: at this point, the dirty rectangle is local to the descriptor space
-            self.texture_cache.update(
-                &mut entry.texture_cache_handle,
-                descriptor,
-                filter,
-                Some(image_data),
-                [0.0; 3],
-                local_dirty_rect,
-                gpu_cache,
-                None,
-                UvRectKind::Rect,
-                eviction,
-            );
+                let filter = match request.rendering {
+                    ImageRendering::Pixelated => {
+                        TextureFilter::Nearest
+                    }
+                    ImageRendering::Auto | ImageRendering::CrispEdges => {
+                        // If the texture uses linear filtering, enable mipmaps and
+                        // trilinear filtering, for better image quality. We only
+                        // support this for now on textures that are not placed
+                        // into the shared cache. This accounts for any image
+                        // that is > 512 in either dimension, so it should cover
+                        // the most important use cases. We may want to support
+                        // mip-maps on shared cache items in the future.
+                        if descriptor.allow_mipmaps &&
+                           descriptor.size.width > 512 &&
+                           descriptor.size.height > 512 &&
+                           !self.texture_cache.is_allowed_in_shared_cache(
+                            TextureFilter::Linear,
+                            &descriptor,
+                        ) {
+                            TextureFilter::Trilinear
+                        } else {
+                            TextureFilter::Linear
+                        }
+                    }
+                };
+
+                let eviction = if image_template.data.is_blob() {
+                    Eviction::Manual
+                } else {
+                    Eviction::Auto
+                };
+
+                //Note: at this point, the dirty rectangle is local to the descriptor space
+                self.texture_cache.update(
+                    &mut entry.texture_cache_handle,
+                    descriptor,
+                    filter,
+                    Some(image_data),
+                    [0.0; 3],
+                    local_dirty_rect,
+                    gpu_cache,
+                    None,
+                    UvRectKind::Rect,
+                    eviction,
+                );
+            }
         }
     }
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AddFont, BlobImageResources, AsyncBlobImageRasterizer, ResourceUpdate};
-use api::{BlobImageDescriptor, BlobImageHandler, BlobImageRequest};
+use api::{BlobImageDescriptor, BlobImageHandler, BlobImageRequest, RasterizedBlobImage};
 use api::{ClearCache, ColorF, DevicePoint, DeviceUintPoint, DeviceUintRect, DeviceUintSize};
 use api::{FontInstanceKey, FontKey, FontTemplate, GlyphIndex};
 use api::{ExternalImageData, ExternalImageType, BlobImageResult, BlobImageParams};
@@ -100,8 +100,9 @@ enum State {
 }
 
 /// Post scene building state.
-struct RasterizedBlobImage {
-    data: FastHashMap<Option<TileOffset>, BlobImageResult>,
+enum RasterizedBlob {
+    Tiled(FastHashMap<TileOffset, RasterizedBlobImage>),
+    NonTiled(RasterizedBlobImage),
 }
 
 /// Pre scene building state.
@@ -405,7 +406,7 @@ pub struct ResourceCache {
     pending_image_requests: FastHashSet<ImageRequest>,
 
     blob_image_handler: Option<Box<BlobImageHandler>>,
-    rasterized_blob_images: FastHashMap<ImageKey, RasterizedBlobImage>,
+    rasterized_blob_images: FastHashMap<ImageKey, RasterizedBlob>,
     blob_image_templates: FastHashMap<ImageKey, BlobImageTemplate>,
 
     // If while building a frame we encounter blobs that we didn't already
@@ -604,10 +605,29 @@ impl ResourceCache {
 
     pub fn add_rasterized_blob_images(&mut self, images: Vec<(BlobImageRequest, BlobImageResult)>) {
         for (request, result) in images {
+            let data = match result {
+                Ok(data) => data,
+                Err(..) => {
+                    warn!("Failed to rasterize a blob image");
+                    continue;
+                }
+            };
+
             let image = self.rasterized_blob_images.entry(request.key).or_insert_with(
-                || { RasterizedBlobImage { data: FastHashMap::default() } }
+                || { RasterizedBlob::Tiled(FastHashMap::default()) }
             );
-            image.data.insert(request.tile, result);
+
+            if let Some(tile) = request.tile {
+                if let RasterizedBlob::NonTiled(..) = *image {
+                    *image = RasterizedBlob::Tiled(FastHashMap::default());
+                }
+
+                if let RasterizedBlob::Tiled(ref mut tiles) = *image {
+                    tiles.insert(tile, data);
+                }
+            } else {
+                *image = RasterizedBlob::NonTiled(data);
+            }
         }
     }
 
@@ -945,9 +965,10 @@ impl ResourceCache {
 
         if template.data.is_blob() {
             let request: BlobImageRequest = request.into();
-            let missing = match self.rasterized_blob_images.get(&request.key) {
-                Some(img) => !img.data.contains_key(&request.tile),
-                None => true,
+            let missing = match (self.rasterized_blob_images.get(&request.key), request.tile) {
+                (Some(RasterizedBlob::Tiled(tiles)), Some(tile)) => !tiles.contains_key(&tile),
+                (Some(RasterizedBlob::NonTiled(..)), None) => false,
+                _ => true,
             };
 
             // For some reason the blob image is missing. We'll fall back to
@@ -1134,28 +1155,19 @@ impl ResourceCache {
             Some(size) => size,
             None => { return; }
         };
-        let image = match self.rasterized_blob_images.get_mut(&key) {
-            Some(image) => image,
-            None => {
-                //println!("Missing rasterized blob (key={:?})!", key);
-                return;
-            }
+
+        let tiles = match self.rasterized_blob_images.get_mut(&key) {
+            Some(RasterizedBlob::Tiled(tiles)) => tiles,
+            _ => { return; }
         };
+
         let tile_range = compute_tile_range(
             &area,
             &template.descriptor.size,
             tile_size,
         );
-        image.data.retain(|tile, _| {
-            match *tile {
-                Some(offset) => tile_range.contains(&offset),
-                // This would be a bug. If we get here the blob should be tiled.
-                None => {
-                    error!("Blob image template and image data tiling don't match.");
-                    false
-                }
-            }
-        });
+
+        tiles.retain(|tile, _| { tile_range.contains(tile) });
     }
 
     pub fn request_glyphs(
@@ -1428,20 +1440,22 @@ impl ResourceCache {
                     image_template.data.clone()
                 }
                 ImageData::Blob(..) => {
+
+
                     let blob_image = self.rasterized_blob_images.get(&request.key).unwrap();
-                    match blob_image.data.get(&request.tile) {
-                        Some(result) => {
-                            let result = result
-                                .as_ref()
-                                .expect("Failed to render a blob image");
+                    match (blob_image, request.tile) {
+                        (RasterizedBlob::Tiled(ref tiles), Some(tile)) => {
+                            let img = &tiles[&tile];
+                            blob_rasterized_rect = Some(img.rasterized_rect);
 
-                            // TODO: we may want to not panic and show a placeholder instead.
-
-                            blob_rasterized_rect = Some(result.rasterized_rect);
-
-                            ImageData::Raw(Arc::clone(&result.data))
+                            ImageData::Raw(Arc::clone(&img.data))
                         }
-                        None => {
+                        (RasterizedBlob::NonTiled(ref img), None) => {
+                            blob_rasterized_rect = Some(img.rasterized_rect);
+
+                            ImageData::Raw(Arc::clone(&img.data))
+                        }
+                        _ =>  {
                             debug_assert!(false, "invalid blob image request during frame building");
                             continue;
                         }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -614,6 +614,8 @@ impl ResourceCache {
                 }
             };
 
+            // First make sure we have an entry for this key (using a placeholder
+            // if need be).
             let image = self.rasterized_blob_images.entry(request.key).or_insert_with(
                 || { RasterizedBlob::Tiled(FastHashMap::default()) }
             );
@@ -1130,7 +1132,7 @@ impl ResourceCache {
                 //
                 // We do the latter here but it's not ideal and might want to revisit and do
                 // the former instead.
-                match self.rasterized_blob_images.get_mut(&key) {
+                match self.rasterized_blob_images.get(&key) {
                     Some(RasterizedBlob::NonTiled(ref queue)) => {
                         if queue.len() > 2 {
                             needs_upload = true;
@@ -1483,7 +1485,7 @@ impl ResourceCache {
                         (RasterizedBlob::NonTiled(ref mut queue), None) => {
                             for img in queue.drain(..) {
                                 updates.push((
-                                    ImageData::Raw(Arc::clone(&img.data)),
+                                    ImageData::Raw(img.data),
                                     Some(img.rasterized_rect)
                                 ));
                             }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -660,7 +660,7 @@ impl TextureCache {
         // anything not used this frame).
         for handle in self.shared_entry_handles.drain(..) {
             let entry = self.entries.get(&handle);
-            if entry.last_access == self.frame_id {
+            if entry.eviction == Eviction::Manual || entry.last_access == self.frame_id {
                 retained_entries.push(handle);
             } else {
                 eviction_candidates.push(handle);


### PR DESCRIPTION
The 3 commits from #3079 which were reverted in #3108 plus a commit that fixes the crash that motivated the backout.

Bugzilla entry: https://bugzilla.mozilla.org/show_bug.cgi?id=1493177


In the texture cache we have an automatic and a manual eviction policy. The manual eviction policy ensures blob images don't get automatically evicted from the cache which could otherwise race with the asynchronous rasterization. The Texture cache was missing a tiny piece of code to ensure the eviction policy was respected in for shared cache entries (it does work for normal cache entries). I bet border images make uses of these shared entries. While scrolling the image eventually gets discarded and next time we see it we request the image. The problem is that when we decide whether a blob image is missing, we only look at whether there is an entry in the rasterized_blob_image map, but we don't check whether that entry contains any actual data to upload in its queue.

Before the regressing commit, the bug would occur without crashing, but we wouldn't necessary upload all of the image (only the last available dirty region). With that commit we end up requesting something we think we have but don't have and later panic with an empty handed upload request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3111)
<!-- Reviewable:end -->
