### PR TITLE
Enable post-render notifications.

### DIFF
--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{DebugCommand, DeviceUintRect, DocumentId, ExternalImageData, ExternalImageId};
-use api::ImageFormat;
+use api::{ImageFormat, NotificationRequest};
 use device::TextureFilter;
 use renderer::PipelineInfo;
 use gpu_cache::GpuCacheUpdateList;
@@ -160,6 +160,7 @@ pub enum ResultMsg {
         TextureUpdateList,
         BackendProfileCounters,
     ),
+    AppendNotificationRequests(Vec<NotificationRequest>),
 }
 
 #[derive(Clone, Debug)]

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1090,6 +1090,10 @@ impl RenderBackend {
             |n| { n.notify(); },
         );
 
+        if !notifications.is_empty() {
+            self.result_tx.send(ResultMsg::AppendNotificationRequests(notifications)).unwrap();
+        }
+
         // Always forward the transaction to the renderer if a frame was requested,
         // otherwise gecko can get into a state where it waits (forever) for the
         // transaction to complete before sending new work.

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1225,6 +1225,7 @@ pub trait RenderNotifier: Send {
 pub enum Checkpoint {
     SceneBuilt,
     FrameBuilt,
+    FrameRendered,
     /// NotificationRequests get notified with this if they get dropped without having been
     /// notified. This provides the guarantee that if a request is created it will get notified.
     TransactionDropped,


### PR DESCRIPTION
Extend Transaction::notify to support notifications requests that are fired after the frame is rendered to the window.
With this we should be able to replace the epoch based resource synchronization in a more robust way (notifications either get notified or they notify themselves on drop with `Checkpoint::TransactionDropped` which means once a notification handler is passed to webrender it is almost impossible to forget to notify it.
The motivation is to avoid the dead-locks we've had a few times when forgetting to forward transactions in unusual situations (for example that race with `genrate_frame` called before the root pipeline arrives on Windows).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3112)
<!-- Reviewable:end -->
