### PR TITLE
Use R8 as internal format instead of RED

### DIFF
--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -2235,7 +2235,7 @@ impl Device {
     fn gl_describe_format(&self, format: ImageFormat) -> FormatDesc {
         match format {
             ImageFormat::R8 => FormatDesc {
-                internal: gl::RED as _,
+                internal: gl::R8 as _,
                 external: gl::RED,
                 pixel_type: gl::UNSIGNED_BYTE,
             },


### PR DESCRIPTION
Using RED caused no issue, but it wasn't technically correct as RED describes a channel/color not a format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3129)
<!-- Reviewable:end -->
