### PR TITLE
Collect clip nodes for any surface, not just raster roots.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -422,20 +422,20 @@ impl ClipStore {
         &self.clip_node_instances[(node_range.first + index) as usize]
     }
 
-    // Notify the clip store that a new rasterization root has been created.
+    // Notify the clip store that a new surface has been created.
     // This means any clips from an earlier root should be collected rather
     // than applied on the primitive itself.
-    pub fn push_raster_root(
+    pub fn push_surface(
         &mut self,
-        raster_spatial_node_index: SpatialNodeIndex,
+        spatial_node_index: SpatialNodeIndex,
     ) {
         self.clip_node_collectors.push(
-            ClipNodeCollector::new(raster_spatial_node_index),
+            ClipNodeCollector::new(spatial_node_index),
         );
     }
 
-    // Mark the end of a rasterization root.
-    pub fn pop_raster_root(
+    // Mark the end of a rendering surface.
+    pub fn pop_surface(
         &mut self,
     ) -> ClipNodeCollector {
         self.clip_node_collectors.pop().unwrap()
@@ -474,7 +474,7 @@ impl ClipStore {
             // Check if any clip node index should actually be
             // handled during compositing of a rasterization root.
             match self.clip_node_collectors.iter_mut().find(|c| {
-                clip_chain_node.spatial_node_index < c.raster_root
+                clip_chain_node.spatial_node_index < c.spatial_node_index
             }) {
                 Some(collector) => {
                     collector.insert(current_clip_chain_id);
@@ -1186,16 +1186,16 @@ pub fn project_inner_rect(
 // root at the end of primitive preparation.
 #[derive(Debug)]
 pub struct ClipNodeCollector {
-    raster_root: SpatialNodeIndex,
+    spatial_node_index: SpatialNodeIndex,
     clips: FastHashSet<ClipChainId>,
 }
 
 impl ClipNodeCollector {
     pub fn new(
-        raster_root: SpatialNodeIndex,
+        spatial_node_index: SpatialNodeIndex,
     ) -> Self {
         ClipNodeCollector {
-            raster_root,
+            spatial_node_index,
             clips: FastHashSet::default(),
         }
     }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -95,7 +95,6 @@ pub struct PictureContext {
     pub inflation_factor: f32,
     pub allow_subpixel_aa: bool,
     pub is_passthrough: bool,
-    pub establishes_raster_root: bool,
     pub raster_space: RasterSpace,
 }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -292,9 +292,9 @@ impl PicturePrimitive {
             raster_spatial_node_index
         };
 
-        if establishes_raster_root {
+        if has_surface {
             frame_state.clip_store
-                       .push_raster_root(raster_spatial_node_index);
+                       .push_surface(surface_spatial_node_index);
         }
 
         let map_pic_to_world = SpaceMapper::new_with_target(
@@ -361,7 +361,6 @@ impl PicturePrimitive {
             inflation_factor,
             allow_subpixel_aa,
             is_passthrough: self.raster_config.is_none(),
-            establishes_raster_root,
             raster_space,
         };
 
@@ -425,10 +424,10 @@ impl PicturePrimitive {
             }
         };
 
-        let clip_node_collector = if context.establishes_raster_root {
-            Some(frame_state.clip_store.pop_raster_root())
-        } else {
+        let clip_node_collector = if context.is_passthrough {
             None
+        } else {
+            Some(frame_state.clip_store.pop_surface())
         };
 
         (local_rect, clip_node_collector)


### PR DESCRIPTION
The existing code collects ancestor clips whenever we encounter
a rasterization root. This patch changes the behavior to
collect ancestor clips for any picture that has a surface.

This is a subtle but important step towards picture caching. It
ensures that any clips that are positioned by ancestors of the
surface positioning node are collected and applied when the
surface is composited into the parent, rather than on the
items in the surface itself. (The CSS specifications ensure
that this will give the equivalent result).

What this means is that a picture can be cached and re-used
on a subsequent frame, even if the clips in ancestor nodes
have moved relative to the positioning of the cached picture,
since those clips are only used during composition and do
not affect the contents of the picture itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3137)
<!-- Reviewable:end -->
