### PR TITLE
Add document and frame resources.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -15,7 +15,7 @@ use internal_types::{FastHashMap};
 use picture::{PictureCompositeMode, PictureSurface, RasterConfig};
 use prim_store::{PrimitiveIndex, PrimitiveStore, SpaceMapper};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
-use render_backend::FrameId;
+use render_backend::{FrameResources, FrameId};
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
 use resource_cache::{ResourceCache};
 use scene::{ScenePipeline, SceneProperties};
@@ -82,7 +82,7 @@ pub struct FrameBuildingState<'a> {
     pub gpu_cache: &'a mut GpuCache,
     pub special_render_passes: &'a mut SpecialRenderPasses,
     pub transforms: &'a mut TransformPalette,
-    pub clip_data_store: &'a mut ClipDataStore,
+    pub resources: &'a mut FrameResources,
     pub segment_builder: SegmentBuilder,
 }
 
@@ -180,7 +180,7 @@ impl FrameBuilder {
         device_pixel_scale: DevicePixelScale,
         scene_properties: &SceneProperties,
         transform_palette: &mut TransformPalette,
-        clip_data_store: &mut ClipDataStore,
+        resources: &mut FrameResources,
     ) -> Option<RenderTaskId> {
         profile_scope!("cull");
 
@@ -218,7 +218,7 @@ impl FrameBuilder {
             gpu_cache,
             special_render_passes,
             transforms: transform_palette,
-            clip_data_store,
+            resources,
             segment_builder: SegmentBuilder::new(),
         };
 
@@ -297,7 +297,7 @@ impl FrameBuilder {
         texture_cache_profile: &mut TextureCacheProfileCounters,
         gpu_cache_profile: &mut GpuCacheProfileCounters,
         scene_properties: &SceneProperties,
-        clip_data_store: &mut ClipDataStore,
+        resources: &mut FrameResources,
     ) -> Frame {
         profile_scope!("build");
         debug_assert!(
@@ -336,7 +336,7 @@ impl FrameBuilder {
             device_pixel_scale,
             scene_properties,
             &mut transform_palette,
-            clip_data_store,
+            resources,
         );
 
         resource_cache.block_until_all_resources_added(gpu_cache,
@@ -380,7 +380,7 @@ impl FrameBuilder {
                 resource_cache,
                 use_dual_source_blending,
                 clip_scroll_tree,
-                clip_data_store,
+                resources,
             };
 
             pass.build(

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1733,7 +1733,7 @@ impl PrimitiveStore {
                     frame_context.device_pixel_scale,
                     &frame_context.world_rect,
                     &clip_node_collector,
-                    frame_state.clip_data_store,
+                    &mut frame_state.resources.clip_data_store,
                 );
 
             let clip_chain = match clip_chain {
@@ -2087,7 +2087,7 @@ fn write_brush_segment_description(
         let clip_instance = frame_state
             .clip_store
             .get_instance_from_range(&clip_chain.clips_range, i);
-        let clip_node = &frame_state.clip_data_store[clip_instance.handle];
+        let clip_node = &frame_state.resources.clip_data_store[clip_instance.handle];
 
         // If this clip item is positioned by another positioning node, its relative position
         // could change during scrolling. This means that we would need to resegment. Instead
@@ -2254,7 +2254,7 @@ impl Primitive {
                     frame_context.device_pixel_scale,
                     &frame_context.world_rect,
                     clip_node_collector,
-                    frame_state.clip_data_store,
+                    &mut frame_state.resources.clip_data_store,
                 );
 
             match segment_clip_chain {
@@ -2287,7 +2287,7 @@ impl Primitive {
                         frame_state.gpu_cache,
                         frame_state.resource_cache,
                         frame_state.render_tasks,
-                        frame_state.clip_data_store,
+                        &mut frame_state.resources.clip_data_store,
                     );
 
                     let clip_task_id = frame_state.render_tasks.add(clip_task);
@@ -2828,7 +2828,7 @@ impl Primitive {
                     frame_state.gpu_cache,
                     frame_state.resource_cache,
                     frame_state.render_tasks,
-                    frame_state.clip_data_store,
+                    &mut frame_state.resources.clip_data_store,
                 );
 
                 let clip_task_id = frame_state.render_tasks.add(clip_task);

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -6,7 +6,7 @@ use api::{ColorF, BorderStyle, DeviceIntPoint, DeviceIntRect, DeviceIntSize, Dev
 use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentLayer, FilterOp, ImageFormat};
 use api::{MixBlendMode, PipelineId};
 use batch::{AlphaBatchBuilder, AlphaBatchContainer, ClipBatcher, resolve_image};
-use clip::{ClipDataStore, ClipStore};
+use clip::ClipStore;
 use clip_scroll_tree::{ClipScrollTree};
 use device::{FrameId, Texture};
 #[cfg(feature = "pathfinder")]
@@ -19,6 +19,7 @@ use internal_types::{FastHashMap, SavedTargetIndex, SourceTexture};
 use pathfinder_partitioner::mesh::Mesh;
 use prim_store::{PrimitiveStore, DeferredResolve};
 use profiler::FrameProfileCounters;
+use render_backend::FrameResources;
 use render_task::{BlitSource, RenderTaskAddress, RenderTaskId, RenderTaskKind};
 use render_task::{BlurTask, ClearMode, GlyphTask, RenderTaskLocation, RenderTaskTree, ScalingTask};
 use resource_cache::ResourceCache;
@@ -42,7 +43,7 @@ pub struct RenderTargetContext<'a, 'rc> {
     pub resource_cache: &'rc mut ResourceCache,
     pub use_dual_source_blending: bool,
     pub clip_scroll_tree: &'a ClipScrollTree,
-    pub clip_data_store: &'a ClipDataStore,
+    pub resources: &'a FrameResources,
 }
 
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -587,7 +588,7 @@ impl RenderTarget for AlphaRenderTarget {
                     clip_store,
                     ctx.clip_scroll_tree,
                     transforms,
-                    ctx.clip_data_store,
+                    &ctx.resources.clip_data_store,
                 );
             }
             RenderTaskKind::ClipRegion(ref task) => {


### PR DESCRIPTION
We were previously passing the clip interner and data store
around directly. In the near future we'll have more interning
structures (e.g. text runs, gradients etc). With this change
it's easy to introduce new interning / data store types without
re-plumbing things through all the WR types.

This change shouldn't have any functional effect, it's just
refactoring for future changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3139)
<!-- Reviewable:end -->
