### PR TITLE
Switch to generic-worker for mac CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -128,7 +128,7 @@ tasks:
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'
     provisionerId: 'localprovisioner'
-    workerType: 'kats-webrender-ci-osx'
+    workerType: 'webrender-ci-osx'
     extra:
       github:
         events:
@@ -140,21 +140,22 @@ tasks:
     payload:
       maxRunTime: 3600
       command:
-        - /bin/bash
-        - '--login'
-        - '-c'
-        - >-
-          rm -rf webrender &&
-          git clone {{event.head.repo.url}} webrender && cd webrender &&
-          git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate && servo-tidy &&
-          export RUST_BACKTRACE=full &&
-          export RUSTFLAGS='--deny warnings' &&
-          export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&
-          export RUSTC_WRAPPER=sccache &&
-          (cd wrench && python script/headless.py reftest) &&
-          (cd wrench && cargo build --release) &&
-          (cd wrench && cargo run --release -- --precache reftest reftests/clip/fixed-position-clipping.yaml)
+        - - /bin/bash
+          - '--login'
+          - '-vec'
+          - |
+            git clone {{event.head.repo.url}} webrender
+            cd webrender
+            git checkout {{event.head.sha}}
+            source $HOME/servotidy-venv/bin/activate
+            servo-tidy
+            export RUST_BACKTRACE=full
+            export RUSTFLAGS='--deny warnings'
+            export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"
+            export RUSTC_WRAPPER=sccache
+            (cd wrench && python script/headless.py reftest)
+            (cd wrench && cargo build --release)
+            (cd wrench && cargo run --release -- --precache reftest reftests/clip/fixed-position-clipping.yaml)
     routes:
       - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.osx-release"
   - metadata:
@@ -163,7 +164,7 @@ tasks:
       owner: '{{ event.head.user.email }}'
       source: '{{ event.head.repo.url }}'
     provisionerId: 'localprovisioner'
-    workerType: 'kats-webrender-ci-osx'
+    workerType: 'webrender-ci-osx'
     extra:
       github:
         events:
@@ -175,26 +176,27 @@ tasks:
     payload:
       maxRunTime: 3600
       command:
-        - /bin/bash
-        - '--login'
-        - '-c'
-        - >-
-          rm -rf webrender &&
-          git clone {{event.head.repo.url}} webrender && cd webrender &&
-          git checkout {{event.head.sha}} &&
-          source ../servotidy-venv/bin/activate && servo-tidy &&
-          export RUST_BACKTRACE=full &&
-          export RUSTFLAGS='--deny warnings' &&
-          export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH" &&
-          export RUSTC_WRAPPER=sccache &&
-          (cd webrender_api && cargo test --verbose --features "ipc") &&
-          (cd webrender && cargo check --verbose --no-default-features) &&
-          (cd webrender && cargo check --verbose --no-default-features --features capture) &&
-          (cd webrender && cargo check --verbose --features capture,profiler) &&
-          (cd webrender && cargo check --verbose --features replay) &&
-          (cd webrender && cargo check --verbose --no-default-features --features pathfinder) &&
-          (cd wrench && cargo check --verbose --features env_logger) &&
-          (cd examples && cargo check --verbose) &&
-          (cargo test --all --verbose)
+        - - /bin/bash
+          - '--login'
+          - '-vec'
+          - |
+            git clone {{event.head.repo.url}} webrender
+            cd webrender
+            git checkout {{event.head.sha}}
+            source $HOME/servotidy-venv/bin/activate
+            servo-tidy
+            export RUST_BACKTRACE=full
+            export RUSTFLAGS='--deny warnings'
+            export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"
+            export RUSTC_WRAPPER=sccache
+            (cd webrender_api && cargo test --verbose --features "ipc")
+            (cd webrender && cargo check --verbose --no-default-features)
+            (cd webrender && cargo check --verbose --no-default-features --features capture)
+            (cd webrender && cargo check --verbose --features capture,profiler)
+            (cd webrender && cargo check --verbose --features replay)
+            (cd webrender && cargo check --verbose --no-default-features --features pathfinder)
+            (cd wrench && cargo check --verbose --features env_logger)
+            (cd examples && cargo check --verbose)
+            (cargo test --all --verbose)
     routes:
       - "index.garbage.webrender.ci.{{event.head.user.login}}.{{event.head.repo.branch}}.osx-debug"


### PR DESCRIPTION
Don't merge this yet, still testing. Also I want @jrmuizel to set up generic-worker on the toronto macmini as well before merging this otherwise we'll be back down to one worker, and doing that setup is blocked on https://bugzilla.mozilla.org/show_bug.cgi?id=1494996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3142)
<!-- Reviewable:end -->
