### PR TITLE
Add 16 bits YUV support

### DIFF
--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -127,6 +127,8 @@ pub enum ColorDepth {
     Color10,
     /// 12 bits image
     Color12,
+    /// 16 bits image
+    Color16,
 }
 
 impl ColorDepth {
@@ -136,6 +138,7 @@ impl ColorDepth {
             ColorDepth::Color8 => 8,
             ColorDepth::Color10 => 10,
             ColorDepth::Color12 => 12,
+            ColorDepth::Color16 => 16,
         }
     }
     /// 10 and 12 bits images are encoded using 16 bits integer, we need to
@@ -145,6 +148,7 @@ impl ColorDepth {
             ColorDepth::Color8 => 1.0,
             ColorDepth::Color10 => 64.0,
             ColorDepth::Color12 => 16.0,
+            ColorDepth::Color16 => 1.0,
         }
     }
 }


### PR DESCRIPTION
Windows use 10 bits content as described in https://docs.microsoft.com/en-us/windows/desktop/medfound/10-bit-and-16-bit-yuv-video-formats
stored on 16 bits DWORD with the lowest 6 bits set to zero.

This is done so that 10, 12, 16 can all be cast to a 16 bits value, with no scaling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3148)
<!-- Reviewable:end -->
