### PR TITLE
Remove transform feature defines from clip shaders

### DIFF
--- a/webrender/src/shade.rs
+++ b/webrender/src/shade.rs
@@ -399,8 +399,7 @@ fn create_prim_shader(
 
 fn create_clip_shader(name: &'static str, device: &mut Device) -> Result<Program, ShaderError> {
     let prefix = format!(
-        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}U\n
-        #define WR_FEATURE_TRANSFORM\n",
+        "#define WR_MAX_VERTEX_TEXTURE_WIDTH {}U\n",
         MAX_VERTEX_TEXTURE_WIDTH
     );
 


### PR DESCRIPTION
`WR_FEATURE_TRANSFORM` is not used anymore in shaders. I assume we can remove the defines as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3152)
<!-- Reviewable:end -->
