### PR TITLE
Fix ordering of transforms on a reference frame.

### DIFF
--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -540,6 +540,7 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn post_translate(&self, new_offset: TypedVector2D<f32, Dst>) -> Self {
         match *self {
             FastTransform::Offset(offset) => {


### PR DESCRIPTION
The updated comment explains why the new ordering is correct. Previously
the scroll offset transform was being applied after the local reference
frame transform, instead of before. A more detailed explanation of why
the old code was incorrect and the new code is correct can be found at
https://bugzilla.mozilla.org/show_bug.cgi?id=1415272#c23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3154)
<!-- Reviewable:end -->
