### PR TITLE
Revert "Fix ordering of transforms on a reference frame."

### DIFF
--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -256,20 +256,12 @@ impl SpatialNode {
                     .pre_mul(&source_transform.into())
                     .pre_mul(&info.source_perspective);
 
-                // In order to compute a transformation to world coordinates, we need to apply the
-                // following transforms in order:
-                //   state.parent_accumulated_scroll_offset
-                //   info.source_perspective
-                //   info.source_transform
-                //   info.origin_in_parent_reference_frame
-                //   state.parent_reference_frame_transform
-                // The first one incorporates the scrolling effect of any scrollframes/sticky nodes
-                // between this reference frame and the parent reference frame. The middle three
-                // transforms (which are combined into info.resolved_transform) do the conversion
-                // into the parent reference frame's coordinate space, and then the last one
-                // applies the parent reference frame's transform to the world space.
+                // The transformation for this viewport in world coordinates is the transformation for
+                // our parent reference frame, plus any accumulated scrolling offsets from nodes
+                // between our reference frame and this node. Finally, we also include
+                // whatever local transformation this reference frame provides.
                 let relative_transform = info.resolved_transform
-                    .pre_translate(&state.parent_accumulated_scroll_offset)
+                    .post_translate(state.parent_accumulated_scroll_offset)
                     .to_transform()
                     .with_destination::<LayoutPixel>();
                 self.world_viewport_transform =

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -599,7 +599,6 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn post_translate(&self, new_offset: TypedVector2D<f32, Dst>) -> Self {
         match *self {
             FastTransform::Offset(offset) => {


### PR DESCRIPTION
This reverts commit dd317cf24e4e0a5abeffc96dd862a754ebb357d6,
for introducing scrolling regressions in gecko such as
https://bugzil.la/1496416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3165)
<!-- Reviewable:end -->
