### PR TITLE
Refactor shadow flattening to do work in pop_all_shadows.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -378,6 +378,11 @@ impl PicturePrimitive {
         Some((context, state, instances))
     }
 
+    /// Return true if this picture doesn't contain any primitives.
+    pub fn is_empty(&self) -> bool {
+        self.prim_instances.is_empty()
+    }
+
     pub fn add_primitive(
         &mut self,
         prim_index: PrimitiveIndex,


### PR DESCRIPTION
This simplifies how shadow contexts are handled, by deferring the
work of adding shadows and primitives until pop_all_shadows.

Longer explanation below:

Instead of adding a picture primitive, and then adding primitives
to it, the picture API will be modified to take an immutable list
of primitives during construction. This will be part of the changes
to support interning of primitives for picture caching. This patch
allows all the primitives for a shadow to be created before the
shadow picture itself is added / created, which is required to work
with these planned changes.

Additionally, we can now detect if the shadow ended up having no
primitives in it, and skip adding the picture in this case. This
is probably a small win in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3167)
<!-- Reviewable:end -->
