### PR TITLE
delete FontInstances from FontContexts when evicting a GlyphCache

### DIFF
--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -325,6 +325,11 @@ impl FontContext {
         }
     }
 
+    pub fn delete_font_instance(&mut self, instance: &FontInstance) {
+        // Remove the CoreText font corresponding to this instance.
+        self.ct_fonts.remove(&(instance.font_key, instance.size, instance.variations.clone()));
+    }
+
     fn get_ct_font(
         &mut self,
         font_key: FontKey,

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -240,6 +240,10 @@ impl FontContext {
         }
     }
 
+    pub fn delete_font_instance(&mut self, _instance: &FontInstance) {
+        // This backend does not yet support variations, so there is nothing to do here.
+    }
+
     fn load_glyph(&self, font: &FontInstance, glyph: &GlyphKey) -> Option<(FT_GlyphSlot, f32)> {
         debug_assert!(self.faces.contains_key(&font.font_key));
         let face = self.faces.get(&font.font_key).unwrap();

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -145,6 +145,18 @@ impl FontContext {
         }
     }
 
+    pub fn delete_font_instance(&mut self, instance: &FontInstance) {
+        // Ensure we don't keep around excessive amounts of stale variations.
+        if !instance.variations.is_empty() {
+            let sims = if instance.flags.contains(FontInstanceFlags::SYNTHETIC_BOLD) {
+                dwrote::DWRITE_FONT_SIMULATIONS_BOLD
+            } else {
+                dwrote::DWRITE_FONT_SIMULATIONS_NONE
+            };
+            self.variations.remove(&(instance.font_key, sims, instance.variations.clone()));
+        }
+    }
+
     // Assumes RGB format from dwrite, which is 3 bytes per pixel as dwrite
     // doesn't output an alpha value via GlyphRunAnalysis::CreateAlphaTexture
     #[allow(dead_code)]

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1395,7 +1395,7 @@ impl ResourceCache {
         debug_assert_eq!(self.state, State::Idle);
         self.state = State::AddResources;
         self.texture_cache.begin_frame(frame_id);
-        self.cached_glyphs.begin_frame(&self.texture_cache, &self.cached_render_tasks);
+        self.cached_glyphs.begin_frame(&self.texture_cache, &self.cached_render_tasks, &mut self.glyph_rasterizer);
         self.cached_render_tasks.begin_frame(&mut self.texture_cache);
         self.current_frame_id = frame_id;
     }


### PR DESCRIPTION
This is to address Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1495661

If we have a page that is animating the variation values within a font, this can cause continuous accumulation of new FontInstances in the FontContext. These will never get cleared out until we delete the FontKey from which they were generated. This may never happen until the tab or window is closed, even though Gecko itself has long ago deleted the corresponding ScaledFonts to and told WR to delete the FontInstanceKeys.

Due to the fact that zoom and device scale can cause a FontInstanceKey to no longer map to the FontInstance used to key the GlyphCache and the FontContext, there can be multiple FontInstances with sizes that can't be traced back to the original FontInstanceKey. This prevents us from doing a straightforward deletion based on the value immediately stored with the FontInstanceKey.

However, we already have a mechanism in place to deal with this in the GlyphCache, evicting GlyphKeyCaches that have also been evicted from the TextureCache, so that we have effective limiting in place of FontInstances that haven't been recently used. So all we need to do here is connect that to deleting the FontInstance in the FontContext when it is being evicted from the GlyphCache. In the worst cases this may cause a false positive that evicts something from the FontContext while it is still alive, but it can be rematerialized when necessary, and this should be relatively rare. This will also give us a natural hard limit on the number of backend API fonts we keep around in this scenario.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3177)
<!-- Reviewable:end -->
