### PR TITLE
supply font variation tags to DWrite as little-endian

### DIFF
--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -197,7 +197,8 @@ impl FontContext {
                         sims,
                         &font.variations.iter().map(|var| {
                             dwrote::DWRITE_FONT_AXIS_VALUE {
-                                axisTag: var.tag,
+                                // OpenType tags are big-endian, but DWrite wants little-endian.
+                                axisTag: var.tag.swap_bytes(),
                                 value: var.value,
                             }
                         }).collect::<Vec<_>>(),


### PR DESCRIPTION
We aren't properly endian-swapping the font variation tags before we hand them off to DWrite, so the tags get ignored. This takes care to swap them so they are actually used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3179)
<!-- Reviewable:end -->
