### PR TITLE
 Add sRGB to linear and back conversion filters

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -845,6 +845,8 @@ impl AlphaBatchBuilder {
                                                     FilterOp::Opacity(..) => 8,
                                                     FilterOp::DropShadow(..) => 9,
                                                     FilterOp::ColorMatrix(..) => 10,
+                                                    FilterOp::SrgbToLinear => 11,
+                                                    FilterOp::LinearToSrgb => 12,
                                                 };
 
                                                 let user_data = match filter {
@@ -858,6 +860,7 @@ impl AlphaBatchBuilder {
                                                     FilterOp::Opacity(_, amount) => {
                                                         (amount * 65536.0) as i32
                                                     }
+                                                    FilterOp::SrgbToLinear | FilterOp::LinearToSrgb => 0,
                                                     FilterOp::HueRotate(angle) => {
                                                         (0.01745329251 * angle * 65536.0) as i32
                                                     }

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -219,7 +219,9 @@ impl FilterOpHelpers for FilterOp {
             FilterOp::Saturate(..) |
             FilterOp::Sepia(..) |
             FilterOp::DropShadow(..) |
-            FilterOp::ColorMatrix(..) => true,
+            FilterOp::ColorMatrix(..) |
+            FilterOp::SrgbToLinear |
+            FilterOp::LinearToSrgb  => true,
             FilterOp::Opacity(_, amount) => {
                 amount > OPACITY_EPSILON
             }
@@ -248,6 +250,7 @@ impl FilterOpHelpers for FilterOp {
                            0.0, 0.0, 0.0, 1.0,
                            0.0, 0.0, 0.0, 0.0]
             }
+            FilterOp::SrgbToLinear | FilterOp::LinearToSrgb => false,
         }
     }
 }

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -612,6 +612,8 @@ pub enum FilterOp {
     Sepia(f32),
     DropShadow(LayoutVector2D, f32, ColorF),
     ColorMatrix([f32; 20]),
+    SrgbToLinear,
+    LinearToSrgb,
 }
 
 impl FilterOp {

--- a/wrench/reftests/filters/reftest.list
+++ b/wrench/reftests/filters/reftest.list
@@ -36,5 +36,7 @@ platform(linux,mac) == blend-clipped.yaml blend-clipped.png
 == filter-segments.yaml filter-segments-ref.yaml
 == iframe-dropshadow.yaml iframe-dropshadow-ref.yaml
 == filter-mix-blend-mode.yaml filter-mix-blend-mode-ref.yaml
+== fuzzy(3,20000) srgb-to-linear.yaml srgb-to-linear-ref.yaml
+!= srgb-to-linear-2.yaml srgb-to-linear-ref.yaml
 != filter-blur-huge.yaml blank.yaml
 != filter-drop-shadow-huge.yaml blank.yaml

--- a/wrench/reftests/filters/srgb-to-linear-2.yaml
+++ b/wrench/reftests/filters/srgb-to-linear-2.yaml
@@ -1,0 +1,16 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 300, 100]
+      filters: [srgb-to-linear]
+      items:
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [200, 200, 200, 1.0]
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [100, 100, 100, 1.0]
+        - type: rect
+          bounds: [200, 0, 100, 100]
+          color: [50, 50, 50, 1.0]

--- a/wrench/reftests/filters/srgb-to-linear-ref.yaml
+++ b/wrench/reftests/filters/srgb-to-linear-ref.yaml
@@ -1,0 +1,15 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 300, 100]
+      items:
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [200, 200, 200, 1.0]
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [100, 100, 100, 1.0]
+        - type: rect
+          bounds: [200, 0, 100, 100]
+          color: [50, 50, 50, 1.0]

--- a/wrench/reftests/filters/srgb-to-linear.yaml
+++ b/wrench/reftests/filters/srgb-to-linear.yaml
@@ -1,0 +1,16 @@
+---
+root:
+  items:
+    - type: stacking-context
+      bounds: [0, 0, 300, 100]
+      filters: [srgb-to-linear, linear-to-srgb]
+      items:
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [200, 200, 200, 1.0]
+        - type: rect
+          bounds: [100, 0, 100, 100]
+          color: [100, 100, 100, 1.0]
+        - type: rect
+          bounds: [200, 0, 100, 100]
+          color: [50, 50, 50, 1.0]

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -250,6 +250,12 @@ fn write_stacking_context(
             FilterOp::ColorMatrix(matrix) => {
                 filters.push(Yaml::String(format!("color-matrix({:?})", matrix)))
             }
+            FilterOp::SrgbToLinear => {
+                filters.push(Yaml::String("srgb-to-linear".to_string()))
+            }
+            FilterOp::LinearToSrgb => {
+                filters.push(Yaml::String("linear-to-srgb".to_string()))
+            }
         }
     }
 

--- a/wrench/src/yaml_helper.rs
+++ b/wrench/src/yaml_helper.rs
@@ -576,6 +576,8 @@ impl YamlHelper for Yaml {
                 ("sepia", ref args, _) if args.len() == 1 => {
                     Some(FilterOp::Sepia(args[0].parse().unwrap()))
                 }
+                ("srgb-to-linear", _, _)  => Some(FilterOp::SrgbToLinear),
+                ("linear-to-srgb", _, _)  => Some(FilterOp::LinearToSrgb),
                 ("drop-shadow", ref args, _) if args.len() == 3 => {
                     let str = format!("---\noffset: {}\nblur-radius: {}\ncolor: {}\n", args[0], args[1], args[2]);
                     let mut yaml_doc = YamlLoader::load_from_str(&str).expect("Failed to parse drop-shadow");


### PR DESCRIPTION
Adds two filters implemented in brush_blend.glsl letting us convert between sRGB and linear color spaces, which we need to support a subset of the SVG filters through our CSS filters implementation.

Long term I'm not sure whether the best strategy would be to keep the extra passes to do the conversion or to add the input and output conversion directly in the other filters  through an extra flag. I suspect that it would be quite fast since the branch would be coherent.

In the mean time the current implementation is as simple as it gets, doesn't need any API change and is certainly faster than computing SVG blurs on the CPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3182)
<!-- Reviewable:end -->
