### PR TITLE
Make compute_tile_range crashes more verbose.

### DIFF
--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -237,12 +237,12 @@ pub fn compute_tile_range(
     let t0 = point2(
         f32::floor(visible_area.origin.x as f32 * tw),
         f32::floor(visible_area.origin.y as f32 * th),
-    ).cast::<u16>();
+    ).try_cast::<u16>().unwrap_or_else(|| panic!("compute_tile_range bad values {:?} {:?}", visible_area, tile_size));
 
     let t1 = point2(
         f32::ceil(visible_area.max_x() as f32 * tw),
         f32::ceil(visible_area.max_y() as f32 * th),
-    ).cast::<u16>();
+    ).try_cast::<u16>().unwrap_or_else(|| panic!("compute_tile_range bad values {:?} {:?}", visible_area, tile_size));
 
     TileRange {
         origin: t0,


### PR DESCRIPTION
These are happening in the wild. Let's figure out what the unexpected
values are.

See bug 1498385.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3192)
<!-- Reviewable:end -->
