### PR TITLE
Cache the current batch for both opaque and alpha batch lists.

### DIFF
--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -9,7 +9,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,
@@ -30,6 +30,7 @@ void main(void) {
     int segment_index = aData.z & 0xffff;
     int edge_flags = (aData.z >> 16) & 0xff;
     int brush_flags = (aData.z >> 24) & 0xff;
+    int segment_user_data = aData.w;
     PrimitiveHeader ph = fetch_prim_header(prim_header_address);
 
     // Fetch the segment of this brush primitive we are drawing.
@@ -102,7 +103,7 @@ void main(void) {
         ph.specific_prim_address,
         ph.local_rect,
         local_segment_rect,
-        ph.user_data,
+        ivec4(ph.user_data, segment_user_data),
         transform.m,
         pic_task,
         brush_flags,

--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -21,7 +21,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -47,7 +47,7 @@ void brush_vs(
     int prim_address,
     RectWithSize prim_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,
@@ -63,7 +63,7 @@ void brush_vs(
     vec2 texture_size = vec2(textureSize(sColor0, 0));
 #endif
 
-    ImageResource res = fetch_image_resource(user_data.x);
+    ImageResource res = fetch_image_resource(user_data.w);
     vec2 uv0 = res.uv_rect.p0;
     vec2 uv1 = res.uv_rect.p1;
 
@@ -106,8 +106,8 @@ void brush_vs(
     vec2 f = (vi.local_pos - local_rect.p0) / local_rect.size;
 
 #ifdef WR_FEATURE_ALPHA_PASS
-    int color_mode = user_data.y >> 16;
-    int raster_space = user_data.y & 0xffff;
+    int color_mode = user_data.x;
+    int raster_space = user_data.y;
 
     if (color_mode == COLOR_MODE_FROM_PASS) {
         color_mode = uMode;
@@ -121,7 +121,7 @@ void brush_vs(
             // Since the screen space UVs specify an arbitrary quad, do
             // a bilinear interpolation to get the correct UV for this
             // local position.
-            ImageResourceExtra extra_data = fetch_image_resource_extra(user_data.x);
+            ImageResourceExtra extra_data = fetch_image_resource_extra(user_data.w);
             vec2 x = mix(extra_data.st_tl, extra_data.st_tr, f.x);
             vec2 y = mix(extra_data.st_bl, extra_data.st_br, f.x);
             f = mix(x, y, f.y);

--- a/webrender/res/brush_linear_gradient.glsl
+++ b/webrender/res/brush_linear_gradient.glsl
@@ -45,7 +45,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/res/brush_mix_blend.glsl
+++ b/webrender/res/brush_mix_blend.glsl
@@ -22,7 +22,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/res/brush_radial_gradient.glsl
+++ b/webrender/res/brush_radial_gradient.glsl
@@ -45,7 +45,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/res/brush_solid.glsl
+++ b/webrender/res/brush_solid.glsl
@@ -28,7 +28,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/res/brush_yuv_image.glsl
+++ b/webrender/res/brush_yuv_image.glsl
@@ -86,7 +86,7 @@ void brush_vs(
     int prim_address,
     RectWithSize local_rect,
     RectWithSize segment_rect,
-    ivec3 user_data,
+    ivec4 user_data,
     mat4 transform,
     PictureTask pic_task,
     int brush_flags,

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -331,6 +331,7 @@ pub struct BrushInstance {
     pub segment_index: i32,
     pub edge_flags: EdgeAaSegmentMask,
     pub brush_flags: BrushFlags,
+    pub user_data: i32,
 }
 
 impl From<BrushInstance> for PrimitiveInstanceData {
@@ -342,7 +343,7 @@ impl From<BrushInstance> for PrimitiveInstanceData {
                 instance.segment_index |
                 ((instance.edge_flags.bits() as i32) << 16) |
                 ((instance.brush_flags.bits() as i32) << 24),
-                0,
+                instance.user_data,
             ]
         }
     }


### PR DESCRIPTION
In the (near) future, we will want to support adding segments
where the texture may be different between segments (it is
currently assumed to be the same for all segments in a single
primitive). To do this efficiently, we need to be able to add
segments while switching batch only when necessary, so we now
cache the current batch in the batch lists, and re-use it if
the batch keys are compatible.

This is also a general optimization for opaque batches - this
patch allows the previously cached batch to be re-used for
different opaque primitives. This can avoid searching the
batch array when sequences of the same opaque primitive are
added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3197)
<!-- Reviewable:end -->
