### PR TITLE
Add border segments to the opaque render pass where possible.

### DIFF
--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -192,6 +192,7 @@ impl<'a> DisplayListFlattener<'a> {
 
 pub trait BorderSideHelpers {
     fn border_color(&self, is_inner_border: bool) -> ColorF;
+    fn is_opaque(&self) -> bool;
 }
 
 impl BorderSideHelpers for BorderSide {
@@ -219,6 +220,11 @@ impl BorderSideHelpers for BorderSide {
 
         let black = if lighter { 0.7 } else { 0.3 };
         ColorF::new(black, black, black, self.color.a)
+    }
+
+    /// Returns true if all pixels in this border style are opaque.
+    fn is_opaque(&self) -> bool {
+        self.color.a >= 1.0 && self.style.is_opaque()
     }
 }
 
@@ -956,6 +962,12 @@ fn add_corner_segment(
         return;
     }
 
+    let is_opaque =
+        side0.is_opaque() &&
+        side1.is_opaque() &&
+        radius.width <= 0.0 &&
+        radius.height <= 0.0;
+
     brush_segments.push(
         BrushSegment::new(
             image_rect,
@@ -969,6 +981,7 @@ fn add_corner_segment(
     border_segments.push(BorderSegmentInfo {
         handle: None,
         local_task_size: image_rect.size,
+        is_opaque,
         cache_key: RenderTaskCacheKey {
             size: DeviceIntSize::zero(),
             kind: RenderTaskCacheKeyKind::BorderCorner(
@@ -1022,6 +1035,8 @@ fn add_edge_segment(
         return;
     }
 
+    let is_opaque = side.is_opaque();
+
     brush_segments.push(
         BrushSegment::new(
             image_rect,
@@ -1035,6 +1050,7 @@ fn add_edge_segment(
     border_segments.push(BorderSegmentInfo {
         handle: None,
         local_task_size: size,
+        is_opaque,
         cache_key: RenderTaskCacheKey {
             size: DeviceIntSize::zero(),
             kind: RenderTaskCacheKeyKind::BorderEdge(

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -352,6 +352,7 @@ pub struct BorderSegmentInfo {
     pub handle: Option<RenderTaskCacheEntryHandle>,
     pub local_task_size: LayoutSize,
     pub cache_key: RenderTaskCacheKey,
+    pub is_opaque: bool,
 }
 
 #[derive(Debug)]
@@ -2868,7 +2869,7 @@ impl Primitive {
                                         frame_state.gpu_cache,
                                         frame_state.render_tasks,
                                         None,
-                                        false,          // TODO(gw): We don't calculate opacity for borders yet!
+                                        segment.is_opaque,
                                         |render_tasks| {
                                             let task = RenderTask::new_border_segment(
                                                 segment.cache_key.size,

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -435,6 +435,29 @@ impl BorderStyle {
     pub fn is_hidden(&self) -> bool {
         *self == BorderStyle::Hidden || *self == BorderStyle::None
     }
+
+    /// Returns true if the border style itself is opaque. Other
+    /// factors (such as color, or border radii) may mean that
+    /// the border segment isn't opaque regardless of this.
+    pub fn is_opaque(&self) -> bool {
+        match *self {
+            BorderStyle::None |
+            BorderStyle::Double |
+            BorderStyle::Dotted |
+            BorderStyle::Dashed |
+            BorderStyle::Hidden => {
+                false
+            }
+
+            BorderStyle::Solid |
+            BorderStyle::Groove |
+            BorderStyle::Ridge |
+            BorderStyle::Inset |
+            BorderStyle::Outset => {
+                true
+            }
+        }
+    }
 }
 
 #[repr(u32)]


### PR DESCRIPTION
Use the new per-segment instance data to allow specifying a
per-segment opacity value. This is used for border segments
to specify which border segments are opaque.

Any time we move segments or primitives to the opaque pass
is typically a significant GPU time win due to the reduced
overdraw. It's also a CPU optimization during batching.