### PR TITLE
Store picture primitives in a vec, and refer by index in prims.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -14,7 +14,7 @@ use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState};
 use frame_builder::{PictureContext, PrimitiveContext};
 use gpu_cache::{GpuCacheHandle};
 use gpu_types::UvRectKind;
-use prim_store::{PrimitiveInstance, SpaceMapper};
+use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper};
 use prim_store::{PrimitiveMetadata, get_raster_rects};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
@@ -242,6 +242,7 @@ impl PicturePrimitive {
 
     pub fn take_context(
         &mut self,
+        pic_index: PictureIndex,
         prim_context: &PrimitiveContext,
         surface_spatial_node_index: SpatialNodeIndex,
         raster_spatial_node_index: SpatialNodeIndex,
@@ -366,6 +367,7 @@ impl PicturePrimitive {
         };
 
         let context = PictureContext {
+            pic_index,
             pipeline_id: self.pipeline_id,
             apply_local_clip_rect: self.apply_local_clip_rect,
             inflation_factor,
@@ -439,6 +441,7 @@ impl PicturePrimitive {
 
     pub fn prepare_for_render(
         &mut self,
+        pic_index: PictureIndex,
         prim_instance: &PrimitiveInstance,
         prim_metadata: &PrimitiveMetadata,
         pic_state: &mut PictureState,
@@ -511,7 +514,7 @@ impl PicturePrimitive {
                             let picture_task = RenderTask::new_picture(
                                 RenderTaskLocation::Dynamic(None, device_rect.size),
                                 unclipped.size,
-                                prim_instance.prim_index,
+                                pic_index,
                                 device_rect.origin,
                                 pic_state_for_children.tasks,
                                 uv_rect_kind,
@@ -569,7 +572,7 @@ impl PicturePrimitive {
                                     let picture_task = RenderTask::new_picture(
                                         RenderTaskLocation::Dynamic(None, device_rect.size),
                                         unclipped.size,
-                                        prim_instance.prim_index,
+                                        pic_index,
                                         device_rect.origin,
                                         child_tasks,
                                         uv_rect_kind,
@@ -626,7 +629,7 @@ impl PicturePrimitive {
                         let mut picture_task = RenderTask::new_picture(
                             RenderTaskLocation::Dynamic(None, device_rect.size),
                             unclipped.size,
-                            prim_instance.prim_index,
+                            pic_index,
                             device_rect.origin,
                             pic_state_for_children.tasks,
                             uv_rect_kind,
@@ -697,7 +700,7 @@ impl PicturePrimitive {
                         let picture_task = RenderTask::new_picture(
                             RenderTaskLocation::Dynamic(None, clipped.size),
                             unclipped.size,
-                            prim_instance.prim_index,
+                            pic_index,
                             clipped.origin,
                             pic_state_for_children.tasks,
                             uv_rect_kind,
@@ -734,7 +737,7 @@ impl PicturePrimitive {
                         let picture_task = RenderTask::new_picture(
                             RenderTaskLocation::Dynamic(None, clipped.size),
                             unclipped.size,
-                            prim_instance.prim_index,
+                            pic_index,
                             clipped.origin,
                             pic_state_for_children.tasks,
                             uv_rect_kind,
@@ -756,7 +759,7 @@ impl PicturePrimitive {
                         let picture_task = RenderTask::new_picture(
                             RenderTaskLocation::Dynamic(None, clipped.size),
                             unclipped.size,
-                            prim_instance.prim_index,
+                            pic_index,
                             clipped.origin,
                             pic_state_for_children.tasks,
                             uv_rect_kind,

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -22,7 +22,7 @@ use internal_types::{CacheTextureId, FastHashMap, LayerIndex, SavedTargetIndex};
 #[cfg(feature = "pathfinder")]
 use pathfinder_partitioner::mesh::Mesh;
 use picture::PictureCacheKey;
-use prim_store::{PrimitiveIndex, ImageCacheKey, LineDecorationCacheKey};
+use prim_store::{PictureIndex, ImageCacheKey, LineDecorationCacheKey};
 #[cfg(feature = "debugger")]
 use print_tree::{PrintTreePrinter};
 use render_backend::FrameId;
@@ -222,7 +222,7 @@ pub struct ClipRegionTask {
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PictureTask {
-    pub prim_index: PrimitiveIndex,
+    pub pic_index: PictureIndex,
     pub can_merge: bool,
     pub content_origin: DeviceIntPoint,
     pub uv_rect_handle: GpuCacheHandle,
@@ -384,7 +384,7 @@ impl RenderTask {
     pub fn new_picture(
         location: RenderTaskLocation,
         unclipped_size: DeviceSize,
-        prim_index: PrimitiveIndex,
+        pic_index: PictureIndex,
         content_origin: DeviceIntPoint,
         children: Vec<RenderTaskId>,
         uv_rect_kind: UvRectKind,
@@ -405,7 +405,7 @@ impl RenderTask {
             location,
             children,
             kind: RenderTaskKind::Picture(PictureTask {
-                prim_index,
+                pic_index,
                 content_origin,
                 can_merge,
                 uv_rect_handle: GpuCacheHandle::new(),
@@ -992,7 +992,7 @@ impl RenderTask {
     pub fn print_with<T: PrintTreePrinter>(&self, pt: &mut T, tree: &RenderTaskTree) -> bool {
         match self.kind {
             RenderTaskKind::Picture(ref task) => {
-                pt.new_level(format!("Picture of {:?}", task.prim_index));
+                pt.new_level(format!("Picture of {:?}", task.pic_index));
             }
             RenderTaskKind::CacheMask(ref task) => {
                 pt.new_level(format!("CacheMask with {} clips", task.clip_node_range.count));

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -407,7 +407,7 @@ impl RenderTarget for ColorRenderTarget {
 
             match task.kind {
                 RenderTaskKind::Picture(ref pic_task) => {
-                    let pic = ctx.prim_store.get_pic(pic_task.prim_index);
+                    let pic = &ctx.prim_store.pictures[pic_task.pic_index.0];
 
                     let (target_rect, _) = task.get_target_rect();
 
@@ -472,7 +472,7 @@ impl RenderTarget for ColorRenderTarget {
                 );
             }
             RenderTaskKind::Picture(ref task_info) => {
-                let pic = ctx.prim_store.get_pic(task_info.prim_index);
+                let pic = &ctx.prim_store.pictures[task_info.pic_index.0];
                 self.alpha_tasks.push(task_id);
 
                 // If this pipeline is registered as a frame output


### PR DESCRIPTION
This is prep work for changing the structure of the prepare_prims
pass.

Currently, the code is (roughly):
 - Traverse primitive tree, recursing through pictures.
  - When visible, call prepare_prim to update GPU cache, clips etc.
 - Assign render tasks to passes.
 - Assign primitive lists for each picture to batches.

In future, it will instead be:
 - Traverse picture tree, but not individual primitives.
  - Determine surface allocation, plane-splitting, visibility.
 - For each visible picture, prepare_prims and add to batches.

This will simplify some existing code, as well as making possible
some requirements for picture caching (e.g. determining the scale
to rasterize a picture at before creating the child render tasks).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3213)
<!-- Reviewable:end -->
