### PR TITLE
Avoid capturing platform-specific font data

### DIFF
--- a/webrender/src/capture.rs
+++ b/webrender/src/capture.rs
@@ -71,7 +71,7 @@ impl CaptureConfig {
             .unwrap();
         match ron::de::from_str(&string) {
             Ok(out) => Some(out),
-            Err(e) => panic!("File {:?} deserilalization failed: {:?}", name.as_ref(), e),
+            Err(e) => panic!("File {:?} deserialization failed: {:?}", name.as_ref(), e),
         }
     }
 

--- a/webrender/src/capture.rs
+++ b/webrender/src/capture.rs
@@ -63,14 +63,16 @@ impl CaptureConfig {
 
         let mut string = String::new();
         let path = root
-            .join(name)
+            .join(name.as_ref())
             .with_extension("ron");
         File::open(path)
             .ok()?
             .read_to_string(&mut string)
             .unwrap();
-        Some(ron::de::from_str(&string)
-            .unwrap())
+        match ron::de::from_str(&string) {
+            Ok(out) => Some(out),
+            Err(e) => panic!("File {:?} deserilalization failed: {:?}", name.as_ref(), e),
+        }
     }
 
     #[cfg(feature = "png")]

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -178,6 +178,7 @@ pub struct FontInstance {
     pub render_mode: FontRenderMode,
     pub flags: FontInstanceFlags,
     pub synthetic_italics: SyntheticItalics,
+    #[cfg_attr(any(feature = "capture", feature = "replay"), serde(skip))]
     pub platform_options: Option<FontInstancePlatformOptions>,
     pub variations: Vec<FontVariation>,
     pub transform: FontTransform,


### PR DESCRIPTION
This PR avoids the capturing to carry or load the platform-specific font instance data. It's less ideal for the case where the replay is done on the same platform, but makes captures more robust and portable overall. Ideally, we'd want to still save it but ignore on other platforms, but this would be less trivial (TODO).
r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3215)
<!-- Reviewable:end -->
