### PR TITLE
Retain texture cache entries if fewer than 32

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -611,19 +611,20 @@ impl TextureCache {
             }
         }
 
-        // Sort by access time so we remove the oldest ones first.
-        eviction_candidates.sort_by_key(|handle| {
-            let entry = self.entries.get(handle);
-            entry.last_access
-        });
-
         // We only allow an arbitrary number of unused
         // standalone textures to remain in GPU memory.
         // TODO(gw): We should make this a better heuristic,
         //           for example based on total memory size.
         if eviction_candidates.len() > 32 {
+            // Sort by access time so we remove the oldest ones first.
+            eviction_candidates.sort_by_key(|handle| {
+                let entry = self.entries.get(handle);
+                entry.last_access
+            });
             let entries_to_keep = eviction_candidates.split_off(32);
             retained_entries.extend(entries_to_keep);
+        } else {
+            retained_entries.extend(eviction_candidates.drain(..));
         }
 
         // Free the selected items


### PR DESCRIPTION
Noticed this when looking at how the caching interacts with
documents. Correct me if I'm wrong but this looks unintended - at
the very least it doesn't seem to match the comment.

Additionally, this moves the sorting inside the > 32 clause, since
there's no point in sorting if we're going to retain them all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3216)
<!-- Reviewable:end -->
