### PR TITLE
Don't update max_size for tasks drawn into the texture cache

### DIFF
--- a/webrender/src/glyph_rasterizer/pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/pathfinder.rs
@@ -302,7 +302,7 @@ fn request_render_task_from_pathfinder(glyph_key: &GlyphKey,
     let embolden_amount = compute_embolden_amount(size.to_f32_px());
 
     let location = RenderTaskLocation::Dynamic(None, *glyph_size);
-    let glyph_render_task = RenderTask::new_glyph(location,
+    let glyph_render_task = RenderTask::new_glyph(location.clone(),
                                                   mesh,
                                                   &glyph_origin,
                                                   &subpixel_offset,
@@ -314,7 +314,7 @@ fn request_render_task_from_pathfinder(glyph_key: &GlyphKey,
         FontRenderMode::Mono | FontRenderMode::Alpha => &mut render_passes.alpha_glyph_pass,
         FontRenderMode::Subpixel => &mut render_passes.color_glyph_pass,
     };
-    render_pass.add_render_task(root_task_id, *glyph_size, RenderTargetKind::Color);
+    render_pass.add_render_task(root_task_id, *glyph_size, RenderTargetKind::Color, &location);
 
     Ok(root_task_id)
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -125,7 +125,7 @@ impl RenderTaskTree {
         };
 
         let pass = &mut passes[pass_index];
-        pass.add_render_task(id, task.get_dynamic_size(), task.target_kind());
+        pass.add_render_task(id, task.get_dynamic_size(), task.target_kind(), &task.location);
     }
 
     pub fn prepare_for_render(&mut self) {
@@ -173,7 +173,7 @@ impl ops::IndexMut<RenderTaskId> for RenderTaskTree {
 }
 
 /// Identifies the output buffer location for a given `RenderTask`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum RenderTaskLocation {
@@ -200,6 +200,16 @@ pub enum RenderTaskLocation {
         /// The target region within the above layer.
         rect: DeviceIntRect,
     },
+}
+
+impl RenderTaskLocation {
+    /// Returns true if this is a dynamic location.
+    pub fn is_dynamic(&self) -> bool {
+        match *self {
+            RenderTaskLocation::Dynamic(..) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -195,13 +195,14 @@ pub enum RenderTargetKind {
 pub struct RenderTargetList<T> {
     screen_size: DeviceIntSize,
     pub format: ImageFormat,
-    /// The maximum width and height of any single primitive we've encountered.
+    /// The maximum width and height of any single primitive we've encountered
+    /// that will be drawn to a dynamic location.
     ///
     /// We initially create our per-slice allocators with a width and height of
     /// IDEAL_MAX_TEXTURE_DIMENSION. If we encounter a larger primitive, the
-    /// allocation will fail, but we'll bump max_size, which will cause the
+    /// allocation will fail, but we'll bump max_dynamic_size, which will cause the
     /// allocator for the next slice to be just large enough to accomodate it.
-    pub max_size: DeviceUintSize,
+    pub max_dynamic_size: DeviceUintSize,
     pub targets: Vec<T>,
     pub saved_index: Option<SavedTargetIndex>,
 }
@@ -214,7 +215,7 @@ impl<T: RenderTarget> RenderTargetList<T> {
         RenderTargetList {
             screen_size,
             format,
-            max_size: DeviceUintSize::new(0, 0),
+            max_dynamic_size: DeviceUintSize::new(0, 0),
             targets: Vec::new(),
             saved_index: None,
         }
@@ -283,8 +284,8 @@ impl<T: RenderTarget> RenderTargetList<T> {
                 // dimensions, unless we've already gone bigger on a previous
                 // slice.
                 let allocator_dimensions = DeviceUintSize::new(
-                    cmp::max(IDEAL_MAX_TEXTURE_DIMENSION, self.max_size.width),
-                    cmp::max(IDEAL_MAX_TEXTURE_DIMENSION, self.max_size.height),
+                    cmp::max(IDEAL_MAX_TEXTURE_DIMENSION, self.max_dynamic_size.width),
+                    cmp::max(IDEAL_MAX_TEXTURE_DIMENSION, self.max_dynamic_size.height),
                 );
                 let mut new_target = T::new(Some(allocator_dimensions), self.screen_size);
                 let origin = new_target.allocate(alloc_size).expect(&format!(
@@ -305,8 +306,8 @@ impl<T: RenderTarget> RenderTargetList<T> {
 
     pub fn check_ready(&self, t: &Texture) {
         let dimensions = t.get_dimensions();
-        assert!(dimensions.width >= self.max_size.width);
-        assert!(dimensions.height >= self.max_size.height);
+        assert!(dimensions.width >= self.max_dynamic_size.width);
+        assert!(dimensions.height >= self.max_dynamic_size.height);
         assert_eq!(t.get_format(), self.format);
         assert_eq!(t.get_layer_count() as usize, self.targets.len());
         assert!(t.supports_depth() >= self.needs_depth());
@@ -893,14 +894,21 @@ impl RenderPass {
         task_id: RenderTaskId,
         size: DeviceIntSize,
         target_kind: RenderTargetKind,
+        location: &RenderTaskLocation,
     ) {
         if let RenderPassKind::OffScreen { ref mut color, ref mut alpha, .. } = self.kind {
-            let max_size = match target_kind {
-                RenderTargetKind::Color => &mut color.max_size,
-                RenderTargetKind::Alpha => &mut alpha.max_size,
-            };
-            max_size.width = cmp::max(max_size.width, size.width as u32);
-            max_size.height = cmp::max(max_size.height, size.height as u32);
+            // If this will be rendered to a dynamically-allocated region on an
+            // off-screen render target, update the max-encountered size. We don't
+            // need to do this for things drawn to the texture cache, since those
+            // don't affect our render target allocation.
+            if location.is_dynamic() {
+                let max_size = match target_kind {
+                    RenderTargetKind::Color => &mut color.max_dynamic_size,
+                    RenderTargetKind::Alpha => &mut alpha.max_dynamic_size,
+                };
+                max_size.width = cmp::max(max_size.width, size.width as u32);
+                max_size.height = cmp::max(max_size.height, size.height as u32);
+            }
         }
 
         self.tasks.push(task_id);


### PR DESCRIPTION
Previously, we sized all render target textures using max_size. This
changed, and now we size them based on the union of the allocator's used_rect
for each slice.

At present, the code updates max_size for every render task. But it's
only used to size the per-slice allocators, which in turn are only used
for RenderTaskLocation::Dynamic. Accounting for this fixes a panic
(wherein check_ready can fail because the texture is smaller than
max_size) and also allows more-efficient render target texture sizing.

Differential Revision: https://phabricator.services.mozilla.com/D9608

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3226)
<!-- Reviewable:end -->
