### PR TITLE
Introduce picture traversal pass.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -16,11 +16,12 @@ use frame_builder::{PictureContext, PrimitiveContext};
 use gpu_cache::{GpuCacheAddress, GpuCacheHandle};
 use gpu_types::{TransformPalette, TransformPaletteId, UvRectKind};
 use plane_split::{Clipper, Polygon, Splitter};
-use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper};
-use prim_store::{get_raster_rects};
+use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper, PrimitiveDetails};
+use prim_store::{Primitive, get_raster_rects, BrushKind, BrushPrimitive};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
 use scene::{FilterOpHelpers, SceneProperties};
+use smallvec::SmallVec;
 use std::mem;
 use tiling::RenderTargetKind;
 use util::{TransformedRectKind, MatrixHelpers, MaxRect};
@@ -34,6 +35,14 @@ use util::{TransformedRectKind, MatrixHelpers, MaxRect};
  * A configuration describing how to draw the primitives on
    this picture (e.g. in screen space or local space).
  */
+
+/// A context structure passed from parent to child
+/// during the first frame building pass, when just
+/// pictures are traversed.
+pub struct PictureUpdateContext {
+    pub surface_spatial_node_index: SpatialNodeIndex,
+    pub raster_spatial_node_index: SpatialNodeIndex,
+}
 
 #[derive(Debug)]
 pub struct RasterConfig {
@@ -183,6 +192,46 @@ pub struct OrderedPictureChild {
     pub gpu_address: GpuCacheAddress,
 }
 
+/// A list of primitive instances that are added to a picture
+/// This ensures we can keep a list of primitives that
+/// are pictures, for a fast initial traversal of the picture
+/// tree without walking the instance list.
+pub struct PrimitiveList {
+    pub prim_instances: Vec<PrimitiveInstance>,
+    pub pictures: SmallVec<[PictureIndex; 4]>,
+}
+
+impl PrimitiveList {
+    pub fn new(
+        prim_instances: Vec<PrimitiveInstance>,
+        primitives: &[Primitive],
+    ) -> Self {
+        let mut pictures = SmallVec::new();
+
+        // Walk the list of primitive instances and extract any that
+        // are pictures.
+        for prim_instance in &prim_instances {
+            let prim = &primitives[prim_instance.prim_index.0];
+            match prim.details {
+                PrimitiveDetails::Brush(BrushPrimitive { kind: BrushKind::Picture { pic_index }, .. }) => {
+                    pictures.push(pic_index);
+                }
+                _ => {
+                    // TODO(gw): For now, we don't do anything with non-picture primitives.
+                    //           However, in the near future we'll accumulate the static
+                    //           bounding rects for primitive clusters here, so that we can
+                    //           quickly determine the size of a picture during frame building.
+                }
+            }
+        }
+
+        PrimitiveList {
+            prim_instances,
+            pictures,
+        }
+    }
+}
+
 pub struct PicturePrimitive {
     // List of primitive runs that make up this picture.
     pub prim_instances: Vec<PrimitiveInstance>,
@@ -223,6 +272,13 @@ pub struct PicturePrimitive {
 
     // Unique identifier for this picture.
     pub id: PictureId,
+
+    /// List of the children that are picture primitives.
+    child_pictures: SmallVec<[PictureIndex; 4]>,
+
+    /// The spatial node index of this picture when it is
+    /// composited into the parent picture.
+    spatial_node_index: SpatialNodeIndex,
 }
 
 impl PicturePrimitive {
@@ -242,6 +298,15 @@ impl PicturePrimitive {
         }
     }
 
+    fn is_visible(&self) -> bool {
+        match self.requested_composite_mode {
+            Some(PictureCompositeMode::Filter(ref filter)) => {
+                filter.is_visible()
+            }
+            _ => true,
+        }
+    }
+
     pub fn new_image(
         id: PictureId,
         requested_composite_mode: Option<PictureCompositeMode>,
@@ -250,10 +315,12 @@ impl PicturePrimitive {
         frame_output_pipeline_id: Option<PipelineId>,
         apply_local_clip_rect: bool,
         requested_raster_space: RasterSpace,
-        prim_instances: Vec<PrimitiveInstance>,
+        prim_list: PrimitiveList,
+        spatial_node_index: SpatialNodeIndex,
     ) -> Self {
         PicturePrimitive {
-            prim_instances,
+            prim_instances: prim_list.prim_instances,
+            child_pictures: prim_list.pictures,
             state: None,
             secondary_render_task_id: None,
             requested_composite_mode,
@@ -265,6 +332,7 @@ impl PicturePrimitive {
             pipeline_id,
             id,
             requested_raster_space,
+            spatial_node_index,
         }
     }
 
@@ -280,7 +348,7 @@ impl PicturePrimitive {
         frame_context: &FrameBuildingContext,
         is_chased: bool,
     ) -> Option<(PictureContext, PictureState, Vec<PrimitiveInstance>)> {
-        if !self.resolve_scene_properties(frame_context.scene_properties) {
+        if !self.is_visible() {
             if cfg!(debug_assertions) && is_chased {
                 println!("\tculled for carrying an invisible composite filter");
             }
@@ -288,51 +356,19 @@ impl PicturePrimitive {
             return None;
         }
 
-        let actual_composite_mode = match self.requested_composite_mode {
-            Some(PictureCompositeMode::Filter(filter)) if filter.is_noop() => None,
-            mode => mode,
+        // Extract the raster and surface spatial nodes from the raster
+        // config, if this picture establishes a surface. Otherwise just
+        // pass in the spatial node indices from the parent context.
+        let (raster_spatial_node_index, surface_spatial_node_index) = match self.raster_config {
+            Some(ref raster_config) => {
+                (raster_config.raster_spatial_node_index, self.spatial_node_index)
+            }
+            None => {
+                (raster_spatial_node_index, surface_spatial_node_index)
+            }
         };
 
-        let has_surface = actual_composite_mode.is_some();
-
-        let surface_spatial_node_index = if has_surface {
-            prim_context.spatial_node_index
-        } else {
-            surface_spatial_node_index
-        };
-
-        let xf = frame_context.clip_scroll_tree.get_relative_transform(
-            raster_spatial_node_index,
-            surface_spatial_node_index,
-        ).expect("todo");
-
-        // Establish a new rasterization root if we have
-        // a surface, and we have perspective or local raster
-        // space request.
-        let raster_space = self.requested_raster_space;
-
-        // TODO(gw): A temporary hack here to revert behavior to
-        //           always raster in screen-space. This is not
-        //           a problem yet, since we're not taking advantage
-        //           of this for caching yet. This is a workaround
-        //           for some existing issues with handling scale
-        //           when rasterizing in local space mode. Once
-        //           the fixes for those are in-place, we can
-        //           remove this hack!
-        //let local_scale = raster_space.local_scale();
-        // let wants_raster_root = xf.has_perspective_component() ||
-        //                         local_scale.is_some();
-        let wants_raster_root = xf.has_perspective_component();
-
-        let establishes_raster_root = has_surface && wants_raster_root;
-
-        let raster_spatial_node_index = if establishes_raster_root {
-            surface_spatial_node_index
-        } else {
-            raster_spatial_node_index
-        };
-
-        if has_surface {
+        if self.raster_config.is_some() {
             frame_state.clip_store
                 .push_surface(surface_spatial_node_index);
         }
@@ -375,14 +411,6 @@ impl PicturePrimitive {
             LayoutRect::zero(), // bounds aren't going to be used for this mapping
         );
 
-        self.raster_config = actual_composite_mode.map(|composite_mode| {
-            RasterConfig {
-                composite_mode,
-                surface: None,
-                raster_spatial_node_index,
-            }
-        });
-
         let state = PictureState {
             tasks: Vec::new(),
             has_non_root_coord_system: false,
@@ -420,7 +448,7 @@ impl PicturePrimitive {
             inflation_factor,
             allow_subpixel_aa,
             is_passthrough: self.raster_config.is_none(),
-            raster_space,
+            raster_space: self.requested_raster_space,
             local_spatial_node_index: prim_context.spatial_node_index,
             raster_spatial_node_index,
             surface_spatial_node_index,
@@ -592,6 +620,85 @@ impl PicturePrimitive {
                 gpu_address,
             });
         }
+    }
+
+    /// Called during initial picture traversal, before we know the
+    /// bounding rect of children. It is possible to determine the
+    /// surface / raster config now though.
+    pub fn pre_update(
+        &mut self,
+        context: &PictureUpdateContext,
+        frame_context: &FrameBuildingContext,
+    ) -> Option<(PictureUpdateContext, SmallVec<[PictureIndex; 4]>)> {
+        // Reset raster config in case we early out below.
+        self.raster_config = None;
+
+        if !self.resolve_scene_properties(frame_context.scene_properties) {
+            return None;
+        }
+
+        let actual_composite_mode = match self.requested_composite_mode {
+            Some(PictureCompositeMode::Filter(filter)) if filter.is_noop() => None,
+            mode => mode,
+        };
+
+        let has_surface = actual_composite_mode.is_some();
+
+        let surface_spatial_node_index = if has_surface {
+            self.spatial_node_index
+        } else {
+            context.surface_spatial_node_index
+        };
+
+        let xf = frame_context.clip_scroll_tree.get_relative_transform(
+            context.raster_spatial_node_index,
+            surface_spatial_node_index,
+        ).expect("BUG: unable to get relative transform");
+
+        // TODO(gw): A temporary hack here to revert behavior to
+        //           always raster in screen-space. This is not
+        //           a problem yet, since we're not taking advantage
+        //           of this for caching yet. This is a workaround
+        //           for some existing issues with handling scale
+        //           when rasterizing in local space mode. Once
+        //           the fixes for those are in-place, we can
+        //           remove this hack!
+        //let local_scale = raster_space.local_scale();
+        // let wants_raster_root = xf.has_perspective_component() ||
+        //                         local_scale.is_some();
+        let wants_raster_root = xf.has_perspective_component();
+
+        let establishes_raster_root = has_surface && wants_raster_root;
+
+        let raster_spatial_node_index = if establishes_raster_root {
+            surface_spatial_node_index
+        } else {
+            context.raster_spatial_node_index
+        };
+
+        self.raster_config = actual_composite_mode.map(|composite_mode| {
+            RasterConfig {
+                composite_mode,
+                surface: None,
+                raster_spatial_node_index,
+            }
+        });
+
+        let child_context = PictureUpdateContext {
+            raster_spatial_node_index,
+            surface_spatial_node_index,
+        };
+
+        Some((child_context, mem::replace(&mut self.child_pictures, SmallVec::new())))
+    }
+
+    /// Called after updating child pictures during the initial
+    /// picture traversal.
+    pub fn post_update(
+        &mut self,
+        child_pictures: SmallVec<[PictureIndex; 4]>,
+    ) {
+        self.child_pictures = child_pictures;
     }
 
     pub fn prepare_for_render(

--- a/wrench/reftests/text/reftest.list
+++ b/wrench/reftests/text/reftest.list
@@ -58,7 +58,7 @@ platform(linux) == two-shadows.yaml two-shadows.png
 == shadow-clip.yaml shadow-clip-ref.yaml
 == shadow-fast-clip.yaml shadow-fast-clip-ref.yaml
 == shadow-partial-glyph.yaml shadow-partial-glyph-ref.yaml
-fuzzy(1,68) platform(linux) == shadow-transforms.yaml shadow-transforms.png
+fuzzy(1,89) platform(linux) == shadow-transforms.yaml shadow-transforms.png
 fuzzy(1,71) platform(linux) == raster-space.yaml raster-space.png
 != allow-subpixel.yaml allow-subpixel-ref.yaml
 == bg-color.yaml bg-color-ref.yaml


### PR DESCRIPTION
This introduces a new pass during frame building. It's a very
quick pass, since we only traverse the picture tree. This pass
must not access individual primitives.

In the future, the prepare_prims pass will be split into two
parts. Some of the work done in that pass will be moved to this
picture traversal pass (e.g. plane splitting), while the rest
(e.g GPU cache updates) will be moved to the batching pass.

The outcome of the first pass will determine whether a picture
has a valid cached surface, and thus decide whether the second
primitive preparation and batching pass is required to build
a new surface cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3229)
<!-- Reviewable:end -->
