### PR TITLE
Prepare opacity consistently

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1294,7 +1294,8 @@ impl AlphaBatchBuilder {
                 for (segment_index, (segment, segment_data)) in segment_desc.segments
                     .iter()
                     .zip(segment_data.iter())
-                    .enumerate() {
+                    .enumerate()
+                {
                     self.add_segment_to_batch(
                         segment,
                         segment_data,
@@ -1315,7 +1316,8 @@ impl AlphaBatchBuilder {
                 // between all segments.
                 for (segment_index, segment) in segment_desc.segments
                     .iter()
-                    .enumerate() {
+                    .enumerate()
+                {
                     self.add_segment_to_batch(
                         segment,
                         segment_data,
@@ -1333,6 +1335,7 @@ impl AlphaBatchBuilder {
             }
             (None, SegmentDataKind::Shared(ref segment_data)) => {
                 // No segments, and thus no per-segment instance data.
+                // Note: the blend mode already takes opacity into account
                 let batch_key = BatchKey {
                     blend_mode: non_segmented_blend_mode,
                     kind: BatchKind::Brush(params.batch_kind),

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2558,7 +2558,7 @@ impl PrimitiveInstance {
             self.prepared_frame_id = frame_state.render_tasks.frame_id();
         }
 
-        match *prim_details {
+        self.opacity = match *prim_details {
             PrimitiveDetails::TextRun(ref mut text) => {
                 // The transform only makes sense for screen space rasterization
                 let transform = prim_context.spatial_node.world_content_transform.to_transform();
@@ -2570,6 +2570,7 @@ impl PrimitiveInstance {
                     display_list,
                     frame_state,
                 );
+                PrimitiveOpacity::translucent()
             }
             PrimitiveDetails::Brush(ref mut brush) => {
                 match brush.kind {
@@ -2599,13 +2600,6 @@ impl PrimitiveInstance {
                                 frame_state.gpu_cache.invalidate(&mut self.gpu_location);
                             }
 
-                            // Update opacity for this primitive to ensure the correct
-                            // batching parameters are used.
-                            self.opacity.is_opaque =
-                                image_properties.descriptor.is_opaque &&
-                                opacity_binding.current == 1.0 &&
-                                color.a == 1.0;
-
                             if *tile_spacing != LayoutSize::zero() && !is_tiled {
                                 *source = ImageSource::Cache {
                                     // Size in device-pixels we need to allocate in render task cache.
@@ -2627,6 +2621,7 @@ impl PrimitiveInstance {
                             }
 
                             let mut request_source_image = false;
+                            let mut is_opaque = image_properties.descriptor.is_opaque;
 
                             // Every frame, for cached items, we need to request the render
                             // task cache item. The closure will be invoked on the first
@@ -2645,9 +2640,7 @@ impl PrimitiveInstance {
                                     size.width += padding.horizontal();
                                     size.height += padding.vertical();
 
-                                    if padding != DeviceIntSideOffsets::zero() {
-                                        self.opacity.is_opaque = false;
-                                    }
+                                    is_opaque &= padding == DeviceIntSideOffsets::zero();
 
                                     let image_cache_key = ImageCacheKey {
                                         request,
@@ -2786,18 +2779,17 @@ impl PrimitiveInstance {
                                     frame_state.gpu_cache,
                                 );
                             }
+
+                            if is_opaque {
+                                PrimitiveOpacity::from_alpha(opacity_binding.current * color.a)
+                            } else {
+                                PrimitiveOpacity::translucent()
+                            }
+                        } else {
+                            PrimitiveOpacity::opaque()
                         }
                     }
                     BrushKind::LineDecoration { color, ref mut handle, style, orientation, wavy_line_thickness } => {
-                        // Update opacity for this primitive to ensure the correct
-                        // batching parameters are used.
-                        self.opacity.is_opaque = match style {
-                            LineStyle::Solid => color.a == 1.0,
-                            LineStyle::Dotted |
-                            LineStyle::Dashed |
-                            LineStyle::Wavy => false,
-                        };
-
                         // Work out the device pixel size to be used to cache this line decoration.
                         let size = get_line_decoration_sizes(
                             &prim_local_rect.size,
@@ -2806,7 +2798,7 @@ impl PrimitiveInstance {
                             wavy_line_thickness,
                         );
 
-                        if is_chased {
+                        if cfg!(debug_assertions) && is_chased {
                             println!("\tline decoration opaque={}, sizes={:?}", self.opacity.is_opaque, size);
                         }
 
@@ -2878,10 +2870,15 @@ impl PrimitiveInstance {
                                 }
                             ));
                         }
+
+                        match style {
+                            LineStyle::Solid => PrimitiveOpacity::from_alpha(color.a),
+                            LineStyle::Dotted |
+                            LineStyle::Dashed |
+                            LineStyle::Wavy => PrimitiveOpacity::translucent(),
+                        }
                     }
                     BrushKind::YuvImage { format, yuv_key, image_rendering, .. } => {
-                        self.opacity = PrimitiveOpacity::opaque();
-
                         let channel_num = format.get_plane_num();
                         debug_assert!(channel_num <= 3);
                         for channel in 0 .. channel_num {
@@ -2894,6 +2891,8 @@ impl PrimitiveInstance {
                                 frame_state.gpu_cache,
                             );
                         }
+
+                        PrimitiveOpacity::opaque()
                     }
                     BrushKind::Border { ref mut source, .. } => {
                         match *source {
@@ -2903,15 +2902,15 @@ impl PrimitiveInstance {
                                     .get_image_properties(request.key);
 
                                 if let Some(image_properties) = image_properties {
-                                    // Update opacity for this primitive to ensure the correct
-                                    // batching parameters are used.
-                                    self.opacity.is_opaque =
-                                        image_properties.descriptor.is_opaque;
-
                                     frame_state.resource_cache.request_image(
                                         request,
                                         frame_state.gpu_cache,
                                     );
+                                    PrimitiveOpacity {
+                                        is_opaque: image_properties.descriptor.is_opaque,
+                                    }
+                                } else {
+                                    PrimitiveOpacity::opaque()
                                 }
                             }
                             BorderSource::Border { ref border, ref widths, ref mut segments, .. } => {
@@ -2954,6 +2953,9 @@ impl PrimitiveInstance {
                                         }
                                     ));
                                 }
+
+                                // Shouldn't matter, since the segment opacity is used instead
+                                PrimitiveOpacity::translucent()
                             }
                         }
                     }
@@ -3006,6 +3008,9 @@ impl PrimitiveInstance {
                                 },
                             );
                         }
+
+                        //TODO: can we make it opaque in some cases?
+                        PrimitiveOpacity::translucent()
                     }
                     BrushKind::LinearGradient {
                         stops_range,
@@ -3020,19 +3025,6 @@ impl PrimitiveInstance {
                         ref mut visible_tiles,
                         ..
                     } => {
-                        // If the coverage of the gradient extends to or beyond
-                        // the primitive rect, then the opacity can be determined
-                        // by the colors of the stops. If we have tiling / spacing
-                        // then we just assume the gradient is translucent for now.
-                        // (In the future we could consider segmenting in some cases).
-                        let stride = stretch_size + tile_spacing;
-                        self.opacity = if stride.width >= prim_local_rect.size.width &&
-                           stride.height >= prim_local_rect.size.height {
-                            stops_opacity
-                        } else {
-                            PrimitiveOpacity::translucent()
-                        };
-
                         build_gradient_stops_request(
                             stops_handle,
                             stops_range,
@@ -3069,6 +3061,19 @@ impl PrimitiveInstance {
                                 }
                             );
                         }
+
+                        // If the coverage of the gradient extends to or beyond
+                        // the primitive rect, then the opacity can be determined
+                        // by the colors of the stops. If we have tiling / spacing
+                        // then we just assume the gradient is translucent for now.
+                        // (In the future we could consider segmenting in some cases).
+                        let stride = stretch_size + tile_spacing;
+                        if stride.width >= prim_local_rect.size.width &&
+                           stride.height >= prim_local_rect.size.height {
+                            stops_opacity
+                        } else {
+                            PrimitiveOpacity::translucent()
+                        }
                     }
                     BrushKind::Picture { pic_index, .. } => {
                         let pic = &mut pictures[pic_index.0];
@@ -3092,6 +3097,8 @@ impl PrimitiveInstance {
                         } else {
                             self.clipped_world_rect = None;
                         }
+
+                        PrimitiveOpacity::translucent()
                     }
                     BrushKind::Solid { ref color, ref mut opacity_binding, .. } => {
                         // If the opacity changed, invalidate the GPU cache so that
@@ -3101,12 +3108,12 @@ impl PrimitiveInstance {
                         if opacity_binding.update(frame_context.scene_properties) {
                             frame_state.gpu_cache.invalidate(&mut self.gpu_location);
                         }
-                        self.opacity = PrimitiveOpacity::from_alpha(opacity_binding.current * color.a);
+                        PrimitiveOpacity::from_alpha(opacity_binding.current * color.a)
                     }
-                    BrushKind::Clear => {}
+                    BrushKind::Clear => PrimitiveOpacity::opaque(),
                 }
             }
-        }
+        };
 
         if is_tiled {
             // we already requested each tile's gpu data.

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -52,7 +52,7 @@ fn render_task_sanity_check(size: &DeviceIntSize) {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct RenderTaskId(pub u32, FrameId); // TODO(gw): Make private when using GPU cache!
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]


### PR DESCRIPTION
This is a follow-up to #3232 
It makes opacity computation more functional, having us to consider it equally important for all primitive types. It's not supposed to change any logic.
try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=6e4ca6f1b473522e93d5fd11e64c563c2bdf50dd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3233)
<!-- Reviewable:end -->
