### PR TITLE
Add into_stops method to GradientBuilder

### DIFF
--- a/webrender_api/src/gradient_builder.rs
+++ b/webrender_api/src/gradient_builder.rs
@@ -35,6 +35,11 @@ impl GradientBuilder {
         self.stops.as_ref()
     }
 
+    /// Return the gradient stops vector.
+    pub fn into_stops(self) -> Vec<GradientStop> {
+        self.stops
+    }
+
     /// Produce a linear gradient, normalize the stops.
     pub fn gradient(
         &mut self,


### PR DESCRIPTION
Useful to avoid cloning the stops.

Forgot to add this. Adding this allows us to remove a call of `to_vec()` from servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3235)
<!-- Reviewable:end -->
