### PR TITLE
 Introduce primitive clustering and use for some basic cases.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -584,7 +584,7 @@ impl AlphaBatchBuilder {
             transform_id,
         };
 
-        if cfg!(debug_assertions) && ctx.prim_store.chase_id == Some(prim_instance.prim_index) {
+        if prim_instance.is_chased() {
             println!("\ttask target {:?}", self.target_rect);
             println!("\t{:?}", prim_header);
         }
@@ -1057,10 +1057,10 @@ impl AlphaBatchBuilder {
                             ctx.resource_cache,
                             gpu_cache,
                             deferred_resolves,
-                            ctx.prim_store.chase_id == Some(prim_instance.prim_index),
+                            prim_instance,
                         ) {
                             let prim_header_index = prim_headers.push(&prim_header, z_id, params.prim_user_data);
-                            if cfg!(debug_assertions) && ctx.prim_store.chase_id == Some(prim_instance.prim_index) {
+                            if prim_instance.is_chased() {
                                 println!("\t{:?} {:?}, task relative bounds {:?}",
                                     params.batch_kind, prim_header_index, bounding_rect);
                             }
@@ -1501,7 +1501,7 @@ impl BrushPrimitive {
         resource_cache: &ResourceCache,
         gpu_cache: &mut GpuCache,
         deferred_resolves: &mut Vec<DeferredResolve>,
-        is_chased: bool,
+        prim_instance: &PrimitiveInstance,
     ) -> Option<BrushBatchParameters> {
         match self.kind {
             BrushKind::Image { request, ref source, .. } => {
@@ -1523,7 +1523,7 @@ impl BrushPrimitive {
                         resource_cache.get_texture_cache_item(&rt_cache_entry.handle)
                     }
                 };
-                if cfg!(debug_assertions) && is_chased {
+                if prim_instance.is_chased() {
                     println!("\tsource {:?}", cache_item);
                 }
 

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -678,6 +678,52 @@ impl ClipStore {
         })
     }
 
+    /// Walk the clip chain of a primitive, and calculate a minimal
+    /// local clip rect for the primitive.
+    #[allow(dead_code)]
+    pub fn build_local_clip_rect(
+        &self,
+        prim_clip_rect: LayoutRect,
+        spatial_node_index: SpatialNodeIndex,
+        clip_chain_id: ClipChainId,
+        clip_interner: &ClipDataInterner,
+    ) -> LayoutRect {
+        let mut clip_rect = prim_clip_rect;
+        let mut current_clip_chain_id = clip_chain_id;
+
+        // for each clip chain node
+        while current_clip_chain_id != ClipChainId::NONE {
+            let clip_chain_node = &self.clip_chain_nodes[current_clip_chain_id.0 as usize];
+
+            // If the clip chain node and the primitive share a spatial node,
+            // then by definition the clip can't move relative to the primitive,
+            // due to scrolling or transform animation. When that constraint
+            // holds, it's fine to include the local clip rect of this
+            // clip node in the local clip rect of the primitive itself. This
+            // is used to minimize the size of any render target allocations
+            // if this primitive ends up being part of an off-screen surface.
+
+            if clip_chain_node.spatial_node_index == spatial_node_index {
+                let clip_data = &clip_interner[clip_chain_node.handle];
+
+                // TODO(gw): For now, if a clip results in the local
+                //           rect of this primitive becoming zero, just
+                //           ignore and continue (it will be culled later
+                //           on). Technically, we could add a code path
+                //           here to drop the primitive immediately, but
+                //           that complicates some of the existing callers
+                //           of build_local_clip_rect.
+                clip_rect = clip_rect
+                    .intersection(&clip_data.clip_rect)
+                    .unwrap_or(LayoutRect::zero());
+            }
+
+            current_clip_chain_id = clip_chain_node.parent_clip_chain_id;
+        }
+
+        clip_rect
+    }
+
     /// Reports the heap usage of this clip store.
     pub fn malloc_size_of(&self, op: VoidPtrToSizeFn) -> usize {
         let mut size = 0;
@@ -758,12 +804,7 @@ impl ClipRegion<Option<ComplexClipRegion>> {
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct ClipItemSceneData {
-    // TODO(gw): We will store the local clip rect of
-    //           the clip item here. This will allow
-    //           calculation of the local clip rect
-    //           for a primitive and its clip chain
-    //           during scene building, rather than
-    //           frame building.
+    pub clip_rect: LayoutRect,
 }
 
 // The ClipItemKey is a hashable representation of the contents

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{ColorF, DeviceIntPoint, DevicePixelScale, LayoutPixel, PicturePixel, RasterPixel};
-use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentLayer, FontRenderMode, PictureRect};
+use api::{DeviceUintPoint, DeviceUintRect, DeviceUintSize, DocumentLayer, FontRenderMode};
 use api::{LayoutPoint, LayoutRect, LayoutSize, PipelineId, RasterSpace, WorldPoint, WorldRect, WorldPixel};
 use clip::{ClipDataStore, ClipStore};
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
@@ -12,7 +12,7 @@ use gpu_cache::GpuCache;
 use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind, ZBufferIdGenerator};
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap, PlaneSplitter};
-use picture::{PictureCompositeMode, PictureSurface, PictureUpdateContext, RasterConfig};
+use picture::{PictureSurface, PictureUpdateContext, SurfaceInfo, SurfaceIndex};
 use prim_store::{PrimitiveStore, SpaceMapper, PictureIndex, PrimitiveId};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::{FrameResources, FrameId};
@@ -85,6 +85,7 @@ pub struct FrameBuildingState<'a> {
     pub transforms: &'a mut TransformPalette,
     pub resources: &'a mut FrameResources,
     pub segment_builder: SegmentBuilder,
+    pub surfaces: &'a mut Vec<SurfaceInfo>,
 }
 
 /// Immutable context of a picture when processing children.
@@ -97,7 +98,6 @@ pub struct PictureContext {
     pub allow_subpixel_aa: bool,
     pub is_passthrough: bool,
     pub raster_space: RasterSpace,
-    pub local_spatial_node_index: SpatialNodeIndex,
     pub surface_spatial_node_index: SpatialNodeIndex,
     pub raster_spatial_node_index: SpatialNodeIndex,
 }
@@ -109,15 +109,10 @@ pub struct PictureState {
     pub has_non_root_coord_system: bool,
     pub is_cacheable: bool,
     pub local_rect_changed: bool,
-    /// Union rectangle of all the items in this picture.
-    pub rect: PictureRect,
     pub map_local_to_pic: SpaceMapper<LayoutPixel, PicturePixel>,
     pub map_pic_to_world: SpaceMapper<PicturePixel, WorldPixel>,
     pub map_pic_to_raster: SpaceMapper<PicturePixel, RasterPixel>,
     pub map_raster_to_world: SpaceMapper<RasterPixel, WorldPixel>,
-    /// Mapping from local space to the containing block, which is the root for
-    /// plane splitting and affects backface visibility.
-    pub map_local_to_containing_block: SpaceMapper<LayoutPixel, LayoutPixel>,
     /// If the plane splitter, the primitives get added to it insted of
     /// batching into their parent pictures.
     pub plane_splitter: Option<PlaneSplitter>,
@@ -196,6 +191,7 @@ impl FrameBuilder {
         scene_properties: &SceneProperties,
         transform_palette: &mut TransformPalette,
         resources: &mut FrameResources,
+        surfaces: &mut Vec<SurfaceInfo>,
     ) -> Option<RenderTaskId> {
         profile_scope!("cull");
 
@@ -222,22 +218,20 @@ impl FrameBuilder {
             ),
         };
 
-        let mut frame_state = FrameBuildingState {
-            render_tasks,
-            profile_counters,
-            clip_store: &mut self.clip_store,
-            resource_cache,
-            gpu_cache,
-            special_render_passes,
-            transforms: transform_palette,
-            resources,
-            segment_builder: SegmentBuilder::new(),
-        };
+        // Construct a dummy root surface, that represents the
+        // main framebuffer surface.
+        let root_surface = SurfaceInfo::new(
+            ROOT_SPATIAL_NODE_INDEX,
+            ROOT_SPATIAL_NODE_INDEX,
+            world_rect,
+            clip_scroll_tree,
+        );
+        surfaces.push(root_surface);
 
-        let pic_update_context = PictureUpdateContext {
-            surface_spatial_node_index: ROOT_SPATIAL_NODE_INDEX,
-            raster_spatial_node_index: ROOT_SPATIAL_NODE_INDEX,
-        };
+        let pic_update_context = PictureUpdateContext::new(
+            SurfaceIndex::root(),
+            ROOT_SPATIAL_NODE_INDEX,
+        );
 
         // The first major pass of building a frame is to walk the picture
         // tree. This pass must be quick (it should never touch individual
@@ -250,20 +244,27 @@ impl FrameBuilder {
             self.root_pic_index,
             &pic_update_context,
             &frame_context,
+            surfaces,
         );
 
-        let prim_context = PrimitiveContext::new(
-            &clip_scroll_tree.spatial_nodes[root_spatial_node_index.0],
-            root_spatial_node_index,
-        );
+        let mut frame_state = FrameBuildingState {
+            render_tasks,
+            profile_counters,
+            clip_store: &mut self.clip_store,
+            resource_cache,
+            gpu_cache,
+            special_render_passes,
+            transforms: transform_palette,
+            resources,
+            segment_builder: SegmentBuilder::new(),
+            surfaces,
+        };
 
-        let (pic_context, mut pic_state, mut instances) = self
+        let (pic_context, mut pic_state, mut prim_list) = self
             .prim_store
             .pictures[self.root_pic_index.0]
             .take_context(
                 self.root_pic_index,
-                &prim_context,
-                root_spatial_node_index,
                 root_spatial_node_index,
                 root_spatial_node_index,
                 true,
@@ -273,20 +274,18 @@ impl FrameBuilder {
             .unwrap();
 
         self.prim_store.prepare_primitives(
-            &mut instances,
+            &mut prim_list,
             &pic_context,
             &mut pic_state,
             &frame_context,
             &mut frame_state,
         );
 
-        let pic_rect = Some(pic_state.rect);
         let pic = &mut self.prim_store.pictures[self.root_pic_index.0];
         pic.restore_context(
-            instances,
+            prim_list,
             pic_context,
             pic_state,
-            pic_rect,
             &mut frame_state,
         );
 
@@ -303,11 +302,11 @@ impl FrameBuilder {
         );
 
         let render_task_id = frame_state.render_tasks.add(root_render_task);
-        pic.raster_config = Some(RasterConfig {
-            composite_mode: PictureCompositeMode::Blit,
-            surface: Some(PictureSurface::RenderTask(render_task_id)),
-            raster_spatial_node_index: ROOT_SPATIAL_NODE_INDEX,
-        });
+        frame_state
+            .surfaces
+            .first_mut()
+            .unwrap()
+            .surface = Some(PictureSurface::RenderTask(render_task_id));
         Some(render_task_id)
     }
 
@@ -348,6 +347,7 @@ impl FrameBuilder {
         );
 
         let mut render_tasks = RenderTaskTree::new(frame_id);
+        let mut surfaces = Vec::new();
 
         let screen_size = self.screen_rect.size.to_i32();
         let mut special_render_passes = SpecialRenderPasses::new(&screen_size);
@@ -364,6 +364,7 @@ impl FrameBuilder {
             scene_properties,
             &mut transform_palette,
             resources,
+            &mut surfaces,
         );
 
         resource_cache.block_until_all_resources_added(gpu_cache,
@@ -410,6 +411,7 @@ impl FrameBuilder {
                 use_dual_source_blending,
                 clip_scroll_tree,
                 resources,
+                surfaces: &surfaces,
             };
 
             pass.build(

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -13,7 +13,7 @@ use gpu_types::{PrimitiveHeaders, TransformPalette, UvRectKind, ZBufferIdGenerat
 use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap, PlaneSplitter};
 use picture::{PictureCompositeMode, PictureSurface, PictureUpdateContext, RasterConfig};
-use prim_store::{PrimitiveIndex, PrimitiveStore, SpaceMapper, PictureIndex};
+use prim_store::{PrimitiveStore, SpaceMapper, PictureIndex, PrimitiveId};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::{FrameResources, FrameId};
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
@@ -32,7 +32,7 @@ use tiling::{SpecialRenderPasses};
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub enum ChasePrimitive {
     Nothing,
-    Index(PrimitiveIndex),
+    Id(PrimitiveId),
     LocalRect(LayoutRect),
 }
 
@@ -269,7 +269,6 @@ impl FrameBuilder {
                 true,
                 &mut frame_state,
                 &frame_context,
-                false,
             )
             .unwrap();
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -346,13 +346,8 @@ impl PicturePrimitive {
         parent_allows_subpixel_aa: bool,
         frame_state: &mut FrameBuildingState,
         frame_context: &FrameBuildingContext,
-        is_chased: bool,
     ) -> Option<(PictureContext, PictureState, Vec<PrimitiveInstance>)> {
         if !self.is_visible() {
-            if cfg!(debug_assertions) && is_chased {
-                println!("\tculled for carrying an invisible composite filter");
-            }
-
             return None;
         }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -3,21 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint};
-use api::{DeviceIntRect, DeviceIntSize, DevicePoint, LayoutRect, PictureToRasterTransform};
+use api::{DeviceIntRect, DeviceIntSize, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel};
 use api::{DevicePixelScale, PictureIntPoint, PictureIntRect, PictureIntSize, RasterRect, RasterSpace};
-use api::{PicturePixel, RasterPixel, WorldPixel};
+use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect};
 use box_shadow::{BLUR_SAMPLE_SCALE};
 use clip::ClipNodeCollector;
 use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
-use euclid::{TypedScale, vec3};
-use internal_types::PlaneSplitter;
-use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState};
-use frame_builder::{PictureContext, PrimitiveContext};
+use euclid::{TypedScale, vec3, TypedRect};
+use internal_types::{FastHashMap, PlaneSplitter};
+use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState, PictureContext};
 use gpu_cache::{GpuCacheAddress, GpuCacheHandle};
 use gpu_types::{TransformPalette, TransformPaletteId, UvRectKind};
 use plane_split::{Clipper, Polygon, Splitter};
-use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper, PrimitiveDetails};
-use prim_store::{Primitive, get_raster_rects, BrushKind, BrushPrimitive};
+use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper, PrimitiveDetails, VisibleFace};
+use prim_store::{Primitive, get_raster_rects, BrushKind, BrushPrimitive, PrimitiveDataInterner};
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
 use scene::{FilterOpHelpers, SceneProperties};
@@ -40,21 +39,99 @@ use util::{TransformedRectKind, MatrixHelpers, MaxRect};
 /// during the first frame building pass, when just
 /// pictures are traversed.
 pub struct PictureUpdateContext {
-    pub surface_spatial_node_index: SpatialNodeIndex,
+    /// Index of the current surface as the picture
+    /// tree is traversed.
+    pub surface_index: SurfaceIndex,
+    /// Used for backface visibility calculations.
+    pub parent_spatial_node_index: SpatialNodeIndex,
+}
+
+impl PictureUpdateContext {
+    pub fn new(
+        surface_index: SurfaceIndex,
+        parent_spatial_node_index: SpatialNodeIndex,
+    ) -> Self {
+        PictureUpdateContext {
+            surface_index,
+            parent_spatial_node_index,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct SurfaceIndex(pub usize);
+
+impl SurfaceIndex {
+    pub fn root() -> Self {
+        SurfaceIndex(0)
+    }
+}
+
+/// Information about an offscreen surface that. For now,
+/// it contains information about the size and coordinate
+/// system of the surface. In the future, it will contain
+/// information about the contents of the surface, which
+/// will allow surfaces to be cached / retained between
+/// frames and display lists.
+#[derive(Debug)]
+pub struct SurfaceInfo {
+    /// A local rect defining the size of this surface, in the
+    /// coordinate system of the surface itself.
+    pub rect: PictureRect,
+    /// Helper structs for mapping local rects in different
+    /// coordinate systems into the surface coordinates.
+    pub map_local_to_surface: SpaceMapper<LayoutPixel, PicturePixel>,
+    pub map_surface_to_world: SpaceMapper<PicturePixel, WorldPixel>,
+    /// Defines the positioning node for the surface itself,
+    /// and the rasterization root for this surface.
     pub raster_spatial_node_index: SpatialNodeIndex,
+    pub surface_spatial_node_index: SpatialNodeIndex,
+    /// This is set when the render task is created.
+    pub surface: Option<PictureSurface>,
+}
+
+impl SurfaceInfo {
+    pub fn new(
+        surface_spatial_node_index: SpatialNodeIndex,
+        raster_spatial_node_index: SpatialNodeIndex,
+        world_rect: WorldRect,
+        clip_scroll_tree: &ClipScrollTree,
+    ) -> Self {
+        let map_surface_to_world = SpaceMapper::new_with_target(
+            ROOT_SPATIAL_NODE_INDEX,
+            surface_spatial_node_index,
+            world_rect,
+            clip_scroll_tree,
+        );
+
+        let pic_bounds = map_surface_to_world
+            .unmap(&map_surface_to_world.bounds)
+            .unwrap_or(PictureRect::max_rect());
+
+        let map_local_to_surface = SpaceMapper::new(
+            surface_spatial_node_index,
+            pic_bounds,
+        );
+
+        SurfaceInfo {
+            rect: PictureRect::zero(),
+            map_surface_to_world,
+            map_local_to_surface,
+            surface: None,
+            raster_spatial_node_index,
+            surface_spatial_node_index,
+        }
+    }
 }
 
 #[derive(Debug)]
 pub struct RasterConfig {
+    /// How this picture should be composited into
+    /// the parent surface.
     pub composite_mode: PictureCompositeMode,
-
-    // If this picture is drawn to an intermediate surface,
-    // the associated target information.
-    pub surface: Option<PictureSurface>,
-
-    // The spatial node of the rasterization root
-    // for this picture.
-    pub raster_spatial_node_index: SpatialNodeIndex,
+    /// Index to the surface descriptor for this
+    /// picture.
+    pub surface_index: SurfaceIndex,
 }
 
 /// Specifies how this Picture should be composited
@@ -192,49 +269,205 @@ pub struct OrderedPictureChild {
     pub gpu_address: GpuCacheAddress,
 }
 
+/// Defines the grouping key for a cluster of
+/// primitives in a picture. In future this
+/// will also contain spatial grouping details.
+#[derive(Hash, Eq, PartialEq, Copy, Clone)]
+struct PrimitiveClusterKey {
+    /// Grouping primitives by spatial node
+    /// ensures that we can calculate a local
+    /// bounding volume for the cluster, and
+    /// then transform that by the spatial
+    /// node transform once to get an updated
+    /// bounding volume for the entire cluster.
+    spatial_node_index: SpatialNodeIndex,
+    /// We want to separate clusters that have
+    /// different backface visibility properties
+    /// so that we can accept / reject an entire
+    /// cluster at once if the backface is not
+    /// visible.
+    is_backface_visible: bool,
+}
+
+/// Descriptor for a cluster of primitives. For now,
+/// this is quite basic but will be extended to
+/// handle more spatial clustering of primitives.
+pub struct PrimitiveCluster {
+    /// The positioning node for this cluster.
+    spatial_node_index: SpatialNodeIndex,
+    /// Whether this cluster is visible when
+    /// the position node is a backface.
+    is_backface_visible: bool,
+    /// The bounding rect of the cluster, in
+    /// the local space of the spatial node. This
+    /// is used to quickly determine the overall
+    /// bounding rect for a picture during the
+    /// first picture traversal, which is needed
+    /// for local scale determination, and render
+    /// task size calculations.
+    bounding_rect: LayoutRect,
+    /// This flag is set during the first pass
+    /// picture traversal, depending on whether
+    /// the cluster is visible or not. It's read
+    /// during the second pass when primitives
+    /// consult their owning clusters to see if
+    /// the primitive itself is visible.
+    pub is_visible: bool,
+}
+
+impl PrimitiveCluster {
+    fn new(
+        spatial_node_index: SpatialNodeIndex,
+        is_backface_visible: bool,
+    ) -> Self {
+        PrimitiveCluster {
+            bounding_rect: LayoutRect::zero(),
+            spatial_node_index,
+            is_backface_visible,
+            is_visible: false,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct PrimitiveClusterIndex(pub u32);
+
+#[derive(Debug, Clone)]
+pub struct ClusterRange {
+    pub first: u32,
+    pub last: u32,
+}
+
+impl ClusterRange {
+    pub fn empty() -> Self {
+        ClusterRange {
+            first: 0,
+            last: 0,
+        }
+    }
+}
+
 /// A list of primitive instances that are added to a picture
 /// This ensures we can keep a list of primitives that
 /// are pictures, for a fast initial traversal of the picture
 /// tree without walking the instance list.
 pub struct PrimitiveList {
+    /// The primitive instances, in render order.
     pub prim_instances: Vec<PrimitiveInstance>,
+    /// List of pictures that are part of this list.
+    /// Used to implement the picture traversal pass.
     pub pictures: SmallVec<[PictureIndex; 4]>,
+    /// List of primitives grouped into clusters.
+    pub clusters: SmallVec<[PrimitiveCluster; 4]>,
+    /// This maps from the cluster_range in a primitive
+    /// instance to a set of cluster(s) that the
+    /// primitive instance belongs to.
+    pub prim_cluster_map: Vec<PrimitiveClusterIndex>,
 }
 
 impl PrimitiveList {
+    /// Construct an empty primitive list. This is
+    /// just used during the take_context / restore_context
+    /// borrow check dance, which will be removed as the
+    /// picture traversal pass is completed.
+    pub fn empty() -> Self {
+        PrimitiveList {
+            prim_instances: Vec::new(),
+            pictures: SmallVec::new(),
+            clusters: SmallVec::new(),
+            prim_cluster_map: Vec::new(),
+        }
+    }
+
+    /// Construct a new prim list from a list of instances
+    /// in render order. This does some work during scene
+    /// building which makes the frame building traversals
+    /// significantly faster.
     pub fn new(
-        prim_instances: Vec<PrimitiveInstance>,
+        mut prim_instances: Vec<PrimitiveInstance>,
         primitives: &[Primitive],
+        prim_interner: &PrimitiveDataInterner,
     ) -> Self {
         let mut pictures = SmallVec::new();
+        let mut clusters_map = FastHashMap::default();
+        let mut clusters: SmallVec<[PrimitiveCluster; 4]> = SmallVec::new();
+        let mut prim_cluster_map = Vec::new();
 
         // Walk the list of primitive instances and extract any that
         // are pictures.
-        for prim_instance in &prim_instances {
+        for prim_instance in &mut prim_instances {
             let prim = &primitives[prim_instance.prim_index.0];
-            match prim.details {
+
+            // Check if this primitive is a picture. In future we should
+            // remove this match and embed this info directly in the primitive instance.
+            let is_pic = match prim.details {
                 PrimitiveDetails::Brush(BrushPrimitive { kind: BrushKind::Picture { pic_index }, .. }) => {
                     pictures.push(pic_index);
+                    true
                 }
                 _ => {
-                    // TODO(gw): For now, we don't do anything with non-picture primitives.
-                    //           However, in the near future we'll accumulate the static
-                    //           bounding rects for primitive clusters here, so that we can
-                    //           quickly determine the size of a picture during frame building.
+                    false
                 }
+            };
+
+            // Get the key for the cluster that this primitive should
+            // belong to.
+            let prim_data = &prim_interner[prim_instance.prim_data_handle];
+            let key = PrimitiveClusterKey {
+                spatial_node_index: prim_instance.spatial_node_index,
+                is_backface_visible: prim_data.is_backface_visible,
+            };
+
+            // Find the cluster, or create a new one.
+            let cluster_index = *clusters_map
+                .entry(key)
+                .or_insert_with(|| {
+                    let index = clusters.len();
+                    clusters.push(PrimitiveCluster::new(
+                        prim_instance.spatial_node_index,
+                        prim_data.is_backface_visible,
+                    ));
+                    index
+                }
+            );
+
+            // Pictures don't have a known static local bounding rect (they are
+            // calculated during the picture traversal dynamically). If not
+            // a picture, include a minimal bounding rect in the cluster bounds.
+            let cluster = &mut clusters[cluster_index];
+            if !is_pic {
+                cluster.bounding_rect = cluster.bounding_rect.union(&prim_data.culling_rect);
             }
+
+            // Define a range of clusters that this primitive belongs to. For now, this
+            // seems like overkill, since a primitive only ever belongs to one cluster.
+            // However, in the future the clusters will include spatial information. It
+            // will often be the case that a primitive may overlap more than one cluster,
+            // and belong to several.
+            let first = prim_cluster_map.len() as u32;
+            let cluster_range = ClusterRange {
+                first,
+                last: first + 1,
+            };
+
+            // Store the cluster index in the map, and the range in the instance.
+            prim_cluster_map.push(PrimitiveClusterIndex(cluster_index as u32));
+            prim_instance.cluster_range = cluster_range;
         }
 
         PrimitiveList {
             prim_instances,
             pictures,
+            clusters,
+            prim_cluster_map,
         }
     }
 }
 
 pub struct PicturePrimitive {
-    // List of primitive runs that make up this picture.
-    pub prim_instances: Vec<PrimitiveInstance>,
+    /// List of primitives, and associated info for this picture.
+    pub prim_list: PrimitiveList,
+
     pub state: Option<(PictureState, PictureContext)>,
 
     // The pipeline that the primitives on this picture belong to.
@@ -272,9 +505,6 @@ pub struct PicturePrimitive {
 
     // Unique identifier for this picture.
     pub id: PictureId,
-
-    /// List of the children that are picture primitives.
-    child_pictures: SmallVec<[PictureIndex; 4]>,
 
     /// The spatial node index of this picture when it is
     /// composited into the parent picture.
@@ -319,8 +549,7 @@ impl PicturePrimitive {
         spatial_node_index: SpatialNodeIndex,
     ) -> Self {
         PicturePrimitive {
-            prim_instances: prim_list.prim_instances,
-            child_pictures: prim_list.pictures,
+            prim_list,
             state: None,
             secondary_render_task_id: None,
             requested_composite_mode,
@@ -339,14 +568,12 @@ impl PicturePrimitive {
     pub fn take_context(
         &mut self,
         pic_index: PictureIndex,
-        prim_context: &PrimitiveContext,
-        parent_spatial_node_index: SpatialNodeIndex,
         surface_spatial_node_index: SpatialNodeIndex,
         raster_spatial_node_index: SpatialNodeIndex,
         parent_allows_subpixel_aa: bool,
         frame_state: &mut FrameBuildingState,
         frame_context: &FrameBuildingContext,
-    ) -> Option<(PictureContext, PictureState, Vec<PrimitiveInstance>)> {
+    ) -> Option<(PictureContext, PictureState, PrimitiveList)> {
         if !self.is_visible() {
             return None;
         }
@@ -356,7 +583,9 @@ impl PicturePrimitive {
         // pass in the spatial node indices from the parent context.
         let (raster_spatial_node_index, surface_spatial_node_index) = match self.raster_config {
             Some(ref raster_config) => {
-                (raster_config.raster_spatial_node_index, self.spatial_node_index)
+                let surface = &frame_state.surfaces[raster_config.surface_index.0];
+
+                (surface.raster_spatial_node_index, self.spatial_node_index)
             }
             None => {
                 (raster_spatial_node_index, surface_spatial_node_index)
@@ -389,34 +618,27 @@ impl PicturePrimitive {
             frame_context,
         );
 
-        let (containing_block_index, plane_splitter) = match self.context_3d {
+        let plane_splitter = match self.context_3d {
             Picture3DContext::Out => {
-                (parent_spatial_node_index, None)
+                None
             }
-            Picture3DContext::In { root_data: Some(_), ancestor_index } => {
-                (ancestor_index, Some(PlaneSplitter::new()))
+            Picture3DContext::In { root_data: Some(_), .. } => {
+                Some(PlaneSplitter::new())
             }
-            Picture3DContext::In { root_data: None, ancestor_index } => {
-                (ancestor_index, None)
+            Picture3DContext::In { root_data: None, .. } => {
+                None
             }
         };
-
-        let map_local_to_containing_block = SpaceMapper::new(
-            containing_block_index,
-            LayoutRect::zero(), // bounds aren't going to be used for this mapping
-        );
 
         let state = PictureState {
             tasks: Vec::new(),
             has_non_root_coord_system: false,
             is_cacheable: true,
             local_rect_changed: false,
-            rect: PictureRect::zero(),
             map_local_to_pic,
             map_pic_to_world,
             map_pic_to_raster,
             map_raster_to_world,
-            map_local_to_containing_block,
             plane_splitter,
         };
 
@@ -444,68 +666,36 @@ impl PicturePrimitive {
             allow_subpixel_aa,
             is_passthrough: self.raster_config.is_none(),
             raster_space: self.requested_raster_space,
-            local_spatial_node_index: prim_context.spatial_node_index,
             raster_spatial_node_index,
             surface_spatial_node_index,
         };
 
-        let instances = mem::replace(&mut self.prim_instances, Vec::new());
+        let prim_list = mem::replace(&mut self.prim_list, PrimitiveList::empty());
 
-        Some((context, state, instances))
+        Some((context, state, prim_list))
     }
 
     pub fn restore_context(
         &mut self,
-        prim_instances: Vec<PrimitiveInstance>,
+        prim_list: PrimitiveList,
         context: PictureContext,
         state: PictureState,
-        local_rect: Option<PictureRect>,
         frame_state: &mut FrameBuildingState,
     ) -> (LayoutRect, Option<ClipNodeCollector>) {
-        let local_rect = match local_rect {
-            Some(local_rect) => {
-                let local_content_rect = LayoutRect::from_untyped(&local_rect.to_untyped());
-
-                match self.raster_config {
-                    Some(RasterConfig { composite_mode: PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)), .. }) => {
-                        let inflate_size = (blur_radius * BLUR_SAMPLE_SCALE).ceil();
-                        local_content_rect.inflate(inflate_size, inflate_size)
-                    }
-                    Some(RasterConfig { composite_mode: PictureCompositeMode::Filter(FilterOp::DropShadow(_, blur_radius, _)), .. }) => {
-                        let inflate_size = (blur_radius * BLUR_SAMPLE_SCALE).ceil();
-                        local_content_rect.inflate(inflate_size, inflate_size)
-
-                        // TODO(gw): When we support culling rect being separate from
-                        //           the task/screen rect, we should include both the
-                        //           content and shadow rect here, which will prevent
-                        //           drop-shadows from disappearing if the main content
-                        //           rect is not visible. Something like:
-                        // let shadow_rect = local_content_rect
-                        //     .inflate(inflate_size, inflate_size)
-                        //     .translate(&offset);
-                        // shadow_rect.union(&local_content_rect)
-                    }
-                    _ => {
-                        local_content_rect
-                    }
-                }
-            }
-            None => {
-                assert!(self.raster_config.is_none());
-                LayoutRect::zero()
-            }
-        };
-
-        let clip_node_collector = if context.is_passthrough {
-            None
-        } else {
-            Some(frame_state.clip_store.pop_surface())
-        };
-
-        self.prim_instances = prim_instances;
+        self.prim_list = prim_list;
         self.state = Some((state, context));
 
-        (local_rect, clip_node_collector)
+        match self.raster_config {
+            Some(ref raster_config) => {
+                let local_rect = frame_state.surfaces[raster_config.surface_index.0].rect;
+                let local_rect = LayoutRect::from_untyped(&local_rect.to_untyped());
+
+                (local_rect, Some(frame_state.clip_store.pop_surface()))
+            }
+            None => {
+                (LayoutRect::zero(), None)
+            }
+        }
     }
 
     pub fn take_state_and_context(&mut self) -> (PictureState, PictureContext) {
@@ -587,7 +777,7 @@ impl PicturePrimitive {
         // Process the accumulated split planes and order them for rendering.
         // Z axis is directed at the screen, `sort` is ascending, and we need back-to-front order.
         for poly in splitter.sort(vec3(0.0, 0.0, 1.0)) {
-            let spatial_node_index = self.prim_instances[poly.anchor].spatial_node_index;
+            let spatial_node_index = self.prim_list.prim_instances[poly.anchor].spatial_node_index;
 
             let transform = frame_state.transforms.get_world_inv_transform(spatial_node_index);
             let transform_id = frame_state.transforms.get_id(
@@ -624,76 +814,192 @@ impl PicturePrimitive {
         &mut self,
         context: &PictureUpdateContext,
         frame_context: &FrameBuildingContext,
+        surfaces: &mut Vec<SurfaceInfo>,
     ) -> Option<(PictureUpdateContext, SmallVec<[PictureIndex; 4]>)> {
         // Reset raster config in case we early out below.
         self.raster_config = None;
 
+        // Resolve animation properties, and early out if the filter
+        // properties make this picture invisible.
         if !self.resolve_scene_properties(frame_context.scene_properties) {
             return None;
         }
 
+        // See if this picture actually needs a surface for compositing.
         let actual_composite_mode = match self.requested_composite_mode {
             Some(PictureCompositeMode::Filter(filter)) if filter.is_noop() => None,
             mode => mode,
         };
 
-        let has_surface = actual_composite_mode.is_some();
+        let surface_index = match actual_composite_mode {
+            Some(composite_mode) => {
+                // Retrieve the positioning node information for the parent surface.
+                let parent_raster_spatial_node_index = surfaces[context.surface_index.0].raster_spatial_node_index;
+                let surface_spatial_node_index = self.spatial_node_index;
 
-        let surface_spatial_node_index = if has_surface {
-            self.spatial_node_index
-        } else {
-            context.surface_spatial_node_index
-        };
+                // Check if there is perspective, and thus whether a new
+                // rasterization root should be established.
+                let xf = frame_context.clip_scroll_tree.get_relative_transform(
+                    parent_raster_spatial_node_index,
+                    surface_spatial_node_index,
+                ).expect("BUG: unable to get relative transform");
 
-        let xf = frame_context.clip_scroll_tree.get_relative_transform(
-            context.raster_spatial_node_index,
-            surface_spatial_node_index,
-        ).expect("BUG: unable to get relative transform");
+                // TODO(gw): A temporary hack here to revert behavior to
+                //           always raster in screen-space. This is not
+                //           a problem yet, since we're not taking advantage
+                //           of this for caching yet. This is a workaround
+                //           for some existing issues with handling scale
+                //           when rasterizing in local space mode. Once
+                //           the fixes for those are in-place, we can
+                //           remove this hack!
+                //let local_scale = raster_space.local_scale();
+                // let wants_raster_root = xf.has_perspective_component() ||
+                //                         local_scale.is_some();
+                let establishes_raster_root = xf.has_perspective_component();
 
-        // TODO(gw): A temporary hack here to revert behavior to
-        //           always raster in screen-space. This is not
-        //           a problem yet, since we're not taking advantage
-        //           of this for caching yet. This is a workaround
-        //           for some existing issues with handling scale
-        //           when rasterizing in local space mode. Once
-        //           the fixes for those are in-place, we can
-        //           remove this hack!
-        //let local_scale = raster_space.local_scale();
-        // let wants_raster_root = xf.has_perspective_component() ||
-        //                         local_scale.is_some();
-        let wants_raster_root = xf.has_perspective_component();
+                let raster_spatial_node_index = if establishes_raster_root {
+                    surface_spatial_node_index
+                } else {
+                    parent_raster_spatial_node_index
+                };
 
-        let establishes_raster_root = has_surface && wants_raster_root;
+                let surface_index = SurfaceIndex(surfaces.len());
+                let surface = SurfaceInfo::new(
+                    surface_spatial_node_index,
+                    raster_spatial_node_index,
+                    frame_context.world_rect,
+                    &frame_context.clip_scroll_tree,
+                );
+                surfaces.push(surface);
 
-        let raster_spatial_node_index = if establishes_raster_root {
-            surface_spatial_node_index
-        } else {
-            context.raster_spatial_node_index
-        };
+                self.raster_config = Some(RasterConfig {
+                    composite_mode,
+                    surface_index,
+                });
 
-        self.raster_config = actual_composite_mode.map(|composite_mode| {
-            RasterConfig {
-                composite_mode,
-                surface: None,
-                raster_spatial_node_index,
+                surface_index
             }
-        });
-
-        let child_context = PictureUpdateContext {
-            raster_spatial_node_index,
-            surface_spatial_node_index,
+            None => {
+                context.surface_index
+            }
         };
 
-        Some((child_context, mem::replace(&mut self.child_pictures, SmallVec::new())))
+        let child_context = PictureUpdateContext::new(
+            surface_index,
+            self.spatial_node_index,
+        );
+
+        Some((child_context, mem::replace(&mut self.prim_list.pictures, SmallVec::new())))
     }
 
     /// Called after updating child pictures during the initial
     /// picture traversal.
     pub fn post_update(
         &mut self,
+        parent_context: &PictureUpdateContext,
+        this_context: &PictureUpdateContext,
         child_pictures: SmallVec<[PictureIndex; 4]>,
+        surfaces: &mut [SurfaceInfo],
+        frame_context: &FrameBuildingContext,
     ) {
-        self.child_pictures = child_pictures;
+        // Check visibility of each cluster, and then use
+        // the cluster bounding rect to calculate the
+        // surface bounding rect.
+
+        for cluster in &mut self.prim_list.clusters {
+            // Reset visibility
+            cluster.is_visible = false;
+
+            // Skip the cluster if backface culled.
+            if !cluster.is_backface_visible {
+                let containing_block_index = match self.context_3d {
+                    Picture3DContext::Out => {
+                        parent_context.parent_spatial_node_index
+                    }
+                    Picture3DContext::In { root_data: Some(_), ancestor_index } => {
+                        ancestor_index
+                    }
+                    Picture3DContext::In { root_data: None, ancestor_index } => {
+                        ancestor_index
+                    }
+                };
+
+                let map_local_to_containing_block: SpaceMapper<LayoutPixel, LayoutPixel> = SpaceMapper::new_with_target(
+                    containing_block_index,
+                    cluster.spatial_node_index,
+                    LayoutRect::zero(),     // bounds aren't going to be used for this mapping
+                    &frame_context.clip_scroll_tree,
+                );
+
+                match map_local_to_containing_block.visible_face() {
+                    VisibleFace::Back => continue,
+                    VisibleFace::Front => {}
+                }
+            }
+
+            // No point including this cluster if it can't be transformed
+            let spatial_node = &frame_context
+                .clip_scroll_tree
+                .spatial_nodes[cluster.spatial_node_index.0];
+            if !spatial_node.invertible {
+                continue;
+            }
+
+            // Map the cluster bounding rect into the space of the surface, and
+            // include it in the surface bounding rect.
+            let surface = &mut surfaces[this_context.surface_index.0];
+            surface.map_local_to_surface.set_target_spatial_node(
+                cluster.spatial_node_index,
+                frame_context.clip_scroll_tree,
+            );
+
+            // Mark the cluster visible, since it passed the invertible and
+            // backface checks. In future, this will include spatial clustering
+            // which will allow the frame building code to skip most of the
+            // current per-primitive culling code.
+            cluster.is_visible = true;
+            if let Some(cluster_rect) = surface.map_local_to_surface.map(&cluster.bounding_rect) {
+                surface.rect = surface.rect.union(&cluster_rect);
+            }
+        }
+
+        // Inflate the local bounding rect if required by the filter effect.
+        let inflation_size = match self.raster_config {
+            Some(RasterConfig { composite_mode: PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)), .. }) |
+            Some(RasterConfig { composite_mode: PictureCompositeMode::Filter(FilterOp::DropShadow(_, blur_radius, _)), .. }) => {
+                Some((blur_radius * BLUR_SAMPLE_SCALE).ceil())
+            }
+            _ => {
+                None
+            }
+        };
+        if let Some(inflation_size) = inflation_size {
+            let surface = &mut surfaces[this_context.surface_index.0];
+            surface.rect = surface.rect.inflate(inflation_size, inflation_size);
+        }
+
+        // If this picture establishes a surface, then map the surface bounding
+        // rect into the parent surface coordinate space, and propagate that up
+        // to the parent.
+        if let Some(ref raster_config) = self.raster_config {
+            let surface_rect = surfaces[raster_config.surface_index.0].rect;
+            let surface_rect = TypedRect::from_untyped(&surface_rect.to_untyped());
+
+            // Propagate up to parent surface, now that we know this surface's static rect
+            let parent_surface = &mut surfaces[parent_context.surface_index.0];
+            parent_surface.map_local_to_surface.set_target_spatial_node(
+                self.spatial_node_index,
+                frame_context.clip_scroll_tree,
+            );
+            if let Some(parent_surface_rect) = parent_surface
+                .map_local_to_surface
+                .map(&surface_rect) {
+                parent_surface.rect = parent_surface.rect.union(&parent_surface_rect);
+            }
+        }
+
+        // Restore the pictures list used during recursion.
+        self.prim_list.pictures = child_pictures;
     }
 
     pub fn prepare_for_render(
@@ -723,9 +1029,11 @@ impl PicturePrimitive {
             }
         };
 
+        let surface_info = &mut frame_state.surfaces[raster_config.surface_index.0];
+
         let (map_raster_to_world, map_pic_to_raster) = create_raster_mappers(
             prim_instance.spatial_node_index,
-            raster_config.raster_spatial_node_index,
+            surface_info.raster_spatial_node_index,
             frame_context,
         );
 
@@ -871,7 +1179,7 @@ impl PicturePrimitive {
                     PictureSurface::TextureCache(cache_item)
                 };
 
-                raster_config.surface = Some(surface);
+                surface_info.surface = Some(surface);
             }
             PictureCompositeMode::Filter(FilterOp::DropShadow(offset, blur_radius, color)) => {
                 let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
@@ -922,7 +1230,7 @@ impl PicturePrimitive {
 
                 let render_task_id = frame_state.render_tasks.add(blur_render_task);
                 pic_state.tasks.push(render_task_id);
-                raster_config.surface = Some(PictureSurface::RenderTask(render_task_id));
+                surface_info.surface = Some(PictureSurface::RenderTask(render_task_id));
 
                 // If the local rect of the contents changed, force the cache handle
                 // to be invalidated so that the primitive data below will get
@@ -987,7 +1295,7 @@ impl PicturePrimitive {
 
                 let render_task_id = frame_state.render_tasks.add(picture_task);
                 pic_state.tasks.push(render_task_id);
-                raster_config.surface = Some(PictureSurface::RenderTask(render_task_id));
+                surface_info.surface = Some(PictureSurface::RenderTask(render_task_id));
             }
             PictureCompositeMode::Filter(filter) => {
                 if let FilterOp::ColorMatrix(m) = filter {
@@ -1017,7 +1325,7 @@ impl PicturePrimitive {
 
                 let render_task_id = frame_state.render_tasks.add(picture_task);
                 pic_state.tasks.push(render_task_id);
-                raster_config.surface = Some(PictureSurface::RenderTask(render_task_id));
+                surface_info.surface = Some(PictureSurface::RenderTask(render_task_id));
             }
             PictureCompositeMode::Blit => {
                 let uv_rect_kind = calculate_uv_rect_kind(
@@ -1039,7 +1347,7 @@ impl PicturePrimitive {
 
                 let render_task_id = frame_state.render_tasks.add(picture_task);
                 pic_state.tasks.push(render_task_id);
-                raster_config.surface = Some(PictureSurface::RenderTask(render_task_id));
+                surface_info.surface = Some(PictureSurface::RenderTask(render_task_id));
             }
         }
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -17,6 +17,7 @@ use gpu_types::{TransformData, TransformPalette, ZBufferIdGenerator};
 use internal_types::{CacheTextureId, FastHashMap, SavedTargetIndex, TextureSource};
 #[cfg(feature = "pathfinder")]
 use pathfinder_partitioner::mesh::Mesh;
+use picture::SurfaceInfo;
 use prim_store::{PrimitiveStore, DeferredResolve};
 use profiler::FrameProfileCounters;
 use render_backend::FrameResources;
@@ -50,6 +51,7 @@ pub struct RenderTargetContext<'a, 'rc> {
     pub use_dual_source_blending: bool,
     pub clip_scroll_tree: &'a ClipScrollTree,
     pub resources: &'a FrameResources,
+    pub surfaces: &'a [SurfaceInfo],
 }
 
 #[cfg_attr(feature = "capture", derive(Serialize))]

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -768,6 +768,17 @@ pub struct ImageMask {
     pub repeat: bool,
 }
 
+impl ImageMask {
+    /// Get a local clipping rect contributed by this mask.
+    pub fn get_local_clip_rect(&self) -> Option<LayoutRect> {
+        if self.repeat {
+            None
+        } else {
+            Some(self.rect)
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Eq, Hash)]
 pub enum ClipMode {
@@ -864,6 +875,19 @@ impl ComplexClipRegion {
     }
 }
 
+impl ComplexClipRegion {
+    /// Get a local clipping rect contributed by this clip region.
+    pub fn get_local_clip_rect(&self) -> Option<LayoutRect> {
+        match self.mode {
+            ClipMode::Clip => {
+                Some(self.rect)
+            }
+            ClipMode::ClipOut => {
+                None
+            }
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ClipChainId(pub u64, pub PipelineId);


### PR DESCRIPTION
Primitive clusters are used to group primitives within a picture
into similar categories during scene building.

Initially, these are only used to group primitives by spatial node
and by backface flags. In future, these will include spatial
clustering, which will allow removal of much of the per-primitive
bounding rect and culling code during frame building.

In this patch each primitive belongs to one cluster only, but
when spatial clusters are introduced, a primitive will belong
to one or more cluster(s). Clusters are processed during the
initial picture traversal, allowing the picture bounding rect to
be found without touching all primitives.

There's a couple of goals of this work:
- Reduce the amount of comparison work we need to do to check
  if a cached picture surface is valid.
- Allow cached picture surfaces to be drawn in tiles, to
  handle cases where only a small portion of a picture
  contents has changed.

There's also a number of other small related changes:
- Store offscreen surface information outside the picture primitives.
  - Simplifies borrow check issues on picture traversal.
  - Eventually the surface structures will be retained between display lists, and hold cached surface details.

- Build minimal local clip rect for primitives during scene building.
  - Used to allow quick calculation of picture bounding rects.
  - Can take advantage of this to reduce work during frame building (not done yet).

- Picture bounding rect calculation is done during initial picture traversal pass.
  - Much faster than previously, as we only need to calculates bounds for each cluster.

 - Backface visibility is done once per cluster now, rather than per-primitive.
 - Intern the primitive local rect and clip rects for future use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3238)
<!-- Reviewable:end -->
