### PR TITLE
Fix srgb/linear conversion filters.

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -136,13 +136,13 @@ vec3 Brightness(vec3 Cs, float amount) {
 vec3 SrgbToLinear(vec3 color) {
     vec3 c1 = color / 12.92;
     vec3 c2 = pow(color / 1.055 + vec3(0.055 / 1.055), vec3(2.4));
-    return mix(c1, c2, lessThanEqual(color, vec3(0.04045)));
+    return if_then_else(lessThanEqual(color, vec3(0.04045)), c1, c2);
 }
 
 vec3 LinearToSrgb(vec3 color) {
     vec3 c1 = color * 12.92;
     vec3 c2 = vec3(1.055) * pow(color, vec3(1.0 / 2.4)) - vec3(0.055);
-    return mix(c1, c2, lessThanEqual(color, vec3(0.0031308)));
+    return if_then_else(lessThanEqual(color, vec3(0.0031308)), c1, c2);
 }
 
 Fragment brush_fs() {

--- a/webrender/res/shared.glsl
+++ b/webrender/res/shared.glsl
@@ -113,6 +113,22 @@
             return 0.0;
         return 0.5 + dist * (0.8431027 * dist * dist - 1.14453603);
     }
+
+    /// Component-wise selection.
+    ///
+    /// The idea of using this is to ensure both potential branches are executed before
+    /// selecting the result, to avoid observable timing differences based on the condition.
+    ///
+    /// Example usage: color = if_then_else(LessThanEqual(color, vec3(0.5)), vec3(0.0), vec3(1.0));
+    ///
+    /// The above example sets each component to 0.0 or 1.0 independently depending on whether
+    /// their values are below or above 0.5.
+    ///
+    /// This is written as a macro in order to work with vectors of any dimension.
+    ///
+    /// Note: Some older android devices don't support mix with bvec. If we ever run into them
+    /// the only option we have is to polyfill it with a branch per component.
+    #define if_then_else(cond, then_branch, else_branch) mix(else_branch, then_branch, cond)
 #endif
 
 //======================================================================================


### PR DESCRIPTION
I made a *very* silly mistake in the srgb/linear conversion filters of swapping c1 and c2 (see the patch). The mistake was symetrical so it passed the tests, but the filter ended up merely quantifying the input color space into 256/13 values which isn't very useful and makes most color matrix filter applied in linear space totally wrong (as soon as the resulting colors fall out of the 0..256/13 range).

So here is the fix. I was going to introduce the `if_then_else` macro in another thing I'm working on but it's a good fit here because the argument positions are less prone to the error I made.

r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3240)
<!-- Reviewable:end -->
