### PR TITLE
Properly evict cached blob tiles when they are out of the visible area.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1202,6 +1202,20 @@ impl ResourceCache {
         );
 
         tiles.retain(|tile, _| { tile_range.contains(tile) });
+
+        let texture_cache = &mut self.texture_cache;
+        match self.cached_images.try_get_mut(&key) {
+            Some(&mut ImageResult::Multi(ref mut entries)) => {
+                entries.retain(|key, entry| {
+                    if key.tile.is_none() || tile_range.contains(&key.tile.unwrap()) {
+                        return true;
+                    }
+                    texture_cache.mark_unused(&entry.texture_cache_handle);
+                    return false;
+                });
+            }
+            _ => {}
+        }
     }
 
     pub fn request_glyphs(


### PR DESCRIPTION
This fixes [bug 1494173](https://bugzilla.mozilla.org/show_bug.cgi?id=1503220). Before this PR we would discard the rasterized blob image but not the cache entries (which didn't mesh well with the manual eviction policy, so tiles would stick around until the image key is deleted).
This aggressively removes the cached tile entry as well as the texture cache entry as soon as the tile is out of the visible area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3250)
<!-- Reviewable:end -->
