### PR TITLE
Apply opacity bindings in vertex shader, rather than CPU.

### DIFF
--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -146,6 +146,9 @@ void brush_vs(
 #ifdef WR_FEATURE_ALPHA_PASS
     vTileRepeat = repeat.xy;
 
+    float opacity = float(user_data.z) / 65535.0;
+    image_data.color *= opacity;
+
     switch (color_mode) {
         case COLOR_MODE_ALPHA:
         case COLOR_MODE_BITMAP:

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -26,6 +26,10 @@ flat varying vec2 vTileRepeat;
 
 #ifdef WR_VERTEX_SHADER
 
+// Must match the AlphaType enum.
+#define BLEND_MODE_ALPHA            0
+#define BLEND_MODE_PREMUL_ALPHA     1
+
 struct ImageBrushData {
     vec4 color;
     vec4 background_color;
@@ -105,7 +109,8 @@ void brush_vs(
     vec2 f = (vi.local_pos - local_rect.p0) / local_rect.size;
 
 #ifdef WR_FEATURE_ALPHA_PASS
-    int color_mode = user_data.x;
+    int color_mode = user_data.x & 0xffff;
+    int blend_mode = user_data.x >> 16;
     int raster_space = user_data.y;
 
     if (color_mode == COLOR_MODE_FROM_PASS) {
@@ -147,7 +152,15 @@ void brush_vs(
     vTileRepeat = repeat.xy;
 
     float opacity = float(user_data.z) / 65535.0;
-    image_data.color *= opacity;
+    switch (blend_mode) {
+        case BLEND_MODE_ALPHA:
+            image_data.color.a *= opacity;
+            break;
+        case BLEND_MODE_PREMUL_ALPHA:
+        default:
+            image_data.color *= opacity;
+            break;
+    }
 
     switch (color_mode) {
         case COLOR_MODE_ALPHA:

--- a/webrender/res/brush_solid.glsl
+++ b/webrender/res/brush_solid.glsl
@@ -35,7 +35,9 @@ void brush_vs(
     vec4 unused
 ) {
     SolidBrush prim = fetch_solid_primitive(prim_address);
-    vColor = prim.color;
+
+    float opacity = float(user_data.x) / 65535.0;
+    vColor = prim.color * opacity;
 
 #ifdef WR_FEATURE_ALPHA_PASS
     vLocalPos = vi.local_pos;


### PR DESCRIPTION
Previously, opacity bindings were calculated on the CPU and
stored in the GPU cache as part of the primitive color. This
required the GPU cache location to be invalidated when the
opacity binding changed.

This complicates primitive interning, where we want to be able
to share the GPU cache data for interned primitives, and not
need to update it during frame building.

Instead, provide the opacity for rectangles and images as part
of the primitive instance header, and apply in the vertex
shader.

This will simplify porting rectangles and images to use
primitive interning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3257)
<!-- Reviewable:end -->
