### PR TITLE
Revert "Add border segments to the opaque render pass where possible."

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -424,7 +424,6 @@ impl AlphaBatchContainer {
 struct SegmentInstanceData {
     textures: BatchTextures,
     user_data: i32,
-    is_opaque_override: Option<bool>,
 }
 
 /// Encapsulates the logic of building batches for items that are blended.
@@ -1249,16 +1248,8 @@ impl AlphaBatchBuilder {
             BrushSegmentTaskId::Empty => return,
         };
 
-        // If the segment instance data specifies opacity for that
-        // segment, use it. Otherwise, assume opacity for the segment
-        // from the overall primitive opacity.
-        let is_segment_opaque = match segment_data.is_opaque_override {
-            Some(is_opaque) => is_opaque,
-            None => prim_instance.opacity.is_opaque,
-        };
-
         let is_inner = segment.edge_flags.is_empty();
-        let needs_blending = !is_segment_opaque ||
+        let needs_blending = !prim_instance.opacity.is_opaque ||
                              segment.clip_task_id.needs_blending() ||
                              (!is_inner && transform_kind == TransformedRectKind::Complex);
 
@@ -1502,7 +1493,6 @@ impl BrushBatchParameters {
                 SegmentInstanceData {
                     textures,
                     user_data: segment_user_data,
-                    is_opaque_override: None,
                 }
             ),
         }
@@ -1630,7 +1620,6 @@ impl BrushPrimitive {
                                 SegmentInstanceData {
                                     textures: BatchTextures::color(cache_item.texture_id),
                                     user_data: cache_item.uv_rect_handle.as_int(gpu_cache),
-                                    is_opaque_override: Some(segment.is_opaque),
                                 }
                             );
                         }

--- a/webrender/src/border.rs
+++ b/webrender/src/border.rs
@@ -192,7 +192,6 @@ impl<'a> DisplayListFlattener<'a> {
 
 pub trait BorderSideHelpers {
     fn border_color(&self, is_inner_border: bool) -> ColorF;
-    fn is_opaque(&self) -> bool;
 }
 
 impl BorderSideHelpers for BorderSide {
@@ -220,11 +219,6 @@ impl BorderSideHelpers for BorderSide {
 
         let black = if lighter { 0.7 } else { 0.3 };
         ColorF::new(black, black, black, self.color.a)
-    }
-
-    /// Returns true if all pixels in this border style are opaque.
-    fn is_opaque(&self) -> bool {
-        self.color.a >= 1.0 && self.style.is_opaque()
     }
 }
 
@@ -962,12 +956,6 @@ fn add_corner_segment(
         return;
     }
 
-    let is_opaque =
-        side0.is_opaque() &&
-        side1.is_opaque() &&
-        radius.width <= 0.0 &&
-        radius.height <= 0.0;
-
     brush_segments.push(
         BrushSegment::new(
             image_rect,
@@ -981,7 +969,6 @@ fn add_corner_segment(
     border_segments.push(BorderSegmentInfo {
         handle: None,
         local_task_size: image_rect.size,
-        is_opaque,
         cache_key: RenderTaskCacheKey {
             size: DeviceIntSize::zero(),
             kind: RenderTaskCacheKeyKind::BorderCorner(
@@ -1035,8 +1022,6 @@ fn add_edge_segment(
         return;
     }
 
-    let is_opaque = side.is_opaque();
-
     brush_segments.push(
         BrushSegment::new(
             image_rect,
@@ -1050,7 +1035,6 @@ fn add_edge_segment(
     border_segments.push(BorderSegmentInfo {
         handle: None,
         local_task_size: size,
-        is_opaque,
         cache_key: RenderTaskCacheKey {
             size: DeviceIntSize::zero(),
             kind: RenderTaskCacheKeyKind::BorderEdge(

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -429,7 +429,6 @@ pub struct BorderSegmentInfo {
     pub handle: Option<RenderTaskCacheEntryHandle>,
     pub local_task_size: LayoutSize,
     pub cache_key: RenderTaskCacheKey,
-    pub is_opaque: bool,
 }
 
 #[derive(Debug)]
@@ -3016,7 +3015,7 @@ impl PrimitiveInstance {
                                         frame_state.gpu_cache,
                                         frame_state.render_tasks,
                                         None,
-                                        segment.is_opaque,
+                                        false,          // TODO(gw): We don't calculate opacity for borders yet!
                                         |render_tasks| {
                                             let task = RenderTask::new_border_segment(
                                                 segment.cache_key.size,

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -435,29 +435,6 @@ impl BorderStyle {
     pub fn is_hidden(&self) -> bool {
         *self == BorderStyle::Hidden || *self == BorderStyle::None
     }
-
-    /// Returns true if the border style itself is opaque. Other
-    /// factors (such as color, or border radii) may mean that
-    /// the border segment isn't opaque regardless of this.
-    pub fn is_opaque(&self) -> bool {
-        match *self {
-            BorderStyle::None |
-            BorderStyle::Double |
-            BorderStyle::Dotted |
-            BorderStyle::Dashed |
-            BorderStyle::Hidden => {
-                false
-            }
-
-            BorderStyle::Solid |
-            BorderStyle::Groove |
-            BorderStyle::Ridge |
-            BorderStyle::Inset |
-            BorderStyle::Outset => {
-                true
-            }
-        }
-    }
 }
 
 #[repr(u32)]


### PR DESCRIPTION
This reverts commit 75ecc8181ae2435e26cd112c12426e5fcf949cfb.

This patch causes regressions in some of the talos performance tests. After initial investigation, it's not clear why this is or how to resolve them. Since it's a minor optimization, revert this patch for now, until we have more time to investigate. (see https://bugzilla.mozilla.org/show_bug.cgi?id=1500101 for details).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3259)
<!-- Reviewable:end -->
