### PR TITLE
Add new notification checkpoint FrameTexturesUpdated.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2155,6 +2155,13 @@ impl Renderer {
                     }
                 }
                 ResultMsg::AppendNotificationRequests(mut notifications) => {
+                    if self.pending_texture_updates.is_empty() {
+                        drain_filter(
+                            &mut notifications,
+                            |n| { n.when() == Checkpoint::FrameTexturesUpdated },
+                            |n| { n.notify(); },
+                        );
+                    }
                     self.notifications.append(&mut notifications);
                 }
                 ResultMsg::RefreshShader(path) => {
@@ -2879,6 +2886,12 @@ impl Renderer {
                 }
             }
         }
+
+        drain_filter(
+            &mut self.notifications,
+            |n| { n.when() == Checkpoint::FrameTexturesUpdated },
+            |n| { n.notify(); },
+        );
     }
 
     pub(crate) fn draw_instanced_batch<T>(

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -1279,6 +1279,7 @@ pub trait RenderNotifier: Send {
 pub enum Checkpoint {
     SceneBuilt,
     FrameBuilt,
+    FrameTexturesUpdated,
     FrameRendered,
     /// NotificationRequests get notified with this if they get dropped without having been
     /// notified. This provides the guarantee that if a request is created it will get notified.


### PR DESCRIPTION
FrameTexturesUpdated notifications should be issued when there are
either no pending texture updates, or all of the pending texture updates
have been applied. This is useful for listeners who would like to
perform an action after updating a resource. In particular this is
useful for Gecko to learn as soon as possible when it can release a
surface after it has swapped the external image ID of an image key such
that it points to a new buffer. Currently we rely upon FrameBuilt for
this, but future changes for recycling previously displayed surfaces for
animated images are more timing sensitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3265)
<!-- Reviewable:end -->
