### PR TITLE
Optimize segment builder no-ops.

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -876,7 +876,7 @@ impl BrushSegment {
     }
 }
 
-pub type BrushSegmentVec = SmallVec<[BrushSegment; 8]>;
+pub type BrushSegmentVec = SmallVec<[BrushSegment; 1]>;
 
 #[derive(Debug)]
 pub struct BrushSegmentDescriptor {


### PR DESCRIPTION
If we don't end up adding any clip regions to the segment builder,
then there is no point in going through the process of creating
events, sorting, and emitting segments.

Instead, detect this case and early out with a single segment.

This takes the backend time on the displaylist_mutate test on
my machine from 10.8ms to 8.2ms, which is quite a significant
improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3273)
<!-- Reviewable:end -->
