### PR TITLE
Store text run primitives outside the primitive instance.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -590,7 +590,8 @@ impl AlphaBatchBuilder {
                     PrimitiveInstanceData::from(instance),
                 );
             }
-            PrimitiveInstanceKind::TextRun { ref run, .. } => {
+            PrimitiveInstanceKind::TextRun { run_index, .. } => {
+                let run = &ctx.prim_store.text_runs[run_index.0];
                 let subpx_dir = run.used_font.get_subpx_dir();
 
                 // The GPU cache data is stored in the template and reused across

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -879,7 +879,7 @@ impl<'a> DisplayListFlattener<'a> {
                 PrimitiveInstanceKind::LegacyPrimitive { prim_index }
             }
             None => {
-                prim_key.to_instance_kind()
+                prim_key.to_instance_kind(&mut self.prim_store)
             }
         };
 


### PR DESCRIPTION
This is a (mostly) temporary workaround for a regression in some
of the talos performance tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3274)
<!-- Reviewable:end -->
