### PR TITLE
Refactor render task chaining.

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -1246,9 +1246,9 @@ impl RenderTaskCache {
         render_tasks: &mut RenderTaskTree,
         user_data: Option<[f32; 3]>,
         is_opaque: bool,
-        mut f: F,
+        f: F,
     ) -> Result<RenderTaskCacheEntryHandle, ()>
-         where F: FnMut(&mut RenderTaskTree) -> Result<RenderTaskId, ()> {
+         where F: FnOnce(&mut RenderTaskTree) -> Result<RenderTaskId, ()> {
         // Get the texture cache handle for this cache key,
         // or create one.
         let cache_entries = &mut self.cache_entries;

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -483,8 +483,8 @@ impl ResourceCache {
         render_tasks: &mut RenderTaskTree,
         user_data: Option<[f32; 3]>,
         is_opaque: bool,
-        mut f: F,
-    ) -> RenderTaskCacheEntryHandle where F: FnMut(&mut RenderTaskTree) -> RenderTaskId {
+        f: F,
+    ) -> RenderTaskCacheEntryHandle where F: FnOnce(&mut RenderTaskTree) -> RenderTaskId {
         self.cached_render_tasks.request_render_task(
             key,
             &mut self.texture_cache,


### PR DESCRIPTION
Instead of passing render task dependencies via the PictureState
stack, directly append to the task list for the surface that
a picture is assigned to render on.

This is a small step to untangling the prepare_prims pass from
the picture traversal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3276)
<!-- Reviewable:end -->
