### PR TITLE
Change add_split_plane to not rely on prim instance.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -483,7 +483,7 @@ pub struct PicturePrimitive {
 
     /// The spatial node index of this picture when it is
     /// composited into the parent picture.
-    spatial_node_index: SpatialNodeIndex,
+    pub spatial_node_index: SpatialNodeIndex,
 
     /// The local rect of this picture. It is built
     /// dynamically during the first picture traversal.
@@ -696,31 +696,29 @@ impl PicturePrimitive {
     pub fn add_split_plane(
         splitter: &mut PlaneSplitter,
         transforms: &TransformPalette,
-        prim_instance: &PrimitiveInstance,
-        original_local_rect: LayoutRect,
+        local_rect: LayoutRect,
+        spatial_node_index: SpatialNodeIndex,
         plane_split_anchor: usize,
+        world_bounds: WorldRect,
     ) -> bool {
-        let transform = transforms
-            .get_world_transform(prim_instance.spatial_node_index);
-        let matrix = transform.cast();
+        // If the picture isn't visible, then ensure it's not added
+        // to the plane splitter, to avoid assertions during batching
+        // about each split plane having a surface.
+        if local_rect.size.width <= 0.0 ||
+           local_rect.size.height <= 0.0 {
+            return false;
+        }
 
-        // Apply the local clip rect here, before splitting. This is
-        // because the local clip rect can't be applied in the vertex
-        // shader for split composites, since we are drawing polygons
-        // rather that rectangles. The interpolation still works correctly
-        // since we determine the UVs by doing a bilerp with a factor
-        // from the original local rect.
-        let local_rect = match original_local_rect
-            .intersection(&prim_instance.combined_local_clip_rect)
-        {
-            Some(rect) => rect.cast(),
-            None => return false,
-        };
+        let transform = transforms
+            .get_world_transform(spatial_node_index);
+        let matrix = transform.cast();
+        let local_rect = local_rect.cast();
+        let world_bounds = world_bounds.cast();
 
         match transform.transform_kind() {
             TransformedRectKind::AxisAligned => {
                 let inv_transform = transforms
-                    .get_world_inv_transform(prim_instance.spatial_node_index);
+                    .get_world_inv_transform(spatial_node_index);
                 let polygon = Polygon::from_transformed_rect_with_inverse(
                     local_rect,
                     &matrix,
@@ -737,7 +735,7 @@ impl PicturePrimitive {
                         plane_split_anchor,
                     ),
                     &matrix,
-                    prim_instance.clipped_world_rect.map(|r| r.to_f64()),
+                    Some(world_bounds),
                 );
                 if let Ok(results) = results {
                     for poly in results {

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2316,9 +2316,10 @@ impl PrimitiveStore {
                         PicturePrimitive::add_split_plane(
                             splitter,
                             frame_state.transforms,
-                            prim_instance,
                             prim_local_rect,
+                            pic.spatial_node_index,
                             plane_split_anchor,
+                            frame_context.world_rect,
                         );
                     }
                 } else {


### PR DESCRIPTION
This will make it easier to move the plane splitting code to the
initial picture traversal pass, instead of during primitive
preparation pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3281)
<!-- Reviewable:end -->
