### PR TITLE
Reduce shared texture cache to 32 layers.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -223,7 +223,7 @@ impl SharedTextures {
             array_rgba8_linear: TextureArray::new(
                 ImageFormat::BGRA8,
                 TextureFilter::Linear,
-                16 * 4,
+                32, /* More than 32 layers breaks on mac intel drivers for some reason */
             ),
             // Used for image-rendering: crisp. This is mostly favicons, which
             // are small. Some other images use it too, but those tend to be


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1505664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3285)
<!-- Reviewable:end -->
