### PR TITLE
Remove PictureId and PictureIdGenerator.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -163,38 +163,6 @@ pub enum PictureSurface {
     TextureCache(RenderTaskCacheEntryHandle),
 }
 
-// A unique identifier for a Picture. Once we start
-// doing deep compares of picture content, these
-// may be the same across display lists, but that's
-// not currently supported.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct PictureId(pub u64);
-
-// TODO(gw): Having to generate globally unique picture
-//           ids for caching is not ideal. We should be
-//           able to completely remove this once we cache
-//           pictures based on their content, rather than
-//           the current cache key structure.
-pub struct PictureIdGenerator {
-    next: u64,
-}
-
-impl PictureIdGenerator {
-    pub fn new() -> Self {
-        PictureIdGenerator {
-            next: 0,
-        }
-    }
-
-    pub fn next(&mut self) -> PictureId {
-        let id = PictureId(self.next);
-        self.next += 1;
-        id
-    }
-}
-
 /// Enum value describing the place of a picture in a 3D context.
 #[derive(Clone, Debug)]
 pub enum Picture3DContext<C> {
@@ -426,9 +394,6 @@ pub struct PicturePrimitive {
     // picture.
     pub extra_gpu_data_handle: GpuCacheHandle,
 
-    // Unique identifier for this picture.
-    pub id: PictureId,
-
     /// The spatial node index of this picture when it is
     /// composited into the parent picture.
     spatial_node_index: SpatialNodeIndex,
@@ -471,7 +436,6 @@ impl PicturePrimitive {
     }
 
     pub fn new_image(
-        id: PictureId,
         requested_composite_mode: Option<PictureCompositeMode>,
         context_3d: Picture3DContext<OrderedPictureChild>,
         pipeline_id: PipelineId,
@@ -517,7 +481,6 @@ impl PicturePrimitive {
             extra_gpu_data_handle: GpuCacheHandle::new(),
             apply_local_clip_rect,
             pipeline_id,
-            id,
             requested_raster_space,
             spatial_node_index,
             local_rect: LayoutRect::zero(),

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -13,7 +13,6 @@ use clip::{ClipDataInterner, ClipDataUpdateList};
 use clip_scroll_tree::ClipScrollTree;
 use display_list_flattener::DisplayListFlattener;
 use internal_types::{FastHashMap, FastHashSet};
-use picture::PictureIdGenerator;
 use prim_store::{PrimitiveDataInterner, PrimitiveDataUpdateList};
 use resource_cache::FontInstanceMap;
 use render_backend::DocumentView;
@@ -199,7 +198,6 @@ pub struct SceneBuilder {
     api_tx: MsgSender<ApiMsg>,
     config: FrameBuilderConfig,
     hooks: Option<Box<SceneBuilderHooks + Send>>,
-    picture_id_generator: PictureIdGenerator,
     simulate_slow_ms: u32,
 }
 
@@ -219,7 +217,6 @@ impl SceneBuilder {
                 api_tx,
                 config,
                 hooks,
-                picture_id_generator: PictureIdGenerator::new(),
                 simulate_slow_ms: 0,
             },
             in_tx,
@@ -328,7 +325,6 @@ impl SceneBuilder {
                     &item.output_pipelines,
                     &self.config,
                     &mut new_scene,
-                    &mut self.picture_id_generator,
                     &mut item.doc_resources,
                 );
 
@@ -432,7 +428,6 @@ impl SceneBuilder {
                     &request.output_pipelines,
                     &self.config,
                     &mut new_scene,
-                    &mut self.picture_id_generator,
                     &mut doc.resources,
                 );
 


### PR DESCRIPTION
They are no longer required since we are comparing the content
of pictures when choosing to cache them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3288)
<!-- Reviewable:end -->
