### PR TITLE
Fix coordinate space confusion in image::tiles.

### DIFF
--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -323,16 +323,16 @@ pub fn tiles(
     // Since we're working in layer space, we can end up computing leftover tiles with an empty
     // size due to floating point precision issues. Detect this case so that we don't return
     // tiles with an empty size.
-    let x_count = {
-        let result = f32::ceil((visible_rect.max_x() - prim_rect.origin.x) / layer_tile_size.width) as u32 - t0.x;
+    let x_max = {
+        let result = f32::ceil((visible_rect.max_x() - prim_rect.origin.x) / layer_tile_size.width) as u32;
         if result == leftover_offset.x + 1 && leftover_layer_size.width == 0.0f32 {
             leftover_offset.x
         } else {
             result
         }
     };
-    let y_count = {
-        let result = f32::ceil((visible_rect.max_y() - prim_rect.origin.y) / layer_tile_size.height) as u32 - t0.y;
+    let y_max = {
+        let result = f32::ceil((visible_rect.max_y() - prim_rect.origin.y) / layer_tile_size.height) as u32;
         if result == leftover_offset.y + 1 && leftover_layer_size.height == 0.0f32 {
             leftover_offset.y
         } else {
@@ -341,14 +341,14 @@ pub fn tiles(
     };
 
     let mut row_flags = EdgeAaSegmentMask::TOP;
-    if y_count == 1 {
+    if y_max - t0.y == 1 {
         row_flags |= EdgeAaSegmentMask::BOTTOM;
     }
     TileIterator {
         current_x: 0,
         current_y: 0,
-        x_count,
-        y_count,
+        x_count: x_max - t0.x,
+        y_count: y_max - t0.y,
         row_flags,
         origin: t0,
         tile_size: layer_tile_size,

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1018,6 +1018,8 @@ impl ResourceCache {
                     }
                 };
 
+                assert!(descriptor.size.width != 0 && descriptor.size.height != 0);
+
                 self.missing_blob_images.push(
                     BlobImageParams {
                         request,


### PR DESCRIPTION
'result' was being computed as a size, but compared with
leftover_offset which is a position.
This changes us to work only with positions, and converts to a size
at the end of the function.

Addresses gecko bug 1506109.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3299)
<!-- Reviewable:end -->
