### PR TITLE
Remove local_rect_changed from PictureState.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -106,7 +106,6 @@ pub struct PictureContext {
 /// the children are processed.
 pub struct PictureState {
     pub is_cacheable: bool,
-    pub local_rect_changed: bool,
     pub map_local_to_pic: SpaceMapper<LayoutPixel, PicturePixel>,
     pub map_pic_to_world: SpaceMapper<PicturePixel, WorldPixel>,
     pub map_pic_to_raster: SpaceMapper<PicturePixel, RasterPixel>,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2200,7 +2200,7 @@ impl PrimitiveStore {
                 }
 
                 // Restore the dependencies (borrow check dance)
-                let (local_rect_changed, clip_node_collector) = self
+                let clip_node_collector = self
                     .pictures[pic_context_for_children.pic_index.0]
                     .restore_context(
                         prim_list,
@@ -2208,8 +2208,6 @@ impl PrimitiveStore {
                         pic_state_for_children,
                         frame_state,
                     );
-
-                pic_state.local_rect_changed |= local_rect_changed;
 
                 (is_passthrough, clip_node_collector)
             }
@@ -2364,7 +2362,6 @@ impl PrimitiveStore {
                     prim_instance,
                     &prim_local_rect,
                     pic_context.surface_index,
-                    pic_state,
                     frame_context,
                     frame_state,
                 ) {


### PR DESCRIPTION
This can now be handled internally, and removes one more need
for the PictureState structure during the main traversal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3302)
<!-- Reviewable:end -->
