### PR TITLE
Add new scene building hooks for the start and end of scene builder so

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4555,6 +4555,8 @@ pub trait SceneBuilderHooks {
     /// This is called exactly once, when the scene builder thread is started
     /// and before it processes anything.
     fn register(&self);
+    /// This is called before each scene build starts.
+    fn pre_scene_build(&self);
     /// This is called before each scene swap occurs.
     fn pre_scene_swap(&self, scenebuild_time: u64);
     /// This is called after each scene swap occurs. The PipelineInfo contains
@@ -4565,6 +4567,11 @@ pub trait SceneBuilderHooks {
     /// thread, in the case where resource updates were applied without a scene
     /// build.
     fn post_resource_update(&self);
+    /// This is called after a scene build completes without any changes being
+    /// made. We guarantee that each pre_scene_build call will be matched with
+    /// exactly one of post_scene_swap, post_resource_update or
+    /// post_empty_scene_build.
+    fn post_empty_scene_build(&self);
     /// This is a generic callback which provides an opportunity to run code
     /// on the scene builder thread. This is called as part of the main message
     /// loop of the scene builder thread, but outside of any specific message

--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -382,6 +382,9 @@ impl SceneBuilder {
 
     /// Do the bulk of the work of the scene builder thread.
     fn process_transaction(&mut self, txn: &mut Transaction) -> Box<BuiltTransaction> {
+        if let &Some(ref hooks) = &self.hooks {
+            hooks.pre_scene_build();
+        }
 
         let scene_build_start_time = precise_time_ns();
 
@@ -536,6 +539,10 @@ impl SceneBuilder {
         } else if has_resources_updates {
             if let &Some(ref hooks) = &self.hooks {
                 hooks.post_resource_update();
+            }
+        } else {
+            if let &Some(ref hooks) = &self.hooks {
+                hooks.post_empty_scene_build();
             }
         }
     }


### PR DESCRIPTION
that we can record profiler markers.

Gecko bug 1506748

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3303)
<!-- Reviewable:end -->
