### PR TITLE
Switch to upstream servo/osmesa-src.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -139,6 +139,8 @@ tasks:
           - master
     payload:
       maxRunTime: 3600
+      env:
+        CARGO_MAKEFLAGS: '-j1' # See #2638
       command:
         - - /bin/bash
           - '--login'
@@ -183,6 +185,8 @@ tasks:
           - master
     payload:
       maxRunTime: 3600
+      env:
+        CARGO_MAKEFLAGS: '-j1' # See #2638
       command:
         - - /bin/bash
           - '--login'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,8 +851,8 @@ dependencies = [
 
 [[package]]
 name = "osmesa-src"
-version = "17.4.0-devel"
-source = "git+https://github.com/jrmuizel/osmesa-src?branch=serialize#0f81d082b4cca16ea4d344bf6758b5a2f8d98277"
+version = "0.1.0"
+source = "git+https://github.com/servo/osmesa-src#e17b23b1cba87f9294a7fd625fffb389d31d2d45"
 
 [[package]]
 name = "osmesa-sys"
@@ -1610,7 +1610,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmesa-src 17.4.0-devel (git+https://github.com/jrmuizel/osmesa-src?branch=serialize)",
+ "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1779,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
-"checksum osmesa-src 17.4.0-devel (git+https://github.com/jrmuizel/osmesa-src?branch=serialize)" = "<none>"
+"checksum osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69376b761943787ebd5cc85a5bc95958651a22609c5c1c2b65de21786baec72b"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -24,7 +24,7 @@ ron = "0.1.5"
 time = "0.1"
 crossbeam = "0.2"
 osmesa-sys = { version = "0.1.2", optional = true }
-osmesa-src = { git = "https://github.com/jrmuizel/osmesa-src", optional = true, branch = "serialize" }
+osmesa-src = { git = "https://github.com/servo/osmesa-src", optional = true }
 webrender = {path = "../webrender", features=["capture","replay","debugger","png","profiler"]}
 webrender_api = {path = "../webrender_api", features=["serialize","deserialize"]}
 winit = "0.16"


### PR DESCRIPTION
Make the mac hack for #2638 specific for CI, via `CARGO_MAKEFLAGS`.