### PR TITLE
[WIP] Remove explicit clip ID from stacking context

### DIFF
--- a/examples/alpha_perf.rs
+++ b/examples/alpha_perf.rs
@@ -34,7 +34,6 @@ impl Example for App {
 
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -59,7 +59,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &filters,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -193,7 +193,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -218,7 +218,6 @@ impl Example for App {
         let info = api::LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             api::TransformStyle::Flat,
             api::MixBlendMode::Normal,
             &[],

--- a/examples/document.rs
+++ b/examples/document.rs
@@ -113,7 +113,6 @@ impl Example for App {
 
             builder.push_stacking_context(
                 &LayoutPrimitiveInfo::new(doc.content_rect),
-                None,
                 TransformStyle::Flat,
                 MixBlendMode::Normal,
                 &[],

--- a/examples/frame_output.rs
+++ b/examples/frame_output.rs
@@ -114,7 +114,6 @@ impl App {
 
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],
@@ -157,7 +156,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new((100, 100).to(200, 200));
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/iframe.rs
+++ b/examples/iframe.rs
@@ -39,7 +39,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(sub_bounds);
         sub_builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],
@@ -68,11 +67,9 @@ impl Example for App {
         );
         builder.push_clip_id(reference_frame_id);
 
-
         // And this is for the root pipeline
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/image_resize.rs
+++ b/examples/image_resize.rs
@@ -41,7 +41,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -190,7 +190,6 @@ impl Window {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -35,7 +35,6 @@ impl Example for App {
         );
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],
@@ -48,7 +47,6 @@ impl Example for App {
             let scrollbox = (0, 0).to(300, 400);
             builder.push_stacking_context(
                 &LayoutPrimitiveInfo::new((10, 10).by(0, 0)),
-                None,
                 TransformStyle::Flat,
                 MixBlendMode::Normal,
                 &[],

--- a/examples/texture_cache_stress.rs
+++ b/examples/texture_cache_stress.rs
@@ -98,7 +98,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/examples/yuv.rs
+++ b/examples/yuv.rs
@@ -95,7 +95,6 @@ impl Example for App {
         let info = LayoutPrimitiveInfo::new(bounds);
         builder.push_stacking_context(
             &info,
-            None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
             &[],

--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -557,7 +557,6 @@ pub struct PushStackingContextDisplayItem {
 pub struct StackingContext {
     pub transform_style: TransformStyle,
     pub mix_blend_mode: MixBlendMode,
-    pub clip_node_id: Option<ClipId>,
     pub raster_space: RasterSpace,
 } // IMPLICIT: filters: Vec<FilterOp>
 

--- a/wrench/src/yaml_frame_writer.rs
+++ b/wrench/src/yaml_frame_writer.rs
@@ -202,7 +202,6 @@ fn write_stacking_context(
     sc: &StackingContext,
     properties: &SceneProperties,
     filter_iter: AuxIter<FilterOp>,
-    clip_id_mapper: &ClipIdMapper,
 ) {
     enum_node(parent, "transform-style", sc.transform_style);
 
@@ -215,10 +214,6 @@ fn write_stacking_context(
         }
     };
     str_node(parent, "raster-space", &raster_space);
-
-    if let Some(clip_node_id) = sc.clip_node_id {
-        yaml_node(parent, "clip-node", clip_id_mapper.map_id(&clip_node_id));
-    }
 
     // mix_blend_mode
     if sc.mix_blend_mode != MixBlendMode::Normal {
@@ -1014,7 +1009,6 @@ impl YamlFrameWriter {
                         &item.stacking_context,
                         &scene.properties,
                         filters,
-                        clip_id_mapper,
                     );
 
                     let mut sub_iter = base.sub_iter();


### PR DESCRIPTION
This is one of the preparatory changes towards #3251

With this in, we should be able to remove this (hacky) code path in Gecko:
https://searchfox.org/mozilla-central/rev/d850d799a0009f851b5535580e0a8b4bb2c591d7/gfx/layers/wr/ClipManager.cpp#224

Currently, we provide a clip ID explicitly when pushing a stacking context. This change makes us use the clip ID on the clip/scroll stack instead, like with every other item. The implementation comes with a few quirks, namely the introduction of "push_clip_id_override" and "push_scroll_id_override" into the API. These aren't conflicting with #3251 and will be removed by it (together with the whole clip/scroll stack).

WIP because: still working on the Gecko side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3311)
<!-- Reviewable:end -->
