### PR TITLE
Use rgba as bgra_format_external on gles if bgra is not supported

### DIFF
--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -1004,14 +1004,18 @@ impl Device {
             }
         } else {
             // BGRA is not supported as an internal format, therefore we will
-            // use RGBA and swizzle during upload. Note that this is not
-            // supported on GLES.
+            // use RGBA. On non-gles we can swizzle during upload. This is not
+            // allowed on gles, so we must us RGBA for the external format too.
+            // Red and blue will appear reversed, but it is the best we can do.
             // Since the internal format will actually be RGBA, if texture
             // storage is supported we can use it for such textures.
-            assert_ne!(gl.get_type(), gl::GlType::Gles, "gles must have compatible internal and external formats");
             (
                 gl::RGBA8,
-                gl::BGRA,
+                if gl.get_type() == gl::GlType::Gles {
+                    gl::RGBA
+                } else {
+                    gl::BGRA
+                },
                 if supports_texture_storage {
                     TexStorageUsage::Always
                 } else {


### PR DESCRIPTION
Fixes #3312.

If BGRA is not supported then we use RGBA as the internal texture
format. Since GLES is not able to swizzle texture data during upload,
we used to also pretend the external format was RGBA in this
case. This resulted in the red and blue channels appearing swapped,
but was better than not working at all.

This workaround got lost, however. And then an assertion was added to
prevent us from trying to swizzle during upload on GLES. This change
removes that assertion, and instead reinstates the workaround of
using RGBA as the external format. This means that on GLES devices
without BGRA support (such as the android emulator) red and blue will
once again appear swapped, but will otherwise work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3314)
<!-- Reviewable:end -->
