### PR TITLE
Don't ignore the clip on the stack for reference frames and clips

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -377,7 +377,7 @@ impl<'a> DisplayListFlattener<'a> {
 
         debug_assert!(info.clip_id != info.scroll_frame_id);
 
-        self.add_clip_node(info.clip_id, clip_and_scroll_ids.scroll_node_id, clip_region);
+        self.add_clip_node(info.clip_id, clip_and_scroll_ids, clip_region);
 
         self.add_scroll_frame(
             info.scroll_frame_id,
@@ -396,12 +396,13 @@ impl<'a> DisplayListFlattener<'a> {
         pipeline_id: PipelineId,
         item: &DisplayItemRef,
         reference_frame: &ReferenceFrame,
-        scroll_node_id: ClipId,
+        clip_and_scroll_ids: &ClipAndScrollInfo,
         reference_frame_relative_offset: LayoutVector2D,
     ) {
         self.push_reference_frame(
             reference_frame.id,
-            Some(scroll_node_id),
+            Some(clip_and_scroll_ids.scroll_node_id),
+            clip_and_scroll_ids.clip_node_id,
             pipeline_id,
             reference_frame.transform,
             reference_frame.perspective,
@@ -472,10 +473,9 @@ impl<'a> DisplayListFlattener<'a> {
             },
         };
 
-        //TODO: use or assert on `clip_and_scroll_ids.clip_node_id` ?
         let clip_chain_index = self.add_clip_node(
             info.clip_id,
-            clip_and_scroll_ids.scroll_node_id,
+            clip_and_scroll_ids,
             ClipRegion::create_for_clip_node_with_local_clip(
                 item.clip_rect(),
                 reference_frame_relative_offset
@@ -488,6 +488,7 @@ impl<'a> DisplayListFlattener<'a> {
         self.push_reference_frame(
             ClipId::root_reference_frame(iframe_pipeline_id),
             Some(info.clip_id),
+            None,
             iframe_pipeline_id,
             None,
             None,
@@ -654,7 +655,7 @@ impl<'a> DisplayListFlattener<'a> {
                     pipeline_id,
                     &item,
                     &info.reference_frame,
-                    clip_and_scroll_ids.scroll_node_id,
+                    &clip_and_scroll_ids,
                     reference_frame_relative_offset,
                 );
                 return Some(subtraversal);
@@ -676,7 +677,7 @@ impl<'a> DisplayListFlattener<'a> {
                     info.image_mask,
                     &reference_frame_relative_offset,
                 );
-                self.add_clip_node(info.id, clip_and_scroll_ids.scroll_node_id, clip_region);
+                self.add_clip_node(info.id, &clip_and_scroll_ids, clip_region);
             }
             SpecificDisplayItem::ClipChain(ref info) => {
                 // For a user defined clip-chain the parent (if specified) must
@@ -1281,13 +1282,14 @@ impl<'a> DisplayListFlattener<'a> {
     pub fn push_reference_frame(
         &mut self,
         reference_frame_id: ClipId,
-        parent_id: Option<ClipId>,
+        parent_scroll_id: Option<ClipId>,
+        parent_clip_id: Option<ClipId>,
         pipeline_id: PipelineId,
         source_transform: Option<PropertyBinding<LayoutTransform>>,
         source_perspective: Option<LayoutTransform>,
         origin_in_parent_reference_frame: LayoutVector2D,
     ) -> SpatialNodeIndex {
-        let parent_index = parent_id.map(|id| self.id_to_index_mapper.get_spatial_node_index(id));
+        let parent_index = parent_scroll_id.map(|id| self.id_to_index_mapper.get_spatial_node_index(id));
         let index = self.clip_scroll_tree.add_reference_frame(
             parent_index,
             source_transform,
@@ -1297,7 +1299,7 @@ impl<'a> DisplayListFlattener<'a> {
         );
         self.id_to_index_mapper.map_spatial_node(reference_frame_id, index);
 
-        match parent_id {
+        match parent_clip_id.or(parent_scroll_id) {
             Some(ref parent_id) =>
                 self.id_to_index_mapper.map_to_parent_clip_chain(reference_frame_id, parent_id),
             _ => self.id_to_index_mapper.add_clip_chain(reference_frame_id, ClipChainId::NONE, 0),
@@ -1319,6 +1321,7 @@ impl<'a> DisplayListFlattener<'a> {
         self.push_reference_frame(
             ClipId::root_reference_frame(pipeline_id),
             None,
+            None,
             pipeline_id,
             None,
             None,
@@ -1339,7 +1342,7 @@ impl<'a> DisplayListFlattener<'a> {
     pub fn add_clip_node<I>(
         &mut self,
         new_node_id: ClipId,
-        parent_id: ClipId,
+        parent: &ClipAndScrollInfo,
         clip_region: ClipRegion<I>,
     ) -> ClipChainId
     where
@@ -1351,9 +1354,9 @@ impl<'a> DisplayListFlattener<'a> {
         // Map from parent ClipId to existing clip-chain.
         let mut parent_clip_chain_index = self
             .id_to_index_mapper
-            .get_clip_chain_id(&parent_id);
+            .get_clip_chain_id(&parent.clip_node_id());
         // Map the ClipId for the positioning node to a spatial node index.
-        let spatial_node = self.id_to_index_mapper.get_spatial_node_index(parent_id);
+        let spatial_node = self.id_to_index_mapper.get_spatial_node_index(parent.scroll_node_id);
 
         // Add a mapping for this ClipId in case it's referenced as a positioning node.
         self.id_to_index_mapper

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -1402,18 +1402,37 @@ impl DisplayListBuilder {
         I: IntoIterator<Item = ComplexClipRegion>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
-        let parent = self.clip_stack.last().unwrap().scroll_node_id;
-        self.define_clip_with_parent(
-            parent,
+        let clip_and_scroll = self.clip_stack.last().unwrap().clone();
+        self.define_clip_impl(
+            clip_and_scroll,
             clip_rect,
             complex_clips,
-            image_mask
+            image_mask,
         )
     }
 
     pub fn define_clip_with_parent<I>(
         &mut self,
         parent: ClipId,
+        clip_rect: LayoutRect,
+        complex_clips: I,
+        image_mask: Option<ImageMask>,
+    ) -> ClipId
+    where
+        I: IntoIterator<Item = ComplexClipRegion>,
+        I::IntoIter: ExactSizeIterator + Clone,
+    {
+        self.define_clip_impl(
+            ClipAndScrollInfo::simple(parent),
+            clip_rect,
+            complex_clips,
+            image_mask,
+        )
+    }
+
+    fn define_clip_impl<I>(
+        &mut self,
+        scrollinfo: ClipAndScrollInfo,
         clip_rect: LayoutRect,
         complex_clips: I,
         image_mask: Option<ImageMask>,
@@ -1430,7 +1449,6 @@ impl DisplayListBuilder {
 
         let info = LayoutPrimitiveInfo::new(clip_rect);
 
-        let scrollinfo = ClipAndScrollInfo::simple(parent);
         self.push_item_with_clip_scroll_info(item, &info, scrollinfo);
         self.push_iter(complex_clips);
         id
@@ -1443,7 +1461,6 @@ impl DisplayListBuilder {
         vertical_offset_bounds: StickyOffsetBounds,
         horizontal_offset_bounds: StickyOffsetBounds,
         previously_applied_offset: LayoutVector2D,
-
     ) -> ClipId {
         let id = self.generate_spatial_index();
         let item = SpecificDisplayItem::StickyFrame(StickyFrameDisplayItem {


### PR DESCRIPTION
Similar to #3311, this is a prelude to #3251, with the main purpose of getting rid of Gecko's hack in https://searchfox.org/mozilla-central/rev/d850d799a0009f851b5535580e0a8b4bb2c591d7/gfx/layers/wr/ClipManager.cpp#224

It also makes sense for WR in isolation (for the current clip/stack model, at least): in those spots addressed, we used to ignore the clip ID on the stack, only to re-interpret (smuggle!) the scroll ID as a clip. Now we are actually using the clip ID more consistently.

Gecko try (that disables the hack in addition to having the WR change):
https://treeherder.mozilla.org/#/jobs?repo=try&selectedJob=212038686&revision=c10e5d839e024ba451a6622fa611c3525457f3ff
(Looks green! :tada: )