### PR TITLE
Make ChangeIndicator bigger

### DIFF
--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -1252,6 +1252,13 @@ impl ChangeIndicator {
         self.counter = (self.counter + 1) % 15;
     }
 
+    const WIDTH : f32 = 10.0;
+    const HEIGHT: f32 = 5.0;
+
+    pub fn width() -> f32 {
+      ChangeIndicator::WIDTH * 16.0
+    }
+
     pub fn draw(
         &self,
         x: f32, y: f32,
@@ -1259,14 +1266,12 @@ impl ChangeIndicator {
         debug_renderer: &mut DebugRenderer
     ) {
         let margin = 0.0;
-        let w = 10.0;
-        let h = 5.0;
-        let tx = self.counter as f32 * w;
+        let tx = self.counter as f32 * ChangeIndicator::WIDTH;
         debug_renderer.add_quad(
             x - margin,
             y - margin,
-            x + 15.0 * w + margin,
-            y + h + margin,
+            x + 15.0 * ChangeIndicator::WIDTH + margin,
+            y + ChangeIndicator::HEIGHT + margin,
             ColorU::new(0, 0, 0, 150),
             ColorU::new(0, 0, 0, 150),
         );
@@ -1274,8 +1279,8 @@ impl ChangeIndicator {
         debug_renderer.add_quad(
             x + tx,
             y,
-            x + tx + w,
-            y + h,
+            x + tx + ChangeIndicator::WIDTH,
+            y + ChangeIndicator::HEIGHT,
             color,
             ColorU::new(25, 25, 25, 255),
         );

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -1252,8 +1252,8 @@ impl ChangeIndicator {
         self.counter = (self.counter + 1) % 15;
     }
 
-    const WIDTH : f32 = 10.0;
-    const HEIGHT: f32 = 5.0;
+    const WIDTH : f32 = 20.0;
+    const HEIGHT: f32 = 10.0;
 
     pub fn width() -> f32 {
       ChangeIndicator::WIDTH * 16.0

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2665,7 +2665,7 @@ impl Renderer {
                         ColorU::new(0, 110, 220, 255),
                         debug_renderer,
                     );
-                    x += 160.0;
+                    x += ChangeIndicator::width();
                 }
             }
 
@@ -2676,7 +2676,7 @@ impl Renderer {
                         ColorU::new(0, 220, 110, 255),
                         debug_renderer,
                     );
-                    x += 160.0;
+                    x += ChangeIndicator::width();
                 }
             }
 


### PR DESCRIPTION
Since I asked people to start using the slow-frame ChangeIndicator, I've had multiple people tell me that it's too small.

We should make it a bit bigger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3330)
<!-- Reviewable:end -->
