### PR TITLE
Ensure that coord system id is propagated for non-invertible nodes.

### DIFF
--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -191,8 +191,12 @@ impl SpatialNode {
         true
     }
 
-    pub fn mark_uninvertible(&mut self) {
+    pub fn mark_uninvertible(
+        &mut self,
+        state: &TransformUpdateState,
+    ) {
         self.invertible = false;
+        self.coordinate_system_id = state.current_coordinate_system_id;
         self.world_content_transform = LayoutToWorldFastTransform::identity();
         self.world_viewport_transform = LayoutToWorldFastTransform::identity();
     }
@@ -221,7 +225,7 @@ impl SpatialNode {
         // If any of our parents was not rendered, we are not rendered either and can just
         // quit here.
         if !state.invertible {
-            self.mark_uninvertible();
+            self.mark_uninvertible(state);
             return;
         }
 
@@ -233,7 +237,7 @@ impl SpatialNode {
         // translations which should be invertible.
         match self.node_type {
             SpatialNodeType::ReferenceFrame(info) if !info.invertible => {
-                self.mark_uninvertible();
+                self.mark_uninvertible(state);
                 return;
             }
             _ => self.invertible = true,


### PR DESCRIPTION
When a spatial node is encountered that has an invalid matrix, we
need to ensure that the coord system ID is always propagated. This
avoids array indexing errors that can occur during calls to
get_relative_transform.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1507323.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3331)
<!-- Reviewable:end -->
