### PR TITLE
Picture caching support, part 1 (of 2).

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -24,13 +24,73 @@ use euclid::Angle;
 use webrender::api::*;
 
 struct App {
-    property_key: PropertyBindingKey<LayoutTransform>,
+    property_key0: PropertyBindingKey<LayoutTransform>,
+    property_key1: PropertyBindingKey<LayoutTransform>,
+    property_key2: PropertyBindingKey<LayoutTransform>,
     opacity_key: PropertyBindingKey<f32>,
-    transform: LayoutTransform,
     opacity: f32,
+    angle0: f32,
+    angle1: f32,
+    angle2: f32,
+}
+
+impl App {
+    fn add_rounded_rect(
+        &mut self,
+        bounds: LayoutRect,
+        color: ColorF,
+        builder: &mut DisplayListBuilder,
+        property_key: PropertyBindingKey<LayoutTransform>,
+    ) {
+        let filters = [
+            FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key, self.opacity), self.opacity),
+        ];
+
+        let reference_frame_id = builder.push_reference_frame(
+            &LayoutPrimitiveInfo::new(LayoutRect::new(bounds.origin, LayoutSize::zero())),
+            Some(PropertyBinding::Binding(property_key, LayoutTransform::identity())),
+            None,
+        );
+
+        builder.push_clip_id(reference_frame_id);
+
+        builder.push_stacking_context(
+            &LayoutPrimitiveInfo::new(LayoutRect::zero()),
+            None,
+            TransformStyle::Flat,
+            MixBlendMode::Normal,
+            &filters,
+            RasterSpace::Screen,
+        );
+
+        let clip_bounds = LayoutRect::new(LayoutPoint::zero(), bounds.size);
+        let complex_clip = ComplexClipRegion {
+            rect: clip_bounds,
+            radii: BorderRadius::uniform(30.0),
+            mode: ClipMode::Clip,
+        };
+        let clip_id = builder.define_clip(clip_bounds, vec![complex_clip], None);
+        builder.push_clip_id(clip_id);
+
+        // Fill it with a white rect
+        builder.push_rect(
+            &LayoutPrimitiveInfo::new(LayoutRect::new(LayoutPoint::zero(), bounds.size)),
+            color,
+        );
+
+        builder.pop_clip_id();
+
+        builder.pop_stacking_context();
+
+        builder.pop_clip_id();
+        builder.pop_reference_frame();
+    }
 }
 
 impl Example for App {
+    const WIDTH: u32 = 1024;
+    const HEIGHT: u32 = 1024;
+
     fn render(
         &mut self,
         _api: &RenderApi,
@@ -40,49 +100,17 @@ impl Example for App {
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
-        // Create a 200x200 stacking context with an animated transform property.
-        let bounds = (0, 0).to(200, 200);
+        let bounds = (150, 150).to(250, 250);
+        let key0 = self.property_key0;
+        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, key0);
 
-        let filters = [
-            FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key, self.opacity), self.opacity),
-        ];
+        let bounds = (400, 400).to(600, 600);
+        let key1 = self.property_key1;
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, key1);
 
-        let info = LayoutPrimitiveInfo::new(bounds);
-        let reference_frame_id = builder.push_reference_frame(
-            &info,
-            Some(PropertyBinding::Binding(self.property_key, LayoutTransform::identity())),
-            None,
-        );
-
-        builder.push_clip_id(reference_frame_id);
-
-        let info = LayoutPrimitiveInfo::new(bounds);
-        builder.push_stacking_context(
-            &info,
-            None,
-            TransformStyle::Flat,
-            MixBlendMode::Normal,
-            &filters,
-            RasterSpace::Screen,
-        );
-
-        let complex_clip = ComplexClipRegion {
-            rect: bounds,
-            radii: BorderRadius::uniform(50.0),
-            mode: ClipMode::Clip,
-        };
-        let clip_id = builder.define_clip(bounds, vec![complex_clip], None);
-        builder.push_clip_id(clip_id);
-
-        // Fill it with a white rect
-        builder.push_rect(&info, ColorF::new(0.0, 1.0, 0.0, 1.0));
-
-        builder.pop_clip_id();
-
-        builder.pop_stacking_context();
-
-        builder.pop_clip_id();
-        builder.pop_reference_frame();
+        let bounds = (200, 500).to(350, 580);
+        let key2 = self.property_key2;
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, key2);
     }
 
     fn on_event(&mut self, win_event: winit::WindowEvent, api: &RenderApi, document_id: DocumentId) -> bool {
@@ -95,31 +123,38 @@ impl Example for App {
                 },
                 ..
             } => {
-                let (offset_x, offset_y, angle, delta_opacity) = match key {
-                    winit::VirtualKeyCode::Down => (0.0, 10.0, 0.0, 0.0),
-                    winit::VirtualKeyCode::Up => (0.0, -10.0, 0.0, 0.0),
-                    winit::VirtualKeyCode::Right => (10.0, 0.0, 0.0, 0.0),
-                    winit::VirtualKeyCode::Left => (-10.0, 0.0, 0.0, 0.0),
-                    winit::VirtualKeyCode::Comma => (0.0, 0.0, 0.1, 0.0),
-                    winit::VirtualKeyCode::Period => (0.0, 0.0, -0.1, 0.0),
-                    winit::VirtualKeyCode::Z => (0.0, 0.0, 0.0, -0.1),
-                    winit::VirtualKeyCode::X => (0.0, 0.0, 0.0, 0.1),
+                let (delta_angle, delta_opacity) = match key {
+                    winit::VirtualKeyCode::Down => (0.0, -0.1),
+                    winit::VirtualKeyCode::Up => (0.0, 0.1),
+                    winit::VirtualKeyCode::Right => (1.0, 0.0),
+                    winit::VirtualKeyCode::Left => (-1.0, 0.0),
                     _ => return false,
                 };
                 // Update the transform based on the keyboard input and push it to
                 // webrender using the generate_frame API. This will recomposite with
                 // the updated transform.
                 self.opacity += delta_opacity;
-                let new_transform = self.transform
-                    .pre_rotate(0.0, 0.0, 1.0, Angle::radians(angle))
-                    .post_translate(LayoutVector3D::new(offset_x, offset_y, 0.0));
+                self.angle0 += delta_angle * 0.1;
+                self.angle1 += delta_angle * 0.2;
+                self.angle2 -= delta_angle * 0.15;
+                let xf0 = LayoutTransform::create_rotation(0.0, 0.0, 1.0, Angle::radians(self.angle0));
+                let xf1 = LayoutTransform::create_rotation(0.0, 0.0, 1.0, Angle::radians(self.angle1));
+                let xf2 = LayoutTransform::create_rotation(0.0, 0.0, 1.0, Angle::radians(self.angle2));
                 let mut txn = Transaction::new();
                 txn.update_dynamic_properties(
                     DynamicProperties {
                         transforms: vec![
                             PropertyValue {
-                                key: self.property_key,
-                                value: new_transform,
+                                key: self.property_key0,
+                                value: xf0,
+                            },
+                            PropertyValue {
+                                key: self.property_key1,
+                                value: xf1,
+                            },
+                            PropertyValue {
+                                key: self.property_key2,
+                                value: xf2,
                             },
                         ],
                         floats: vec![
@@ -132,7 +167,6 @@ impl Example for App {
                 );
                 txn.generate_frame();
                 api.send_transaction(document_id, txn);
-                self.transform = new_transform;
             }
             _ => (),
         }
@@ -143,10 +177,14 @@ impl Example for App {
 
 fn main() {
     let mut app = App {
-        property_key: PropertyBindingKey::new(42), // arbitrary magic number
+        property_key0: PropertyBindingKey::new(42), // arbitrary magic number
+        property_key1: PropertyBindingKey::new(44), // arbitrary magic number
+        property_key2: PropertyBindingKey::new(45), // arbitrary magic number
         opacity_key: PropertyBindingKey::new(43),
-        transform: LayoutTransform::create_translation(0.0, 0.0, 0.0),
         opacity: 0.5,
+        angle0: 0.0,
+        angle1: 0.0,
+        angle2: 0.0,
     };
     boilerplate::main_wrapper(&mut app, None);
 }

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -179,6 +179,8 @@ pub fn main_wrapper<E: Example>(
         renderer.set_external_image_handler(external_image_handler);
     }
 
+    renderer.toggle_debug_flags(webrender::DebugFlags::TEXTURE_CACHE_DBG);
+
     let epoch = Epoch(0);
     let pipeline_id = PipelineId(0, 0);
     let layout_size = framebuffer_size.to_f32() / euclid::TypedScale::new(device_pixel_ratio);
@@ -195,7 +197,7 @@ pub fn main_wrapper<E: Example>(
     );
     txn.set_display_list(
         epoch,
-        None,
+        Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
         layout_size,
         builder.finalize(),
         true,
@@ -293,7 +295,7 @@ pub fn main_wrapper<E: Example>(
             );
             txn.set_display_list(
                 epoch,
-                None,
+                Some(ColorF::new(0.3, 0.0, 0.0, 1.0)),
                 layout_size,
                 builder.finalize(),
                 true,

--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -35,12 +35,20 @@ void main(void) {
     PrimitiveHeader ph = fetch_prim_header(prim_header_address);
 
     // Fetch the segment of this brush primitive we are drawing.
-    int segment_address = ph.specific_prim_address +
-                          VECS_PER_SPECIFIC_BRUSH +
-                          segment_index * VECS_PER_SEGMENT;
+    vec4 segment_data;
+    RectWithSize segment_rect;
+    if (segment_index == 0xffff) {
+        segment_rect = ph.local_rect;
+        segment_data = vec4(0.0);
+    } else {
+        int segment_address = ph.specific_prim_address +
+                              VECS_PER_SPECIFIC_BRUSH +
+                              segment_index * VECS_PER_SEGMENT;
 
-    vec4[2] segment_data = fetch_from_gpu_cache_2(segment_address);
-    RectWithSize local_segment_rect = RectWithSize(segment_data[0].xy, segment_data[0].zw);
+        vec4 segment_info[2] = fetch_from_gpu_cache_2(segment_address);
+        segment_rect = RectWithSize(segment_info[0].xy, segment_info[0].zw);
+        segment_data = segment_info[1];
+    }
 
     VertexInfo vi;
 
@@ -53,7 +61,7 @@ void main(void) {
     // Write the normal vertex information out.
     if (transform.is_axis_aligned) {
         vi = write_vertex(
-            local_segment_rect,
+            segment_rect,
             ph.local_clip_rect,
             ph.z,
             transform,
@@ -74,7 +82,7 @@ void main(void) {
         bvec4 edge_mask = notEqual(edge_flags & ivec4(1, 2, 4, 8), ivec4(0));
 
         vi = write_transform_vertex(
-            local_segment_rect,
+            segment_rect,
             ph.local_rect,
             ph.local_clip_rect,
             mix(vec4(0.0), vec4(1.0), edge_mask),
@@ -103,12 +111,12 @@ void main(void) {
         vi,
         ph.specific_prim_address,
         ph.local_rect,
-        local_segment_rect,
+        segment_rect,
         ivec4(ph.user_data, segment_user_data),
         transform.m,
         pic_task,
         brush_flags,
-        segment_data[1]
+        segment_data
     );
 }
 #endif

--- a/webrender/res/brush.glsl
+++ b/webrender/res/brush.glsl
@@ -24,6 +24,8 @@ void brush_vs(
 #define BRUSH_FLAG_SEGMENT_REPEAT_Y             8
 #define BRUSH_FLAG_TEXEL_RECT                  16
 
+#define INVALID_SEGMENT_INDEX                   0xffff
+
 void main(void) {
     // Load the brush instance from vertex attributes.
     int prim_header_address = aData.x;
@@ -37,7 +39,7 @@ void main(void) {
     // Fetch the segment of this brush primitive we are drawing.
     vec4 segment_data;
     RectWithSize segment_rect;
-    if (segment_index == 0xffff) {
+    if (segment_index == INVALID_SEGMENT_INDEX) {
         segment_rect = ph.local_rect;
         segment_data = vec4(0.0);
     } else {
@@ -45,7 +47,7 @@ void main(void) {
                               VECS_PER_SPECIFIC_BRUSH +
                               segment_index * VECS_PER_SEGMENT;
 
-        vec4 segment_info[2] = fetch_from_gpu_cache_2(segment_address);
+        vec4[2] segment_info = fetch_from_gpu_cache_2(segment_address);
         segment_rect = RectWithSize(segment_info[0].xy, segment_info[0].zw);
         segment_data = segment_info[1];
     }

--- a/webrender/res/brush_image.glsl
+++ b/webrender/res/brush_image.glsl
@@ -73,6 +73,9 @@ void brush_vs(
 
     RectWithSize local_rect = prim_rect;
     vec2 stretch_size = image_data.stretch_size;
+    if (stretch_size.x < 0.0) {
+        stretch_size = local_rect.size;
+    }
 
     // If this segment should interpolate relative to the
     // segment, modify the parameters for that.

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -33,7 +33,7 @@ use util::{TransformedRectKind};
 // a dummy task that doesn't mask out anything.
 const OPAQUE_TASK_ADDRESS: RenderTaskAddress = RenderTaskAddress(0x7fff);
 
-// Used to signal there are no segments provided with this primitive.
+/// Used to signal there are no segments provided with this primitive.
 const INVALID_SEGMENT_INDEX: i32 = 0xffff;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, ClipMode, DeviceIntRect, DeviceIntPoint, DeviceIntSize};
-use api::{ExternalImageType, FilterOp, ImageRendering, LayoutRect};
-use api::{YuvColorSpace, YuvFormat, PictureRect, ColorDepth};
+use api::{ExternalImageType, FilterOp, ImageRendering, LayoutRect, LayoutSize};
+use api::{YuvColorSpace, YuvFormat, PictureRect, ColorDepth, LayoutPoint};
 use clip::{ClipDataStore, ClipNodeFlags, ClipNodeRange, ClipItem, ClipStore};
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
 use glyph_rasterizer::GlyphFormat;
@@ -27,11 +27,14 @@ use scene::FilterOpHelpers;
 use smallvec::SmallVec;
 use std::{f32, i32, usize};
 use tiling::{RenderTargetContext};
-use util::{RectHelpers, TransformedRectKind};
+use util::{TransformedRectKind};
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.
 const OPAQUE_TASK_ADDRESS: RenderTaskAddress = RenderTaskAddress(0x7fff);
+
+// Used to signal there are no segments provided with this primitive.
+const INVALID_SEGMENT_INDEX: i32 = 0xffff;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -906,78 +909,84 @@ impl AlphaBatchBuilder {
 
                                 let tile_cache = picture.tile_cache.as_ref().unwrap();
 
-                                for y in 0 .. tile_cache.y_tiles {
-                                    for x in 0 .. tile_cache.x_tiles {
-                                        let i = y * tile_cache.x_tiles + x;
+                                for y in 0 .. tile_cache.tile_rect.size.height {
+                                    for x in 0 .. tile_cache.tile_rect.size.width {
+                                        let i = y * tile_cache.tile_rect.size.width + x;
                                         let tile = &tile_cache.tiles[i as usize];
 
                                         // Check if the tile is visible.
-                                        if tile.is_visible {
-
-                                            // Get the local rect of the tile.
-                                            let tx0 = (tile_cache.tile_x0 + x) as f32 * tile_cache.local_tile_size.width;
-                                            let ty0 = (tile_cache.tile_y0 + y) as f32 * tile_cache.local_tile_size.height;
-                                            let tx1 = tx0 + tile_cache.local_tile_size.width;
-                                            let ty1 = ty0 + tile_cache.local_tile_size.height;
-                                            let tile_rect = LayoutRect::from_floats(tx0, ty0, tx1, ty1);
-
-                                            // Construct a local clip rect that ensures we only draw pixels where
-                                            // the local bounds of the picture extend to within the edge tiles.
-                                            let local_clip_rect = prim_instance
-                                                .combined_local_clip_rect
-                                                .intersection(&picture.local_rect)
-                                                .expect("bug: invalid picture local rect");
-
-                                            let prim_header = PrimitiveHeader {
-                                                local_rect: tile_rect,
-                                                local_clip_rect,
-                                                task_address,
-                                                specific_prim_address: prim_cache_address,
-                                                clip_task_address,
-                                                transform_id,
-                                            };
-
-                                            let prim_header_index = prim_headers.push(&prim_header, z_id, [
-                                                ShaderColorMode::Image as i32 | ((AlphaType::PremultipliedAlpha as i32) << 16),
-                                                RasterizationSpace::Local as i32,
-                                                get_shader_opacity(1.0),
-                                            ]);
-
-                                            let cache_item = ctx
-                                                .resource_cache
-                                                .get_texture_cache_item(&tile.handle);
-
-                                            let key = BatchKey::new(
-                                                kind,
-                                                non_segmented_blend_mode,
-                                                BatchTextures::color(cache_item.texture_id),
-                                            );
-
-                                            let uv_rect_address = gpu_cache
-                                                .get_address(&cache_item.uv_rect_handle)
-                                                .as_int();
-
-                                            let instance = BrushInstance {
-                                                prim_header_index,
-                                                clip_task_address,
-                                                segment_index: 0xffff,
-                                                edge_flags: EdgeAaSegmentMask::empty(),
-                                                brush_flags: BrushFlags::empty(),
-                                                user_data: uv_rect_address,
-                                            };
-
-                                            // Instead of retrieving the batch once and adding each tile instance,
-                                            // use this API to get an appropriate batch for each tile, since
-                                            // the batch textures may be different. The batch list internally
-                                            // caches the current batch if the key hasn't changed.
-                                            let batch = self.batch_list.set_params_and_get_batch(
-                                                key,
-                                                bounding_rect,
-                                                z_id,
-                                            );
-
-                                            batch.push(PrimitiveInstanceData::from(instance));
+                                        if !tile.is_visible {
+                                            continue;
                                         }
+
+                                        // Get the local rect of the tile.
+                                        let tile_rect = LayoutRect::new(
+                                            LayoutPoint::new(
+                                                (tile_cache.tile_rect.origin.x + x) as f32 * tile_cache.local_tile_size.width,
+                                                (tile_cache.tile_rect.origin.y + y) as f32 * tile_cache.local_tile_size.height,
+                                            ),
+                                            LayoutSize::new(
+                                                tile_cache.local_tile_size.width,
+                                                tile_cache.local_tile_size.height,
+                                            ),
+                                        );
+
+                                        // Construct a local clip rect that ensures we only draw pixels where
+                                        // the local bounds of the picture extend to within the edge tiles.
+                                        let local_clip_rect = prim_instance
+                                            .combined_local_clip_rect
+                                            .intersection(&picture.local_rect)
+                                            .expect("bug: invalid picture local rect");
+
+                                        let prim_header = PrimitiveHeader {
+                                            local_rect: tile_rect,
+                                            local_clip_rect,
+                                            task_address,
+                                            specific_prim_address: prim_cache_address,
+                                            clip_task_address,
+                                            transform_id,
+                                        };
+
+                                        let prim_header_index = prim_headers.push(&prim_header, z_id, [
+                                            ShaderColorMode::Image as i32 | ((AlphaType::PremultipliedAlpha as i32) << 16),
+                                            RasterizationSpace::Local as i32,
+                                            get_shader_opacity(1.0),
+                                        ]);
+
+                                        let cache_item = ctx
+                                            .resource_cache
+                                            .get_texture_cache_item(&tile.handle);
+
+                                        let key = BatchKey::new(
+                                            kind,
+                                            non_segmented_blend_mode,
+                                            BatchTextures::color(cache_item.texture_id),
+                                        );
+
+                                        let uv_rect_address = gpu_cache
+                                            .get_address(&cache_item.uv_rect_handle)
+                                            .as_int();
+
+                                        let instance = BrushInstance {
+                                            prim_header_index,
+                                            clip_task_address,
+                                            segment_index: INVALID_SEGMENT_INDEX,
+                                            edge_flags: EdgeAaSegmentMask::empty(),
+                                            brush_flags: BrushFlags::empty(),
+                                            user_data: uv_rect_address,
+                                        };
+
+                                        // Instead of retrieving the batch once and adding each tile instance,
+                                        // use this API to get an appropriate batch for each tile, since
+                                        // the batch textures may be different. The batch list internally
+                                        // caches the current batch if the key hasn't changed.
+                                        let batch = self.batch_list.set_params_and_get_batch(
+                                            key,
+                                            bounding_rect,
+                                            z_id,
+                                        );
+
+                                        batch.push(PrimitiveInstanceData::from(instance));
                                     }
                                 }
                             }

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, ClipMode, DeviceIntRect, DeviceIntPoint, DeviceIntSize};
-use api::{ExternalImageType, FilterOp, ImageRendering};
+use api::{ExternalImageType, FilterOp, ImageRendering, LayoutRect};
 use api::{YuvColorSpace, YuvFormat, PictureRect, ColorDepth};
 use clip::{ClipDataStore, ClipNodeFlags, ClipNodeRange, ClipItem, ClipStore};
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
@@ -27,7 +27,7 @@ use scene::FilterOpHelpers;
 use smallvec::SmallVec;
 use std::{f32, i32, usize};
 use tiling::{RenderTargetContext};
-use util::{TransformedRectKind};
+use util::{RectHelpers, TransformedRectKind};
 
 // Special sentinel value recognized by the shader. It is considered to be
 // a dummy task that doesn't mask out anything.
@@ -894,12 +894,98 @@ impl AlphaBatchBuilder {
 
                 match picture.raster_config {
                     Some(ref raster_config) => {
-                        let surface = ctx.surfaces[raster_config.surface_index.0]
-                            .surface
-                            .as_ref()
-                            .expect("bug: surface must be allocated by now");
                         match raster_config.composite_mode {
+                            PictureCompositeMode::TileCache { .. } => {
+
+                                // Step through each tile in the cache, and draw it with an image
+                                // brush primitive if visible.
+
+                                let kind = BatchKind::Brush(
+                                    BrushBatchKind::Image(ImageBufferKind::Texture2DArray)
+                                );
+
+                                let tile_cache = picture.tile_cache.as_ref().unwrap();
+
+                                for y in 0 .. tile_cache.y_tiles {
+                                    for x in 0 .. tile_cache.x_tiles {
+                                        let i = y * tile_cache.x_tiles + x;
+                                        let tile = &tile_cache.tiles[i as usize];
+
+                                        // Check if the tile is visible.
+                                        if tile.is_visible {
+
+                                            // Get the local rect of the tile.
+                                            let tx0 = (tile_cache.tile_x0 + x) as f32 * tile_cache.local_tile_size.width;
+                                            let ty0 = (tile_cache.tile_y0 + y) as f32 * tile_cache.local_tile_size.height;
+                                            let tx1 = tx0 + tile_cache.local_tile_size.width;
+                                            let ty1 = ty0 + tile_cache.local_tile_size.height;
+                                            let tile_rect = LayoutRect::from_floats(tx0, ty0, tx1, ty1);
+
+                                            // Construct a local clip rect that ensures we only draw pixels where
+                                            // the local bounds of the picture extend to within the edge tiles.
+                                            let local_clip_rect = prim_instance
+                                                .combined_local_clip_rect
+                                                .intersection(&picture.local_rect)
+                                                .expect("bug: invalid picture local rect");
+
+                                            let prim_header = PrimitiveHeader {
+                                                local_rect: tile_rect,
+                                                local_clip_rect,
+                                                task_address,
+                                                specific_prim_address: prim_cache_address,
+                                                clip_task_address,
+                                                transform_id,
+                                            };
+
+                                            let prim_header_index = prim_headers.push(&prim_header, z_id, [
+                                                ShaderColorMode::Image as i32 | ((AlphaType::PremultipliedAlpha as i32) << 16),
+                                                RasterizationSpace::Local as i32,
+                                                get_shader_opacity(1.0),
+                                            ]);
+
+                                            let cache_item = ctx
+                                                .resource_cache
+                                                .get_texture_cache_item(&tile.handle);
+
+                                            let key = BatchKey::new(
+                                                kind,
+                                                non_segmented_blend_mode,
+                                                BatchTextures::color(cache_item.texture_id),
+                                            );
+
+                                            let uv_rect_address = gpu_cache
+                                                .get_address(&cache_item.uv_rect_handle)
+                                                .as_int();
+
+                                            let instance = BrushInstance {
+                                                prim_header_index,
+                                                clip_task_address,
+                                                segment_index: 0xffff,
+                                                edge_flags: EdgeAaSegmentMask::empty(),
+                                                brush_flags: BrushFlags::empty(),
+                                                user_data: uv_rect_address,
+                                            };
+
+                                            // Instead of retrieving the batch once and adding each tile instance,
+                                            // use this API to get an appropriate batch for each tile, since
+                                            // the batch textures may be different. The batch list internally
+                                            // caches the current batch if the key hasn't changed.
+                                            let batch = self.batch_list.set_params_and_get_batch(
+                                                key,
+                                                bounding_rect,
+                                                z_id,
+                                            );
+
+                                            batch.push(PrimitiveInstanceData::from(instance));
+                                        }
+                                    }
+                                }
+                            }
                             PictureCompositeMode::Filter(filter) => {
+                                let surface = ctx.surfaces[raster_config.surface_index.0]
+                                    .surface
+                                    .as_ref()
+                                    .expect("bug: surface must be allocated by now");
                                 assert!(filter.is_visible());
                                 match filter {
                                     FilterOp::Blur(..) => {
@@ -1117,6 +1203,10 @@ impl AlphaBatchBuilder {
                                 }
                             }
                             PictureCompositeMode::MixBlend(mode) => {
+                                let surface = ctx.surfaces[raster_config.surface_index.0]
+                                    .surface
+                                    .as_ref()
+                                    .expect("bug: surface must be allocated by now");
                                 let cache_task_id = surface.resolve_render_task_id();
                                 let backdrop_id = picture.secondary_render_task_id.expect("no backdrop!?");
 
@@ -1156,6 +1246,10 @@ impl AlphaBatchBuilder {
                                 );
                             }
                             PictureCompositeMode::Blit => {
+                                let surface = ctx.surfaces[raster_config.surface_index.0]
+                                    .surface
+                                    .as_ref()
+                                    .expect("bug: surface must be allocated by now");
                                 let cache_task_id = surface.resolve_render_task_id();
                                 let kind = BatchKind::Brush(
                                     BrushBatchKind::Image(ImageBufferKind::Texture2DArray)

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -203,7 +203,11 @@ impl<'a> DisplayListFlattener<'a> {
             &root_pipeline.viewport_size,
             &root_pipeline.content_size,
         );
-        flattener.flatten_root(root_pipeline, &root_pipeline.viewport_size);
+
+        flattener.flatten_root(
+            root_pipeline,
+            &root_pipeline.viewport_size,
+        );
 
         debug_assert!(flattener.sc_stack.is_empty());
 
@@ -241,7 +245,11 @@ impl<'a> DisplayListFlattener<'a> {
             .get(items)
     }
 
-    fn flatten_root(&mut self, pipeline: &'a ScenePipeline, frame_size: &LayoutSize) {
+    fn flatten_root(
+        &mut self,
+        pipeline: &'a ScenePipeline,
+        frame_size: &LayoutSize,
+    ) {
         let pipeline_id = pipeline.pipeline_id;
         let reference_frame_info = self.simple_scroll_and_clip_chain(
             &ClipId::root_reference_frame(pipeline_id),
@@ -262,6 +270,8 @@ impl<'a> DisplayListFlattener<'a> {
 
         // For the root pipeline, there's no need to add a full screen rectangle
         // here, as it's handled by the framebuffer clear.
+        // TODO(gw): In future, we can probably remove this code completely and handle
+        //           it as part of the tile cache background color clearing.
         if self.scene.root_pipeline_id != Some(pipeline_id) {
             if let Some(pipeline) = self.scene.pipelines.get(&pipeline_id) {
                 if let Some(bg_color) = pipeline.background_color {
@@ -499,7 +509,10 @@ impl<'a> DisplayListFlattener<'a> {
             ScrollSensitivity::ScriptAndInputEvents,
         );
 
-        self.flatten_root(pipeline, &iframe_rect.size);
+        self.flatten_root(
+            pipeline,
+            &iframe_rect.size,
+        );
 
         self.pipeline_clip_chain_stack.pop();
     }

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -325,10 +325,8 @@ impl TileCache {
                 let tile = if tx >= 0 && ty >= 0 && tx < self.tile_rect.size.width && ty < self.tile_rect.size.height {
                     let index = (ty * self.tile_rect.size.width + tx) as usize;
                     mem::replace(&mut self.tiles[index], Tile::new())
-                } else if let Some(tile) = self.old_tiles.remove(&TileOffset::new(x + x0, y + y0)) {
-                    tile
                 } else {
-                    Tile::new()
+                    self.old_tiles.remove(&TileOffset::new(x + x0, y + y0)).unwrap_or_else(Tile::new)
                 };
                 new_tiles.push(tile);
             }
@@ -449,8 +447,10 @@ impl TileCache {
             }
         }
 
-        for (key, value) in &mut opacity_bindings {
-            *value = scene_properties.get_float_value(*key).unwrap_or(*value);
+        for (key, current) in &mut opacity_bindings {
+            if let Some(value) = scene_properties.get_float_value(*key) {
+                *current = value;
+            }
         }
 
         // The transforms of any clips that are relative to the picture may affect

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -3,28 +3,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint};
-use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel};
-use api::{DevicePixelScale, RasterRect, RasterSpace};
-use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect};
+use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel, PropertyBinding, PropertyBindingId};
+use api::{DevicePixelScale, RasterRect, RasterSpace, PictureSize, DeviceIntPoint, ColorF, ImageKey};
+use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor};
 use box_shadow::{BLUR_SAMPLE_SCALE};
-use clip::{ClipNodeCollector, ClipStore};
+use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode};
 use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
+use device::TextureFilter;
 use euclid::{TypedScale, vec3, TypedRect};
+use euclid::approxeq::ApproxEq;
 use internal_types::{FastHashMap, PlaneSplitter};
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState, PictureContext};
 use gpu_cache::{GpuCacheAddress, GpuCacheHandle};
 use gpu_types::{TransformPalette, TransformPaletteId, UvRectKind};
+use internal_types::FastHashSet;
 use plane_split::{Clipper, Polygon, Splitter};
 use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper, VisibleFace, PrimitiveInstanceKind};
-use prim_store::{get_raster_rects, PrimitiveDataInterner};
-use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle};
+use prim_store::{get_raster_rects, PrimitiveDataInterner, PrimitiveDataStore, CoordinateSpaceMapping};
+use prim_store::{PrimitiveDetails, BrushKind, Primitive};
+use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle, TileBlit};
 use render_task::{RenderTaskCacheKey, RenderTaskCacheKeyKind, RenderTaskId, RenderTaskLocation};
+use resource_cache::ResourceCache;
 use scene::{FilterOpHelpers, SceneProperties};
 use smallvec::SmallVec;
-use surface::SurfaceDescriptor;
+use surface::{SurfaceDescriptor, TransformKey};
 use std::{mem, ops};
+use texture_cache::{Eviction, TextureCacheHandle};
 use tiling::RenderTargetKind;
-use util::{TransformedRectKind, MatrixHelpers, MaxRect};
+use util::{TransformedRectKind, MatrixHelpers, MaxRect, RectHelpers};
 
 /*
  A picture represents a dynamically rendered image. It consists of:
@@ -43,12 +49,573 @@ struct PictureInfo {
     spatial_node_index: SpatialNodeIndex,
 }
 
+/// The size in device pixels of a cached tile. The currently chosen
+/// size is arbitrary. We should do some profiling to find the best
+/// size for real world pages.
+pub const TILE_SIZE_DP: f32 = 512.0;
+
+/// Information about the state of a transform dependency.
+#[derive(Debug)]
+pub struct TransformInfo {
+    /// Quantized transform value
+    key: TransformKey,
+    /// Tiles check this to see if the dependencies have changed.
+    changed: bool,
+}
+
+/// Information about a cached tile.
+#[derive(Debug)]
+pub struct Tile {
+    // TODO(gw): We could perhaps use a bitset here instead of a hash set?
+    /// The set of transform values that primitives in this tile depend on.
+    transforms: FastHashSet<SpatialNodeIndex>,
+    /// The set of opacity bindings that this tile depends on.
+    opacity_bindings: FastHashMap<PropertyBindingId, f32>,
+    /// Set of image keys that this tile depends on.
+    image_keys: FastHashSet<ImageKey>,
+    /// If true, this tile is marked valid.
+    is_valid: bool,
+    /// If false, this tile cannot be cached (e.g. it has an external
+    /// video image attached to it). In future, we could add an API
+    /// for the embedder to tell us if the external image changed.
+    is_cacheable: bool,
+    /// If true, this tile is currently in use by the cache. It
+    /// may be false if the tile is outside the bounding rect of
+    /// the current picture, but hasn't been discarded yet.
+    in_use: bool,
+    /// If true, this tile is currently visible on screen.
+    pub is_visible: bool,
+    /// Handle to the cached texture for this tile.
+    pub handle: TextureCacheHandle,
+}
+
+impl Tile {
+    /// Construct a new, invalid tile.
+    fn new() -> Self {
+        Tile {
+            transforms: FastHashSet::default(),
+            opacity_bindings: FastHashMap::default(),
+            image_keys: FastHashSet::default(),
+            is_valid: false,
+            is_visible: false,
+            is_cacheable: true,
+            in_use: false,
+            handle: TextureCacheHandle::invalid(),
+        }
+    }
+}
+
+/// Represents the dirty region of a tile cache picture.
+/// In future, we will want to support multiple dirty
+/// regions.
+#[derive(Debug)]
+pub struct DirtyRegion {
+    tile_offset: DeviceIntPoint,
+    dirty_rect: PictureRect,
+    dirty_world_rect: WorldRect,
+}
+
+/// Represents a cache of tiles that make up a picture primitives.
+pub struct TileCache {
+    /// The size of each tile in local-space coordinates of the picture.
+    pub local_tile_size: PictureSize,
+    /// List of tiles present in this picture (stored as a 2D array)
+    pub tiles: Vec<Tile>,
+    /// A set of tiles that were used last time we built
+    /// the tile grid, that may be reused or discarded next time.
+    pub old_tiles: FastHashMap<(i32, i32), Tile>,
+    /// The current size of the 2D grid in ```tiles```
+    pub x_tiles: i32,
+    pub y_tiles: i32,
+    /// An offset in tile units based on the picture origin
+    /// of the bounding rect.
+    pub tile_x0: i32,
+    pub tile_y0: i32,
+    /// List of transform keys - used to check if transforms
+    /// have changed.
+    pub transforms: Vec<TransformInfo>,
+    /// A helper struct to map local rects into picture coords.
+    pub space_mapper: SpaceMapper<LayoutPixel, PicturePixel>,
+    /// If true, we need to update the prim dependencies.
+    pub needs_update: bool,
+    /// If Some(..) the region that is dirty in this picture.
+    pub dirty_region: Option<DirtyRegion>,
+}
+
+impl TileCache {
+    /// Construct a new tile cache.
+    pub fn new() -> Self {
+        TileCache {
+            tiles: Vec::new(),
+            old_tiles: FastHashMap::default(),
+            x_tiles: 0,
+            y_tiles: 0,
+            tile_x0: 0,
+            tile_y0: 0,
+            local_tile_size: PictureSize::zero(),
+            transforms: Vec::new(),
+            needs_update: true,
+            dirty_region: None,
+            space_mapper: SpaceMapper::new(
+                ROOT_SPATIAL_NODE_INDEX,
+                PictureRect::zero(),
+            ),
+        }
+    }
+
+    /// Update the transforms array for this tile cache from the clip-scroll
+    /// tree. This marks each transform as changed for later use during
+    /// tile invalidation.
+    pub fn update_transforms(
+        &mut self,
+        surface_spatial_node_index: SpatialNodeIndex,
+        world_rect: WorldRect,
+        device_pixel_scale: DevicePixelScale,
+        clip_scroll_tree: &ClipScrollTree,
+    ) {
+        // Initialize the space mapper with current bounds,
+        // which is used during primitive dependency updates.
+        let world_mapper = SpaceMapper::new_with_target(
+            ROOT_SPATIAL_NODE_INDEX,
+            surface_spatial_node_index,
+            world_rect,
+            clip_scroll_tree,
+        );
+
+        let pic_bounds = world_mapper
+            .unmap(&world_rect)
+            .unwrap_or(PictureRect::max_rect());
+
+        self.space_mapper = SpaceMapper::new(
+            surface_spatial_node_index,
+            pic_bounds,
+        );
+
+        // Work out the local space size of each tile, based on the
+        // device pixel size of tiles.
+        // TODO(gw): Perhaps add a map_point API to SpaceMapper.
+        let world_tile_rect = WorldRect::from_floats(
+            0.0,
+            0.0,
+            TILE_SIZE_DP / device_pixel_scale.0,
+            TILE_SIZE_DP / device_pixel_scale.0,
+        );
+        let local_tile_rect = world_mapper
+            .unmap(&world_tile_rect)
+            .expect("bug: unable to get local tile size");
+        self.local_tile_size = local_tile_rect.size;
+
+        // Walk the transforms and see if we need to rebuild the primitive
+        // dependencies for each tile.
+        // TODO(gw): We could be smarter here and only rebuild for the primitives
+        //           which are affected by transforms that have changed.
+        self.needs_update = if self.transforms.len() == clip_scroll_tree.spatial_nodes.len() {
+            // If the transform array length is the same, then we can walk the list
+            // and check if the values of each transform are the same.
+            let mut any_transforms_changed = false;
+
+            for (i, transform) in self.transforms.iter_mut().enumerate() {
+                let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
+                    surface_spatial_node_index,
+                    SpatialNodeIndex(i),
+                    clip_scroll_tree,
+                ).expect("todo: handle invalid mappings");
+
+                let key = mapping.into();
+                transform.changed = transform.key != key;
+                transform.key = key;
+
+                any_transforms_changed |= transform.changed;
+            }
+
+            any_transforms_changed
+        } else {
+            // If the size of the transforms array changed, just invalidate all the transforms for now.
+            self.transforms.clear();
+
+            for i in 0 .. clip_scroll_tree.spatial_nodes.len() {
+                let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
+                    surface_spatial_node_index,
+                    SpatialNodeIndex(i),
+                    clip_scroll_tree,
+                ).expect("todo: handle invalid mappings");
+
+                self.transforms.push(TransformInfo {
+                    key: mapping.into(),
+                    changed: true,
+                });
+            }
+
+            true
+        };
+
+        // If we need to update the dependencies for tiles, walk each tile
+        // and clear the transforms and opacity bindings arrays.
+        if self.needs_update {
+            debug_assert!(self.old_tiles.is_empty());
+
+            // Clear any dependencies on the set of existing tiles, since
+            // they are going to be rebuilt. Drain the tiles list and add
+            // them to the old_tiles hash, for re-use next frame build.
+            for (i, mut tile) in self.tiles.drain(..).enumerate() {
+                let y = i as i32 / self.x_tiles;
+                let x = i as i32 % self.x_tiles;
+                tile.transforms.clear();
+                tile.opacity_bindings.clear();
+                tile.image_keys.clear();
+                tile.in_use = false;
+                self.old_tiles.insert((x + self.tile_x0, y + self.tile_y0), tile);
+            }
+
+            // Reset the size of the tile grid.
+            self.x_tiles = 0;
+            self.y_tiles = 0;
+            self.tile_x0 = 0;
+            self.tile_y0 = 0;
+        }
+    }
+
+    /// Resize the 2D tiles array if needed in order to fit dependencies
+    /// for a given primitive.
+    fn reconfigure_tiles_if_required(
+        &mut self,
+        mut x0: i32,
+        mut y0: i32,
+        mut x1: i32,
+        mut y1: i32,
+    ) {
+        // Determine and store the tile bounds that are now required.
+        if self.x_tiles > 0 {
+            x0 = x0.min(self.tile_x0);
+            x1 = x1.max(self.tile_x0 + self.x_tiles);
+        }
+        if self.y_tiles > 0 {
+            y0 = y0.min(self.tile_y0);
+            y1 = y1.max(self.tile_y0 + self.y_tiles);
+        }
+
+        // See how many tiles are now required, and it that's different from current config.
+        let x_tiles = x1 - x0;
+        let y_tiles = y1 - y0;
+
+        if self.x_tiles != x_tiles || self.y_tiles != y_tiles {
+            // We will need to create a new tile array.
+            let mut new_tiles = Vec::with_capacity((x_tiles * y_tiles) as usize);
+
+            for y in 0 .. y_tiles {
+                for x in 0 .. x_tiles {
+                    // See if we can re-use an existing tile from the old array, by mapping
+                    // the tile address. This saves invalidating existing tiles when we
+                    // just resize the picture by adding / remove primitives.
+                    let tx = x0 - self.tile_x0 + x;
+                    let ty = y0 - self.tile_y0 + y;
+
+                    if tx >= 0 && ty >= 0 && tx < self.x_tiles && ty < self.y_tiles {
+                        let index = (ty * self.x_tiles + tx) as usize;
+                        let old_tile = mem::replace(&mut self.tiles[index], Tile::new());
+                        new_tiles.push(old_tile);
+                    } else if let Some(tile) = self.old_tiles.remove(&(x + x0, y + y0)) {
+                        new_tiles.push(tile);
+                    } else {
+                        new_tiles.push(Tile::new());
+                    }
+                }
+            }
+
+            self.tiles = new_tiles;
+            self.x_tiles = x_tiles;
+            self.y_tiles = y_tiles;
+            self.tile_x0 = x0;
+            self.tile_y0 = y0;
+        }
+    }
+
+    /// Update the dependencies for each tile for a given primitive instance.
+    pub fn update_prim_dependencies(
+        &mut self,
+        prim_instance: &PrimitiveInstance,
+        surface_spatial_node_index: SpatialNodeIndex,
+        clip_scroll_tree: &ClipScrollTree,
+        prim_data_store: &PrimitiveDataStore,
+        clip_chain_nodes: &[ClipChainNode],
+        primitives: &[Primitive],
+        pictures: &[PicturePrimitive],
+        resource_cache: &mut ResourceCache,
+        scene_properties: &SceneProperties,
+    ) {
+        self.space_mapper.set_target_spatial_node(
+            prim_instance.spatial_node_index,
+            clip_scroll_tree,
+        );
+
+        let prim_data = &prim_data_store[prim_instance.prim_data_handle];
+
+        // Map the primitive local rect into the picture space.
+        let rect = match self.space_mapper.map(&prim_data.prim_rect) {
+            Some(rect) => rect,
+            None => {
+                return;
+            }
+        };
+
+        // If the rect is invalid, no need to create dependencies.
+        // TODO(gw): Need to handle pictures with filters here.
+        if rect.size.width <= 0.0 || rect.size.height <= 0.0 {
+            return;
+        }
+
+        // Get the tile coordinates in the picture space.
+        let x0 = (rect.origin.x / self.local_tile_size.width).floor() as i32;
+        let y0 = (rect.origin.y / self.local_tile_size.height).floor() as i32;
+        let x1 = ((rect.origin.x + rect.size.width) / self.local_tile_size.width).ceil() as i32;
+        let y1 = ((rect.origin.y + rect.size.height) / self.local_tile_size.height).ceil() as i32;
+
+        // Update the tile array allocation if needed.
+        self.reconfigure_tiles_if_required(x0, y0, x1, y1);
+
+        // Build the list of resources that this primitive has dependencies on.
+        let mut is_cacheable = true;
+        let mut opacity_bindings: SmallVec<[(PropertyBindingId, f32); 4]> = SmallVec::new();
+        let mut clip_chain_spatial_nodes: SmallVec<[SpatialNodeIndex; 8]> = SmallVec::new();
+        let mut image_keys: SmallVec<[ImageKey; 8]> = SmallVec::new();
+        let mut current_clip_chain_id = prim_instance.clip_chain_id;
+
+        match prim_instance.kind {
+            PrimitiveInstanceKind::Picture { pic_index } => {
+                // Pictures can depend on animated opacity bindings.
+                let pic = &pictures[pic_index.0];
+                if let Some(PictureCompositeMode::Filter(FilterOp::Opacity(binding, _))) = pic.requested_composite_mode {
+                    if let PropertyBinding::Binding(key, default) = binding {
+                        let value = scene_properties.get_float_value(key.id).unwrap_or(default);
+                        opacity_bindings.push((key.id, value));
+                    }
+                }
+            }
+            PrimitiveInstanceKind::LegacyPrimitive { prim_index } => {
+                let prim = &primitives[prim_index.0];
+
+                // Some primitives can not be cached (e.g. external video images)
+                is_cacheable = prim_instance.is_cacheable(
+                    &prim.details,
+                    resource_cache,
+                );
+
+                match prim.details {
+                    PrimitiveDetails::Brush(ref brush) => {
+                        match brush.kind {
+                            // Rectangles and images may depend on opacity bindings.
+                            // TODO(gw): In future, we might be able to completely remove
+                            //           opacity collapsing support. It's of limited use
+                            //           once we have full picture caching.
+                            BrushKind::Solid { ref opacity_binding, .. } => {
+                                for binding in &opacity_binding.bindings {
+                                    if let PropertyBinding::Binding(key, default) = binding {
+                                        let value = scene_properties.get_float_value(key.id).unwrap_or(*default);
+                                        opacity_bindings.push((key.id, value));
+                                    }
+                                }
+                            }
+                            BrushKind::Image { ref opacity_binding, ref request, .. } => {
+                                for binding in &opacity_binding.bindings {
+                                    if let PropertyBinding::Binding(key, default) = binding {
+                                        let value = scene_properties.get_float_value(key.id).unwrap_or(*default);
+                                        opacity_bindings.push((key.id, value));
+                                    }
+                                }
+
+                                image_keys.push(request.key);
+                            }
+                            BrushKind::YuvImage { ref yuv_key, .. } => {
+                                image_keys.extend_from_slice(yuv_key);
+                            }
+                            BrushKind::RadialGradient { .. } |
+                            BrushKind::LinearGradient { .. } |
+                            BrushKind::Border { .. } => {
+                            }
+                        }
+                    }
+                }
+            }
+            PrimitiveInstanceKind::TextRun { .. } |
+            PrimitiveInstanceKind::LineDecoration { .. } |
+            PrimitiveInstanceKind::Clear => {
+                // These don't contribute dependencies
+            }
+        }
+
+        // The transforms of any clips that are relative to the picture may affect
+        // the content rendered by this primitive.
+        while current_clip_chain_id != ClipChainId::NONE {
+            let clip_chain_node = &clip_chain_nodes[current_clip_chain_id.0 as usize];
+            if clip_chain_node.spatial_node_index > surface_spatial_node_index {
+                clip_chain_spatial_nodes.push(clip_chain_node.spatial_node_index);
+            }
+            current_clip_chain_id = clip_chain_node.parent_clip_chain_id;
+        }
+
+        // Normalize the tile coordinates before adding to tile dependencies.
+        let x0 = x0 - self.tile_x0;
+        let x1 = x1 - self.tile_x0;
+        let y0 = y0 - self.tile_y0;
+        let y1 = y1 - self.tile_y0;
+
+        // For each affected tile, mark any of the primitive dependencies.
+        for y in y0 .. y1 {
+            for x in x0 .. x1 {
+                let index = (y * self.x_tiles + x) as usize;
+                let tile = &mut self.tiles[index];
+
+                // Mark if the tile is cacheable at all.
+                tile.is_cacheable |= is_cacheable;
+                tile.in_use = true;
+
+                // Include any image keys this tile depends on.
+                for image_key in &image_keys {
+                    tile.image_keys.insert(*image_key);
+                }
+
+                // Include the transform of the primitive itself.
+                tile.transforms.insert(prim_instance.spatial_node_index);
+
+                // Include the transforms of any relevant clip nodes for this primitive.
+                for clip_chain_spatial_node in &clip_chain_spatial_nodes {
+                    tile.transforms.insert(*clip_chain_spatial_node);
+                }
+
+                // Include any opacity bindings this primitive depends on.
+                for &(id, value) in &opacity_bindings {
+                    tile.opacity_bindings.insert(id, value);
+                }
+            }
+        }
+    }
+
+    /// Build the dirty region(s) for the tile cache after all primitive
+    /// dependencies have been updated.
+    pub fn build_dirty_regions(
+        &mut self,
+        surface_spatial_node_index: SpatialNodeIndex,
+        world_rect: WorldRect,
+        clip_scroll_tree: &ClipScrollTree,
+        resource_cache: &mut ResourceCache,
+        scene_properties: &SceneProperties,
+    ) {
+        self.needs_update = false;
+
+        for (_, tile) in self.old_tiles.drain() {
+            if resource_cache.texture_cache.is_allocated(&tile.handle) {
+                resource_cache.texture_cache.mark_unused(&tile.handle);
+            }
+        }
+
+        let world_mapper = SpaceMapper::new_with_target(
+            ROOT_SPATIAL_NODE_INDEX,
+            surface_spatial_node_index,
+            world_rect,
+            clip_scroll_tree,
+        );
+
+        let mut tile_offset = DeviceIntPoint::new(
+            self.x_tiles,
+            self.y_tiles,
+        );
+
+        let mut dirty_rect = PictureRect::zero();
+
+        // Step through each tile and invalidate if the dependencies have changed.
+        for y in 0 .. self.y_tiles {
+            for x in 0 .. self.x_tiles {
+                let i = y * self.x_tiles + x;
+                let tile = &mut self.tiles[i as usize];
+
+                let tile_rect = PictureRect::new(
+                    PicturePoint::new(
+                        (self.tile_x0 + x) as f32 * self.local_tile_size.width,
+                        (self.tile_y0 + y) as f32 * self.local_tile_size.height,
+                    ),
+                    self.local_tile_size,
+                );
+
+                // Invalidate the tile if not cacheable
+                if !tile.is_cacheable {
+                    tile.is_valid = false;
+                }
+
+                if !tile.in_use {
+                    tile.is_valid = false;
+                }
+
+                // Invalidate the tile if any images have changed
+                for image_key in &tile.image_keys {
+                    if resource_cache.is_image_dirty(*image_key) {
+                        tile.is_valid = false;
+                        break;
+                    }
+                }
+
+                // Invalidate the tile if any dependent transforms changed
+                for node_index in &tile.transforms {
+                    if self.transforms[node_index.0].changed {
+                        tile.is_valid = false;
+                        break;
+                    }
+                }
+
+                // Invalidate the tile if any opacity bindings changed.
+                for (id, old) in &mut tile.opacity_bindings {
+                    if let Some(new) = scene_properties.get_float_value(*id) {
+                        if !new.approx_eq(old) {
+                            tile.is_valid = false;
+                            break;
+                        }
+                    }
+                }
+
+                // Invalidate the tile if it was evicted by the texture cache.
+                if !resource_cache.texture_cache.is_allocated(&tile.handle) {
+                    tile.is_valid = false;
+                }
+
+                // Check if this tile is actually visible.
+                let tile_world_rect = world_mapper
+                    .map(&tile_rect)
+                    .expect("bug: unable to map tile to world coords");
+                tile.is_visible = world_rect.intersection(&tile_world_rect).is_some();
+
+                // If we have an invalid tile, which is also visible, add it to the
+                // dirty rect we will need to draw.
+                if !tile.is_valid && tile.is_visible {
+                    dirty_rect = dirty_rect.union(&tile_rect);
+                    tile_offset.x = tile_offset.x.min(x);
+                    tile_offset.y = tile_offset.y.min(y);
+                }
+            }
+        }
+
+        self.dirty_region = if dirty_rect.size.width == 0.0 || dirty_rect.size.height == 0.0 {
+            None
+        } else {
+            let dirty_world_rect = world_mapper.map(&dirty_rect).expect("todo");
+            Some(DirtyRegion {
+                dirty_rect,
+                tile_offset,
+                dirty_world_rect,
+            })
+        };
+    }
+}
+
 /// Maintains a stack of picture and surface information, that
 /// is used during the initial picture traversal.
 pub struct PictureUpdateState<'a> {
     pub surfaces: &'a mut Vec<SurfaceInfo>,
     surface_stack: Vec<SurfaceIndex>,
     picture_stack: Vec<PictureInfo>,
+    /// A stack of currently active tile caches during traversal.
+    tile_cache_stack: Vec<TileCache>,
+    /// A ref count of how many tile caches on the stack actually
+    /// need to have their primitive dependencies updated.
+    tile_cache_update_count: usize,
 }
 
 impl<'a> PictureUpdateState<'a> {
@@ -57,6 +624,8 @@ impl<'a> PictureUpdateState<'a> {
             surfaces,
             surface_stack: vec![SurfaceIndex(0)],
             picture_stack: Vec::new(),
+            tile_cache_stack: Vec::new(),
+            tile_cache_update_count: 0,
         }
     }
 
@@ -107,6 +676,30 @@ impl<'a> PictureUpdateState<'a> {
     ) -> PictureInfo {
         self.picture_stack.pop().unwrap()
     }
+
+    /// Push a tile cache onto the traversal state.
+    pub fn push_tile_cache(
+        &mut self,
+        tile_cache: TileCache,
+    ) {
+        if tile_cache.needs_update {
+            self.tile_cache_update_count += 1;
+        }
+        self.tile_cache_stack.push(tile_cache);
+    }
+
+    /// Pop a tile cache from the traversal state.
+    pub fn pop_tile_cache(
+        &mut self,
+    ) -> TileCache {
+        let tile_cache = self.tile_cache_stack.pop().unwrap();
+
+        if tile_cache.needs_update {
+            self.tile_cache_update_count -= 1;
+        }
+
+        tile_cache
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -128,7 +721,6 @@ pub struct SurfaceInfo {
     /// Helper structs for mapping local rects in different
     /// coordinate systems into the surface coordinates.
     pub map_local_to_surface: SpaceMapper<LayoutPixel, PicturePixel>,
-    pub map_surface_to_world: SpaceMapper<PicturePixel, WorldPixel>,
     /// Defines the positioning node for the surface itself,
     /// and the rasterization root for this surface.
     pub raster_spatial_node_index: SpatialNodeIndex,
@@ -137,12 +729,15 @@ pub struct SurfaceInfo {
     pub surface: Option<PictureSurface>,
     /// A list of render tasks that are dependencies of this surface.
     pub tasks: Vec<RenderTaskId>,
+    /// How much the local surface rect should be inflated (for blur radii).
+    pub inflation_factor: f32,
 }
 
 impl SurfaceInfo {
     pub fn new(
         surface_spatial_node_index: SpatialNodeIndex,
         raster_spatial_node_index: SpatialNodeIndex,
+        inflation_factor: f32,
         world_rect: WorldRect,
         clip_scroll_tree: &ClipScrollTree,
     ) -> Self {
@@ -164,12 +759,12 @@ impl SurfaceInfo {
 
         SurfaceInfo {
             rect: PictureRect::zero(),
-            map_surface_to_world,
             map_local_to_surface,
             surface: None,
             raster_spatial_node_index,
             surface_spatial_node_index,
             tasks: Vec::new(),
+            inflation_factor,
         }
     }
 
@@ -192,6 +787,7 @@ pub struct RasterConfig {
 
 /// Specifies how this Picture should be composited
 /// onto the target it belongs to.
+#[allow(dead_code)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum PictureCompositeMode {
     /// Apply CSS mix-blend-mode effect.
@@ -201,6 +797,10 @@ pub enum PictureCompositeMode {
     /// Draw to intermediate surface, copy straight across. This
     /// is used for CSS isolation, and plane splitting.
     Blit,
+    /// Used to cache a picture as a series of tiles.
+    TileCache {
+        clear_color: ColorF,
+    },
 }
 
 // Stores the location of the picture if it is drawn to
@@ -450,7 +1050,7 @@ pub struct PicturePrimitive {
 
     /// The spatial node index of this picture when it is
     /// composited into the parent picture.
-    spatial_node_index: SpatialNodeIndex,
+    pub spatial_node_index: SpatialNodeIndex,
 
     /// The local rect of this picture. It is built
     /// dynamically during the first picture traversal.
@@ -463,6 +1063,9 @@ pub struct PicturePrimitive {
     surface_desc: Option<SurfaceDescriptor>,
 
     pub gpu_location: GpuCacheHandle,
+
+    /// If Some(..) the tile cache that is associated with this picture.
+    pub tile_cache: Option<TileCache>,
 }
 
 impl PicturePrimitive {
@@ -525,6 +1128,15 @@ impl PicturePrimitive {
             None
         };
 
+        let tile_cache = match requested_composite_mode {
+            Some(PictureCompositeMode::TileCache { .. }) => {
+                Some(TileCache::new())
+            }
+            Some(_) | None => {
+                None
+            }
+        };
+
         PicturePrimitive {
             surface_desc,
             prim_list,
@@ -542,6 +1154,7 @@ impl PicturePrimitive {
             local_rect: LayoutRect::zero(),
             local_clip_rect,
             gpu_location: GpuCacheHandle::new(),
+            tile_cache,
         }
     }
 
@@ -558,6 +1171,26 @@ impl PicturePrimitive {
         if !self.is_visible() {
             return None;
         }
+
+        // Work out the dirty world rect for this picture.
+        let dirty_world_rect = match self.tile_cache {
+            Some(ref tile_cache) => {
+                // If a tile cache is present, extract the dirty
+                // world rect from the dirty region. If there is
+                // no dirty region there is nothing to render.
+                // TODO(gw): We could early out here in that case?
+                tile_cache
+                    .dirty_region
+                    .as_ref()
+                    .map_or(WorldRect::zero(), |region| {
+                        region.dirty_world_rect
+                    })
+            }
+            None => {
+                // No tile cache - just assume the world rect of the screen.
+                frame_context.screen_world_rect
+            }
+        };
 
         // Extract the raster and surface spatial nodes from the raster
         // config, if this picture establishes a surface. Otherwise just
@@ -581,7 +1214,7 @@ impl PicturePrimitive {
         let map_pic_to_world = SpaceMapper::new_with_target(
             ROOT_SPATIAL_NODE_INDEX,
             surface_spatial_node_index,
-            frame_context.world_rect,
+            dirty_world_rect,
             frame_context.clip_scroll_tree,
         );
 
@@ -596,7 +1229,8 @@ impl PicturePrimitive {
         let (map_raster_to_world, map_pic_to_raster) = create_raster_mappers(
             surface_spatial_node_index,
             raster_spatial_node_index,
-            frame_context,
+            dirty_world_rect,
+            frame_context.clip_scroll_tree,
         );
 
         let plane_splitter = match self.context_3d {
@@ -622,31 +1256,33 @@ impl PicturePrimitive {
 
         // Disallow subpixel AA if an intermediate surface is needed.
         // TODO(lsalzman): allow overriding parent if intermediate surface is opaque
-        let allow_subpixel_aa = parent_allows_subpixel_aa &&
-            self.raster_config.is_none();
-
-        let inflation_factor = match self.raster_config {
-            Some(RasterConfig { composite_mode: PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)), .. }) => {
-                // The amount of extra space needed for primitives inside
-                // this picture to ensure the visibility check is correct.
-                BLUR_SAMPLE_SCALE * blur_radius
+        let allow_subpixel_aa = match self.raster_config {
+            Some(RasterConfig { composite_mode: PictureCompositeMode::TileCache { clear_color, .. }, .. }) => {
+                // If the tile cache has an opaque background, then it's fine to use
+                // subpixel rendering (this is the common case).
+                clear_color.a >= 1.0
+            },
+            Some(_) => {
+                false
             }
-            _ => {
-                0.0
+            None => {
+                true
             }
         };
+        // Still disable subpixel AA if parent forbids it
+        let allow_subpixel_aa = parent_allows_subpixel_aa && allow_subpixel_aa;
 
         let context = PictureContext {
             pic_index,
             pipeline_id: self.pipeline_id,
             apply_local_clip_rect: self.apply_local_clip_rect,
-            inflation_factor,
             allow_subpixel_aa,
             is_passthrough: self.raster_config.is_none(),
             raster_space: self.requested_raster_space,
             raster_spatial_node_index,
             surface_spatial_node_index,
             surface_index,
+            dirty_world_rect,
         };
 
         let prim_list = mem::replace(&mut self.prim_list, PrimitiveList::empty());
@@ -821,6 +1457,20 @@ impl PicturePrimitive {
             return None;
         }
 
+        // If we have a tile cache for this picture, see if any of the
+        // relative transforms have changed, which means we need to
+        // re-map the dependencies of any child primitives.
+        if let Some(mut tile_cache) = self.tile_cache.take() {
+            tile_cache.update_transforms(
+                self.spatial_node_index,
+                frame_context.screen_world_rect,
+                frame_context.device_pixel_scale,
+                &frame_context.clip_scroll_tree,
+            );
+
+            state.push_tile_cache(tile_cache);
+        }
+
         // Push information about this pic on stack for children to read.
         state.push_picture(PictureInfo {
             spatial_node_index: self.spatial_node_index,
@@ -869,11 +1519,23 @@ impl PicturePrimitive {
                 parent_raster_spatial_node_index
             };
 
+            let inflation_factor = match composite_mode {
+                PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)) => {
+                    // The amount of extra space needed for primitives inside
+                    // this picture to ensure the visibility check is correct.
+                    BLUR_SAMPLE_SCALE * blur_radius
+                }
+                _ => {
+                    0.0
+                }
+            };
+
             let surface_index = state.push_surface(
                 SurfaceInfo::new(
                     surface_spatial_node_index,
                     raster_spatial_node_index,
-                    frame_context.world_rect,
+                    inflation_factor,
+                    frame_context.screen_world_rect,
                     &frame_context.clip_scroll_tree,
                 )
             );
@@ -898,6 +1560,37 @@ impl PicturePrimitive {
         Some(mem::replace(&mut self.prim_list.pictures, SmallVec::new()))
     }
 
+    /// Update the primitive dependencies for any active tile caches,
+    /// but only *if* the transforms have made the mappings out of date.
+    pub fn update_prim_dependencies(
+        &self,
+        state: &mut PictureUpdateState,
+        frame_context: &FrameBuildingContext,
+        resource_cache: &mut ResourceCache,
+        prim_data_store: &PrimitiveDataStore,
+        primitives: &[Primitive],
+        pictures: &[PicturePrimitive],
+        clip_store: &ClipStore,
+    ) {
+        if state.tile_cache_update_count > 0 {
+            for prim_instance in &self.prim_list.prim_instances {
+                for tile_cache in &mut state.tile_cache_stack {
+                    tile_cache.update_prim_dependencies(
+                        prim_instance,
+                        self.spatial_node_index,
+                        &frame_context.clip_scroll_tree,
+                        prim_data_store,
+                        &clip_store.clip_chain_nodes,
+                        primitives,
+                        pictures,
+                        resource_cache,
+                        frame_context.scene_properties,
+                    );
+                }
+            }
+        }
+    }
+
     /// Called after updating child pictures during the initial
     /// picture traversal.
     pub fn post_update(
@@ -905,6 +1598,7 @@ impl PicturePrimitive {
         child_pictures: PictureList,
         state: &mut PictureUpdateState,
         frame_context: &FrameBuildingContext,
+        resource_cache: &mut ResourceCache,
     ) {
         // Pop the state information about this picture.
         state.pop_picture();
@@ -986,12 +1680,36 @@ impl PicturePrimitive {
         // If this picture establishes a surface, then map the surface bounding
         // rect into the parent surface coordinate space, and propagate that up
         // to the parent.
-        if self.raster_config.is_some() {
+        if let Some(ref raster_config) = self.raster_config {
             let surface_rect = state.current_surface().rect;
-            let surface_rect = TypedRect::from_untyped(&surface_rect.to_untyped());
+
+            if let PictureCompositeMode::TileCache { .. } = raster_config.composite_mode {
+                let mut tile_cache = state.pop_tile_cache();
+
+                // Build the dirty region(s) for this tile cache.
+                tile_cache.build_dirty_regions(
+                    self.spatial_node_index,
+                    frame_context.screen_world_rect,
+                    frame_context.clip_scroll_tree,
+                    resource_cache,
+                    frame_context.scene_properties,
+                );
+
+                self.tile_cache = Some(tile_cache);
+            }
+
+            let mut surface_rect = TypedRect::from_untyped(&surface_rect.to_untyped());
 
             // Pop this surface from the stack
             state.pop_surface();
+
+            // Drop shadows draw both a content and shadow rect, so need to expand the local
+            // rect of any surfaces to be composited in parent surfaces correctly.
+            if let PictureCompositeMode::Filter(FilterOp::DropShadow(offset, ..)) = raster_config.composite_mode {
+                let content_rect = surface_rect;
+                let shadow_rect = surface_rect.translate(&offset);
+                surface_rect = content_rect.union(&shadow_rect);
+            }
 
             // Propagate up to parent surface, now that we know this surface's static rect
             let parent_surface = state.current_surface_mut();
@@ -1043,7 +1761,8 @@ impl PicturePrimitive {
         let (map_raster_to_world, map_pic_to_raster) = create_raster_mappers(
             prim_instance.spatial_node_index,
             raster_spatial_node_index,
-            frame_context,
+            pic_context.dirty_world_rect,
+            frame_context.clip_scroll_tree,
         );
 
         let pic_rect = PictureRect::from_untyped(&prim_local_rect.to_untyped());
@@ -1068,6 +1787,121 @@ impl PicturePrimitive {
         //           it's not used by that shader.
 
         let surface = match raster_config.composite_mode {
+            PictureCompositeMode::TileCache { clear_color, .. } => {
+                let tile_cache = self.tile_cache.as_mut().unwrap();
+
+                // Build the render task for a tile cache picture, if there is
+                // any dirty rect.
+
+                match tile_cache.dirty_region {
+                    Some(ref dirty_region) => {
+                        // Texture cache descriptor for each tile.
+                        let descriptor = ImageDescriptor::new(
+                            TILE_SIZE_DP as i32,
+                            TILE_SIZE_DP as i32,
+                            ImageFormat::BGRA8,
+                            false,          // TODO(gw): Detect when background color is opaque!
+                            false,
+                        );
+
+                        // Get a picture rect, aligned to tile boundaries.
+                        let p0 = pic_rect.origin;
+                        let p1 = pic_rect.bottom_right();
+                        let local_tile_size = tile_cache.local_tile_size;
+                        let aligned_pic_rect = PictureRect::from_floats(
+                            (p0.x / local_tile_size.width).floor() * local_tile_size.width,
+                            (p0.y / local_tile_size.height).floor() * local_tile_size.height,
+                            (p1.x / local_tile_size.width).ceil() * local_tile_size.width,
+                            (p1.y / local_tile_size.height).ceil() * local_tile_size.height,
+                        );
+
+                        let mut blits = Vec::new();
+
+                        // Step through each tile and build the dirty rect
+                        for y in 0 .. tile_cache.y_tiles {
+                            for x in 0 .. tile_cache.x_tiles {
+                                let i = y * tile_cache.x_tiles + x;
+                                let tile = &mut tile_cache.tiles[i as usize];
+
+                                // If tile is invalidated, and on-screen, then we will
+                                // need to rasterize it.
+                                if !tile.is_valid && tile.is_visible {
+                                    // Notify the texture cache that we want to use this handle
+                                    // and make sure it is allocated.
+                                    frame_state.resource_cache.texture_cache.update(
+                                        &mut tile.handle,
+                                        descriptor,
+                                        TextureFilter::Linear,
+                                        None,
+                                        [0.0; 3],
+                                        None,
+                                        frame_state.gpu_cache,
+                                        None,
+                                        UvRectKind::Rect,
+                                        Eviction::Eager,
+                                    );
+
+                                    let cache_item = frame_state
+                                        .resource_cache
+                                        .get_texture_cache_item(&tile.handle);
+
+                                    // Set up the blit command now that we know where the dest
+                                    // rect is in the texture cache.
+                                    let offset = DeviceIntPoint::new(
+                                        ((x - dirty_region.tile_offset.x) as f32 * TILE_SIZE_DP).round() as i32,
+                                        ((y - dirty_region.tile_offset.y) as f32 * TILE_SIZE_DP).round() as i32,
+                                    );
+
+                                    blits.push(TileBlit {
+                                        target: cache_item,
+                                        offset,
+                                    });
+
+                                    tile.is_valid = true;
+                                }
+                            }
+                        }
+
+                        // We want to clip the drawing of this and any children to the
+                        // dirty rect.
+                        let clipped_rect = dirty_region.dirty_world_rect;
+
+                        let (clipped, unclipped) = match get_raster_rects(
+                            aligned_pic_rect,
+                            &map_pic_to_raster,
+                            &map_raster_to_world,
+                            clipped_rect,
+                            frame_context.device_pixel_scale,
+                        ) {
+                            Some(info) => info,
+                            None => {
+                                return false;
+                            }
+                        };
+
+                        let picture_task = RenderTask::new_picture(
+                            RenderTaskLocation::Dynamic(None, clipped.size),
+                            unclipped.size,
+                            pic_index,
+                            clipped.origin,
+                            child_tasks,
+                            UvRectKind::Rect,
+                            pic_context.raster_spatial_node_index,
+                            Some(clear_color),
+                            blits,
+                        );
+
+                        let render_task_id = frame_state.render_tasks.add(picture_task);
+                        surfaces[surface_index.0].tasks.push(render_task_id);
+
+                        PictureSurface::RenderTask(render_task_id)
+                    }
+                    None => {
+                        // None of the tiles have changed, so we can skip any drawing!
+                        return true;
+                    }
+                }
+            }
             PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)) => {
                 let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
                 let blur_range = (blur_std_deviation * BLUR_SAMPLE_SCALE).ceil() as i32;
@@ -1127,6 +1961,8 @@ impl PicturePrimitive {
                         child_tasks,
                         uv_rect_kind,
                         pic_context.raster_spatial_node_index,
+                        None,
+                        Vec::new(),
                     );
 
                     let picture_task_id = frame_state.render_tasks.add(picture_task);
@@ -1182,6 +2018,8 @@ impl PicturePrimitive {
                                 child_tasks,
                                 uv_rect_kind,
                                 pic_context.raster_spatial_node_index,
+                                None,
+                                Vec::new(),
                             );
 
                             let picture_task_id = render_tasks.add(picture_task);
@@ -1237,6 +2075,8 @@ impl PicturePrimitive {
                     child_tasks,
                     uv_rect_kind,
                     pic_context.raster_spatial_node_index,
+                    None,
+                    Vec::new(),
                 );
                 picture_task.mark_for_saving();
 
@@ -1301,6 +2141,8 @@ impl PicturePrimitive {
                     child_tasks,
                     uv_rect_kind,
                     pic_context.raster_spatial_node_index,
+                    None,
+                    Vec::new(),
                 );
 
                 let readback_task_id = frame_state.render_tasks.add(
@@ -1338,6 +2180,8 @@ impl PicturePrimitive {
                     child_tasks,
                     uv_rect_kind,
                     pic_context.raster_spatial_node_index,
+                    None,
+                    Vec::new(),
                 );
 
                 let render_task_id = frame_state.render_tasks.add(picture_task);
@@ -1360,6 +2204,8 @@ impl PicturePrimitive {
                     child_tasks,
                     uv_rect_kind,
                     pic_context.raster_spatial_node_index,
+                    None,
+                    Vec::new(),
                 );
 
                 let render_task_id = frame_state.render_tasks.add(picture_task);
@@ -1457,23 +2303,24 @@ fn calculate_uv_rect_kind(
 fn create_raster_mappers(
     surface_spatial_node_index: SpatialNodeIndex,
     raster_spatial_node_index: SpatialNodeIndex,
-    frame_context: &FrameBuildingContext,
+    dirty_world_rect: WorldRect,
+    clip_scroll_tree: &ClipScrollTree,
 ) -> (SpaceMapper<RasterPixel, WorldPixel>, SpaceMapper<PicturePixel, RasterPixel>) {
     let map_raster_to_world = SpaceMapper::new_with_target(
         ROOT_SPATIAL_NODE_INDEX,
         raster_spatial_node_index,
-        frame_context.world_rect,
-        frame_context.clip_scroll_tree,
+        dirty_world_rect,
+        clip_scroll_tree,
     );
 
-    let raster_bounds = map_raster_to_world.unmap(&frame_context.world_rect)
+    let raster_bounds = map_raster_to_world.unmap(&dirty_world_rect)
                                            .unwrap_or(RasterRect::max_rect());
 
     let map_pic_to_raster = SpaceMapper::new_with_target(
         raster_spatial_node_index,
         surface_spatial_node_index,
         raster_bounds,
-        frame_context.clip_scroll_tree,
+        clip_scroll_tree,
     );
 
     (map_raster_to_world, map_pic_to_raster)

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2046,6 +2046,7 @@ impl PrimitiveStore {
                 &self.primitives,
                 &self.pictures,
                 clip_store,
+                &self.opacity_bindings,
             );
 
             self.pictures[pic_index.0].post_update(

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -11,6 +11,7 @@ use api::{DeviceIntSideOffsets, WorldPixel, BoxShadowClipMode, NormalBorder, Wor
 use api::{PicturePixel, RasterPixel, ColorDepth, LineStyle, LineOrientation, LayoutSizeAu, AuHelpers, LayoutVector2DAu};
 use app_units::Au;
 use border::{get_max_scale_for_border, build_border_instances, create_normal_border_prim};
+use clip::ClipStore;
 use clip_scroll_tree::{ClipScrollTree, SpatialNodeIndex};
 use clip::{ClipNodeFlags, ClipChainId, ClipChainInstance, ClipItem, ClipNodeCollector};
 use euclid::{TypedTransform3D, TypedRect, TypedScale};
@@ -127,30 +128,32 @@ impl<F, T> CoordinateSpaceMapping<F, T> {
         ref_spatial_node_index: SpatialNodeIndex,
         target_node_index: SpatialNodeIndex,
         clip_scroll_tree: &ClipScrollTree,
-    ) -> Self {
+    ) -> Option<Self> {
         let spatial_nodes = &clip_scroll_tree.spatial_nodes;
         let ref_spatial_node = &spatial_nodes[ref_spatial_node_index.0];
         let target_spatial_node = &spatial_nodes[target_node_index.0];
 
         if ref_spatial_node_index == target_node_index {
-            CoordinateSpaceMapping::Local
+            Some(CoordinateSpaceMapping::Local)
         } else if ref_spatial_node.coordinate_system_id == target_spatial_node.coordinate_system_id {
-            CoordinateSpaceMapping::ScaleOffset(
+            Some(CoordinateSpaceMapping::ScaleOffset(
                 ref_spatial_node.coordinate_system_relative_scale_offset
                     .inverse()
                     .accumulate(
                         &target_spatial_node.coordinate_system_relative_scale_offset
                     )
-            )
+            ))
         } else {
             let transform = clip_scroll_tree.get_relative_transform(
                 target_node_index,
                 ref_spatial_node_index,
-            ).expect("bug: should have already been culled");
+            );
 
-            CoordinateSpaceMapping::Transform(
-                transform.with_source::<F>().with_destination::<T>()
-            )
+            transform.map(|transform| {
+                CoordinateSpaceMapping::Transform(
+                    transform.with_source::<F>().with_destination::<T>()
+                )
+            })
         }
     }
 }
@@ -199,7 +202,7 @@ impl<F, T> SpaceMapper<F, T> where F: fmt::Debug {
                 self.ref_spatial_node_index,
                 target_node_index,
                 clip_scroll_tree,
-            );
+            ).expect("bug: should have been culled by invalid node");
         }
     }
 
@@ -610,7 +613,7 @@ pub type PrimitiveUid = intern::ItemUid<PrimitiveDataMarker>;
 // uses of opacity filters.
 #[derive(Debug)]
 pub struct OpacityBinding {
-    bindings: Vec<PropertyBinding<f32>>,
+    pub bindings: Vec<PropertyBinding<f32>>,
     pub current: f32,
 }
 
@@ -2016,6 +2019,9 @@ impl PrimitiveStore {
         pic_index: PictureIndex,
         state: &mut PictureUpdateState,
         frame_context: &FrameBuildingContext,
+        resource_cache: &mut ResourceCache,
+        prim_data_store: &PrimitiveDataStore,
+        clip_store: &ClipStore,
     ) {
         if let Some(children) = self.pictures[pic_index.0].pre_update(
             state,
@@ -2026,13 +2032,27 @@ impl PrimitiveStore {
                     *child_pic_index,
                     state,
                     frame_context,
+                    resource_cache,
+                    prim_data_store,
+                    clip_store,
                 );
             }
+
+            self.pictures[pic_index.0].update_prim_dependencies(
+                state,
+                frame_context,
+                resource_cache,
+                prim_data_store,
+                &self.primitives,
+                &self.pictures,
+                clip_store,
+            );
 
             self.pictures[pic_index.0].post_update(
                 children,
                 state,
                 frame_context,
+                resource_cache,
             );
         }
     }
@@ -2294,6 +2314,12 @@ impl PrimitiveStore {
             }
         };
 
+        // TODO(gw): Eventually we can move all the code handling below for
+        //           visibility and clip chain building to be done during the
+        //           update_prim_dependencies pass. That will mean that:
+        //           (a) We only do the work if the relative transforms change.
+        //           (b) Local clip rects can reduce the # of tile dependencies.
+
         // TODO(gw): Having this declared outside is a hack / workaround. We
         //           need it in pic.prepare_for_render below, but that code
         //           path will only read it in the !is_passthrough case
@@ -2318,8 +2344,11 @@ impl PrimitiveStore {
             // the picture context. This ensures that even if the primitive itself
             // is not visible, any effects from the blur radius will be correctly
             // taken into account.
+            let inflation_factor = frame_state
+                .surfaces[pic_context.surface_index.0]
+                .inflation_factor;
             let local_rect = prim_local_rect
-                .inflate(pic_context.inflation_factor, pic_context.inflation_factor)
+                .inflate(inflation_factor, inflation_factor)
                 .intersection(&prim_local_clip_rect);
             let local_rect = match local_rect {
                 Some(local_rect) => local_rect,
@@ -2345,7 +2374,7 @@ impl PrimitiveStore {
                     frame_state.gpu_cache,
                     frame_state.resource_cache,
                     frame_context.device_pixel_scale,
-                    &frame_context.world_rect,
+                    &pic_context.dirty_world_rect,
                     &clip_node_collector,
                     &mut frame_state.resources.clip_data_store,
                 );
@@ -2386,7 +2415,7 @@ impl PrimitiveStore {
                 }
             };
 
-            clipped_world_rect = match world_rect.intersection(&frame_context.world_rect) {
+            clipped_world_rect = match world_rect.intersection(&pic_context.dirty_world_rect) {
                 Some(rect) => rect,
                 None => {
                     return false;
@@ -2402,7 +2431,7 @@ impl PrimitiveStore {
                 clipped_world_rect,
                 pic_context.raster_spatial_node_index,
                 &clip_chain,
-                pic_context.surface_index,
+                pic_context,
                 pic_state,
                 frame_context,
                 frame_state,
@@ -2438,7 +2467,7 @@ impl PrimitiveStore {
                             frame_state.transforms,
                             prim_instance,
                             prim_local_rect,
-                            frame_context.world_rect,
+                            pic_context.dirty_world_rect,
                             plane_split_anchor,
                         );
                     }
@@ -2450,8 +2479,8 @@ impl PrimitiveStore {
                     request.push(PremultipliedColorF::WHITE);
                     request.push(PremultipliedColorF::WHITE);
                     request.push([
-                        pic.local_rect.size.width,
-                        pic.local_rect.size.height,
+                        -1.0,       // -ve means use prim rect for stretch size
+                        0.0,
                         0.0,
                         0.0,
                     ]);
@@ -2479,7 +2508,7 @@ impl PrimitiveStore {
                     prim_local_rect,
                     prim_details,
                     prim_context,
-                    pic_context.surface_index,
+                    pic_context,
                     pic_state,
                     frame_context,
                     frame_state,
@@ -2987,7 +3016,7 @@ impl PrimitiveInstance {
         prim_bounding_rect: WorldRect,
         prim_context: &PrimitiveContext,
         prim_clip_chain: &ClipChainInstance,
-        surface_index: SurfaceIndex,
+        pic_context: &PictureContext,
         pic_state: &mut PictureState,
         frame_context: &FrameBuildingContext,
         frame_state: &mut FrameBuildingState,
@@ -3041,7 +3070,7 @@ impl PrimitiveInstance {
                 Some(prim_clip_chain),
                 prim_bounding_rect,
                 root_spatial_node_index,
-                surface_index,
+                pic_context.surface_index,
                 pic_state,
                 frame_context,
                 frame_state,
@@ -3065,7 +3094,7 @@ impl PrimitiveInstance {
                         frame_state.gpu_cache,
                         frame_state.resource_cache,
                         frame_context.device_pixel_scale,
-                        &frame_context.world_rect,
+                        &pic_context.dirty_world_rect,
                         clip_node_collector,
                         &mut frame_state.resources.clip_data_store,
                     );
@@ -3074,7 +3103,7 @@ impl PrimitiveInstance {
                     segment_clip_chain.as_ref(),
                     prim_bounding_rect,
                     root_spatial_node_index,
-                    surface_index,
+                    pic_context.surface_index,
                     pic_state,
                     frame_context,
                     frame_state,
@@ -3091,7 +3120,7 @@ impl PrimitiveInstance {
         prim_local_rect: LayoutRect,
         prim_details: &mut PrimitiveDetails,
         prim_context: &PrimitiveContext,
-        surface_index: SurfaceIndex,
+        pic_context: &PictureContext,
         pic_state: &mut PictureState,
         frame_context: &FrameBuildingContext,
         frame_state: &mut FrameBuildingState,
@@ -3218,7 +3247,7 @@ impl PrimitiveInstance {
                                             let target_to_cache_task_id = render_tasks.add(target_to_cache_task);
 
                                             // Hook this into the render task tree at the right spot.
-                                            surfaces[surface_index.0].tasks.push(target_to_cache_task_id);
+                                            surfaces[pic_context.surface_index.0].tasks.push(target_to_cache_task_id);
 
                                             // Pass the image opacity, so that the cached render task
                                             // item inherits the same opacity properties.
@@ -3244,7 +3273,7 @@ impl PrimitiveInstance {
 
                                 let visible_rect = compute_conservative_visible_rect(
                                     prim_context,
-                                    &frame_context.world_rect,
+                                    &pic_context.dirty_world_rect,
                                     &tight_clip_rect
                                 );
 
@@ -3394,7 +3423,7 @@ impl PrimitiveInstance {
 
                                             let task_id = render_tasks.add(task);
 
-                                            surfaces[surface_index.0].tasks.push(task_id);
+                                            surfaces[pic_context.surface_index.0].tasks.push(task_id);
 
                                             task_id
                                         }
@@ -3438,7 +3467,7 @@ impl PrimitiveInstance {
                                 &tile_spacing,
                                 prim_context,
                                 frame_state,
-                                &frame_context.world_rect,
+                                &pic_context.dirty_world_rect,
                                 &mut |rect, mut request| {
                                     request.push([
                                         center.x,
@@ -3492,7 +3521,7 @@ impl PrimitiveInstance {
                                 &tile_spacing,
                                 prim_context,
                                 frame_state,
-                                &frame_context.world_rect,
+                                &pic_context.dirty_world_rect,
                                 &mut |rect, mut request| {
                                     request.push([
                                         start_point.x,
@@ -3560,7 +3589,7 @@ impl PrimitiveInstance {
         prim_bounding_rect: WorldRect,
         root_spatial_node_index: SpatialNodeIndex,
         clip_chain: &ClipChainInstance,
-        surface_index: SurfaceIndex,
+        pic_context: &PictureContext,
         pic_state: &mut PictureState,
         frame_context: &FrameBuildingContext,
         frame_state: &mut FrameBuildingState,
@@ -3582,7 +3611,7 @@ impl PrimitiveInstance {
             prim_bounding_rect,
             prim_context,
             &clip_chain,
-            surface_index,
+            pic_context,
             pic_state,
             frame_context,
             frame_state,
@@ -3623,7 +3652,7 @@ impl PrimitiveInstance {
                 let clip_task_index = ClipTaskIndex(frame_state.scratch.clip_mask_instances.len() as _);
                 frame_state.scratch.clip_mask_instances.push(ClipMaskKind::Mask(clip_task_id));
                 self.clip_task_index = clip_task_index;
-                frame_state.surfaces[surface_index.0].tasks.push(clip_task_id);
+                frame_state.surfaces[pic_context.surface_index.0].tasks.push(clip_task_id);
             }
         }
     }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -66,6 +66,8 @@ pub struct GlyphFetchResult {
 // we don't need to go through and update
 // various CPU-side structures.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct CacheItem {
     pub texture_id: TextureSource,
     pub uv_rect_handle: GpuCacheHandle,
@@ -408,7 +410,7 @@ pub struct ResourceCache {
     state: State,
     current_frame_id: FrameId,
 
-    texture_cache: TextureCache,
+    pub texture_cache: TextureCache,
 
     // TODO(gw): We should expire (parts of) this cache semi-regularly!
     cached_glyph_dimensions: GlyphDimensionsCache,
@@ -877,6 +879,32 @@ impl ResourceCache {
             None => {
                 warn!("Delete the non-exist key");
                 debug!("key={:?}", image_key);
+            }
+        }
+    }
+
+    /// Check if an image has changed since it was last requested.
+    pub fn is_image_dirty(
+        &self,
+        image_key: ImageKey,
+    ) -> bool {
+        match self.cached_images.try_get(&image_key) {
+            Some(ImageResult::UntiledAuto(ref info)) => {
+                info.dirty_rect.is_some()
+            }
+            Some(ImageResult::Multi(ref entries)) => {
+                for (_, entry) in &entries.resources {
+                    if entry.dirty_rect.is_some() {
+                        return true;
+                    }
+                }
+                false
+            }
+            Some(ImageResult::Err(..)) => {
+                false
+            }
+            None => {
+                true
             }
         }
     }

--- a/webrender/src/scene.rs
+++ b/webrender/src/scene.rs
@@ -112,6 +112,15 @@ impl SceneProperties {
             }
         }
     }
+
+    pub fn get_float_value(
+        &self,
+        id: PropertyBindingId,
+    ) -> Option<f32> {
+        self.float_properties
+            .get(&id)
+            .cloned()
+    }
 }
 
 /// A representation of the layout within the display port for a given document or iframe.

--- a/webrender/src/surface.rs
+++ b/webrender/src/surface.rs
@@ -300,7 +300,7 @@ impl SurfaceDescriptor {
                     raster_spatial_node_index,
                     surface_spatial_node_index,
                     clip_scroll_tree,
-                ).into();
+                ).expect("bug: unable to get coord mapping").into();
 
                 if let TransformKey::ScaleOffset(ref mut key) = key {
                     if raster_spatial_node.coordinate_system_id == surface_spatial_node.coordinate_system_id {
@@ -325,7 +325,7 @@ impl SurfaceDescriptor {
                 raster_spatial_node_index,
                 *spatial_node_index,
                 clip_scroll_tree,
-            ).into();
+            ).expect("bug: unable to get coord mapping").into();
         }
     }
 }

--- a/wrench/src/reftest.rs
+++ b/wrench/src/reftest.rs
@@ -395,7 +395,8 @@ impl<'a> ReftestHarness<'a> {
 
         if let Some(expected_draw_calls) = t.expected_draw_calls {
             if expected_draw_calls != stats.total_draw_calls {
-                println!("REFTEST TEST-UNEXPECTED-FAIL | {}/{} | expected_draw_calls",
+                println!("REFTEST TEST-UNEXPECTED-FAIL | {} | {}/{} | expected_draw_calls",
+                    t,
                     stats.total_draw_calls,
                     expected_draw_calls
                 );
@@ -405,7 +406,8 @@ impl<'a> ReftestHarness<'a> {
         }
         if let Some(expected_alpha_targets) = t.expected_alpha_targets {
             if expected_alpha_targets != stats.alpha_target_count {
-                println!("REFTEST TEST-UNEXPECTED-FAIL | {}/{} | alpha_target_count",
+                println!("REFTEST TEST-UNEXPECTED-FAIL | {} | {}/{} | alpha_target_count",
+                    t,
                     stats.alpha_target_count,
                     expected_alpha_targets
                 );
@@ -415,7 +417,8 @@ impl<'a> ReftestHarness<'a> {
         }
         if let Some(expected_color_targets) = t.expected_color_targets {
             if expected_color_targets != stats.color_target_count {
-                println!("REFTEST TEST-UNEXPECTED-FAIL | {}/{} | color_target_count",
+                println!("REFTEST TEST-UNEXPECTED-FAIL | {} | {}/{} | color_target_count",
+                    t,
                     stats.color_target_count,
                     expected_color_targets
                 );


### PR DESCRIPTION
This patch introduces a picture composite mode that caches the
surface in a grid of tiles in the texture cache. This is enabled
by setting the picture composite mode to PictureCompositeMode::TileCache.

Basic overview:
 * During initial picture traversal, any tile caches encountered
   are pushed / popped onto the PictureUpdateState stack.
 * If a tile cache is present, and if the transforms have changed
   since last frame build, then the primitive instances are walked,
   mapping each prim instance to a set of tiles in the cache. This
   allows dependencies for each tile (transforms, images, animated
   property bindings etc) to be set. Although this does involve an
   extra pass of primitive instances, it's only used when the tile
   cache mappings (the relative transforms) have changed, so it's
   done quite rarely. In addition, in the future we can move much
   of the second primitive traversal (clip chain building) etc to
   also happen here, which will mean that doesn't get done each
   frame build.
 * During prim prepare, a picture with tile cache enabled checks
   the dependencies on each tile, to see if it needs to be invalidated.
   It builds a dirty rect that is the union of the set of dirty
   tiles for this picture. Right now, we support only a single
   dirty rect for simplicity, but this can easily be expanded in
   the future to support a number of regions as required. This
   dirty rect is then passed via the PictureContext to any child
   primitives, and is used as the culling rect for primitive, clip
   mask and child picture allocations.
 * The picture preparation step also maintains a list of texture
   cache handles per tile, and records a series of blit commands
   for the renderer to execute after drawing the picture. These
   blits are executed to cache the picture output in texture
   cache tiles.
 * On subsequent frames, if the tile(s) are not invalid, they are
   drawn as a series of images with the brush_image shader.

Other changes included in this patch series:
 * Make reftest failure messages for draw/color targets more useful.
 * Make animation example more useful for picture caching debugging.
 * Fix a texture cache bug where UV rect kind isn't updated if the size of the texture cache update is the same.
 * Add a method to resource cache to check if an image is dirty.
 * Shader changes to support using prim header for segment rect and/or stretch size.
 * Add method to scene properties to get a current float value by id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3332)
<!-- Reviewable:end -->
