### PR TITLE
Fix texture cache bug where uv rect kind isn't updated if size is same.

### DIFF
--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -710,6 +710,7 @@ impl TextureCache {
 
         // Install the new eviction notice for this update, if applicable.
         entry.eviction_notice = eviction_notice.cloned();
+        entry.uv_rect_kind = uv_rect_kind;
 
         // Invalidate the contents of the resource rect in the GPU cache.
         // This ensures that the update_gpu_cache below will add


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3333)
<!-- Reviewable:end -->
