### PR TITLE
Add PrimitiveScratchBuffer implementation.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -617,7 +617,7 @@ impl AlphaBatchBuilder {
                     transform_id,
                 };
 
-                let glyph_keys = &ctx.prim_store.glyph_keys[run.glyph_keys_range];
+                let glyph_keys = &ctx.scratch.glyph_keys[run.glyph_keys_range];
 
                 ctx.resource_cache.fetch_glyphs(
                     run.used_font.clone(),

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -539,7 +539,7 @@ impl AlphaBatchBuilder {
 
         // Get the clip task address for the global primitive, if one was set.
         let clip_task_address = get_clip_task_address(
-            &ctx.prim_store.clip_mask_instances,
+            &ctx.scratch.clip_mask_instances,
             prim_instance.clip_task_index,
             0,
             render_tasks,
@@ -828,7 +828,7 @@ impl AlphaBatchBuilder {
 
                             // Get clip task, if set, for the picture primitive.
                             let clip_task_address = get_clip_task_address(
-                                &ctx.prim_store.clip_mask_instances,
+                                &ctx.scratch.clip_mask_instances,
                                 prim_instance.clip_task_index,
                                 0,
                                 render_tasks,
@@ -1416,7 +1416,7 @@ impl AlphaBatchBuilder {
         // Get GPU address of clip task for this segment, or None if
         // the entire segment is clipped out.
         let clip_task_address = match get_clip_task_address(
-            &ctx.prim_store.clip_mask_instances,
+            &ctx.scratch.clip_mask_instances,
             clip_task_index,
             segment_index,
             render_tasks,

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -25,7 +25,7 @@ use internal_types::{FastHashMap, FastHashSet};
 use picture::{Picture3DContext, PictureCompositeMode, PicturePrimitive, PrimitiveList};
 use prim_store::{BrushKind, BrushPrimitive, PrimitiveInstance, PrimitiveDataInterner, PrimitiveKeyKind};
 use prim_store::{ImageSource, PrimitiveOpacity, PrimitiveKey, PrimitiveSceneData, PrimitiveInstanceKind};
-use prim_store::{BorderSource, PrimitiveContainer, PrimitiveDataHandle, PrimitiveStore};
+use prim_store::{BorderSource, PrimitiveContainer, PrimitiveDataHandle, PrimitiveStore, PrimitiveStoreStats};
 use prim_store::{OpacityBinding, ScrollNodeAndClipChain, PictureIndex, register_prim_chase_id};
 use render_backend::{DocumentView};
 use resource_cache::{FontInstanceMap, ImageRequest};
@@ -170,6 +170,7 @@ impl<'a> DisplayListFlattener<'a> {
         frame_builder_config: &FrameBuilderConfig,
         new_scene: &mut Scene,
         resources: &mut DocumentResources,
+        prim_store_stats: &PrimitiveStoreStats,
     ) -> FrameBuilder {
         // We checked that the root pipeline is available on the render backend.
         let root_pipeline_id = scene.root_pipeline_id.unwrap();
@@ -190,7 +191,7 @@ impl<'a> DisplayListFlattener<'a> {
             pending_shadow_items: VecDeque::new(),
             sc_stack: Vec::new(),
             pipeline_clip_chain_stack: vec![ClipChainId::NONE],
-            prim_store: PrimitiveStore::new(),
+            prim_store: PrimitiveStore::new(&prim_store_stats),
             clip_store: ClipStore::new(),
             resources,
             prim_count_estimate: 0,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -14,6 +14,8 @@ use hit_test::{HitTester, HitTestingRun};
 use internal_types::{FastHashMap, PlaneSplitter};
 use picture::{PictureSurface, PictureUpdateState, SurfaceInfo, ROOT_SURFACE_INDEX, SurfaceIndex};
 use prim_store::{PrimitiveStore, SpaceMapper, PictureIndex, PrimitiveDebugId, PrimitiveScratchBuffer};
+#[cfg(feature = "replay")]
+use prim_store::{PrimitiveStoreStats};
 use profiler::{FrameProfileCounters, GpuCacheProfileCounters, TextureCacheProfileCounters};
 use render_backend::{FrameResources, FrameStamp};
 use render_task::{RenderTask, RenderTaskId, RenderTaskLocation, RenderTaskTree};
@@ -138,7 +140,7 @@ impl FrameBuilder {
     pub fn empty() -> Self {
         FrameBuilder {
             hit_testing_runs: Vec::new(),
-            prim_store: PrimitiveStore::new(),
+            prim_store: PrimitiveStore::new(&PrimitiveStoreStats::empty()),
             clip_store: ClipStore::new(),
             screen_rect: DeviceIntRect::zero(),
             window_size: DeviceIntSize::zero(),

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1935,7 +1935,7 @@ impl PrimitiveScratchBuffer {
     pub fn new() -> Self {
         PrimitiveScratchBuffer {
             clip_mask_instances: Vec::new(),
-            glyph_keys: GlyphKeyStorage::new(),
+            glyph_keys: GlyphKeyStorage::new(0),
         }
     }
 
@@ -1953,6 +1953,25 @@ impl PrimitiveScratchBuffer {
     }
 }
 
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+#[derive(Clone, Debug)]
+pub struct PrimitiveStoreStats {
+    primitive_count: usize,
+    picture_count: usize,
+    text_run_count: usize,
+}
+
+impl PrimitiveStoreStats {
+    pub fn empty() -> Self {
+        PrimitiveStoreStats {
+            primitive_count: 0,
+            picture_count: 0,
+            text_run_count: 0,
+        }
+    }
+}
+
 pub struct PrimitiveStore {
     pub primitives: Vec<Primitive>,
     pub pictures: Vec<PicturePrimitive>,
@@ -1960,11 +1979,19 @@ pub struct PrimitiveStore {
 }
 
 impl PrimitiveStore {
-    pub fn new() -> PrimitiveStore {
+    pub fn new(stats: &PrimitiveStoreStats) -> PrimitiveStore {
         PrimitiveStore {
-            primitives: Vec::new(),
-            pictures: Vec::new(),
-            text_runs: TextRunStorage::new(),
+            primitives: Vec::with_capacity(stats.primitive_count),
+            pictures: Vec::with_capacity(stats.picture_count),
+            text_runs: TextRunStorage::new(stats.text_run_count),
+        }
+    }
+
+    pub fn get_stats(&self) -> PrimitiveStoreStats {
+        PrimitiveStoreStats {
+            primitive_count: self.primitives.len(),
+            picture_count: self.pictures.len(),
+            text_run_count: self.text_runs.len(),
         }
     }
 

--- a/webrender/src/storage.rs
+++ b/webrender/src/storage.rs
@@ -59,8 +59,14 @@ pub struct Storage<T> {
 }
 
 impl<T> Storage<T> {
-    pub fn new() -> Self {
-        Storage { data: vec![] }
+    pub fn new(initial_capacity: usize) -> Self {
+        Storage {
+            data: Vec::with_capacity(initial_capacity),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
     }
 
     pub fn push(&mut self, t: T) -> Index<T> {

--- a/webrender/src/storage.rs
+++ b/webrender/src/storage.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::{iter::Extend, ops, marker::PhantomData};
+use util::recycle_vec;
 
 #[derive(Debug, Hash)]
 #[cfg_attr(feature = "capture", derive(Serialize))]
@@ -66,6 +67,10 @@ impl<T> Storage<T> {
         let index = self.data.len();
         self.data.push(t);
         Index(index as u32, PhantomData)
+    }
+
+    pub fn recycle(&mut self) {
+        recycle_vec(&mut self.data);
     }
 
     pub fn extend<II: IntoIterator<Item=T>>(&mut self, iter: II) -> Range<T> {

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -18,7 +18,7 @@ use internal_types::{CacheTextureId, FastHashMap, SavedTargetIndex, TextureSourc
 #[cfg(feature = "pathfinder")]
 use pathfinder_partitioner::mesh::Mesh;
 use picture::SurfaceInfo;
-use prim_store::{PrimitiveStore, DeferredResolve};
+use prim_store::{PrimitiveStore, DeferredResolve, PrimitiveScratchBuffer};
 use profiler::FrameProfileCounters;
 use render_backend::{FrameId, FrameResources};
 use render_task::{BlitSource, RenderTaskAddress, RenderTaskId, RenderTaskKind};
@@ -52,6 +52,7 @@ pub struct RenderTargetContext<'a, 'rc> {
     pub clip_scroll_tree: &'a ClipScrollTree,
     pub resources: &'a FrameResources,
     pub surfaces: &'a [SurfaceInfo],
+    pub scratch: &'a PrimitiveScratchBuffer,
 }
 
 #[cfg_attr(feature = "capture", derive(Serialize))]

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -773,3 +773,15 @@ where
         }
     }
 }
+
+/// Clear a vector for re-use, while retaining the backing memory buffer. May shrink the buffer
+/// if it's currently much larger than was actually used.
+pub fn recycle_vec<T>(vec: &mut Vec<T>) {
+    if vec.capacity() > 2 * vec.len() {
+        // Reduce capacity of the buffer if it is a lot larger than it needs to be. This prevents
+        // a frame with exceptionally large allocations to cause subsequent frames to retain
+        // more memory than they need.
+        vec.shrink_to_fit();
+    }
+    vec.clear();
+}


### PR DESCRIPTION
This splits some information from the PrimitiveStore into the new
scratch buffer type.

The scratch buffer is specifically for storing information that
is only read / written during frame building, as opposed to other
items in the primitive store which is created during scene building.

Since the scratch buffer information is not moved between threads,
it's easy to retain it between both frame builds and also when a
new display list is sent by the scene builder thread.

When a new scene arrives, the recycle method allows the storage
of the scratch buffer to possibly be shrunk, if it is now
consuming much more memory than was used on the previous frame.

NOTE: This initial commit only uses the scratch buffer for clip
      mask instances, but there will be more fields moved to make
      use of the retained scratch buffer soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3335)
<!-- Reviewable:end -->
