### PR TITLE
Add simple RGBA8 support

### DIFF
--- a/webrender/src/device/gl.rs
+++ b/webrender/src/device/gl.rs
@@ -2627,6 +2627,13 @@ impl Device {
                     pixel_type: gl::UNSIGNED_BYTE,
                 }
             },
+            ImageFormat::RGBA8 => {
+                FormatDesc {
+                    internal: gl::RGBA8,
+                    external: gl::RGBA,
+                    pixel_type: gl::UNSIGNED_BYTE,
+                }
+            },
             ImageFormat::RGBAF32 => FormatDesc {
                 internal: gl::RGBA32F,
                 external: gl::RGBA,
@@ -2783,6 +2790,7 @@ impl<'a> UploadTarget<'a> {
             ImageFormat::R8 => (gl::RED, 1, gl::UNSIGNED_BYTE),
             ImageFormat::R16 => (gl::RED, 2, gl::UNSIGNED_SHORT),
             ImageFormat::BGRA8 => (self.bgra_format, 4, gl::UNSIGNED_BYTE),
+            ImageFormat::RGBA8 => (gl::RGBA, 4, gl::UNSIGNED_BYTE),
             ImageFormat::RG8 => (gl::RG, 2, gl::UNSIGNED_BYTE),
             ImageFormat::RGBAF32 => (gl::RGBA, 16, gl::FLOAT),
             ImageFormat::RGBAI32 => (gl::RGBA_INTEGER, 16, gl::INT),

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -953,6 +953,12 @@ impl TextureCache {
     ) -> bool {
         let mut allowed_in_shared_cache = true;
 
+        // TODO(sotaro): For now, anything that requests RGBA8 just fails to allocate
+        // in a texture page, and gets a standalone texture.
+        if descriptor.format == ImageFormat::RGBA8 {
+            allowed_in_shared_cache = false;
+        }
+
         // TODO(gw): For now, anything that requests nearest filtering and isn't BGRA8
         //           just fails to allocate in a texture page, and gets a standalone
         //           texture. This is probably rare enough that it can be fixed up later.

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -101,6 +101,8 @@ pub enum ImageFormat {
     RG8 = 5,
     /// Four channels, signed integer storage.
     RGBAI32 = 6,
+    /// Four channels, byte storage.
+    RGBA8 = 7,
 }
 
 impl ImageFormat {
@@ -113,6 +115,7 @@ impl ImageFormat {
             ImageFormat::RGBAF32 => 16,
             ImageFormat::RG8 => 2,
             ImageFormat::RGBAI32 => 16,
+            ImageFormat::RGBA8 => 4,
         }
     }
 }

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -178,7 +178,8 @@ fn generate_solid_color_image(
 
 fn is_image_opaque(format: ImageFormat, bytes: &[u8]) -> bool {
     match format {
-        ImageFormat::BGRA8 => {
+        ImageFormat::BGRA8 |
+        ImageFormat::RGBA8 => {
             let mut is_opaque = true;
             for i in 0 .. (bytes.len() / 4) {
                 if bytes[i * 4 + 3] != 255 {


### PR DESCRIPTION
Current Linux with Wayland causes crash when WebGL exists. By [Bug 1482350 Comment 15](https://bugzilla.mozilla.org/show_bug.cgi?id=1482350#c15), WebRender needs to support RGBA8.

This is a simple quick fix for supporting RGBA8.

See [Bug 1482350](https://bugzilla.mozilla.org/show_bug.cgi?id=1482350)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3337)
<!-- Reviewable:end -->
