### PR TITLE
Add default deserializer for frame_id

### DIFF
--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -54,6 +54,7 @@ pub struct RenderTaskId {
     pub index: u32,
 
     #[cfg(debug_assertions)]
+    #[cfg_attr(feature = "replay", serde(default = "FrameId::first"))]
     frame_id: FrameId,
 }
 


### PR DESCRIPTION
Since frame ID is debug-only, it's not serialized when capturing from a release-built Firefox, making us unable to replay it with debug Wrench. This PR fixes this (broken recently by #3289).

r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3339)
<!-- Reviewable:end -->
