### PR TITLE
Remove prim_count_estimate.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -152,9 +152,6 @@ pub struct DisplayListFlattener<'a> {
     /// shared (interned) data between display lists.
     resources: &'a mut DocumentResources,
 
-    /// The estimated count of primtives we expect to encounter during flattening.
-    prim_count_estimate: usize,
-
     /// The root picture index for this flattener. This is the picture
     /// to start the culling phase from.
     pub root_pic_index: PictureIndex,
@@ -194,7 +191,6 @@ impl<'a> DisplayListFlattener<'a> {
             prim_store: PrimitiveStore::new(&prim_store_stats),
             clip_store: ClipStore::new(),
             resources,
-            prim_count_estimate: 0,
             root_pic_index: PictureIndex(0),
         };
 
@@ -285,9 +281,6 @@ impl<'a> DisplayListFlattener<'a> {
                 }
             }
         }
-
-        self.prim_count_estimate += pipeline.display_list.prim_count_estimate();
-        self.prim_store.primitives.reserve(self.prim_count_estimate);
 
         self.flatten_items(&mut pipeline.display_list.iter(), pipeline_id, LayoutVector2D::zero());
 

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -89,8 +89,6 @@ pub struct BuiltDisplayListDescriptor {
     total_clip_nodes: usize,
     /// The amount of spatial nodes created while building this display list.
     total_spatial_nodes: usize,
-    /// An estimate of the number of primitives that will be created by this display list.
-    prim_count_estimate: usize,
 }
 
 pub struct BuiltDisplayListIter<'a> {
@@ -146,10 +144,6 @@ impl BuiltDisplayList {
 
     pub fn descriptor(&self) -> &BuiltDisplayListDescriptor {
         &self.descriptor
-    }
-
-    pub fn prim_count_estimate(&self) -> usize {
-        self.descriptor.prim_count_estimate
     }
 
     pub fn times(&self) -> (u64, u64, u64) {
@@ -610,7 +604,6 @@ impl<'de> Deserialize<'de> for BuiltDisplayList {
                 send_start_time: 0,
                 total_clip_nodes,
                 total_spatial_nodes,
-                prim_count_estimate: 0,
             },
         })
     }
@@ -847,7 +840,6 @@ pub struct DisplayListBuilder {
     clip_stack: Vec<ClipAndScrollInfo>,
     next_clip_index: usize,
     next_spatial_index: usize,
-    prim_count_estimate: usize,
     next_clip_chain_id: u64,
     builder_start_time: u64,
 
@@ -877,7 +869,6 @@ impl DisplayListBuilder {
             ],
             next_clip_index: FIRST_CLIP_NODE_INDEX,
             next_spatial_index: FIRST_SPATIAL_NODE_INDEX,
-            prim_count_estimate: 0,
             next_clip_chain_id: 0,
             builder_start_time: start_time,
             content_size,
@@ -974,7 +965,6 @@ impl DisplayListBuilder {
     /// display items. Pushing unexpected or invalid items here may
     /// result in WebRender panicking or behaving in unexpected ways.
     pub fn push_item(&mut self, item: SpecificDisplayItem, info: &LayoutPrimitiveInfo) {
-        self.prim_count_estimate += 1;
         serialize_fast(
             &mut self.data,
             &DisplayItem {
@@ -991,7 +981,6 @@ impl DisplayListBuilder {
         info: &LayoutPrimitiveInfo,
         scrollinfo: ClipAndScrollInfo
     ) {
-        self.prim_count_estimate += 1;
         serialize_fast(
             &mut self.data,
             &DisplayItem {
@@ -1548,7 +1537,6 @@ impl DisplayListBuilder {
                     send_start_time: 0,
                     total_clip_nodes: self.next_clip_index,
                     total_spatial_nodes: self.next_spatial_index,
-                    prim_count_estimate: self.prim_count_estimate,
                 },
                 data: self.data,
             },


### PR DESCRIPTION
The use of prim_count_estimate has been superceded by PrimStoreStats and the
reverse() calls was causing ~0.5s regression on displaylist_mutate.