### PR TITLE
Add primitive interning for YUV images.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -2093,22 +2093,17 @@ impl<'a> DisplayListFlattener<'a> {
             YuvData::InterleavedYCbCr(plane_0) => [plane_0, ImageKey::DUMMY, ImageKey::DUMMY],
         };
 
-        let prim = BrushPrimitive::new(
-            BrushKind::YuvImage {
-                yuv_key,
-                format,
-                color_depth,
-                color_space,
-                image_rendering,
-            },
-            None,
-        );
-
         self.add_primitive(
             clip_and_scroll,
             info,
             Vec::new(),
-            PrimitiveContainer::Brush(prim),
+            PrimitiveContainer::YuvImage {
+                color_depth,
+                yuv_key,
+                format,
+                color_space,
+                image_rendering,
+            },
         );
     }
 

--- a/webrender/src/surface.rs
+++ b/webrender/src/surface.rs
@@ -240,6 +240,7 @@ impl SurfaceDescriptor {
                 PrimitiveInstanceKind::LegacyPrimitive { .. } => {
                     return None;
                 }
+                PrimitiveInstanceKind::YuvImage { .. } |
                 PrimitiveInstanceKind::LineDecoration { .. } |
                 PrimitiveInstanceKind::TextRun { .. } |
                 PrimitiveInstanceKind::NormalBorder { .. } |


### PR DESCRIPTION
Also restructure and tidy up some of the code that handles
segment building + interned primitives. This reduces some of
the code duplication and will simplify porting the remaining
primitives to interning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3349)
<!-- Reviewable:end -->
