### PR TITLE
Fix panic when updating a non-tiled "multi" image cache entry.

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -794,11 +794,10 @@ impl ResourceCache {
                 entry.dirty_rect = entry.dirty_rect.union(dirty_rect);
             }
             Some(&mut ImageResult::Multi(ref mut entries)) => {
-                let tile_size = tiling.unwrap();
                 for (key, entry) in entries.iter_mut() {
                     // We want the dirty rect relative to the tile and not the whole image.
-                    let local_dirty_rect = match key.tile {
-                        Some(tile) => {
+                    let local_dirty_rect = match (tiling, key.tile) {
+                        (Some(tile_size), Some(tile)) => {
                             dirty_rect.map(|mut rect|{
                                 let tile_offset = DeviceIntPoint::new(
                                     tile.x as i32,
@@ -809,7 +808,8 @@ impl ResourceCache {
                                 rect
                             })
                         }
-                        None => *dirty_rect,
+                        (None, Some(..)) => DirtyRect::All,
+                        _ => *dirty_rect,
                     };
                     entry.dirty_rect = entry.dirty_rect.union(&local_dirty_rect);
                 }


### PR DESCRIPTION
In  #3277 I introduced the expectation that if a cached image entry is `ImageResult::Multi(..)` then it must be tiled and we can `unwrap` an optional tiling related variable.

It turns out (from [bug 1509643](https://bugzilla.mozilla.org/show_bug.cgi?id=1509643)) that this assumption doesn't always hold true. This change restores the previous behavior and also invalidates the entire entry if it is tiled but we don't have information about the tile size. I don't know for sure whether this case can happen in practice but I'd rather be conservative about it since invalidation bugs tend to be hard to track down.