### PR TITLE
Moved wrench to depend on yaml-rust from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
  "webrender 0.57.2",
  "webrender_api 0.57.2",
  "winit 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1666,16 +1666,16 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.3.4"
-source = "git+https://github.com/vvuk/yaml-rust#0b40211a89f2a2998824ec888541e750198758fb"
-dependencies = [
- "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yaml-rust"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
@@ -1860,5 +1860,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x11-dl 2.17.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3235540540fde1ae074c8df49054166c0e070407f1c6e1ee17b8c87c2c7bcc7d"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum yaml-rust 0.3.4 (git+https://github.com/vvuk/yaml-rust)" = "<none>"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -18,7 +18,7 @@ image = "0.20"
 clap = { version = "2", features = ["yaml"] }
 lazy_static = "1"
 log = "0.4"
-yaml-rust = { git = "https://github.com/vvuk/yaml-rust", features = ["preserve_order"] }
+yaml-rust = "0.4"
 serde_json = "1.0"
 ron = "0.1.5"
 time = "0.1"


### PR DESCRIPTION
The preserve_order feature is now the default behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3356)
<!-- Reviewable:end -->
