### PR TITLE
[WIP] Avoid copies of large picture primitives during flattening

### DIFF
--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -36,7 +36,7 @@ use std::{cmp, fmt, mem, ops, u32, usize};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use storage;
 use tiling::SpecialRenderPasses;
-use util::{ScaleOffset, MatrixHelpers, MaxRect, recycle_vec};
+use util::{ScaleOffset, MatrixHelpers, MaxRect, VecPushWith, recycle_vec};
 use util::{pack_as_float, project_rect, raster_rect_to_device_pixels};
 use smallvec::SmallVec;
 
@@ -2002,13 +2002,10 @@ impl PrimitiveStore {
         }
     }
 
-    pub fn create_picture(
-        &mut self,
-        prim: PicturePrimitive,
+    pub fn create_picture_with<F: FnOnce() -> PicturePrimitive>(
+        &mut self, fun: F
     ) -> PictureIndex {
-        let index = PictureIndex(self.pictures.len());
-        self.pictures.push(prim);
-        index
+        PictureIndex(self.pictures.push_with(fun))
     }
 
     /// Update a picture, determining surface configuration,


### PR DESCRIPTION
Addresses some of the bigger #3358 parts related to `PicturePrimitive`. Adds the basic `push_with` helper to vectors that avoid copy (kudos to @jrmuizel ).
TODO:
- [ ] verify that the copies are gone (need the tool hosted/opened somewhere)
- [ ] rebase
- [ ] Gecko try push with talos jobs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3360)
<!-- Reviewable:end -->
