### PR TITLE
Introduce SerializedDisplayItem to reduce mem copies on DL construction

### DIFF
--- a/webrender_api/src/display_item.rs
+++ b/webrender_api/src/display_item.rs
@@ -66,6 +66,15 @@ pub struct GenericDisplayItem<T> {
 
 pub type DisplayItem = GenericDisplayItem<SpecificDisplayItem>;
 
+/// A modified version of DI where every field is borrowed instead of owned.
+/// It allows us to reduce copies during serialization.
+#[derive(Serialize)]
+pub struct SerializedDisplayItem<'a> {
+    pub item: &'a SpecificDisplayItem,
+    pub clip_and_scroll: &'a ClipAndScrollInfo,
+    pub info: &'a LayoutPrimitiveInfo,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PrimitiveInfo<T> {
     pub rect: TypedRect<f32, T>,


### PR DESCRIPTION
This PR addresses the part of #3358 about DL construction: instead of constructing the display items and associated data and passing through the serializer by value, we just pass the references around, which guarantees that no extra copies are made.

TODO:
- [x] verify that the copies are gone (need the tool hosted/opened somewhere)
- [x] Gecko try push with talos jobs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3361)
<!-- Reviewable:end -->
