### PR TITLE
Avoid picture primitive copies via VecHelper

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -372,7 +372,7 @@ impl FrameBuilder {
         let mut profile_counters = FrameProfileCounters::new();
         profile_counters
             .total_primitives
-            .set(self.prim_store.prim_count);
+            .set(self.prim_store.prim_count());
 
         resource_cache.begin_frame(stamp);
         gpu_cache.begin_frame(stamp.frame_id());

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -2587,10 +2587,6 @@ pub struct PrimitiveStore {
 
     /// List of animated opacity bindings for a primitive.
     pub opacity_bindings: OpacityBindingStorage,
-
-    /// Total count of primitive instances contained in pictures.
-    /// This is used for profile counters only.
-    pub prim_count: usize,
 }
 
 impl PrimitiveStore {
@@ -2600,7 +2596,6 @@ impl PrimitiveStore {
             text_runs: TextRunStorage::new(stats.text_run_count),
             images: ImageInstanceStorage::new(stats.image_count),
             opacity_bindings: OpacityBindingStorage::new(stats.opacity_binding_count),
-            prim_count: 0,
         }
     }
 
@@ -2626,14 +2621,12 @@ impl PrimitiveStore {
         }
     }
 
-    pub fn create_picture(
-        &mut self,
-        prim: PicturePrimitive,
-    ) -> PictureIndex {
-        let index = PictureIndex(self.pictures.len());
-        self.prim_count += prim.prim_list.prim_instances.len();
-        self.pictures.push(prim);
-        index
+    /// Returns the total count of primitive instances contained in pictures.
+    pub fn prim_count(&self) -> usize {
+        self.pictures
+            .iter()
+            .map(|p| p.prim_list.prim_instances.len())
+            .sum()
     }
 
     /// Update a picture, determining surface configuration,

--- a/webrender_api/src/display_list.rs
+++ b/webrender_api/src/display_list.rs
@@ -950,7 +950,7 @@ impl DisplayListBuilder {
             let mut iter = BuiltDisplayListIter::new(&temp);
             while let Some(item) = iter.next_raw() {
                 if index >= range.start.unwrap_or(0) && range.end.map_or(true, |e| index < e) {
-                    writeln!(sink, "{}{:?}", "  ".repeat(indent), item.display_item());
+                    writeln!(sink, "{}{:?}", "  ".repeat(indent), item.display_item()).unwrap();
                 }
                 index += 1;
             }


### PR DESCRIPTION
This is a successor of #3360 that avoids the borrow checker dance via RAII 
Addresses part of #3358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3362)
<!-- Reviewable:end -->
