### PR TITLE
Fix a bug in invalidating tiles from a previous scene.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -278,6 +278,14 @@ impl FrameBuilder {
             &mut retained_tiles,
         );
 
+        // If we had any retained tiles from the last scene that were not picked
+        // up by the new frame, then just discard them eagerly.
+        // TODO(gw): Maybe it's worth keeping them around for a bit longer in
+        //           some cases?
+        for (_, handle) in retained_tiles.drain() {
+            resource_cache.texture_cache.mark_unused(&handle);
+        }
+
         let mut frame_state = FrameBuildingState {
             render_tasks,
             profile_counters,

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -857,14 +857,6 @@ impl TileCache {
             }
         }
 
-        // If we had any retained tiles from the last scene that were not picked
-        // up by the new frame, then just discard them eagerly.
-        // TODO(gw): Maybe it's worth keeping them around for a bit longer in
-        //           some cases?
-        for (_, handle) in retained_tiles.drain() {
-            resource_cache.texture_cache.mark_unused(&handle);
-        }
-
         self.dirty_region = if dirty_rect.is_empty() {
             None
         } else {


### PR DESCRIPTION
Any retained tiles from a previous scene were being dropped if not
used after building the dirty region for the first tile cache.

This works in simple applications, but in Gecko, where multiple
tile caches exist, it means that we were dropping any retained
tiles that other tile caches may want, after the first tile cache
updated.

Instead, only drop previous scene tiles after all tile caches
have had a chance to retain tiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3365)
<!-- Reviewable:end -->
