### PR TITLE
Add a RendererOption to configure if picture caching is enabled.

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -4771,6 +4771,7 @@ pub struct RendererOptions {
     pub chase_primitive: ChasePrimitive,
     pub support_low_priority_transactions: bool,
     pub namespace_alloc_by_client: bool,
+    pub enable_picture_caching: bool,
 }
 
 impl Default for RendererOptions {
@@ -4806,6 +4807,7 @@ impl Default for RendererOptions {
             chase_primitive: ChasePrimitive::Nothing,
             support_low_priority_transactions: false,
             namespace_alloc_by_client: false,
+            enable_picture_caching: false,
         }
     }
 }


### PR DESCRIPTION
Although not hooked up internally yet, this provides a hook so
that the gecko pref can be added.

We'll use this to provide a temporary way to compare performance
and also to allow picture caching to be disabled temporarily if
we encounter any bad regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3367)
<!-- Reviewable:end -->
