### PR TITLE
Some helpers and bug fixes for picture caching work.

### DIFF
--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -10,7 +10,7 @@ use internal_types::{FastHashMap, FastHashSet};
 use print_tree::{PrintTree, PrintTreePrinter};
 use scene::SceneProperties;
 use smallvec::SmallVec;
-use spatial_node::{ScrollFrameInfo, SpatialNode, SpatialNodeType, StickyFrameInfo};
+use spatial_node::{ScrollFrameInfo, SpatialNode, SpatialNodeType, StickyFrameInfo, ScrollFrameKind};
 use util::{LayoutToWorldFastTransform, ScaleOffset};
 
 pub type ScrollStates = FastHashMap<ExternalScrollId, ScrollFrameInfo>;
@@ -326,7 +326,7 @@ impl ClipScrollTree {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
-        is_pipeline_root: bool,
+        frame_kind: ScrollFrameKind,
     ) -> SpatialNodeIndex {
         let node = SpatialNode::new_scroll_frame(
             pipeline_id,
@@ -335,7 +335,7 @@ impl ClipScrollTree {
             frame_rect,
             content_size,
             scroll_sensitivity,
-            is_pipeline_root,
+            frame_kind,
         );
         self.add_spatial_node(node)
     }
@@ -470,7 +470,7 @@ impl ClipScrollTree {
                 }
                 SpatialNodeType::ScrollFrame(ref info) => {
                     // Assume not identity since it may change with scrolling.
-                    if !info.is_pipeline_root {
+                    if let ScrollFrameKind::Explicit = info.frame_kind {
                         return false;
                     }
                 }

--- a/webrender/src/clip_scroll_tree.rs
+++ b/webrender/src/clip_scroll_tree.rs
@@ -326,6 +326,7 @@ impl ClipScrollTree {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
+        is_pipeline_root: bool,
     ) -> SpatialNodeIndex {
         let node = SpatialNode::new_scroll_frame(
             pipeline_id,
@@ -334,6 +335,7 @@ impl ClipScrollTree {
             frame_rect,
             content_size,
             scroll_sensitivity,
+            is_pipeline_root,
         );
         self.add_spatial_node(node)
     }

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -382,6 +382,7 @@ impl<'a> DisplayListFlattener<'a> {
             &frame_rect,
             &content_rect.size,
             info.scroll_sensitivity,
+            false,
         );
     }
 
@@ -499,6 +500,7 @@ impl<'a> DisplayListFlattener<'a> {
             &iframe_rect,
             &pipeline.content_size,
             ScrollSensitivity::ScriptAndInputEvents,
+            true,
         );
 
         self.flatten_root(
@@ -1344,6 +1346,7 @@ impl<'a> DisplayListFlattener<'a> {
             &LayoutRect::new(LayoutPoint::zero(), *viewport_size),
             content_size,
             ScrollSensitivity::ScriptAndInputEvents,
+            true,
         );
     }
 
@@ -1455,6 +1458,7 @@ impl<'a> DisplayListFlattener<'a> {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
+        is_pipeline_root: bool,
     ) -> SpatialNodeIndex {
         let parent_node_index = self.id_to_index_mapper.get_spatial_node_index(parent_id);
         let node_index = self.clip_scroll_tree.add_scroll_frame(
@@ -1464,6 +1468,7 @@ impl<'a> DisplayListFlattener<'a> {
             frame_rect,
             content_size,
             scroll_sensitivity,
+            is_pipeline_root,
         );
         self.id_to_index_mapper.map_spatial_node(new_node_id, node_index);
         self.id_to_index_mapper.map_to_parent_clip_chain(new_node_id, &parent_id);

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -30,7 +30,7 @@ use render_backend::{DocumentView};
 use resource_cache::{FontInstanceMap, ImageRequest};
 use scene::{Scene, ScenePipeline, StackingContextHelpers};
 use scene_builder::DocumentResources;
-use spatial_node::{StickyFrameInfo};
+use spatial_node::{StickyFrameInfo, ScrollFrameKind};
 use std::{f32, mem};
 use std::collections::vec_deque::VecDeque;
 use tiling::{CompositeOps};
@@ -382,7 +382,7 @@ impl<'a> DisplayListFlattener<'a> {
             &frame_rect,
             &content_rect.size,
             info.scroll_sensitivity,
-            false,
+            ScrollFrameKind::Explicit,
         );
     }
 
@@ -500,7 +500,7 @@ impl<'a> DisplayListFlattener<'a> {
             &iframe_rect,
             &pipeline.content_size,
             ScrollSensitivity::ScriptAndInputEvents,
-            true,
+            ScrollFrameKind::PipelineRoot,
         );
 
         self.flatten_root(
@@ -1365,7 +1365,7 @@ impl<'a> DisplayListFlattener<'a> {
             &LayoutRect::new(LayoutPoint::zero(), *viewport_size),
             content_size,
             ScrollSensitivity::ScriptAndInputEvents,
-            true,
+            ScrollFrameKind::PipelineRoot,
         );
     }
 
@@ -1477,7 +1477,7 @@ impl<'a> DisplayListFlattener<'a> {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
-        is_pipeline_root: bool,
+        frame_kind: ScrollFrameKind,
     ) -> SpatialNodeIndex {
         let parent_node_index = self.id_to_index_mapper.get_spatial_node_index(parent_id);
         let node_index = self.clip_scroll_tree.add_scroll_frame(
@@ -1487,7 +1487,7 @@ impl<'a> DisplayListFlattener<'a> {
             frame_rect,
             content_size,
             scroll_sensitivity,
-            is_pipeline_root,
+            frame_kind,
         );
         self.id_to_index_mapper.map_spatial_node(new_node_id, node_index);
         self.id_to_index_mapper.map_to_parent_clip_chain(new_node_id, &parent_id);

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -96,7 +96,7 @@ impl SpatialNode {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
-        is_pipeline_root: bool,
+        frame_kind: ScrollFrameKind,
     ) -> Self {
         let node_type = SpatialNodeType::ScrollFrame(ScrollFrameInfo::new(
                 *frame_rect,
@@ -106,7 +106,7 @@ impl SpatialNode {
                     (content_size.height - frame_rect.size.height).max(0.0)
                 ),
                 external_id,
-                is_pipeline_root,
+                frame_kind,
             )
         );
 
@@ -569,6 +569,14 @@ impl SpatialNode {
     }
 }
 
+/// Defines whether we have an implicit scroll frame for a pipeline root,
+/// or an explicitly defined scroll frame from the display list.
+#[derive(Copy, Clone, Debug)]
+pub enum ScrollFrameKind {
+    PipelineRoot,
+    Explicit,
+}
+
 #[derive(Copy, Clone, Debug)]
 pub struct ScrollFrameInfo {
     /// The rectangle of the viewport of this scroll frame. This is important for
@@ -586,14 +594,14 @@ pub struct ScrollFrameInfo {
     /// which may change between frames.
     pub external_id: Option<ExternalScrollId>,
 
-    /// If true, this is a scroll frame added implicitly by WR when adding
+    /// Stores whether this is a scroll frame added implicitly by WR when adding
     /// a pipeline (either the root or an iframe). We need to exclude these
     /// when searching for scroll roots we care about for picture caching.
     /// TODO(gw): I think we can actually completely remove the implicit
     ///           scroll frame being added by WR, and rely on the embedder
     ///           to define scroll frames. However, that involves API changes
     ///           so we will use this as a temporary hack!
-    pub is_pipeline_root: bool,
+    pub frame_kind: ScrollFrameKind,
 }
 
 /// Manages scrolling offset.
@@ -603,7 +611,7 @@ impl ScrollFrameInfo {
         scroll_sensitivity: ScrollSensitivity,
         scrollable_size: LayoutSize,
         external_id: Option<ExternalScrollId>,
-        is_pipeline_root: bool,
+        frame_kind: ScrollFrameKind,
     ) -> ScrollFrameInfo {
         ScrollFrameInfo {
             viewport_rect,
@@ -611,7 +619,7 @@ impl ScrollFrameInfo {
             scroll_sensitivity,
             scrollable_size,
             external_id,
-            is_pipeline_root,
+            frame_kind,
         }
     }
 
@@ -632,7 +640,7 @@ impl ScrollFrameInfo {
             scroll_sensitivity: self.scroll_sensitivity,
             scrollable_size: self.scrollable_size,
             external_id: self.external_id,
-            is_pipeline_root: self.is_pipeline_root,
+            frame_kind: self.frame_kind,
         }
     }
 }

--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -96,6 +96,7 @@ impl SpatialNode {
         frame_rect: &LayoutRect,
         content_size: &LayoutSize,
         scroll_sensitivity: ScrollSensitivity,
+        is_pipeline_root: bool,
     ) -> Self {
         let node_type = SpatialNodeType::ScrollFrame(ScrollFrameInfo::new(
                 *frame_rect,
@@ -105,6 +106,7 @@ impl SpatialNode {
                     (content_size.height - frame_rect.size.height).max(0.0)
                 ),
                 external_id,
+                is_pipeline_root,
             )
         );
 
@@ -584,6 +586,14 @@ pub struct ScrollFrameInfo {
     /// which may change between frames.
     pub external_id: Option<ExternalScrollId>,
 
+    /// If true, this is a scroll frame added implicitly by WR when adding
+    /// a pipeline (either the root or an iframe). We need to exclude these
+    /// when searching for scroll roots we care about for picture caching.
+    /// TODO(gw): I think we can actually completely remove the implicit
+    ///           scroll frame being added by WR, and rely on the embedder
+    ///           to define scroll frames. However, that involves API changes
+    ///           so we will use this as a temporary hack!
+    pub is_pipeline_root: bool,
 }
 
 /// Manages scrolling offset.
@@ -593,6 +603,7 @@ impl ScrollFrameInfo {
         scroll_sensitivity: ScrollSensitivity,
         scrollable_size: LayoutSize,
         external_id: Option<ExternalScrollId>,
+        is_pipeline_root: bool,
     ) -> ScrollFrameInfo {
         ScrollFrameInfo {
             viewport_rect,
@@ -600,6 +611,7 @@ impl ScrollFrameInfo {
             scroll_sensitivity,
             scrollable_size,
             external_id,
+            is_pipeline_root,
         }
     }
 
@@ -620,6 +632,7 @@ impl ScrollFrameInfo {
             scroll_sensitivity: self.scroll_sensitivity,
             scrollable_size: self.scrollable_size,
             external_id: self.external_id,
+            is_pipeline_root: self.is_pipeline_root,
         }
     }
 }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -588,8 +588,8 @@ impl<Src, Dst> FastTransform<Src, Dst> {
             FastTransform::Offset(offset) => {
                 offset == TypedVector2D::zero()
             }
-            FastTransform::Transform { transform, .. } => {
-                transform == TypedTransform3D::identity()
+            FastTransform::Transform { ref transform, .. } => {
+                *transform == TypedTransform3D::identity()
             }
         }
     }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -582,6 +582,18 @@ impl<Src, Dst> FastTransform<Src, Dst> {
         }
     }
 
+    /// Return true if this is an identity transform
+    pub fn is_identity(&self)-> bool {
+        match *self {
+            FastTransform::Offset(offset) => {
+                offset == TypedVector2D::zero()
+            }
+            FastTransform::Transform { transform, .. } => {
+                transform == TypedTransform3D::identity()
+            }
+        }
+    }
+
     #[inline(always)]
     pub fn pre_mul<NewSrc>(
         &self,

--- a/wrench/reftests/clip/fixed-position-clipping-ref.yaml
+++ b/wrench/reftests/clip/fixed-position-clipping-ref.yaml
@@ -5,11 +5,11 @@ root:
       bounds: [10, 10, 100, 100]
       clip-rect: [10, 10, 100, 100]
       type: rect
-      color: 0 256 0 1.0
+      color: 0 255 0 1.0
     -
       bounds: [110, 10, 100, 100]
       clip-rect: [110, 10, 100, 100]
       type: rect
-      color: 0 256 0 1.0
+      color: 0 255 0 1.0
   id: [0, 1]
 pipelines: []

--- a/wrench/reftests/clip/fixed-position-clipping.yaml
+++ b/wrench/reftests/clip/fixed-position-clipping.yaml
@@ -22,7 +22,7 @@ root:
             clip-rect: [0, 0, 100, 100]
             clip-and-scroll: root-reference-frame
             type: rect
-            color: 0 256 0 1.0
+            color: 0 255 0 1.0
     # The same test as above, except this time the stacking context also starts its
     # own reference frame.
     -
@@ -44,6 +44,6 @@ root:
             clip-rect: [0, 0, 100, 100]
             clip-and-scroll: 4
             type: rect
-            color: 0 256 0 1.0
+            color: 0 255 0 1.0
   id: [0, 1]
 pipelines: []


### PR DESCRIPTION
From the individual commits:

* Fix debug assert due to color being out of bounds. 
* Store whether a scroll frame is implicitly added or not. 
* Add a fast path for no-op stacking contexts.
* Fix texture cache eviction of tiles that are still useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3368)
<!-- Reviewable:end -->
