### PR TITLE
Advance frame ID per frame build, rather than per new scene.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -410,6 +410,9 @@ impl Document {
         let accumulated_scale_factor = self.view.accumulated_scale_factor();
         let pan = self.view.pan.to_f32() / accumulated_scale_factor;
 
+        // Advance to the next frame.
+        self.stamp.advance();
+
         assert!(self.stamp.frame_id() != FrameId::INVALID,
                 "First frame increment must happen before build_frame()");
 
@@ -532,9 +535,6 @@ impl Document {
         let old_scrolling_states = self.clip_scroll_tree.drain();
         self.clip_scroll_tree = built_scene.clip_scroll_tree;
         self.clip_scroll_tree.finalize_and_apply_pending_scroll_offsets(old_scrolling_states);
-
-        // Advance to the next frame.
-        self.stamp.advance();
     }
 }
 

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -822,19 +822,19 @@ impl TextureCache {
     ///
     /// These parameters come from very rough instrumentation of hits in the
     /// shared cache, with simple browsing on a few pages. In rough terms, more
-    /// than 95% of cache hits occur for entries that were used in the previous
-    /// frame, and 99% occur within two frames. If we exclude immediately-reused
-    /// (first frame) entries, 90% of the remaining hits happen within the first
-    /// 30 frames. So we can be relatively agressive about eviction without
-    /// sacrificing much in terms of cache performance.
-    ///
+    /// than 99.5% of cache hits occur for entries that were used in the previous
+    /// frame. This is obviously the dominant case, but we still want good behavior
+    /// in long-tail cases (i.e. a large image is scrolled off-screen and on again).
+    /// If we exclude immediately-reused (first frame) entries, 70% of the remaining
+    /// hits happen within the first 200 frames. So we can be relatively agressive
+    /// about eviction without sacrificing much in terms of cache performance.
     /// The one wrinkle is that animation-heavy pages do tend to extend the
     /// distribution, presumably because they churn through FrameIds faster than
     /// their more-static counterparts. As such, we _also_ provide a time floor
     /// (which was not measured with the same degree of rigour).
     fn default_eviction(&self) -> EvictionThreshold {
         EvictionThresholdBuilder::new(self.now)
-            .max_frames(30)
+            .max_frames(200)
             .max_time_s(3)
             .scale_by_pressure()
             .build()


### PR DESCRIPTION
This fixes the way texture eviction works with picture caching
when scrolling or property animation is occurring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3370)
<!-- Reviewable:end -->
