### PR TITLE
Extend the scope of render target allocation strategy acrosss layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "pathfinder_path_utils 0.2.0 (git+https://github.com/pcwalton/pathfinder?branch=webrender)",
  "plane-split 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
   TARGET: x86_64-pc-windows-msvc
 
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.27.0-${env:TARGET}.msi"
-  - msiexec /passive /i "rust-1.27.0-%TARGET%.msi" ADDLOCAL=Rustc,Cargo,Std INSTALLDIR=C:\Rust
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.30.0-${env:TARGET}.msi"
+  - msiexec /passive /i "rust-1.30.0-%TARGET%.msi" ADDLOCAL=Rustc,Cargo,Std INSTALLDIR=C:\Rust
   - rustc -V
   - cargo -V
 

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -68,6 +68,7 @@ optional = true
 
 [dev-dependencies]
 mozangle = "0.1"
+rand = "0.4"
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
 freetype = { version = "0.4", default-features = false }

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -151,7 +151,8 @@ impl AlphaBatchList {
     ) -> &mut Vec<PrimitiveInstanceData> {
         if z_id != self.current_z_id ||
            self.current_batch_index == usize::MAX ||
-           !self.batches[self.current_batch_index].key.is_compatible_with(&key) {
+           !self.batches[self.current_batch_index].key.is_compatible_with(&key)
+        {
             let mut selected_batch_index = None;
 
             match key.blend_mode {

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -190,6 +190,8 @@ extern crate image as image_loader;
 extern crate base64;
 #[cfg(all(feature = "capture", feature = "png"))]
 extern crate png;
+#[cfg(test)]
+extern crate rand;
 
 pub extern crate webrender_api;
 

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -144,8 +144,12 @@ impl RenderTaskTree {
             pass_index
         };
 
-        let pass = &mut passes[pass_index];
-        pass.add_render_task(id, task.get_dynamic_size(), task.target_kind(), &task.location);
+        passes[pass_index].add_render_task(
+            id,
+            task.get_dynamic_size(),
+            task.target_kind(),
+            &task.location,
+        );
     }
 
     pub fn prepare_for_render(&mut self) {

--- a/webrender/src/texture_allocator.rs
+++ b/webrender/src/texture_allocator.rs
@@ -3,182 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
-use std::ops;
 use util;
+
+//TODO: gather real-world statistics on the bin usage in order to assist the decision
+// on where to place the size thresholds.
+
+/// This is an optimization tweak to enable looking through all the free rectangles in a bin
+/// and choosing the smallest, as opposed to picking the first match.
+const FIND_SMALLEST_AREA: bool = false;
 
 const NUM_BINS: usize = 3;
 /// The minimum number of pixels on each side that we require for rects to be classified as
 /// particular bin of freelists.
 const MIN_RECT_AXIS_SIZES: [i32; NUM_BINS] = [1, 16, 32];
-
-/// A texture allocator using the guillotine algorithm with the rectangle merge improvement. See
-/// sections 2.2 and 2.2.5 in "A Thousand Ways to Pack the Bin - A Practical Approach to Two-
-/// Dimensional Rectangle Bin Packing":
-///
-///    http://clb.demon.fi/files/RectangleBinPack.pdf
-///
-/// This approach was chosen because of its simplicity, good performance, and easy support for
-/// dynamic texture deallocation.
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-pub struct GuillotineAllocator {
-    texture_size: DeviceIntSize,
-    free_list: FreeRectList,
-    allocations: u32,
-}
-
-impl GuillotineAllocator {
-    pub fn new(texture_size: DeviceIntSize) -> Self {
-        let mut free_list = FreeRectList::new();
-        free_list.push(DeviceIntRect::new(
-            DeviceIntPoint::zero(),
-            texture_size,
-        ));
-        GuillotineAllocator {
-            texture_size,
-            free_list,
-            allocations: 0,
-        }
-    }
-
-    fn find_index_of_best_rect_in_bin(
-        &self,
-        bin: FreeListBin,
-        requested_dimensions: &DeviceIntSize,
-    ) -> Option<FreeListIndex> {
-        let mut smallest_index_and_area = None;
-        for (candidate_index, candidate_rect) in self.free_list[bin].iter().enumerate() {
-            if requested_dimensions.width > candidate_rect.size.width ||
-                requested_dimensions.height > candidate_rect.size.height
-            {
-                continue;
-            }
-
-            let candidate_area = candidate_rect.size.area();
-            match smallest_index_and_area {
-                Some((_, area)) if candidate_area >= area => continue,
-                _ => smallest_index_and_area = Some((candidate_index, candidate_area)),
-            }
-        }
-
-        smallest_index_and_area.map(|(index, _)| FreeListIndex(index))
-    }
-
-    /// Find a suitable rect in the free list. We choose the smallest such rect
-    /// in terms of area (Best-Area-Fit, BAF).
-    fn find_index_of_best_rect(
-        &self,
-        requested_dimensions: &DeviceIntSize,
-    ) -> Option<(FreeListBin, FreeListIndex)> {
-        let start_bin = FreeListBin::for_size(requested_dimensions);
-        (start_bin.0 .. NUM_BINS as u8)
-            .find_map(|id| {
-                self.find_index_of_best_rect_in_bin(FreeListBin(id), requested_dimensions)
-                    .map(|index| (FreeListBin(id), index))
-            })
-    }
-
-    pub fn allocate(&mut self, requested_dimensions: &DeviceIntSize) -> Option<DeviceIntPoint> {
-        if requested_dimensions.width == 0 || requested_dimensions.height == 0 {
-            return Some(DeviceIntPoint::new(0, 0));
-        }
-        let (bin, index) = self.find_index_of_best_rect(requested_dimensions)?;
-
-        // Remove the rect from the free list and decide how to guillotine it. We choose the split
-        // that results in the single largest area (Min Area Split Rule, MINAS).
-        let chosen_rect = self.free_list[bin].swap_remove(index.0);
-        let candidate_free_rect_to_right = DeviceIntRect::new(
-            DeviceIntPoint::new(
-                chosen_rect.origin.x + requested_dimensions.width,
-                chosen_rect.origin.y,
-            ),
-            DeviceIntSize::new(
-                chosen_rect.size.width - requested_dimensions.width,
-                requested_dimensions.height,
-            ),
-        );
-        let candidate_free_rect_to_bottom = DeviceIntRect::new(
-            DeviceIntPoint::new(
-                chosen_rect.origin.x,
-                chosen_rect.origin.y + requested_dimensions.height,
-            ),
-            DeviceIntSize::new(
-                requested_dimensions.width,
-                chosen_rect.size.height - requested_dimensions.height,
-            ),
-        );
-
-        // Guillotine the rectangle.
-        let new_free_rect_to_right;
-        let new_free_rect_to_bottom;
-        if candidate_free_rect_to_right.size.area() > candidate_free_rect_to_bottom.size.area() {
-            new_free_rect_to_right = DeviceIntRect::new(
-                candidate_free_rect_to_right.origin,
-                DeviceIntSize::new(
-                    candidate_free_rect_to_right.size.width,
-                    chosen_rect.size.height,
-                ),
-            );
-            new_free_rect_to_bottom = candidate_free_rect_to_bottom
-        } else {
-            new_free_rect_to_right = candidate_free_rect_to_right;
-            new_free_rect_to_bottom = DeviceIntRect::new(
-                candidate_free_rect_to_bottom.origin,
-                DeviceIntSize::new(
-                    chosen_rect.size.width,
-                    candidate_free_rect_to_bottom.size.height,
-                ),
-            )
-        }
-
-        // Add the guillotined rects back to the free list.
-        if !util::rect_is_empty(&new_free_rect_to_right) {
-            self.free_list[bin].push(new_free_rect_to_right);
-        }
-        if !util::rect_is_empty(&new_free_rect_to_bottom) {
-            self.free_list[bin].push(new_free_rect_to_bottom);
-        }
-
-        // Bump the allocation counter.
-        self.allocations += 1;
-
-        // Return the result.
-        Some(chosen_rect.origin)
-    }
-}
-
-/// A binning free list. Binning is important to avoid sifting through lots of small strips when
-/// allocating many texture items.
-#[cfg_attr(feature = "capture", derive(Serialize))]
-#[cfg_attr(feature = "replay", derive(Deserialize))]
-struct FreeRectList {
-    bins: [Vec<DeviceIntRect>; NUM_BINS],
-}
-
-impl ops::Index<FreeListBin> for FreeRectList {
-    type Output = Vec<DeviceIntRect>;
-    fn index(&self, bin: FreeListBin) -> &Self::Output {
-        &self.bins[bin.0 as usize]
-    }
-}
-
-impl ops::IndexMut<FreeListBin> for FreeRectList {
-    fn index_mut(&mut self, bin: FreeListBin) -> &mut Self::Output {
-        &mut self.bins[bin.0 as usize]
-    }
-}
-
-impl FreeRectList {
-    fn new() -> Self {
-        FreeRectList {
-            bins: [Vec::new(), Vec::new(), Vec::new()],
-        }
-    }
-
-    fn push(&mut self, rect: DeviceIntRect) {
-        self[FreeListBin::for_size(&rect.size)].push(rect)
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 struct FreeListBin(u8);
@@ -195,5 +32,175 @@ impl FreeListBin {
             .find(|(_, &min_size)| min_size <= size.width && min_size <= size.height)
             .map(|(id, _)| FreeListBin(id as u8))
             .expect("Unable to find a bin!")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct FreeRectSlice(pub u32);
+
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct FreeRect {
+    slice: FreeRectSlice,
+    rect: DeviceIntRect,
+}
+
+/// A texture allocator using the guillotine algorithm with the rectangle merge improvement. See
+/// sections 2.2 and 2.2.5 in "A Thousand Ways to Pack the Bin - A Practical Approach to Two-
+/// Dimensional Rectangle Bin Packing":
+///
+///    http://clb.demon.fi/files/RectangleBinPack.pdf
+///
+/// This approach was chosen because of its simplicity, good performance, and easy support for
+/// dynamic texture deallocation.
+///
+/// Note: the allocations are spread across multiple textures, and also are binned
+/// orthogonally in order to speed up the search.
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub struct ArrayAllocationTracker {
+    bins: [Vec<FreeRect>; NUM_BINS],
+}
+
+impl ArrayAllocationTracker {
+    pub fn new() -> Self {
+        ArrayAllocationTracker {
+            bins: [
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ],
+        }
+    }
+
+    fn push(&mut self, slice: FreeRectSlice, rect: DeviceIntRect) {
+        let id = FreeListBin::for_size(&rect.size).0 as usize;
+        self.bins[id].push(FreeRect {
+            slice,
+            rect,
+        })
+    }
+
+    /// Find a suitable rect in the free list. We choose the smallest such rect
+    /// in terms of area (Best-Area-Fit, BAF).
+    fn find_index_of_best_rect(
+        &self,
+        requested_dimensions: &DeviceIntSize,
+    ) -> Option<(FreeListBin, FreeListIndex)> {
+        let start_bin = FreeListBin::for_size(requested_dimensions);
+        (start_bin.0 .. NUM_BINS as u8)
+            .find_map(|id| if FIND_SMALLEST_AREA {
+                let mut smallest_index_and_area = None;
+                for (candidate_index, candidate) in self.bins[id as usize].iter().enumerate() {
+                    if requested_dimensions.width > candidate.rect.size.width ||
+                        requested_dimensions.height > candidate.rect.size.height
+                    {
+                        continue;
+                    }
+
+                    let candidate_area = candidate.rect.size.area();
+                    match smallest_index_and_area {
+                        Some((_, area)) if candidate_area >= area => continue,
+                        _ => smallest_index_and_area = Some((candidate_index, candidate_area)),
+                    }
+                }
+
+                smallest_index_and_area
+                    .map(|(index, _)| (FreeListBin(id), FreeListIndex(index)))
+            } else {
+                self.bins[id as usize]
+                    .iter()
+                    .position(|candidate| {
+                        requested_dimensions.width <= candidate.rect.size.width &&
+                        requested_dimensions.height <= candidate.rect.size.height
+                    })
+                    .map(|index| (FreeListBin(id), FreeListIndex(index)))
+            })
+    }
+
+    // Split that results in the single largest area (Min Area Split Rule, MINAS).
+    fn split_guillotine(&mut self, chosen: &FreeRect, requested_dimensions: &DeviceIntSize) {
+        let candidate_free_rect_to_right = DeviceIntRect::new(
+            DeviceIntPoint::new(
+                chosen.rect.origin.x + requested_dimensions.width,
+                chosen.rect.origin.y,
+            ),
+            DeviceIntSize::new(
+                chosen.rect.size.width - requested_dimensions.width,
+                requested_dimensions.height,
+            ),
+        );
+        let candidate_free_rect_to_bottom = DeviceIntRect::new(
+            DeviceIntPoint::new(
+                chosen.rect.origin.x,
+                chosen.rect.origin.y + requested_dimensions.height,
+            ),
+            DeviceIntSize::new(
+                requested_dimensions.width,
+                chosen.rect.size.height - requested_dimensions.height,
+            ),
+        );
+
+        // Guillotine the rectangle.
+        let new_free_rect_to_right;
+        let new_free_rect_to_bottom;
+        if candidate_free_rect_to_right.size.area() > candidate_free_rect_to_bottom.size.area() {
+            new_free_rect_to_right = DeviceIntRect::new(
+                candidate_free_rect_to_right.origin,
+                DeviceIntSize::new(
+                    candidate_free_rect_to_right.size.width,
+                    chosen.rect.size.height,
+                ),
+            );
+            new_free_rect_to_bottom = candidate_free_rect_to_bottom
+        } else {
+            new_free_rect_to_right = candidate_free_rect_to_right;
+            new_free_rect_to_bottom = DeviceIntRect::new(
+                candidate_free_rect_to_bottom.origin,
+                DeviceIntSize::new(
+                    chosen.rect.size.width,
+                    candidate_free_rect_to_bottom.size.height,
+                ),
+            )
+        }
+
+        // Add the guillotined rects back to the free list.
+        if !util::rect_is_empty(&new_free_rect_to_right) {
+            self.push(chosen.slice, new_free_rect_to_right);
+        }
+        if !util::rect_is_empty(&new_free_rect_to_bottom) {
+            self.push(chosen.slice, new_free_rect_to_bottom);
+        }
+    }
+
+    pub fn allocate(
+        &mut self, requested_dimensions: &DeviceIntSize
+    ) -> Option<(FreeRectSlice, DeviceIntPoint)> {
+        if requested_dimensions.width == 0 || requested_dimensions.height == 0 {
+            return Some((FreeRectSlice(0), DeviceIntPoint::new(0, 0)));
+        }
+        let (bin, index) = self.find_index_of_best_rect(requested_dimensions)?;
+
+        // Remove the rect from the free list and decide how to guillotine it.
+        let chosen = self.bins[bin.0 as usize].swap_remove(index.0);
+        self.split_guillotine(&chosen, requested_dimensions);
+
+        // Return the result.
+        Some((chosen.slice, chosen.rect.origin))
+    }
+
+    /// Add a new slice to the allocator, and immediately allocate a rect from it.
+    pub fn extend(
+        &mut self,
+        slice: FreeRectSlice,
+        total_size: DeviceIntSize,
+        requested_dimensions: DeviceIntSize,
+    ) {
+        self.split_guillotine(
+            &FreeRect { slice, rect: total_size.into() },
+            &requested_dimensions
+        );
     }
 }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -82,12 +82,7 @@ impl TextureAllocator {
         let origin = self.allocator.allocate(size);
 
         if let Some(origin) = origin {
-            // TODO(gw): We need to make all the device rects
-            //           be consistent in the use of the
-            //           DeviceIntRect and DeviceIntRect types!
-            let origin = DeviceIntPoint::new(origin.x as i32, origin.y as i32);
-            let size = DeviceIntSize::new(size.width as i32, size.height as i32);
-            let rect = DeviceIntRect::new(origin, size);
+            let rect = DeviceIntRect::new(origin, *size);
             self.used_rect = rect.union(&self.used_rect);
         }
 


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1509672

Technically consists of 3 parts:
  - cleanup bits, don't affect performance
  - spread the dynamic target allocation bins across the layers. Previously, we had each layer with it's own allocator, and we were only ever trying to allocate from the last one. This scheme was weak against cases where we reach the ideal maximum target size, since guillotine allocation of small bits forced us to spawn more and more layers... reaching almost 150 in the target case. New scheme uses the layers more efficiently, reducing the layers to just 3 (.. 50x reduction :P). Pending [try push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=27464c7d62f0f05a0bc96a7133b55e9706d3d449).
  - when we reach the ideal max size, also round up the requested size to 256. This makes allocations *within a layer* to be more robust against small inputs. With this change, the number of layers drops to just 2 (.. 75x reduction lol), which appears to be minimal for this case. Pending [try push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=1f4593fd68455842a7b12f396d0abbdf887a11a0).

The page scrolls smoothly with those changes, on my GTX TI 1050 at least.

r? @gw3583 

Note: the bugzilla issue also suffers from poor batching, I'm going to look at it separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3374)
<!-- Reviewable:end -->
