### PR TITLE
Make eager texture cache eviction not quite so eager.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -103,7 +103,7 @@ impl FrameId {
     }
 
     /// Advances this FrameId to the next frame.
-    fn advance(&mut self) {
+    pub fn advance(&mut self) {
         self.0 += 1;
     }
 


### PR DESCRIPTION
Texture cache entries can be evicted at the start of
a frame, or at any time during the frame when a cache
allocation is occurring. This means that entries tagged
with eager eviction may get evicted before they have a
chance to be requested on the current frame. Instead,
advance the frame id of the entry by one before
comparison. This ensures that an eager entry will
not be evicted until it is not used for at least
one complete frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3376)
<!-- Reviewable:end -->
