### PR TITLE
Remove early returns from brush_fs shader functions

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -148,10 +148,6 @@ vec3 LinearToSrgb(vec3 color) {
 Fragment brush_fs() {
     vec4 Cs = texture(sColor0, vUv);
 
-    if (Cs.a == 0.0) {
-        return Fragment(vec4(0.0)); // could also `discard`
-    }
-
     // Un-premultiply the input.
     float alpha = Cs.a;
     vec3 color = Cs.rgb / Cs.a;

--- a/webrender/res/brush_mix_blend.glsl
+++ b/webrender/res/brush_mix_blend.glsl
@@ -208,16 +208,14 @@ Fragment brush_fs() {
     vec4 Cb = textureLod(sPrevPassColor, vBackdropUv, 0.0);
     vec4 Cs = textureLod(sPrevPassColor, vSrcUv, 0.0);
 
-    if (Cb.a == 0.0) {
-        return Fragment(Cs);
-    }
-    if (Cs.a == 0.0) {
-        return Fragment(vec4(0.0));
+    // The mix-blend-mode functions assume no premultiplied alpha
+    if (Cb.a != 0.0) {
+        Cb.rgb /= Cb.a;
     }
 
-    // The mix-blend-mode functions assume no premultiplied alpha
-    Cb.rgb /= Cb.a;
-    Cs.rgb /= Cs.a;
+    if (Cs.a != 0.0) {
+        Cs.rgb /= Cs.a;
+    }
 
     // Return yellow if none of the branches match (shouldn't happen).
     vec4 result = vec4(1.0, 1.0, 0.0, 1.0);


### PR DESCRIPTION
We generate SPIR-V binaries from the shaders and use them in our WR which has `gfx-rs` as backend. For some reason the Vulkan implementation on the Windows try server machines crashes if we have this early return in the `brush_blend.glsl` shader, but works fine with discard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3377)
<!-- Reviewable:end -->
