### PR TITLE
Fix cache synchronization crash with blob images.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1111,6 +1111,9 @@ impl RenderBackend {
         }
 
         if !transaction_msg.use_scene_builder_thread && txn.can_skip_scene_builder() {
+            if let Some(rasterizer) = txn.blob_rasterizer.take() {
+                self.resource_cache.set_blob_rasterizer(rasterizer);
+            }
             self.update_document(
                 txn.document_id,
                 replace(&mut txn.resource_updates, Vec::new()),


### PR DESCRIPTION
On the first pass of prepare_transaction:
1) Resource update contains only an AddBlobImage, but it is not visible according to viewport_tiles (set in SetBlobImageVisibleArea)
2) We call ResourceCache::create_blob_scene_builder_requests but since the image is not visible, it doesn't create any BlobImageParams entries (containing the blob image key) to be stored in txn.blob_requests
3) Since the transaction has no blob image updates, we can take the shortcut to call RenderBackend::update_document directly
4) We didn't call ResourceCache::set_blob_rasterizer with the updated txn.blob_rasterizer.

On the second pass of prepare_transaction:
1) Resource update contains only an SetBlobImageVisibleArea
2) We don't call ResourceCache::create_blob_scene_builder_requests since there is no Add/UpdateBlobImage entries.
3) Since the transaction has no blob image updates, we can take the shortcut to call RenderBackend::update_document directly
4) We are missing the blob we added in the previous step in ResourceCache::request_image, and it adds it to missing_blob_images.
5) We try to process missing_blob_images in ResourceCache::rasterize_missing_blob_images with the old blob_rasterizer.
6) Crash.

Potentially fixes bug 1492241.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3378)
<!-- Reviewable:end -->
