### PR TITLE
Unbreak wrench on FreeBSD

### DIFF
--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -42,5 +42,5 @@ pathfinder = [ "webrender/pathfinder" ]
 dwrote = "0.6.2"
 mozangle = {version = "0.1.5", features = ["egl"]}
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 font-loader = "0.7"

--- a/wrench/src/main.rs
+++ b/wrench/src/main.rs
@@ -18,7 +18,7 @@ extern crate dwrote;
 #[cfg(feature = "env_logger")]
 extern crate env_logger;
 extern crate euclid;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(unix, not(target_os = "android")))]
 extern crate font_loader;
 extern crate gleam;
 extern crate glutin;

--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -8,7 +8,7 @@ use blob;
 use crossbeam::sync::chase_lev;
 #[cfg(windows)]
 use dwrote;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(unix, not(target_os = "android")))]
 use font_loader::system_fonts;
 use winit::EventsLoopProxy;
 use json_frame_writer::JsonFrameWriter;
@@ -423,7 +423,7 @@ impl Wrench {
         self.font_key_from_native_handle(&desc)
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(all(unix, not(target_os = "android")))]
     pub fn font_key_from_properties(
         &mut self,
         family: &str,
@@ -438,7 +438,18 @@ impl Wrench {
         self.font_key_from_bytes(font, index as u32)
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "android")]
+    pub fn font_key_from_properties(
+        &mut self,
+        family: &str,
+        _weight: u32,
+        _style: u32,
+        _stretch: u32,
+    ) -> FontKey {
+        unimplemented!()
+    }
+
+    #[cfg(all(unix, not(target_os = "android")))]
     pub fn font_key_from_name(&mut self, font_name: &str) -> FontKey {
         let property = system_fonts::FontPropertyBuilder::new()
             .family(font_name)


### PR DESCRIPTION
`font_loader` usage is inconsistent:
https://github.com/servo/webrender/blob/6ca634197cfe26738194f87042020fe838c0047a/wrench/src/wrench.rs#L11-L12
https://github.com/servo/webrender/blob/6ca634197cfe26738194f87042020fe838c0047a/wrench/src/wrench.rs#L441-L448
Android has duplicate `font_key_from_name`:
https://github.com/servo/webrender/blob/6ca634197cfe26738194f87042020fe838c0047a/wrench/src/wrench.rs#L450-L453

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3380)
<!-- Reviewable:end -->
