### PR TITLE
Remove most use of the local prim rect by primitive templates.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1107,7 +1107,7 @@ impl AlphaBatchBuilder {
 
                                         let instance = BrushInstance {
                                             prim_header_index,
-                                            segment_index: 0,
+                                            segment_index: INVALID_SEGMENT_INDEX,
                                             edge_flags: EdgeAaSegmentMask::empty(),
                                             brush_flags: BrushFlags::empty(),
                                             clip_task_address,
@@ -1189,7 +1189,7 @@ impl AlphaBatchBuilder {
                                         let shadow_instance = BrushInstance {
                                             prim_header_index: shadow_prim_header_index,
                                             clip_task_address,
-                                            segment_index: 0,
+                                            segment_index: INVALID_SEGMENT_INDEX,
                                             edge_flags: EdgeAaSegmentMask::empty(),
                                             brush_flags: BrushFlags::empty(),
                                             user_data: shadow_uv_rect_address,
@@ -1198,7 +1198,7 @@ impl AlphaBatchBuilder {
                                         let content_instance = BrushInstance {
                                             prim_header_index: content_prim_header_index,
                                             clip_task_address,
-                                            segment_index: 0,
+                                            segment_index: INVALID_SEGMENT_INDEX,
                                             edge_flags: EdgeAaSegmentMask::empty(),
                                             brush_flags: BrushFlags::empty(),
                                             user_data: content_uv_rect_address,
@@ -1283,7 +1283,7 @@ impl AlphaBatchBuilder {
                                         let instance = BrushInstance {
                                             prim_header_index,
                                             clip_task_address,
-                                            segment_index: 0,
+                                            segment_index: INVALID_SEGMENT_INDEX,
                                             edge_flags: EdgeAaSegmentMask::empty(),
                                             brush_flags: BrushFlags::empty(),
                                             user_data: 0,
@@ -1328,7 +1328,7 @@ impl AlphaBatchBuilder {
                                 let instance = BrushInstance {
                                     prim_header_index,
                                     clip_task_address,
-                                    segment_index: 0,
+                                    segment_index: INVALID_SEGMENT_INDEX,
                                     edge_flags: EdgeAaSegmentMask::empty(),
                                     brush_flags: BrushFlags::empty(),
                                     user_data: 0,
@@ -1368,7 +1368,7 @@ impl AlphaBatchBuilder {
                                 let instance = BrushInstance {
                                     prim_header_index,
                                     clip_task_address,
-                                    segment_index: 0,
+                                    segment_index: INVALID_SEGMENT_INDEX,
                                     edge_flags: EdgeAaSegmentMask::empty(),
                                     brush_flags: BrushFlags::empty(),
                                     user_data: uv_rect_address,

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -586,7 +586,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let instance = PrimitiveInstanceData::from(BrushInstance {
-                    segment_index: 0,
+                    segment_index: INVALID_SEGMENT_INDEX,
                     edge_flags: EdgeAaSegmentMask::all(),
                     clip_task_address,
                     brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,
@@ -862,7 +862,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let instance = PrimitiveInstanceData::from(BrushInstance {
-                    segment_index: 0,
+                    segment_index: INVALID_SEGMENT_INDEX,
                     edge_flags: EdgeAaSegmentMask::all(),
                     clip_task_address,
                     brush_flags: BrushFlags::PERSPECTIVE_INTERPOLATION,

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -1017,7 +1017,7 @@ impl PrimitiveTemplateKind {
     fn write_prim_gpu_blocks(
         &self,
         request: &mut GpuDataRequest,
-        prim_rect: LayoutRect,
+        prim_size: LayoutSize,
     ) {
         match *self {
             PrimitiveTemplateKind::Clear => {
@@ -1034,8 +1034,8 @@ impl PrimitiveTemplateKind {
                 request.push(PremultipliedColorF::WHITE);
                 request.push(PremultipliedColorF::WHITE);
                 request.push([
-                    prim_rect.size.width,
-                    prim_rect.size.height,
+                    prim_size.width,
+                    prim_size.height,
                     0.0,
                     0.0,
                 ]);
@@ -1047,8 +1047,8 @@ impl PrimitiveTemplateKind {
                 request.push(PremultipliedColorF::WHITE);
                 request.push(PremultipliedColorF::WHITE);
                 request.push([
-                    prim_rect.size.width,
-                    prim_rect.size.height,
+                    prim_size.width,
+                    prim_size.height,
                     0.0,
                     0.0,
                 ]);
@@ -1165,15 +1165,8 @@ impl PrimitiveTemplateKind {
     fn write_segment_gpu_blocks(
         &self,
         request: &mut GpuDataRequest,
-        prim_rect: LayoutRect,
     ) {
         match *self {
-            PrimitiveTemplateKind::Clear => {
-                request.write_segment(
-                    prim_rect,
-                    [0.0; 4],
-                );
-            }
             PrimitiveTemplateKind::NormalBorder { ref template, .. } => {
                 for segment in &template.brush_segments {
                     // has to match VECS_PER_SEGMENT
@@ -1192,12 +1185,6 @@ impl PrimitiveTemplateKind {
                     );
                 }
             }
-            PrimitiveTemplateKind::LineDecoration { .. } => {
-                request.write_segment(
-                    prim_rect,
-                    [0.0; 4],
-                );
-            }
             PrimitiveTemplateKind::LinearGradient { ref brush_segments, .. } |
             PrimitiveTemplateKind::RadialGradient { ref brush_segments, .. } => {
                 for segment in brush_segments {
@@ -1208,6 +1195,8 @@ impl PrimitiveTemplateKind {
                     );
                 }
             }
+            PrimitiveTemplateKind::Clear |
+            PrimitiveTemplateKind::LineDecoration { .. } |
             PrimitiveTemplateKind::Image { .. } |
             PrimitiveTemplateKind::Rectangle { .. } |
             PrimitiveTemplateKind::TextRun { .. } |
@@ -1233,8 +1222,11 @@ impl PrimitiveTemplate {
         frame_state: &mut FrameBuildingState,
     ) {
         if let Some(mut request) = frame_state.gpu_cache.request(&mut self.gpu_cache_handle) {
-            self.kind.write_prim_gpu_blocks(&mut request, self.prim_rect);
-            self.kind.write_segment_gpu_blocks(&mut request, self.prim_rect);
+            self.kind.write_prim_gpu_blocks(
+                &mut request,
+                self.prim_rect.size,
+            );
+            self.kind.write_segment_gpu_blocks(&mut request);
         }
 
         self.opacity = match self.kind {
@@ -3604,7 +3596,10 @@ impl PrimitiveStore {
             if let Some(mut request) = frame_state.gpu_cache.request(&mut segment_instance.gpu_cache_handle) {
                 let segments = &scratch.segments[segment_instance.segments_range];
 
-                prim_data.kind.write_prim_gpu_blocks(&mut request, prim_data.prim_rect);
+                prim_data.kind.write_prim_gpu_blocks(
+                    &mut request,
+                    prim_data.prim_rect.size,
+                );
 
                 for segment in segments {
                     request.write_segment(

--- a/webrender/src/prim_store.rs
+++ b/webrender/src/prim_store.rs
@@ -3089,10 +3089,6 @@ impl PrimitiveStore {
                         0.0,
                         0.0,
                     ]);
-                    request.write_segment(
-                        pic.local_rect,
-                        [0.0; 4],
-                    );
                 }
             }
             PrimitiveInstanceKind::TextRun { .. } |


### PR DESCRIPTION
The current picture caching code invalidates cached regions more
than expected, due to how gecko handles scroll offsets.

If a display list is received, then a scroll event occurs, and then
a new display list is sent, the local rects will contain different
coordinates, since the scroll offsets are baked into the local
rects rather than in the scroll / reference frames. This results
in primitives being interned with a different value, and cached
surfaces being incorrectly invalidated.

Since the way this works is non-trivial to change in Gecko, we need
to handle this in WR.

If we change primitive and clip keys and templates to store their
rectangles in a true local primitive space (where the origin is
always zero) then the interning will work as expected. To do this,
we'll store the origin of a primitive in the instance, and only
the size in the template.

A side benefit of this approach is that test cases like dl_mutate
will become much faster, since the only difference between the
thousands of rectangles is the origin. This will effectively
allow true instancing of primitives with common data.

This is the first step towards that - by removing reliance of the
primitive local rect from the primitive template code. The rest
will be done as a series of incremental patches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3381)
<!-- Reviewable:end -->
