### PR TITLE
Pass AsyncImageBlobRasterizer through the stack explicitly

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use api::{AsyncBlobImageRasterizer};
 use api::{ColorF, DeviceIntPoint, DevicePixelScale, LayoutPixel, PicturePixel, RasterPixel};
 use api::{DeviceIntRect, DeviceIntSize, DocumentLayer, FontRenderMode};
 use api::{LayoutPoint, LayoutRect, LayoutSize, PipelineId, RasterSpace, WorldPoint, WorldRect, WorldPixel};
@@ -372,6 +373,7 @@ impl FrameBuilder {
         scene_properties: &SceneProperties,
         resources: &mut FrameResources,
         scratch: &mut PrimitiveScratchBuffer,
+        blob_rasterizer: Option<Box<AsyncBlobImageRasterizer>>,
     ) -> Frame {
         profile_scope!("build");
         debug_assert!(
@@ -416,9 +418,12 @@ impl FrameBuilder {
             scratch,
         );
 
-        resource_cache.block_until_all_resources_added(gpu_cache,
-                                                       &mut render_tasks,
-                                                       texture_cache_profile);
+        resource_cache.block_until_all_resources_added(
+            gpu_cache,
+            &mut render_tasks,
+            blob_rasterizer,
+            texture_cache_profile,
+        );
 
         let mut passes = vec![
             special_render_passes.alpha_glyph_pass,


### PR DESCRIPTION
Similar to #3378, this PR attempts to address our failures in bug 1492241.
If we aren't sure that the blob image rasterizer, being a state of the resource cache, is the right one to build the scene, then perhaps it shouldn't be a state in the first place. This is what this PR is doing. It's not guaranteed to fix anything, just bringing more clarity to the code, hopefully helping us to rule out one of the possible causes.

r? @nical cc @aosmond 

Gecko try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=726e01545625a20153893dbb22509b70294651bb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3382)
<!-- Reviewable:end -->
