### PR TITLE
Move primitive origin from template data to the instance.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -549,6 +549,12 @@ impl AlphaBatchBuilder {
             render_tasks,
         ).unwrap_or(OPAQUE_TASK_ADDRESS);
 
+        let prim_data = &ctx.resources.as_common_data(&prim_instance);
+        let prim_rect = LayoutRect::new(
+            prim_instance.prim_origin,
+            prim_data.prim_size,
+        );
+
         match prim_instance.kind {
             PrimitiveInstanceKind::Clear { data_handle } => {
                 let prim_data = &ctx.resources.prim_data_store[data_handle];
@@ -559,7 +565,7 @@ impl AlphaBatchBuilder {
                 //           use of interning.
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -628,7 +634,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -684,7 +690,7 @@ impl AlphaBatchBuilder {
                 let prim_cache_address = gpu_cache.get_address(&prim_data.gpu_cache_handle);
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -832,7 +838,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -1421,7 +1427,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -1495,7 +1501,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -1609,7 +1615,7 @@ impl AlphaBatchBuilder {
                 };
 
                 let prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: prim_cache_address,
@@ -1718,7 +1724,7 @@ impl AlphaBatchBuilder {
                     };
 
                     let prim_header = PrimitiveHeader {
-                        local_rect: prim_data.prim_rect,
+                        local_rect: prim_rect,
                         local_clip_rect: prim_instance.combined_local_clip_rect,
                         task_address,
                         specific_prim_address: prim_cache_address,
@@ -1794,7 +1800,7 @@ impl AlphaBatchBuilder {
                 let specified_blend_mode = BlendMode::PremultipliedAlpha;
 
                 let mut prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: GpuCacheAddress::invalid(),
@@ -1881,7 +1887,7 @@ impl AlphaBatchBuilder {
                 let specified_blend_mode = BlendMode::PremultipliedAlpha;
 
                 let mut prim_header = PrimitiveHeader {
-                    local_rect: prim_data.prim_rect,
+                    local_rect: prim_rect,
                     local_clip_rect: prim_instance.combined_local_clip_rect,
                     task_address,
                     specific_prim_address: GpuCacheAddress::invalid(),

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -325,7 +325,7 @@ impl<'a> DisplayListFlattener<'a> {
                 .prim_interner
                 .intern(&prim_key, || {
                     PrimitiveSceneData {
-                        normalized_clip_rect: LayoutRect::max_rect(),
+                        prim_relative_clip_rect: LayoutRect::max_rect(),
                         prim_size: LayoutSize::zero(),
                         is_backface_visible: true,
                     }
@@ -1045,19 +1045,20 @@ impl<'a> DisplayListFlattener<'a> {
         P::Source: AsInstanceKind<Handle<P::Marker>>,
         DocumentResources: InternerMut<P>,
     {
-        let normalized_clip_rect = info.clip_rect
-            .translate(&LayoutVector2D::new(-info.rect.origin.x, -info.rect.origin.y))
+        let offset = info.rect.origin.to_vector();
+        let prim_relative_clip_rect = info.clip_rect
+            .translate(&-offset)
             .into();
 
         // Build a primitive key.
-        let prim_key = prim.build_key(info, normalized_clip_rect);
+        let prim_key = prim.build_key(info, prim_relative_clip_rect);
 
         let interner = self.resources.interner_mut();
         let prim_data_handle =
             interner
             .intern(&prim_key, || {
                 PrimitiveSceneData {
-                    normalized_clip_rect,
+                    prim_relative_clip_rect,
                     prim_size: info.rect.size,
                     is_backface_visible: info.is_backface_visible,
                 }
@@ -1273,7 +1274,7 @@ impl<'a> DisplayListFlattener<'a> {
             .prim_interner
             .intern(&prim_key, || {
                 PrimitiveSceneData {
-                    normalized_clip_rect: LayoutRect::max_rect(),
+                    prim_relative_clip_rect: LayoutRect::max_rect(),
                     prim_size: LayoutSize::zero(),
                     is_backface_visible,
                 }
@@ -1842,7 +1843,7 @@ impl<'a> DisplayListFlattener<'a> {
                             .prim_interner
                             .intern(&shadow_prim_key, || {
                                 PrimitiveSceneData {
-                                    normalized_clip_rect: LayoutRect::max_rect(),
+                                    prim_relative_clip_rect: LayoutRect::max_rect(),
                                     prim_size: LayoutSize::zero(),
                                     is_backface_visible: true,
                                 }

--- a/webrender/src/intern.rs
+++ b/webrender/src/intern.rs
@@ -391,6 +391,6 @@ pub trait Internable {
     fn build_key(
         self,
         info: &LayoutPrimitiveInfo,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
     ) -> Self::Source;
 }

--- a/webrender/src/intern.rs
+++ b/webrender/src/intern.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::LayoutPrimitiveInfo;
+use api::{LayoutPrimitiveInfo, LayoutRect};
 use internal_types::FastHashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -388,5 +388,9 @@ pub trait Internable {
     type InternData;
 
     /// Build a new key from self with `info`.
-    fn build_key(self, info: &LayoutPrimitiveInfo) -> Self::Source;
+    fn build_key(
+        self,
+        info: &LayoutPrimitiveInfo,
+        normalized_clip_rect: LayoutRect,
+    ) -> Self::Source;
 }

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -5,7 +5,7 @@
 use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint};
 use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel, PropertyBinding, PropertyBindingId};
 use api::{DevicePixelScale, RasterRect, RasterSpace, PictureSize, DeviceIntPoint, ColorF, ImageKey, DirtyRect};
-use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor, LayoutVector2D};
+use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor};
 use box_shadow::{BLUR_SAMPLE_SCALE};
 use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode};
 use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
@@ -622,8 +622,8 @@ impl TileCache {
             prim_data.prim_size,
         );
         let clip_rect = prim_data
-            .normalized_clip_rect
-            .translate(&LayoutVector2D::new(prim_instance.prim_origin.x, prim_instance.prim_origin.y));
+            .prim_relative_clip_rect
+            .translate(&prim_instance.prim_origin.to_vector());
 
         // Map the primitive local rect into the picture space.
         // TODO(gw): We should maybe store this in the primitive template
@@ -1341,8 +1341,8 @@ impl PrimitiveList {
                     prim_data.prim_size,
                 );
                 let clip_rect = prim_data
-                    .normalized_clip_rect
-                    .translate(&LayoutVector2D::new(prim_instance.prim_origin.x, prim_instance.prim_origin.y));
+                    .prim_relative_clip_rect
+                    .translate(&prim_instance.prim_origin.to_vector());
                 let culling_rect = clip_rect
                     .intersection(&prim_rect)
                     .unwrap_or(LayoutRect::zero());

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -337,7 +337,8 @@ impl GpuCacheAddress {
 #[cfg_attr(feature = "capture", derive(Serialize))]
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PrimitiveSceneData {
-    pub culling_rect: LayoutRect,
+    pub prim_size: LayoutSize,
+    pub normalized_clip_rect: LayoutRect,
     pub is_backface_visible: bool,
 }
 
@@ -625,16 +626,19 @@ impl From<LayoutPoint> for PointKey {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct PrimKeyCommonData {
     pub is_backface_visible: bool,
-    pub prim_rect: RectangleKey,
-    pub clip_rect: RectangleKey,
+    pub prim_size: SizeKey,
+    pub normalized_clip_rect: RectangleKey,
 }
 
 impl PrimKeyCommonData {
-    pub fn with_info(info: &LayoutPrimitiveInfo) -> Self {
+    pub fn with_info(
+        info: &LayoutPrimitiveInfo,
+        normalized_clip_rect: LayoutRect,
+    ) -> Self {
         PrimKeyCommonData {
             is_backface_visible: info.is_backface_visible,
-            prim_rect: info.rect.into(),
-            clip_rect: info.clip_rect.into(),
+            prim_size: info.rect.size.into(),
+            normalized_clip_rect: normalized_clip_rect.into(),
         }
     }
 }
@@ -650,15 +654,15 @@ pub struct PrimitiveKey {
 impl PrimitiveKey {
     pub fn new(
         is_backface_visible: bool,
-        prim_rect: LayoutRect,
-        clip_rect: LayoutRect,
+        prim_size: LayoutSize,
+        normalized_clip_rect: LayoutRect,
         kind: PrimitiveKeyKind,
     ) -> Self {
         PrimitiveKey {
             common: PrimKeyCommonData {
                 is_backface_visible,
-                prim_rect: prim_rect.into(),
-                clip_rect: clip_rect.into(),
+                prim_size: prim_size.into(),
+                normalized_clip_rect: normalized_clip_rect.into(),
             },
             kind,
         }
@@ -821,7 +825,7 @@ pub enum PrimitiveTemplateKind {
 impl PrimitiveKeyKind {
     fn into_template(
         self,
-        rect: &LayoutRect,
+        size: LayoutSize,
     ) -> PrimitiveTemplateKind {
         match self {
             PrimitiveKeyKind::Unused => PrimitiveTemplateKind::Unused,
@@ -839,7 +843,7 @@ impl PrimitiveKeyKind {
                 let mut border_segments = Vec::new();
 
                 create_border_segments(
-                    rect.size,
+                    size,
                     &border,
                     &widths,
                     &mut border_segments,
@@ -860,7 +864,7 @@ impl PrimitiveKeyKind {
                 ref nine_patch,
                 ..
             } => {
-                let brush_segments = nine_patch.create_segments(rect.size);
+                let brush_segments = nine_patch.create_segments(size);
 
                 PrimitiveTemplateKind::ImageBorder {
                     request,
@@ -927,7 +931,7 @@ impl PrimitiveKeyKind {
                 let mut brush_segments = Vec::new();
 
                 if let Some(ref nine_patch) = nine_patch {
-                    brush_segments = nine_patch.create_segments(rect.size);
+                    brush_segments = nine_patch.create_segments(size);
                 }
 
                 // Save opacity of the stops for use in
@@ -961,7 +965,7 @@ impl PrimitiveKeyKind {
                 let mut brush_segments = Vec::new();
 
                 if let Some(ref nine_patch) = nine_patch {
-                    brush_segments = nine_patch.create_segments(rect.size);
+                    brush_segments = nine_patch.create_segments(size);
                 }
 
                 let stops = stops.iter().map(|stop| {
@@ -990,8 +994,8 @@ impl PrimitiveKeyKind {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PrimTemplateCommonData {
     pub is_backface_visible: bool,
-    pub prim_rect: LayoutRect,
-    pub clip_rect: LayoutRect,
+    pub prim_size: LayoutSize,
+    pub normalized_clip_rect: LayoutRect,
     pub opacity: PrimitiveOpacity,
     /// The GPU cache handle for a primitive template. Since this structure
     /// is retained across display lists by interning, this GPU cache handle
@@ -1004,8 +1008,8 @@ impl PrimTemplateCommonData {
     pub fn with_key_common(common: PrimKeyCommonData) -> Self {
         PrimTemplateCommonData {
             is_backface_visible: common.is_backface_visible,
-            prim_rect: common.prim_rect.into(),
-            clip_rect: common.clip_rect.into(),
+            prim_size: common.prim_size.into(),
+            normalized_clip_rect: common.normalized_clip_rect.into(),
             gpu_cache_handle: GpuCacheHandle::new(),
             opacity: PrimitiveOpacity::translucent(),
         }
@@ -1035,7 +1039,7 @@ impl ops::DerefMut for PrimitiveTemplate {
 impl From<PrimitiveKey> for PrimitiveTemplate {
     fn from(item: PrimitiveKey) -> Self {
         let common = PrimTemplateCommonData::with_key_common(item.common);
-        let kind = item.kind.into_template(&common.prim_rect);
+        let kind = item.kind.into_template(common.prim_size);
 
         PrimitiveTemplate { common, kind, }
     }
@@ -1218,7 +1222,7 @@ impl PrimitiveTemplate {
         if let Some(mut request) = frame_state.gpu_cache.request(&mut self.common.gpu_cache_handle) {
             self.kind.write_prim_gpu_blocks(
                 &mut request,
-                self.common.prim_rect.size,
+                self.common.prim_size,
             );
             self.kind.write_segment_gpu_blocks(&mut request);
         }
@@ -1257,8 +1261,8 @@ impl PrimitiveTemplate {
                 // then we just assume the gradient is translucent for now.
                 // (In the future we could consider segmenting in some cases).
                 let stride = stretch_size + tile_spacing;
-                if stride.width >= self.common.prim_rect.size.width &&
-                   stride.height >= self.common.prim_rect.size.height {
+                if stride.width >= self.common.prim_size.width &&
+                   stride.height >= self.common.prim_size.height {
                     stops_opacity
                 } else {
                     PrimitiveOpacity::translucent()
@@ -1465,11 +1469,15 @@ impl intern::Internable for PrimitiveKeyKind {
     type StoreData = PrimitiveTemplate;
     type InternData = PrimitiveSceneData;
 
-    fn build_key(self, info: &LayoutPrimitiveInfo) -> PrimitiveKey {
+    fn build_key(
+        self,
+        info: &LayoutPrimitiveInfo,
+        normalized_clip_rect: LayoutRect,
+    ) -> PrimitiveKey {
         PrimitiveKey::new(
             info.is_backface_visible,
-            info.rect,
-            info.clip_rect,
+            info.rect.size,
+            normalized_clip_rect,
             self,
         )
     }
@@ -2313,6 +2321,10 @@ pub struct PrimitiveInstance {
     /// can be found.
     pub kind: PrimitiveInstanceKind,
 
+    /// Local space origin of this primitive. The size
+    /// of the primitive is defined by the template.
+    pub prim_origin: LayoutPoint,
+
     /// The current combined local clip for this primitive, from
     /// the primitive local clip above and the current clip chain.
     pub combined_local_clip_rect: LayoutRect,
@@ -2349,11 +2361,13 @@ pub struct PrimitiveInstance {
 
 impl PrimitiveInstance {
     pub fn new(
+        prim_origin: LayoutPoint,
         kind: PrimitiveInstanceKind,
         clip_chain_id: ClipChainId,
         spatial_node_index: SpatialNodeIndex,
     ) -> Self {
         PrimitiveInstance {
+            prim_origin,
             kind,
             combined_local_clip_rect: LayoutRect::zero(),
             bounding_rect: None,
@@ -2839,7 +2853,16 @@ impl PrimitiveStore {
             }
             _ => {
                 let prim_data = &resources.as_common_data(&prim_instance);
-                (prim_data.prim_rect, prim_data.clip_rect)
+
+                let prim_rect = LayoutRect::new(
+                    prim_instance.prim_origin,
+                    prim_data.prim_size,
+                );
+                let clip_rect = prim_data
+                    .normalized_clip_rect
+                    .translate(&LayoutVector2D::new(prim_instance.prim_origin.x, prim_instance.prim_origin.y));
+
+                (prim_rect, clip_rect)
             }
         };
 
@@ -3034,6 +3057,7 @@ impl PrimitiveStore {
             PrimitiveInstanceKind::LineDecoration { .. } => {
                 self.prepare_interned_prim_for_render(
                     prim_instance,
+                    prim_local_rect,
                     prim_context,
                     pic_context,
                     frame_context,
@@ -3142,6 +3166,7 @@ impl PrimitiveStore {
     fn prepare_interned_prim_for_render(
         &mut self,
         prim_instance: &mut PrimitiveInstance,
+        prim_local_rect: LayoutRect,
         prim_context: &PrimitiveContext,
         pic_context: &PictureContext,
         frame_context: &FrameBuildingContext,
@@ -3395,7 +3420,7 @@ impl PrimitiveStore {
                         // rect and we want to clip these extra parts out.
                         let tight_clip_rect = prim_instance
                             .combined_local_clip_rect
-                            .intersection(&prim_data.prim_rect).unwrap();
+                            .intersection(&prim_local_rect).unwrap();
 
                         let visible_rect = compute_conservative_visible_rect(
                             prim_context,
@@ -3408,7 +3433,7 @@ impl PrimitiveStore {
                         let stride = *stretch_size + *tile_spacing;
 
                         let repetitions = image::repetitions(
-                            &prim_data.prim_rect,
+                            &prim_local_rect,
                             &visible_rect,
                             stride,
                         );
@@ -3490,7 +3515,7 @@ impl PrimitiveStore {
                 if *tile_spacing != LayoutSize::zero() {
                     *visible_tiles_range = decompose_repeated_primitive(
                         &prim_instance.combined_local_clip_rect,
-                        &prim_data.prim_rect,
+                        &prim_local_rect,
                         &stretch_size,
                         &tile_spacing,
                         prim_context,
@@ -3541,7 +3566,7 @@ impl PrimitiveStore {
                 if *tile_spacing != LayoutSize::zero() {
                     *visible_tiles_range = decompose_repeated_primitive(
                         &prim_instance.combined_local_clip_rect,
-                        &prim_data.prim_rect,
+                        &prim_local_rect,
                         &stretch_size,
                         &tile_spacing,
                         prim_context,
@@ -3594,7 +3619,7 @@ fn write_segment(
 
             prim_data.kind.write_prim_gpu_blocks(
                 &mut request,
-                prim_data.prim_rect.size,
+                prim_data.prim_size,
             );
 
             for segment in segments {

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -338,7 +338,7 @@ impl GpuCacheAddress {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct PrimitiveSceneData {
     pub prim_size: LayoutSize,
-    pub normalized_clip_rect: LayoutRect,
+    pub prim_relative_clip_rect: LayoutRect,
     pub is_backface_visible: bool,
 }
 
@@ -627,18 +627,18 @@ impl From<LayoutPoint> for PointKey {
 pub struct PrimKeyCommonData {
     pub is_backface_visible: bool,
     pub prim_size: SizeKey,
-    pub normalized_clip_rect: RectangleKey,
+    pub prim_relative_clip_rect: RectangleKey,
 }
 
 impl PrimKeyCommonData {
     pub fn with_info(
         info: &LayoutPrimitiveInfo,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
     ) -> Self {
         PrimKeyCommonData {
             is_backface_visible: info.is_backface_visible,
             prim_size: info.rect.size.into(),
-            normalized_clip_rect: normalized_clip_rect.into(),
+            prim_relative_clip_rect: prim_relative_clip_rect.into(),
         }
     }
 }
@@ -655,14 +655,14 @@ impl PrimitiveKey {
     pub fn new(
         is_backface_visible: bool,
         prim_size: LayoutSize,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
         kind: PrimitiveKeyKind,
     ) -> Self {
         PrimitiveKey {
             common: PrimKeyCommonData {
                 is_backface_visible,
                 prim_size: prim_size.into(),
-                normalized_clip_rect: normalized_clip_rect.into(),
+                prim_relative_clip_rect: prim_relative_clip_rect.into(),
             },
             kind,
         }
@@ -995,7 +995,7 @@ impl PrimitiveKeyKind {
 pub struct PrimTemplateCommonData {
     pub is_backface_visible: bool,
     pub prim_size: LayoutSize,
-    pub normalized_clip_rect: LayoutRect,
+    pub prim_relative_clip_rect: LayoutRect,
     pub opacity: PrimitiveOpacity,
     /// The GPU cache handle for a primitive template. Since this structure
     /// is retained across display lists by interning, this GPU cache handle
@@ -1009,7 +1009,7 @@ impl PrimTemplateCommonData {
         PrimTemplateCommonData {
             is_backface_visible: common.is_backface_visible,
             prim_size: common.prim_size.into(),
-            normalized_clip_rect: common.normalized_clip_rect.into(),
+            prim_relative_clip_rect: common.prim_relative_clip_rect.into(),
             gpu_cache_handle: GpuCacheHandle::new(),
             opacity: PrimitiveOpacity::translucent(),
         }
@@ -1472,12 +1472,12 @@ impl intern::Internable for PrimitiveKeyKind {
     fn build_key(
         self,
         info: &LayoutPrimitiveInfo,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
     ) -> PrimitiveKey {
         PrimitiveKey::new(
             info.is_backface_visible,
             info.rect.size,
-            normalized_clip_rect,
+            prim_relative_clip_rect,
             self,
         )
     }
@@ -2859,7 +2859,7 @@ impl PrimitiveStore {
                     prim_data.prim_size,
                 );
                 let clip_rect = prim_data
-                    .normalized_clip_rect
+                    .prim_relative_clip_rect
                     .translate(&LayoutVector2D::new(prim_instance.prim_origin.x, prim_instance.prim_origin.y));
 
                 (prim_rect, clip_rect)
@@ -4323,10 +4323,10 @@ fn test_struct_sizes() {
     //     test expectations and move on.
     // (b) You made a structure larger. This is not necessarily a problem, but should only
     //     be done with care, and after checking if talos performance regresses badly.
-    assert_eq!(mem::size_of::<PrimitiveInstance>(), 120, "PrimitiveInstance size changed");
+    assert_eq!(mem::size_of::<PrimitiveInstance>(), 128, "PrimitiveInstance size changed");
     assert_eq!(mem::size_of::<PrimitiveInstanceKind>(), 40, "PrimitiveInstanceKind size changed");
-    assert_eq!(mem::size_of::<PrimitiveTemplate>(), 176, "PrimitiveTemplate size changed");
+    assert_eq!(mem::size_of::<PrimitiveTemplate>(), 168, "PrimitiveTemplate size changed");
     assert_eq!(mem::size_of::<PrimitiveTemplateKind>(), 112, "PrimitiveTemplateKind size changed");
-    assert_eq!(mem::size_of::<PrimitiveKey>(), 136, "PrimitiveKey size changed");
+    assert_eq!(mem::size_of::<PrimitiveKey>(), 128, "PrimitiveKey size changed");
     assert_eq!(mem::size_of::<PrimitiveKeyKind>(), 96, "PrimitiveKeyKind size changed");
 }

--- a/webrender/src/prim_store/text_run.rs
+++ b/webrender/src/prim_store/text_run.rs
@@ -36,13 +36,13 @@ pub struct TextRunKey {
 impl TextRunKey {
     pub fn new(
         info: &LayoutPrimitiveInfo,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
         text_run: TextRun,
     ) -> Self {
         TextRunKey {
             common: PrimKeyCommonData::with_info(
                 info,
-                normalized_clip_rect,
+                prim_relative_clip_rect,
             ),
             font: text_run.font,
             offset: text_run.offset.into(),
@@ -185,11 +185,11 @@ impl intern::Internable for TextRun {
     fn build_key(
         self,
         info: &LayoutPrimitiveInfo,
-        normalized_clip_rect: LayoutRect,
+        prim_relative_clip_rect: LayoutRect,
     ) -> TextRunKey {
         TextRunKey::new(
             info,
-            normalized_clip_rect,
+            prim_relative_clip_rect,
             self,
         )
     }
@@ -338,7 +338,7 @@ fn test_struct_sizes() {
     // (b) You made a structure larger. This is not necessarily a problem, but should only
     //     be done with care, and after checking if talos performance regresses badly.
     assert_eq!(mem::size_of::<TextRun>(), 112, "TextRun size changed");
-    assert_eq!(mem::size_of::<TextRunTemplate>(), 168, "TextRunTemplate size changed");
-    assert_eq!(mem::size_of::<TextRunKey>(), 144, "TextRunKey size changed");
+    assert_eq!(mem::size_of::<TextRunTemplate>(), 160, "TextRunTemplate size changed");
+    assert_eq!(mem::size_of::<TextRunKey>(), 136, "TextRunKey size changed");
     assert_eq!(mem::size_of::<TextRunPrimitive>(), 88, "TextRunPrimitive size changed");
 }

--- a/webrender/src/prim_store/text_run.rs
+++ b/webrender/src/prim_store/text_run.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AuHelpers, ColorF, DevicePixelScale, GlyphInstance, LayoutPrimitiveInfo};
-use api::{LayoutToWorldTransform, LayoutVector2DAu, RasterSpace};
+use api::{LayoutRect, LayoutToWorldTransform, LayoutVector2DAu, RasterSpace};
 use api::Shadow;
 use display_list_flattener::{AsInstanceKind, CreateShadow, IsVisible};
 use frame_builder::{FrameBuildingState, PictureContext};
@@ -34,9 +34,16 @@ pub struct TextRunKey {
 }
 
 impl TextRunKey {
-    pub fn new(info: &LayoutPrimitiveInfo, text_run: TextRun) -> Self {
+    pub fn new(
+        info: &LayoutPrimitiveInfo,
+        normalized_clip_rect: LayoutRect,
+        text_run: TextRun,
+    ) -> Self {
         TextRunKey {
-            common: PrimKeyCommonData::with_info(info),
+            common: PrimKeyCommonData::with_info(
+                info,
+                normalized_clip_rect,
+            ),
             font: text_run.font,
             offset: text_run.offset.into(),
             glyphs: text_run.glyphs,
@@ -175,8 +182,16 @@ impl intern::Internable for TextRun {
     type InternData = PrimitiveSceneData;
 
     /// Build a new key from self with `info`.
-    fn build_key(self, info: &LayoutPrimitiveInfo) -> TextRunKey {
-        TextRunKey::new(info, self)
+    fn build_key(
+        self,
+        info: &LayoutPrimitiveInfo,
+        normalized_clip_rect: LayoutRect,
+    ) -> TextRunKey {
+        TextRunKey::new(
+            info,
+            normalized_clip_rect,
+            self,
+        )
     }
 }
 


### PR DESCRIPTION
This allows sharing of primitive templates where the only difference
between two primitives is the local space position.

This also means that interning works as expected for primitives
sent by Gecko that contain baked in scroll offsets.

This patch changes the primitive rect only - the next step is a
follow up patch that makes the clip rect, and a few other params
in PrimitiveTemplateKind to also be in a true local space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3386)
<!-- Reviewable:end -->
