### PR TITLE
Fix a BlobImageRasterizer race condition.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1110,10 +1110,10 @@ impl RenderBackend {
             txn.blob_rasterizer = blob_rasterizer;
         }
 
-        if !transaction_msg.use_scene_builder_thread && txn.can_skip_scene_builder() {
-            if let Some(rasterizer) = txn.blob_rasterizer.take() {
-                self.resource_cache.set_blob_rasterizer(rasterizer);
-            }
+        if !transaction_msg.use_scene_builder_thread &&
+            txn.can_skip_scene_builder() &&
+            txn.blob_rasterizer.is_none() {
+
             self.update_document(
                 txn.document_id,
                 replace(&mut txn.resource_updates, Vec::new()),

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1082,7 +1082,7 @@ impl ResourceCache {
         &mut self,
         keys: &[BlobImageKey]
     ) -> (Option<Box<AsyncBlobImageRasterizer>>, Vec<BlobImageParams>) {
-        if self.blob_image_handler.is_none() {
+        if self.blob_image_handler.is_none() || keys.is_empty() {
             return (None, Vec::new());
         }
 


### PR DESCRIPTION
We can only make a blob image rasterizer the render backend thread's current rasterizer after it went through the scene builder thread, otherwise the rastirezer might race ahead of other rasterizers that are on going through the scene builder thread.

We also need to make sure that if there is a blob image update, we don't skip the scene builder thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3387)
<!-- Reviewable:end -->
