### PR TITLE
switch to using a Debian based Docker image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -18,19 +18,8 @@ metadata:
 # instances configured and running.
 tasks:
   # For the docker-worker tasks, the Docker image used
-  # (staktrace/webrender-test:freetype28) was created using this Dockerfile:
-  # ---
-  #   FROM ubuntu:16.04
-  #   RUN apt-get -y update && apt-get install -y curl git python python-pip cmake pkg-config libx11-dev libgl1-mesa-dev libfontconfig1-dev software-properties-common
-  #   RUN add-apt-repository -y -u ppa:glasen/freetype2
-  #   RUN apt-get -y install freetype2-demos
-  #   RUN pip install mako voluptuous PyYAML servo-tidy
-  #   RUN useradd -d /home/worker -s /bin/bash -m worker
-  #   USER worker
-  #   WORKDIR /home/worker
-  #   ENV PATH $PATH:/home/worker/.cargo/bin
-  #   CMD /bin/bash
-  # ---
+  # (staktrace/webrender-test:freetype28) was created using the Dockerfile in
+  # ci-scripts/docker-image.
   #
   # The docker image may need to be updated over time if the set of required
   # packages increases. Note in particular that rust/cargo are not part of the

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -18,7 +18,7 @@ metadata:
 # instances configured and running.
 tasks:
   # For the docker-worker tasks, the Docker image used
-  # (staktrace/webrender-test:freetype28) was created using the Dockerfile in
+  # (staktrace/webrender-test:debian) was created using the Dockerfile in
   # ci-scripts/docker-image.
   #
   # The docker image may need to be updated over time if the set of required
@@ -44,7 +44,7 @@ tasks:
           - master
     payload:
       maxRunTime: 7200
-      image: 'staktrace/webrender-test:freetype28'
+      image: 'staktrace/webrender-test:debian'
       env:
         RUST_BACKTRACE: 'full'
         RUSTFLAGS: '--deny warnings'
@@ -54,6 +54,7 @@ tasks:
         - '-c'
         - >-
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
+          source $HOME/.cargo/env &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
           servo-tidy &&
@@ -77,7 +78,7 @@ tasks:
           - master
     payload:
       maxRunTime: 7200
-      image: 'staktrace/webrender-test:freetype28'
+      image: 'staktrace/webrender-test:debian'
       env:
         RUST_BACKTRACE: 'full'
         RUSTFLAGS: '--deny warnings'
@@ -87,6 +88,7 @@ tasks:
         - '-c'
         - >-
           curl https://sh.rustup.rs -sSf | sh -s -- -y &&
+          source $HOME/.cargo/env &&
           git clone {{event.head.repo.url}} webrender && cd webrender &&
           git checkout {{event.head.sha}} &&
           servo-tidy &&

--- a/ci-scripts/docker-image/Dockerfile
+++ b/ci-scripts/docker-image/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:16.04
+RUN apt-get -y update && apt-get install -y curl git python python-pip cmake pkg-config libx11-dev libgl1-mesa-dev libfontconfig1-dev software-properties-common
+RUN add-apt-repository -y -u ppa:glasen/freetype2
+RUN apt-get -y install freetype2-demos
+RUN pip install mako voluptuous PyYAML servo-tidy
+RUN useradd -d /home/worker -s /bin/bash -m worker
+USER worker
+WORKDIR /home/worker
+ENV PATH $PATH:/home/worker/.cargo/bin
+CMD /bin/bash

--- a/ci-scripts/docker-image/Dockerfile
+++ b/ci-scripts/docker-image/Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:16.04
-RUN apt-get -y update && apt-get install -y curl git python python-pip cmake pkg-config libx11-dev libgl1-mesa-dev libfontconfig1-dev software-properties-common
-RUN add-apt-repository -y -u ppa:glasen/freetype2
-RUN apt-get -y install freetype2-demos
-RUN pip install mako voluptuous PyYAML servo-tidy
+FROM debian:stretch-20181112
+
+COPY setup.sh /root
+RUN cd /root && ./setup.sh
+
 RUN useradd -d /home/worker -s /bin/bash -m worker
 USER worker
 WORKDIR /home/worker
-ENV PATH $PATH:/home/worker/.cargo/bin
 CMD /bin/bash

--- a/ci-scripts/docker-image/setup.sh
+++ b/ci-scripts/docker-image/setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+test "$(whoami)" == 'root'
+
+# Install stuff we need
+apt-get -y update
+apt-get install -y \
+    cmake \
+    curl \
+    git \
+    libfontconfig1-dev \
+    libgl1-mesa-dev \
+    libx11-dev \
+    pkg-config \
+    python \
+    python-pip \
+    software-properties-common
+
+# Build freetype with subpixel rendering enabled
+curl -sSfL -o ft.tar.bz2 \
+    https://download.savannah.gnu.org/releases/freetype/freetype-2.8.1.tar.bz2
+tar xjf ft.tar.bz2
+cd freetype-2.8.1
+# Need to respect 80-char line limit for servo-tidy, or this would be neater
+SUBPIXEL_OPTION="FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
+sed --in-place="" \
+    -e "s/.*${SUBPIXEL_OPTION}.*/#define ${SUBPIXEL_OPTION}/" \
+    include/freetype/config/ftoption.h
+./configure
+make
+make install
+
+# Replace the system libfreetype with the one we just built
+cd /usr/lib/x86_64-linux-gnu/
+rm -f libfreetype.so.6
+ln -s /usr/local/lib/libfreetype.so.6
+
+# Other stuff we need
+pip install mako voluptuous PyYAML servo-tidy


### PR DESCRIPTION
This makes it easier to share the docker setup with the tasks that will run on Firefox CI, and gives us better docker image build reproducibility since Debian keeps snapshots of their old packages unlike Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3388)
<!-- Reviewable:end -->
