### PR TITLE
Add memory profile counters for interners.

### DIFF
--- a/webrender/src/intern.rs
+++ b/webrender/src/intern.rs
@@ -4,6 +4,7 @@
 
 use api::{LayoutPrimitiveInfo, LayoutRect};
 use internal_types::FastHashMap;
+use profiler::ResourceProfileCounter;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -153,6 +154,7 @@ impl<S, T, M> DataStore<S, T, M> where S: Debug, T: From<S>, M: Debug
     pub fn apply_updates(
         &mut self,
         update_list: UpdateList<S>,
+        profile_counter: &mut ResourceProfileCounter,
     ) {
         let mut data_iter = update_list.data.into_iter();
         for update in update_list.updates {
@@ -171,6 +173,10 @@ impl<S, T, M> DataStore<S, T, M> where S: Debug, T: From<S>, M: Debug
                 }
             }
         }
+
+        let per_item_size = mem::size_of::<S>() + mem::size_of::<T>();
+        profile_counter.set(self.items.len(), per_item_size * self.items.len());
+
         debug_assert!(data_iter.next().is_none());
     }
 }

--- a/webrender/src/profiler.rs
+++ b/webrender/src/profiler.rs
@@ -381,6 +381,7 @@ pub struct BackendProfileCounters {
     pub total_time: TimeProfileCounter,
     pub resources: ResourceProfileCounters,
     pub ipc: IpcProfileCounters,
+    pub intern: InternProfileCounters,
 }
 
 #[derive(Clone)]
@@ -398,6 +399,13 @@ pub struct IpcProfileCounters {
     pub send_time: TimeProfileCounter,
     pub total_time: TimeProfileCounter,
     pub display_lists: ResourceProfileCounter,
+}
+
+#[derive(Clone)]
+pub struct InternProfileCounters {
+    pub prims: ResourceProfileCounter,
+    pub text_runs: ResourceProfileCounter,
+    pub clips: ResourceProfileCounter,
 }
 
 impl IpcProfileCounters {
@@ -437,6 +445,11 @@ impl BackendProfileCounters {
                 send_time: TimeProfileCounter::new("Display List Send Time", false),
                 total_time: TimeProfileCounter::new("Total Display List Time", false),
                 display_lists: ResourceProfileCounter::new("Display Lists Sent"),
+            },
+            intern: InternProfileCounters {
+                prims: ResourceProfileCounter::new("Interned primitives"),
+                text_runs: ResourceProfileCounter::new("Interned text runs"),
+                clips: ResourceProfileCounter::new("Interned clips"),
             },
         }
     }
@@ -1076,6 +1089,17 @@ impl Profiler {
             &[
                 &backend_profile.resources.font_templates,
                 &backend_profile.resources.image_templates,
+            ],
+            debug_renderer,
+            true,
+            &mut self.draw_state
+        );
+
+        Profiler::draw_counters(
+            &[
+                &backend_profile.intern.clips,
+                &backend_profile.intern.prims,
+                &backend_profile.intern.text_runs,
             ],
             debug_renderer,
             true,

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1203,9 +1203,18 @@ impl RenderBackend {
         // If there are any additions or removals of clip modes
         // during the scene build, apply them to the data store now.
         if let Some(updates) = doc_resource_updates {
-            doc.resources.clip_data_store.apply_updates(updates.clip_updates);
-            doc.resources.prim_data_store.apply_updates(updates.prim_updates);
-            doc.resources.text_run_data_store.apply_updates(updates.text_run_updates);
+            doc.resources.clip_data_store.apply_updates(
+                updates.clip_updates,
+                &mut profile_counters.intern.clips,
+            );
+            doc.resources.prim_data_store.apply_updates(
+                updates.prim_updates,
+                &mut profile_counters.intern.prims,
+            );
+            doc.resources.text_run_data_store.apply_updates(
+                updates.text_run_updates,
+                &mut profile_counters.intern.text_runs,
+            );
         }
 
         // TODO: this scroll variable doesn't necessarily mean we scrolled. It is only used


### PR DESCRIPTION
This doesn't include indirect memory referenced by the interned
primitives (e.g. glyph arrays), but it's a start point, and gives
a good sense of how often new primitives are being interned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3391)
<!-- Reviewable:end -->
