### PR TITLE
Store glyphs in a normalized local space.

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -166,6 +166,8 @@ void main(void) {
     }
 
     Glyph glyph = fetch_glyph(ph.specific_prim_address, glyph_index);
+    glyph.offset += ph.local_rect.p0 - text.offset;
+
     GlyphResource res = fetch_glyph_resource(resource_address);
 
 #ifdef WR_FEATURE_GLYPH_TRANSFORM

--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -2340,12 +2340,21 @@ impl<'a> DisplayListFlattener<'a> {
             //           the primitive key, when the common case is that the
             //           hash will match and we won't end up creating a new
             //           primitive template.
-            let glyphs = display_list.get(glyph_range).collect();
+            let prim_offset = prim_info.rect.origin.to_vector() - offset;
+            let glyphs = display_list
+                .get(glyph_range)
+                .map(|glyph| {
+                    GlyphInstance {
+                        index: glyph.index,
+                        point: glyph.point - prim_offset,
+                    }
+                })
+                .collect();
 
             TextRun {
                 glyphs,
                 font,
-                offset: offset.to_au(),
+                offset,
                 shadow: false,
             }
         };


### PR DESCRIPTION
This prevents text runs being interned more often than they
should be when scrolling in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3395)
<!-- Reviewable:end -->
