### PR TITLE
Mark picture cached tiles as opaque.

### DIFF
--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1040,7 +1040,7 @@ impl AlphaBatchBuilder {
 
                                         let key = BatchKey::new(
                                             kind,
-                                            non_segmented_blend_mode,
+                                            BlendMode::None,
                                             BatchTextures::color(cache_item.texture_id),
                                         );
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -2189,11 +2189,15 @@ impl PicturePrimitive {
                 match tile_cache.dirty_region {
                     Some(ref dirty_region) => {
                         // Texture cache descriptor for each tile.
+                        // TODO(gw): If / when we start to use tile caches with
+                        //           clip masks and/or transparent backgrounds,
+                        //           we will need to correctly select an opacity
+                        //           here and a blend mode in batch.rs.
                         let descriptor = ImageDescriptor::new(
                             TILE_SIZE_DP,
                             TILE_SIZE_DP,
                             ImageFormat::BGRA8,
-                            false,          // TODO(gw): Detect when background color is opaque!
+                            true,
                             false,
                         );
 


### PR DESCRIPTION
We know that all picture cache tiles are opaque, for now, due to
the background color of the content frame being opaque. This
gives a good performance win by putting these tiles into the
opaque pass.

If we ever decide we want to support non-opaque tiles, we can
add the logic to handle this correctly at that time, making use
of the segment batching logic to draw the cached tiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3396)
<!-- Reviewable:end -->
