### PR TITLE
Set SCCACHE_IDLE_TIMEOUT=0 when starting the sccache server

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -133,7 +133,7 @@ tasks:
             servo-tidy
             sccache --stop-server || true
             mkdir -p ../artifacts
-            RUST_LOG=sccache=trace SCCACHE_ERROR_LOG=$PWD/../artifacts/sccache.log sccache --start-server
+            RUST_LOG=sccache=trace SCCACHE_ERROR_LOG=$PWD/../artifacts/sccache.log SCCACHE_IDLE_TIMEOUT=0 sccache --start-server
             export RUST_BACKTRACE=full
             export RUSTFLAGS='--deny warnings'
             export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig:$PKG_CONFIG_PATH"


### PR DESCRIPTION
This will prevent the sccache server from shutting down due to a lack of activity which can manifest as build failures. This is effectively a workaround for this sccache issue: https://github.com/mozilla/sccache/issues/204 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3403)
<!-- Reviewable:end -->
