### PR TITLE
Optimize the allocation of rasterized blobs a bit

### DIFF
--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -75,8 +75,13 @@ impl Transaction {
 
     fn rasterize_blobs(&mut self, is_low_priority: bool) {
         if let Some((ref mut rasterizer, _)) = self.blob_rasterizer {
-            let rasterized_blobs = rasterizer.rasterize(&self.blob_requests, is_low_priority);
-            self.rasterized_blobs.extend(rasterized_blobs);
+            let mut rasterized_blobs = rasterizer.rasterize(&self.blob_requests, is_low_priority);
+            // try using the existing allocation if our current list is empty
+            if self.rasterized_blobs.is_empty() {
+                self.rasterized_blobs = rasterized_blobs;
+            } else {
+                self.rasterized_blobs.append(&mut rasterized_blobs);
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #3398
Aimed to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1513521
Pending try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=26ea31fd69e8ed47167f33afefbd711424f0250a

I think it's harmless either way, waiting to see if talos results are back to normal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3405)
<!-- Reviewable:end -->
