### PR TITLE
Support picture caching where content rect moves between display lists.

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -115,6 +115,8 @@ impl Example for App {
     }
 
     fn on_event(&mut self, win_event: winit::WindowEvent, api: &RenderApi, document_id: DocumentId) -> bool {
+        let mut rebuild_display_list = false;
+
         match win_event {
             winit::WindowEvent::KeyboardInput {
                 input: winit::KeyboardInput {
@@ -129,6 +131,10 @@ impl Example for App {
                     winit::VirtualKeyCode::Up => (0.0, 0.1),
                     winit::VirtualKeyCode::Right => (1.0, 0.0),
                     winit::VirtualKeyCode::Left => (-1.0, 0.0),
+                    winit::VirtualKeyCode::R => {
+                        rebuild_display_list = true;
+                        (0.0, 0.0)
+                    }
                     _ => return false,
                 };
                 // Update the transform based on the keyboard input and push it to
@@ -172,7 +178,7 @@ impl Example for App {
             _ => (),
         }
 
-        false
+        rebuild_display_list
     }
 }
 

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{AlphaType, ClipMode, DeviceIntRect, DeviceIntPoint, DeviceIntSize};
-use api::{ExternalImageType, FilterOp, ImageRendering, LayoutRect, LayoutSize};
+use api::{ExternalImageType, FilterOp, ImageRendering, LayoutRect};
 use api::{YuvColorSpace, YuvFormat, PictureRect, ColorDepth, LayoutPoint};
 use clip::{ClipDataStore, ClipNodeFlags, ClipNodeRange, ClipItem, ClipStore};
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
@@ -1001,16 +1001,7 @@ impl AlphaBatchBuilder {
                                         }
 
                                         // Get the local rect of the tile.
-                                        let tile_rect = LayoutRect::new(
-                                            LayoutPoint::new(
-                                                (tile_cache.tile_rect.origin.x + x) as f32 * tile_cache.local_tile_size.width,
-                                                (tile_cache.tile_rect.origin.y + y) as f32 * tile_cache.local_tile_size.height,
-                                            ),
-                                            LayoutSize::new(
-                                                tile_cache.local_tile_size.width,
-                                                tile_cache.local_tile_size.height,
-                                            ),
-                                        );
+                                        let tile_rect = tile_cache.get_tile_rect(x, y);
 
                                         // Construct a local clip rect that ensures we only draw pixels where
                                         // the local bounds of the picture extend to within the edge tiles.

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -4,8 +4,8 @@
 
 use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint};
 use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel, PropertyBinding, PropertyBindingId};
-use api::{DevicePixelScale, RasterRect, RasterSpace, PictureSize, DeviceIntPoint, ColorF, ImageKey, DirtyRect};
-use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor};
+use api::{DevicePixelScale, RasterRect, RasterSpace, DeviceIntPoint, ColorF, ImageKey, DirtyRect};
+use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor, LayoutSize, LayoutPoint};
 use box_shadow::{BLUR_SAMPLE_SCALE};
 use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode};
 use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
@@ -50,6 +50,20 @@ use util::{TransformedRectKind, MatrixHelpers, MaxRect, RectHelpers};
 struct PictureInfo {
     /// The spatial node for this picture.
     spatial_node_index: SpatialNodeIndex,
+}
+
+/// Stores a map of cached picture tiles that are retained
+/// between new scenes.
+pub struct RetainedTiles {
+    pub tiles: FastHashMap<TileDescriptor, TextureCacheHandle>,
+}
+
+impl RetainedTiles {
+    pub fn new() -> Self {
+        RetainedTiles {
+            tiles: FastHashMap::default(),
+        }
+    }
 }
 
 /// Unit for tile coordinates.
@@ -302,14 +316,14 @@ impl TileDescriptor {
 #[derive(Debug)]
 pub struct DirtyRegion {
     tile_offset: DeviceIntPoint,
-    dirty_rect: PictureRect,
+    dirty_rect: LayoutRect,
     dirty_world_rect: WorldRect,
 }
 
 /// Represents a cache of tiles that make up a picture primitives.
 pub struct TileCache {
     /// The size of each tile in local-space coordinates of the picture.
-    pub local_tile_size: PictureSize,
+    pub local_tile_size: LayoutSize,
     /// List of tiles present in this picture (stored as a 2D array)
     pub tiles: Vec<Tile>,
     /// A set of tiles that were used last time we built
@@ -324,7 +338,7 @@ pub struct TileCache {
     /// about whether they changed since last frame.
     pub opacity_bindings: FastHashMap<PropertyBindingId, OpacityBindingInfo>,
     /// A helper struct to map local rects into picture coords.
-    pub space_mapper: SpaceMapper<LayoutPixel, PicturePixel>,
+    pub space_mapper: SpaceMapper<LayoutPixel, LayoutPixel>,
     /// If true, we need to update the prim dependencies, due
     /// to relative transforms changing. The dependencies are
     /// stored in each tile, and are a list of things that
@@ -337,6 +351,13 @@ pub struct TileCache {
     /// invalidating tiles if the surface transform changes.
     /// This is only relevant when raster_space == RasterSpace::Screen.
     raster_transform: TransformKey,
+
+    /// Contains the offset between the local picture rect that this
+    /// tile cache covers, and the aligned origin where tiles are
+    /// placed. This ensures that tiles are placed on correctly
+    /// aligned locations between new scenes when the enclosing
+    /// picture rect has a different local origin.
+    local_origin: LayoutPoint,
 }
 
 impl TileCache {
@@ -346,16 +367,17 @@ impl TileCache {
             tiles: Vec::new(),
             old_tiles: FastHashMap::default(),
             tile_rect: TileRect::zero(),
-            local_tile_size: PictureSize::zero(),
+            local_tile_size: LayoutSize::zero(),
             transforms: Vec::new(),
             opacity_bindings: FastHashMap::default(),
             needs_update: true,
             dirty_region: None,
             space_mapper: SpaceMapper::new(
                 ROOT_SPATIAL_NODE_INDEX,
-                PictureRect::zero(),
+                LayoutRect::zero(),
             ),
             raster_transform: TransformKey::Local,
+            local_origin: LayoutPoint::zero(),
         }
     }
 
@@ -368,6 +390,7 @@ impl TileCache {
         raster_spatial_node_index: SpatialNodeIndex,
         raster_space: RasterSpace,
         frame_context: &FrameBuildingContext,
+        pic_rect: LayoutRect,
     ) {
         // Initialize the space mapper with current bounds,
         // which is used during primitive dependency updates.
@@ -380,7 +403,7 @@ impl TileCache {
 
         let pic_bounds = world_mapper
             .unmap(&frame_context.screen_world_rect)
-            .unwrap_or(PictureRect::max_rect());
+            .unwrap_or(LayoutRect::max_rect());
 
         self.space_mapper = SpaceMapper::new(
             surface_spatial_node_index,
@@ -400,6 +423,7 @@ impl TileCache {
             .unmap(&world_tile_rect)
             .expect("bug: unable to get local tile size");
         self.local_tile_size = local_tile_rect.size;
+        self.local_origin = pic_rect.origin;
 
         // Walk the transforms and see if we need to rebuild the primitive
         // dependencies for each tile.
@@ -438,6 +462,7 @@ impl TileCache {
         // used later on during tile invalidation tests.
         let current_properties = frame_context.scene_properties.float_properties();
         let old_properties = mem::replace(&mut self.opacity_bindings, FastHashMap::default());
+
         for (id, value) in current_properties {
             let changed = match old_properties.get(id) {
                 Some(old_property) => !old_property.value.approx_eq(value),
@@ -528,6 +553,18 @@ impl TileCache {
             // Reset the size of the tile grid.
             self.tile_rect = TileRect::zero();
         }
+
+        // Get the tile coordinates in the picture space.
+        let pic_rect = TypedRect::from_untyped(&pic_rect.to_untyped());
+        let local_pic_rect = pic_rect.translate(&-self.local_origin.to_vector());
+
+        let x0 = (local_pic_rect.origin.x / self.local_tile_size.width).floor() as i32;
+        let y0 = (local_pic_rect.origin.y / self.local_tile_size.height).floor() as i32;
+        let x1 = ((local_pic_rect.origin.x + local_pic_rect.size.width) / self.local_tile_size.width).ceil() as i32;
+        let y1 = ((local_pic_rect.origin.y + local_pic_rect.size.height) / self.local_tile_size.height).ceil() as i32;
+
+        // Update the tile array allocation if needed.
+        self.reconfigure_tiles_if_required(x0, y0, x1, y1);
     }
 
     /// Resize the 2D tiles array if needed in order to fit dependencies
@@ -553,7 +590,11 @@ impl TileCache {
         let x_tiles = x1 - x0;
         let y_tiles = y1 - y0;
 
-        if self.tile_rect.size.width == x_tiles && self.tile_rect.size.height == y_tiles {
+        // Early exit if the tile configuration is the same.
+        if self.tile_rect.size.width == x_tiles &&
+           self.tile_rect.size.height == y_tiles &&
+           self.tile_rect.origin.x == x0 &&
+           self.tile_rect.origin.y == y0 {
             return;
         }
 
@@ -610,6 +651,10 @@ impl TileCache {
         opacity_binding_store: &OpacityBindingStorage,
         image_instances: &ImageInstanceStorage,
     ) {
+        if !self.needs_update {
+            return;
+        }
+
         self.space_mapper.set_target_spatial_node(
             prim_instance.spatial_node_index,
             clip_scroll_tree,
@@ -647,14 +692,14 @@ impl TileCache {
             return;
         }
 
+        // Translate the rectangle into the virtual tile space
+        let rect = rect.translate(&-self.local_origin.to_vector());
+
         // Get the tile coordinates in the picture space.
         let x0 = (rect.origin.x / self.local_tile_size.width).floor() as i32;
         let y0 = (rect.origin.y / self.local_tile_size.height).floor() as i32;
         let x1 = ((rect.origin.x + rect.size.width) / self.local_tile_size.width).ceil() as i32;
         let y1 = ((rect.origin.y + rect.size.height) / self.local_tile_size.height).ceil() as i32;
-
-        // Update the tile array allocation if needed.
-        self.reconfigure_tiles_if_required(x0, y0, x1, y1);
 
         // Build the list of resources that this primitive has dependencies on.
         let mut opacity_bindings: SmallVec<[PropertyBindingId; 4]> = SmallVec::new();
@@ -796,6 +841,17 @@ impl TileCache {
         }
     }
 
+    /// Get a local space rectangle for a given tile coordinate.
+    pub fn get_tile_rect(&self, x: i32, y: i32) -> LayoutRect {
+        LayoutRect::new(
+            LayoutPoint::new(
+                self.local_origin.x + (self.tile_rect.origin.x + x) as f32 * self.local_tile_size.width,
+                self.local_origin.y + (self.tile_rect.origin.y + y) as f32 * self.local_tile_size.height,
+            ),
+            self.local_tile_size,
+        )
+    }
+
     /// Build the dirty region(s) for the tile cache after all primitive
     /// dependencies have been updated.
     pub fn build_dirty_regions(
@@ -804,7 +860,7 @@ impl TileCache {
         frame_context: &FrameBuildingContext,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
-        retained_tiles: &mut FastHashMap<TileDescriptor, TextureCacheHandle>,
+        retained_tiles: &mut RetainedTiles,
     ) {
         self.needs_update = false;
 
@@ -824,12 +880,13 @@ impl TileCache {
             self.tile_rect.size.height,
         );
 
-        let mut dirty_rect = PictureRect::zero();
+        let mut dirty_rect = LayoutRect::zero();
 
         // Step through each tile and invalidate if the dependencies have changed.
         for y in 0 .. self.tile_rect.size.height {
             for x in 0 .. self.tile_rect.size.width {
                 let i = y * self.tile_rect.size.width + x;
+                let tile_rect = self.get_tile_rect(x, y);
                 let tile = &mut self.tiles[i as usize];
 
                 // If this tile is unused (has no primitives on it), we can just
@@ -837,14 +894,6 @@ impl TileCache {
                 if !tile.in_use {
                     continue;
                 }
-
-                let tile_rect = PictureRect::new(
-                    PicturePoint::new(
-                        (self.tile_rect.origin.x + x) as f32 * self.local_tile_size.width,
-                        (self.tile_rect.origin.y + y) as f32 * self.local_tile_size.height,
-                    ),
-                    self.local_tile_size,
-                );
 
                 // Check if this tile is actually visible.
                 let tile_world_rect = world_mapper
@@ -857,7 +906,8 @@ impl TileCache {
                 if tile.is_visible && !resource_cache.texture_cache.is_allocated(&tile.handle) {
                     // See if we have a retained tile from last scene that matches the
                     // exact content of this tile.
-                    if let Some(retained_handle) = retained_tiles.remove(&tile.descriptor) {
+
+                    if let Some(retained_handle) = retained_tiles.tiles.remove(&tile.descriptor) {
                         // Only use if not evicted from texture cache in the meantime.
                         if resource_cache.texture_cache.is_allocated(&retained_handle) {
                             // We found a matching tile from the previous scene, so use it!
@@ -943,17 +993,25 @@ impl TileCache {
     }
 }
 
+/// State structure that is used during the tile cache update picture traversal.
+pub struct TileCacheUpdateState {
+    pub tile_cache: Option<(TileCache, SpatialNodeIndex)>,
+}
+
+impl TileCacheUpdateState {
+    pub fn new() -> Self {
+        TileCacheUpdateState {
+            tile_cache: None,
+        }
+    }
+}
+
 /// Maintains a stack of picture and surface information, that
 /// is used during the initial picture traversal.
 pub struct PictureUpdateState<'a> {
     pub surfaces: &'a mut Vec<SurfaceInfo>,
     surface_stack: Vec<SurfaceIndex>,
     picture_stack: Vec<PictureInfo>,
-    /// A stack of currently active tile caches during traversal.
-    tile_cache_stack: Vec<TileCache>,
-    /// A ref count of how many tile caches on the stack actually
-    /// need to have their primitive dependencies updated.
-    tile_cache_update_count: usize,
 }
 
 impl<'a> PictureUpdateState<'a> {
@@ -962,8 +1020,6 @@ impl<'a> PictureUpdateState<'a> {
             surfaces,
             surface_stack: vec![SurfaceIndex(0)],
             picture_stack: Vec::new(),
-            tile_cache_stack: Vec::new(),
-            tile_cache_update_count: 0,
         }
     }
 
@@ -1013,30 +1069,6 @@ impl<'a> PictureUpdateState<'a> {
         &mut self,
     ) -> PictureInfo {
         self.picture_stack.pop().unwrap()
-    }
-
-    /// Push a tile cache onto the traversal state.
-    pub fn push_tile_cache(
-        &mut self,
-        tile_cache: TileCache,
-    ) {
-        if tile_cache.needs_update {
-            self.tile_cache_update_count += 1;
-        }
-        self.tile_cache_stack.push(tile_cache);
-    }
-
-    /// Pop a tile cache from the traversal state.
-    pub fn pop_tile_cache(
-        &mut self,
-    ) -> TileCache {
-        let tile_cache = self.tile_cache_stack.pop().unwrap();
-
-        if tile_cache.needs_update {
-            self.tile_cache_update_count -= 1;
-        }
-
-        tile_cache
     }
 }
 
@@ -1470,12 +1502,17 @@ impl PicturePrimitive {
     /// may be useful during the next scene build.
     pub fn destroy(
         mut self,
-        retained_tiles: &mut FastHashMap<TileDescriptor, TextureCacheHandle>,
+        retained_tiles: &mut RetainedTiles,
     ) {
         if let Some(tile_cache) = self.tile_cache.take() {
             debug_assert!(tile_cache.old_tiles.is_empty());
             for tile in tile_cache.tiles {
-                retained_tiles.extend(tile.destroy());
+                if let Some((descriptor, handle)) = tile.destroy() {
+                    retained_tiles.tiles.insert(
+                        descriptor,
+                        handle,
+                    );
+                }
             }
         }
     }
@@ -1686,33 +1723,9 @@ impl PicturePrimitive {
         self.prim_list = prim_list;
         self.state = Some((state, context));
 
-        match self.raster_config {
-            Some(ref raster_config) => {
-                let local_rect = frame_state.surfaces[raster_config.surface_index.0].rect;
-                let local_rect = LayoutRect::from_untyped(&local_rect.to_untyped());
-
-                // If the local rect changed (due to transforms in child primitives) then
-                // invalidate the GPU cache location to re-upload the new local rect
-                // and stretch size. Drop shadow filters also depend on the local rect
-                // size for the extra GPU cache data handle.
-                // TODO(gw): In future, if we support specifying a flag which gets the
-                //           stretch size from the segment rect in the shaders, we can
-                //           remove this invalidation here completely.
-                if self.local_rect != local_rect {
-                    frame_state.gpu_cache.invalidate(&self.gpu_location);
-                    if let PictureCompositeMode::Filter(FilterOp::DropShadow(..)) = raster_config.composite_mode {
-                        frame_state.gpu_cache.invalidate(&self.extra_gpu_data_handle);
-                    }
-                }
-
-                self.local_rect = local_rect;
-
-                Some(frame_state.clip_store.pop_surface())
-            }
-            None => {
-                None
-            }
-        }
+        self.raster_config.as_ref().map(|_| {
+            frame_state.clip_store.pop_surface()
+        })
     }
 
     pub fn take_state_and_context(&mut self) -> (PictureState, PictureContext) {
@@ -1917,20 +1930,6 @@ impl PicturePrimitive {
                 surface_index,
             });
 
-            // If we have a tile cache for this picture, see if any of the
-            // relative transforms have changed, which means we need to
-            // re-map the dependencies of any child primitives.
-            if let Some(mut tile_cache) = self.tile_cache.take() {
-                tile_cache.update_transforms(
-                    surface_spatial_node_index,
-                    raster_spatial_node_index,
-                    raster_space,
-                    frame_context,
-                );
-
-                state.push_tile_cache(tile_cache);
-            }
-
             // If we have a cache key / descriptor for this surface,
             // update any transforms it cares about.
             if let Some(ref mut surface_desc) = self.surface_desc {
@@ -1950,7 +1949,8 @@ impl PicturePrimitive {
     /// but only *if* the transforms have made the mappings out of date.
     pub fn update_prim_dependencies(
         &self,
-        state: &mut PictureUpdateState,
+        tile_cache: &mut TileCache,
+        surface_spatial_node_index: SpatialNodeIndex,
         frame_context: &FrameBuildingContext,
         resource_cache: &mut ResourceCache,
         resources: &FrameResources,
@@ -1959,26 +1959,18 @@ impl PicturePrimitive {
         opacity_binding_store: &OpacityBindingStorage,
         image_instances: &ImageInstanceStorage,
     ) {
-        if state.tile_cache_update_count == 0 {
-            return;
-        }
-
-        let surface_spatial_node_index = state.current_surface().surface_spatial_node_index;
-
         for prim_instance in &self.prim_list.prim_instances {
-            for tile_cache in &mut state.tile_cache_stack {
-                tile_cache.update_prim_dependencies(
-                    prim_instance,
-                    surface_spatial_node_index,
-                    &frame_context.clip_scroll_tree,
-                    resources,
-                    &clip_store.clip_chain_nodes,
-                    pictures,
-                    resource_cache,
-                    opacity_binding_store,
-                    image_instances,
-                );
-            }
+            tile_cache.update_prim_dependencies(
+                prim_instance,
+                surface_spatial_node_index,
+                &frame_context.clip_scroll_tree,
+                resources,
+                &clip_store.clip_chain_nodes,
+                pictures,
+                resource_cache,
+                opacity_binding_store,
+                image_instances,
+            );
         }
     }
 
@@ -1989,9 +1981,7 @@ impl PicturePrimitive {
         child_pictures: PictureList,
         state: &mut PictureUpdateState,
         frame_context: &FrameBuildingContext,
-        resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
-        retained_tiles: &mut FastHashMap<TileDescriptor, TextureCacheHandle>,
     ) {
         // Pop the state information about this picture.
         state.pop_picture();
@@ -2076,25 +2066,25 @@ impl PicturePrimitive {
         if let Some(ref raster_config) = self.raster_config {
             let surface_rect = state.current_surface().rect;
 
-            if let PictureCompositeMode::TileCache { .. } = raster_config.composite_mode {
-                let mut tile_cache = state.pop_tile_cache();
-
-                // Build the dirty region(s) for this tile cache.
-                tile_cache.build_dirty_regions(
-                    self.spatial_node_index,
-                    frame_context,
-                    resource_cache,
-                    gpu_cache,
-                    retained_tiles,
-                );
-
-                self.tile_cache = Some(tile_cache);
-            }
-
             let mut surface_rect = TypedRect::from_untyped(&surface_rect.to_untyped());
 
             // Pop this surface from the stack
             state.pop_surface();
+
+            // If the local rect changed (due to transforms in child primitives) then
+            // invalidate the GPU cache location to re-upload the new local rect
+            // and stretch size. Drop shadow filters also depend on the local rect
+            // size for the extra GPU cache data handle.
+            // TODO(gw): In future, if we support specifying a flag which gets the
+            //           stretch size from the segment rect in the shaders, we can
+            //           remove this invalidation here completely.
+            if self.local_rect != surface_rect {
+                gpu_cache.invalidate(&self.gpu_location);
+                if let PictureCompositeMode::Filter(FilterOp::DropShadow(..)) = raster_config.composite_mode {
+                    gpu_cache.invalidate(&self.extra_gpu_data_handle);
+                }
+            }
+            self.local_rect = surface_rect;
 
             // Drop shadows draw both a content and shadow rect, so need to expand the local
             // rect of any surfaces to be composited in parent surfaces correctly.

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -693,13 +693,13 @@ impl TileCache {
         }
 
         // Translate the rectangle into the virtual tile space
-        let rect = rect.translate(&-self.local_origin.to_vector());
+        let origin = rect.origin - self.local_origin;
 
         // Get the tile coordinates in the picture space.
-        let x0 = (rect.origin.x / self.local_tile_size.width).floor() as i32;
-        let y0 = (rect.origin.y / self.local_tile_size.height).floor() as i32;
-        let x1 = ((rect.origin.x + rect.size.width) / self.local_tile_size.width).ceil() as i32;
-        let y1 = ((rect.origin.y + rect.size.height) / self.local_tile_size.height).ceil() as i32;
+        let x0 = (origin.x / self.local_tile_size.width).floor() as i32;
+        let y0 = (origin.y / self.local_tile_size.height).floor() as i32;
+        let x1 = ((origin.x + rect.size.width) / self.local_tile_size.width).ceil() as i32;
+        let y1 = ((origin.y + rect.size.height) / self.local_tile_size.height).ceil() as i32;
 
         // Build the list of resources that this primitive has dependencies on.
         let mut opacity_bindings: SmallVec<[PropertyBindingId; 4]> = SmallVec::new();
@@ -2083,8 +2083,8 @@ impl PicturePrimitive {
                 if let PictureCompositeMode::Filter(FilterOp::DropShadow(..)) = raster_config.composite_mode {
                     gpu_cache.invalidate(&self.extra_gpu_data_handle);
                 }
+                self.local_rect = surface_rect;
             }
-            self.local_rect = surface_rect;
 
             // Drop shadows draw both a content and shadow rect, so need to expand the local
             // rect of any surfaces to be composited in parent surfaces correctly.

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -30,6 +30,7 @@ use frame_builder::{FrameBuilder, FrameBuilderConfig};
 use gpu_cache::GpuCache;
 use hit_test::{HitTest, HitTester};
 use internal_types::{DebugOutput, FastHashMap, FastHashSet, RenderedDocument, ResultMsg};
+use picture::RetainedTiles;
 use prim_store::{PrimitiveDataStore, PrimitiveScratchBuffer, PrimitiveInstance};
 use prim_store::{PrimitiveInstanceKind, PrimTemplateCommonData};
 use prim_store::gradient::{LinearGradientDataStore, RadialGradientDataStore};
@@ -548,7 +549,7 @@ impl Document {
         // Give the old frame builder a chance to destroy any resources.
         // Right now, all this does is build a hash map of any cached
         // surface tiles, that can be provided to the next frame builder.
-        let mut retained_tiles = FastHashMap::default();
+        let mut retained_tiles = RetainedTiles::new();
         if let Some(frame_builder) = self.frame_builder.take() {
             frame_builder.destroy(
                 &mut retained_tiles,


### PR DESCRIPTION
Gecko bakes scroll offsets into new display lists. Consider the
following example:

(a) WR receives a new display list.
(b) Scroll the display list, generating frames but not a new scene.
(c) Generate a new scene, due to hover / click etc.

In this case, the local coordinates of the primitives (and thus the
enclosing content rect) will be different between (a) and (c), due to
the current scroll offsets being baked into the local primitive rects.

Since this is non-trivial to change in Gecko, we need to ensure that
picture caching handles this case correctly.

There are two parts to this:

(a) Interned primitives must be stored and keyed in a true primitive
    local space, removing the local origin. Patches for this have
    already landed, and provide an optimization in cases where the
    same primitive template is instanced multiple times.
(b) Correctly create cache tiles even if the enclosing content rect
    has different coordinates. This is addressed by this patch.

We need to ensure that when generating tiles for a given content rect
the number of tiles (and local offsets) is the same for identical content,
regardless of the location of the content rect. To do this, we need to know
the local bounding rect of the enclosing content, and make tiles placed
relative to that. This moves the tile cache update pass to be done
*after* the initial picture traversal, so we know the content bounding
rect.

This also means we can reconfigure the tile grid once during
update_transforms, rather than checking after adding each primitive
whether we need to re-allocate the tile grid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3407)
<!-- Reviewable:end -->
