### PR TITLE
Check for alpha to be 0.0 in brush_fs

### DIFF
--- a/webrender/res/brush_blend.glsl
+++ b/webrender/res/brush_blend.glsl
@@ -150,7 +150,7 @@ Fragment brush_fs() {
 
     // Un-premultiply the input.
     float alpha = Cs.a;
-    vec3 color = Cs.rgb / Cs.a;
+    vec3 color = alpha != 0.0 ? Cs.rgb / alpha : Cs.rgb;
 
     switch (vOp) {
         case 0:


### PR DESCRIPTION
This is a follow up to #3377
Supposedly fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1513697
Pending try: https://treeherder.mozilla.org/#/jobs?repo=try&revision=6342e2c465fd8ab6591ab806ad3eba90ebe334ca

cc @emilio @staktrace @zakorgy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3411)
<!-- Reviewable:end -->
