### PR TITLE
Clear clip_node_instances on new frame builds.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -696,6 +696,11 @@ impl ClipStore {
         })
     }
 
+    pub fn clear_old_instances(&mut self) {
+        self.clip_node_instances.clear();
+    }
+
+
     /// Walk the clip chain of a primitive, and calculate a minimal
     /// local clip rect for the primitive.
     #[allow(dead_code)]

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -407,6 +407,7 @@ impl FrameBuilder {
             scene_properties,
             Some(&mut transform_palette),
         );
+        self.clip_store.clear_old_instances();
 
         let mut render_tasks = RenderTaskTree::new(stamp.frame_id());
         let mut surfaces = Vec::new();


### PR DESCRIPTION
The clip node instances are rebuilt for each frame built from a given
scene, but are not cleared until a new scene is built. So if a given
scene builds many frames, the clip node instances just accumulate and
eat up memory.

Fixes #3416.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3417)
<!-- Reviewable:end -->
