### PR TITLE
Save external images as PNGs

### DIFF
--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -5085,6 +5085,13 @@ impl Renderer {
                         .expect(&format!("Unable to create {}", short_path))
                         .write_all(&bytes)
                         .unwrap();
+                    #[cfg(feature = "png")]
+                    CaptureConfig::save_png(
+                        config.root.join(&short_path).with_extension("png"),
+                        def.descriptor.size,
+                        ReadPixelsFormat::Standard(def.descriptor.format),
+                        &bytes,
+                    );
                 }
                 let plain = PlainExternalImage {
                     data: short_path,


### PR DESCRIPTION
As we get more external images, this is useful to ease debugging.
r? @aosmond

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3419)
<!-- Reviewable:end -->
