### PR TITLE
Fix a picture caching race condition.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -490,8 +490,9 @@ impl FrameBuilder {
                 &mut z_generator,
             );
 
-            if let RenderPassKind::OffScreen { ref texture_cache, .. } = pass.kind {
+            if let RenderPassKind::OffScreen { ref texture_cache, ref color, .. } = pass.kind {
                 has_texture_cache_tasks |= !texture_cache.is_empty();
+                has_texture_cache_tasks |= color.must_be_drawn();
             }
         }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -732,13 +732,23 @@ impl TileCache {
 
         let prim_data = &resources.as_common_data(&prim_instance);
 
-        let prim_rect = LayoutRect::new(
-            prim_instance.prim_origin,
-            prim_data.prim_size,
-        );
-        let clip_rect = prim_data
-            .prim_relative_clip_rect
-            .translate(&prim_instance.prim_origin.to_vector());
+        let (prim_rect, clip_rect) = match prim_instance.kind {
+            PrimitiveInstanceKind::Picture { pic_index, .. } => {
+                let pic = &pictures[pic_index.0];
+                (pic.local_rect, LayoutRect::max_rect())
+            }
+            _ => {
+                let prim_rect = LayoutRect::new(
+                    prim_instance.prim_origin,
+                    prim_data.prim_size,
+                );
+                let clip_rect = prim_data
+                    .prim_relative_clip_rect
+                    .translate(&prim_instance.prim_origin.to_vector());
+
+                (prim_rect, clip_rect)
+            }
+        };
 
         // Map the primitive local rect into the picture space.
         // TODO(gw): We should maybe store this in the primitive template

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -860,7 +860,7 @@ impl TileCache {
             // We only care about clip nodes that have transforms that are children
             // of the surface, since clips that are positioned by parents will be
             // handled by the clip collector when these tiles are composited.
-            if clip_chain_node.spatial_node_index > surface_spatial_node_index {
+            if clip_chain_node.spatial_node_index >= surface_spatial_node_index {
                 clip_chain_spatial_nodes.push(clip_chain_node.spatial_node_index);
                 clip_chain_uids.push(clip_chain_node.handle.uid());
             }

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -110,6 +110,7 @@ pub trait RenderTarget {
     );
 
     fn needs_depth(&self) -> bool;
+    fn must_be_drawn(&self) -> bool;
 
     fn used_rect(&self) -> DeviceIntRect;
     fn add_used(&mut self, rect: DeviceIntRect);
@@ -256,6 +257,10 @@ impl<T: RenderTarget> RenderTargetList<T> {
 
     pub fn needs_depth(&self) -> bool {
         self.targets.iter().any(|target| target.needs_depth())
+    }
+
+    pub fn must_be_drawn(&self) -> bool {
+        self.targets.iter().any(|target| target.must_be_drawn())
     }
 
     pub fn check_ready(&self, t: &Texture) {
@@ -544,6 +549,10 @@ impl RenderTarget for ColorRenderTarget {
         }
     }
 
+    fn must_be_drawn(&self) -> bool {
+        !self.tile_blits.is_empty()
+    }
+
     fn needs_depth(&self) -> bool {
         self.alpha_batch_containers.iter().any(|ab| {
             !ab.opaque_batches.is_empty()
@@ -671,6 +680,10 @@ impl RenderTarget for AlphaRenderTarget {
     }
 
     fn needs_depth(&self) -> bool {
+        false
+    }
+
+    fn must_be_drawn(&self) -> bool {
         false
     }
 


### PR DESCRIPTION
Sometimes, the render backend produces frames faster than they
can be drawn by the renderer. The renderer has a code path for
this situation that drops frames in the render queue if there
are more recent frames to draw.

However, if the frame contains render tasks that will be persisted
in the texture cache, that frame must be executed in order to
ensure the texture cache is updated.

This patch extends that check to also consider render tasks that
will be blitted to the texture cache as a result of picture
caching.

This case occurs very rarely in real world usage, but _does_
occur quite commonly when running reftests on CI where the
time spent building simple frames is often much less than the
time for the software rasterizer to draw them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3424)
<!-- Reviewable:end -->
