### PR TITLE
make SubpixelOffset::quantize less fragile with unexpected values

### DIFF
--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -350,11 +350,10 @@ impl SubpixelOffset {
         let apos = ((pos - pos.floor()) * 8.0) as i32;
 
         match apos {
-            0 | 7 => SubpixelOffset::Zero,
             1...2 => SubpixelOffset::Quarter,
             3...4 => SubpixelOffset::Half,
             5...6 => SubpixelOffset::ThreeQuarters,
-            _ => unreachable!("bug: unexpected quantized result"),
+            _ => SubpixelOffset::Zero,
         }
     }
 }


### PR DESCRIPTION
This resolves Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1509229

When we encounter unexpected values due to floating point precision issues, we can crash. Rather than try to belabor things trying to do anything fancy, it makes most sense to just zero out the subpixel offset in those cases rather than leave the code brittle with crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3425)
<!-- Reviewable:end -->
