### PR TITLE
Properly handle nested sticky nodes

### DIFF
--- a/webrender/src/spatial_node.rs
+++ b/webrender/src/spatial_node.rs
@@ -481,6 +481,9 @@ impl SpatialNode {
                 // offsets actually adjust the node position itself, whereas scroll offsets
                 // only apply to contents inside the node.
                 state.parent_accumulated_scroll_offset += info.current_offset;
+                // We want nested sticky items to take into account the shift
+                // we applied as well.
+                state.nearest_scrolling_ancestor_offset += info.current_offset;
             }
             SpatialNodeType::ScrollFrame(ref scrolling) => {
                 state.parent_accumulated_scroll_offset += scrolling.offset;

--- a/wrench/reftests/scrolling/nested-stickys-ref.yaml
+++ b/wrench/reftests/scrolling/nested-stickys-ref.yaml
@@ -1,0 +1,11 @@
+root:
+  items:
+    # This is a scroll frame with an out-of-viewport rect that should be pushed into the
+    # viewport by its "bottom" sticky constraint.
+    - type: scroll-frame
+      bounds: [10, 10, 50, 50]
+      content-size: [200, 200]
+      items:
+        - type: rect
+          bounds: [10, 20, 50, 50]
+          color: green

--- a/wrench/reftests/scrolling/nested-stickys.yaml
+++ b/wrench/reftests/scrolling/nested-stickys.yaml
@@ -1,0 +1,20 @@
+root:
+  items:
+    - type: scroll-frame
+      bounds: [10, 10, 50, 50]
+      content-size: [200, 200]
+      scroll-offset: [0, 30]
+      items:
+      - type: sticky-frame
+        bounds: [10, 30, 50, 50]
+        margin-top: 5
+        vertical-offset-bounds: [0, 500]
+        items:
+        - type: sticky-frame
+          bounds: [10, 30, 50, 50]
+          margin-top: 10
+          vertical-offset-bounds: [0, 500]
+          items:
+          - type: rect
+            bounds: [10, 30, 50, 50]
+            color: green

--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -15,3 +15,4 @@
 == sticky-transformed.yaml sticky-transformed-ref.yaml
 == sibling-hidden-clip.yaml sibling-hidden-clip-ref.yaml
 == scale-offsets.yaml scale-offsets-ref.yaml
+== nested-stickys.yaml nested-stickys-ref.yaml


### PR DESCRIPTION
It's possible to have a nested sticky node (i.e. a scrollframe that
contains a sticky node descendant which contains another sticky node
descendant). In this case, we want the scroll offset from the outer
sticky node to be used in the computation for the inner sticky node in
order to produce correct behaviour.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1495962, which
includes Gecko reftests that exercise this scenario.

r? @kvark or @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3427)
<!-- Reviewable:end -->
