### PR TITLE
More version pinning of docker packages

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -18,7 +18,7 @@ metadata:
 # instances configured and running.
 tasks:
   # For the docker-worker tasks, the Docker image used
-  # (staktrace/webrender-test:debian-v2) was created using the Dockerfile in
+  # (staktrace/webrender-test:debian-v3) was created using the Dockerfile in
   # ci-scripts/docker-image.
   #
   # The docker image may need to be updated over time if the set of required
@@ -44,7 +44,7 @@ tasks:
           - master
     payload:
       maxRunTime: 7200
-      image: 'staktrace/webrender-test:debian-v2'
+      image: 'staktrace/webrender-test:debian-v3'
       env:
         RUST_BACKTRACE: 'full'
         RUSTFLAGS: '--deny warnings'
@@ -78,7 +78,7 @@ tasks:
           - master
     payload:
       maxRunTime: 7200
-      image: 'staktrace/webrender-test:debian-v2'
+      image: 'staktrace/webrender-test:debian-v3'
       env:
         RUST_BACKTRACE: 'full'
         RUSTFLAGS: '--deny warnings'

--- a/ci-scripts/docker-image/setup.sh
+++ b/ci-scripts/docker-image/setup.sh
@@ -25,28 +25,22 @@ apt-get install -y \
     libx11-dev \
     pkg-config \
     python \
+    python-mako \
     python-pip \
+    python-setuptools \
+    python-voluptuous \
+    python-yaml \
     software-properties-common
 
-# Build freetype with subpixel rendering enabled
-curl -sSfL -o ft.tar.bz2 \
-    https://download.savannah.gnu.org/releases/freetype/freetype-2.8.1.tar.bz2
-tar xjf ft.tar.bz2
-cd freetype-2.8.1
-# Need to respect 80-char line limit for servo-tidy, or this would be neater
-SUBPIXEL_OPTION="FT_CONFIG_OPTION_SUBPIXEL_RENDERING"
-sed --in-place="" \
-    -e "s/.*${SUBPIXEL_OPTION}.*/#define ${SUBPIXEL_OPTION}/" \
-    include/freetype/config/ftoption.h
-./configure
-make
-make install
-
-# Replace the system libfreetype with the one we just built
-cd /usr/lib/x86_64-linux-gnu/
-rm -f libfreetype.so.6
-ln -s /usr/local/lib/libfreetype.so.6
+# Get freetype 2.8 with subpixel rendering enabled. The SNAPSHOT_ARCHIVE
+# variable is just to work around servo-tidy's moronic 80-char width limit
+# in shell scripts.
+SNAPSHOT_ARCHIVE=http://snapshot.debian.org/archive/debian/20180213T153535Z
+curl -sSfL -o libfreetype6.deb \
+  "${SNAPSHOT_ARCHIVE}/pool/main/f/freetype/libfreetype6_2.8.1-2_amd64.deb"
+curl -sSfL -o libfreetype6-dev.deb \
+  "${SNAPSHOT_ARCHIVE}/pool/main/f/freetype/libfreetype6-dev_2.8.1-2_amd64.deb"
+apt install -y ./libfreetype6.deb ./libfreetype6-dev.deb
 
 # Other stuff we need
-pip install setuptools
-pip install mako voluptuous PyYAML servo-tidy
+pip install servo-tidy==0.3.0


### PR DESCRIPTION
Installing with pip is also unsafe in that it will just use the latest
version and so the resulting behaviour will be dependent on when the
docker image is built. This switches to use debian packages instead of
pip where possible, and locks a particular version for the remaining
python package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3434)
<!-- Reviewable:end -->
