### PR TITLE
Fix out of bounds access of clip tasks in rare conditions.

### DIFF
--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -1591,6 +1591,12 @@ impl PrimitiveInstance {
         }
     }
 
+    // Reset any pre-frame state for this primitive.
+    pub fn reset(&mut self) {
+        self.bounding_rect = None;
+        self.clip_task_index = ClipTaskIndex::INVALID;
+    }
+
     #[cfg(debug_assertions)]
     pub fn is_chased(&self) -> bool {
         PRIM_CHASE_ID.load(Ordering::SeqCst) == self.id.0
@@ -2384,7 +2390,7 @@ impl PrimitiveStore {
         scratch: &mut PrimitiveScratchBuffer,
     ) {
         for (plane_split_anchor, prim_instance) in prim_list.prim_instances.iter_mut().enumerate() {
-            prim_instance.bounding_rect = None;
+            prim_instance.reset();
 
             if prim_instance.is_chased() {
                 #[cfg(debug_assertions)]
@@ -3386,9 +3392,6 @@ impl PrimitiveInstance {
         if self.is_chased() {
             println!("\tupdating clip task with pic rect {:?}", clip_chain.pic_clip_rect);
         }
-
-        // Reset clips from previous frames since we may clip differently each frame.
-        self.clip_task_index = ClipTaskIndex::INVALID;
 
         self.build_segments_if_needed(
             prim_local_rect,


### PR DESCRIPTION
In rare cases, a picture primitive may have a surface (e.g. due
to opacity) on one frame, and then become a pass-through primitive
on the next frame (e.g. opacity is animated to 1).

In these cases, it was possible that the primitive instance for
the picture has a clip task index set from the previous frame
that is not correctly reset. This can cause an out of bounds
access of the scratch buffer clip instances array during
batching.

To ensure this can't happen, reset the clip task index for the
primitive instance to invalid as early as possible (at the same
time the primitive instance visibility is reset).