### PR TITLE
Optimize pop_stacking_context.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -1325,7 +1325,14 @@ impl<'a> DisplayListFlattener<'a> {
                 parent_sc,
                 self.clip_scroll_tree,
             ) {
-                parent_sc.primitives.extend(stacking_context.primitives);
+                // If the parent context primitives list is empty, it's faster
+                // to assign the storage of the popped context instead of paying
+                // the copying cost for extend.
+                if parent_sc.primitives.is_empty() {
+                    parent_sc.primitives = stacking_context.primitives;
+                } else {
+                    parent_sc.primitives.extend(stacking_context.primitives);
+                }
                 return;
             }
         }


### PR DESCRIPTION
Profiling showed that the `parent_sc.primitives.extend(...)` was a hot spot in
scene building.  Further investigation showed that `parent_sc.primitives` is empty
a majority of the time, so copy the storage instead of copying all the elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3439)
<!-- Reviewable:end -->
