### PR TITLE
Render cached render tasks in a separate pass. 

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -435,6 +435,10 @@ impl FrameBuilder {
                                                        &mut render_tasks,
                                                        texture_cache_profile);
 
+        // TODO(emilio): Now that cached render tasks know how to create these
+        // extra passes, are the special render passes needed? i.e., does
+        // anything depend on the alpha -> color ordering? If not, seems we
+        // could just ditch them.
         let mut passes = vec![
             special_render_passes.alpha_glyph_pass,
             special_render_passes.color_glyph_pass,

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -440,7 +440,30 @@ impl FrameBuilder {
             special_render_passes.color_glyph_pass,
         ];
 
+        {
+            let passes_start = passes.len();
+            let mut required_pass_count = 0;
+            for cacheable_render_task in &render_tasks.cacheable_render_tasks {
+                render_tasks.max_depth(
+                    *cacheable_render_task,
+                    0,
+                    &mut required_pass_count,
+                );
+            }
+            for _ in 0 .. required_pass_count {
+                passes.push(RenderPass::new_off_screen(screen_size));
+            }
+            for cacheable_render_task in &render_tasks.cacheable_render_tasks {
+                render_tasks.assign_to_passes(
+                    *cacheable_render_task,
+                    required_pass_count - 1,
+                    &mut passes[passes_start..],
+                );
+            }
+        }
+
         if let Some(main_render_task_id) = main_render_task_id {
+            let passes_start = passes.len();
             let mut required_pass_count = 0;
             render_tasks.max_depth(main_render_task_id, 0, &mut required_pass_count);
             assert_ne!(required_pass_count, 0);
@@ -455,7 +478,7 @@ impl FrameBuilder {
             render_tasks.assign_to_passes(
                 main_render_task_id,
                 required_pass_count - 1,
-                &mut passes[2..],
+                &mut passes[passes_start..],
             );
         }
 

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -2286,7 +2286,6 @@ impl PrimitiveStore {
                     //           based on the current transform?
                     let scale_factor = TypedScale::new(1.0) * frame_context.device_pixel_scale;
                     let task_size = (LayoutSize::from_au(cache_key.size) * scale_factor).ceil().to_i32();
-                    let surfaces = &mut frame_state.surfaces;
 
                     // Request a pre-rendered image task.
                     // TODO(gw): This match is a bit untidy, but it should disappear completely
@@ -2310,9 +2309,7 @@ impl PrimitiveStore {
                                 cache_key.wavy_line_thickness.to_f32_px(),
                                 LayoutSize::from_au(cache_key.size),
                             );
-                            let task_id = render_tasks.add(task);
-                            surfaces[pic_context.surface_index.0].tasks.push(task_id);
-                            task_id
+                            render_tasks.add(task)
                         }
                     ));
                 }
@@ -2376,7 +2373,6 @@ impl PrimitiveStore {
                 // from the render task cache. This ensures that the render task for
                 // this segment will be available for batching later in the frame.
                 let mut handles: SmallVec<[RenderTaskCacheEntryHandle; 8]> = SmallVec::new();
-                let surfaces = &mut frame_state.surfaces;
 
                 for segment in &border_data.border_segments {
                     // Update the cache key device size based on requested scale.
@@ -2403,11 +2399,7 @@ impl PrimitiveStore {
                                 ),
                             );
 
-                            let task_id = render_tasks.add(task);
-
-                            surfaces[pic_context.surface_index.0].tasks.push(task_id);
-
-                            task_id
+                            render_tasks.add(task)
                         }
                     ));
                 }
@@ -2460,11 +2452,7 @@ impl PrimitiveStore {
 
                 // Update the template this instane references, which may refresh the GPU
                 // cache with any shared template data.
-                image_data.update(
-                    pic_context.surface_index,
-                    common_data,
-                    frame_state,
-                );
+                image_data.update(common_data, frame_state);
 
                 let image_instance = &mut self.images[*image_instance_index];
 


### PR DESCRIPTION
This prevents us from culling out the picture that contains that render task and
making other pictures that hit the cache and need it from finding that the task
was not drawn.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1503373, and similar issues with line decorations and such.

I think it also allows us to get rid of the `SpecialRenderPasses` that pathfinder uses, but I've left a FIXME instead for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3444)
<!-- Reviewable:end -->
