### PR TITLE
render_task: Assign passes in a single pass.

### DIFF
--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -27,7 +27,6 @@ use spatial_node::SpatialNode;
 use std::{f32, mem};
 use std::sync::Arc;
 use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext};
-use tiling::{SpecialRenderPasses};
 
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -86,7 +85,6 @@ pub struct FrameBuildingState<'a> {
     pub clip_store: &'a mut ClipStore,
     pub resource_cache: &'a mut ResourceCache,
     pub gpu_cache: &'a mut GpuCache,
-    pub special_render_passes: &'a mut SpecialRenderPasses,
     pub transforms: &'a mut TransformPalette,
     pub segment_builder: SegmentBuilder,
     pub surfaces: &'a mut Vec<SurfaceInfo>,
@@ -210,7 +208,6 @@ impl FrameBuilder {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
-        special_render_passes: &mut SpecialRenderPasses,
         profile_counters: &mut FrameProfileCounters,
         device_pixel_scale: DevicePixelScale,
         scene_properties: &SceneProperties,
@@ -308,7 +305,6 @@ impl FrameBuilder {
             clip_store: &mut self.clip_store,
             resource_cache,
             gpu_cache,
-            special_render_passes,
             transforms: transform_palette,
             segment_builder: SegmentBuilder::new(),
             surfaces: pic_update_state.surfaces,
@@ -413,7 +409,6 @@ impl FrameBuilder {
         let mut surfaces = Vec::new();
 
         let screen_size = self.screen_rect.size.to_i32();
-        let mut special_render_passes = SpecialRenderPasses::new(&screen_size);
 
         let main_render_task_id = self.build_layer_screen_rects_and_cull_layers(
             clip_scroll_tree,
@@ -421,7 +416,6 @@ impl FrameBuilder {
             resource_cache,
             gpu_cache,
             &mut render_tasks,
-            &mut special_render_passes,
             &mut profile_counters,
             device_pixel_scale,
             scene_properties,
@@ -435,56 +429,34 @@ impl FrameBuilder {
                                                        &mut render_tasks,
                                                        texture_cache_profile);
 
-        // TODO(emilio): Now that cached render tasks know how to create these
-        // extra passes, are the special render passes needed? i.e., does
-        // anything depend on the alpha -> color ordering? If not, seems we
-        // could just ditch them.
-        let mut passes = vec![
-            special_render_passes.alpha_glyph_pass,
-            special_render_passes.color_glyph_pass,
-        ];
+        let mut passes = vec![];
 
-        {
-            let passes_start = passes.len();
-            let mut required_pass_count = 0;
-            for cacheable_render_task in &render_tasks.cacheable_render_tasks {
-                render_tasks.max_depth(
-                    *cacheable_render_task,
-                    0,
-                    &mut required_pass_count,
-                );
-            }
-            for _ in 0 .. required_pass_count {
-                passes.push(RenderPass::new_off_screen(screen_size));
-            }
+        // Add passes as required for our cached render tasks.
+        if !render_tasks.cacheable_render_tasks.is_empty() {
+            passes.push(RenderPass::new_off_screen(screen_size));
             for cacheable_render_task in &render_tasks.cacheable_render_tasks {
                 render_tasks.assign_to_passes(
                     *cacheable_render_task,
-                    required_pass_count - 1,
-                    &mut passes[passes_start..],
+                    0,
+                    screen_size,
+                    &mut passes,
                 );
             }
+            passes.reverse();
         }
 
         if let Some(main_render_task_id) = main_render_task_id {
             let passes_start = passes.len();
-            let mut required_pass_count = 0;
-            render_tasks.max_depth(main_render_task_id, 0, &mut required_pass_count);
-            assert_ne!(required_pass_count, 0);
-
-            // Do the allocations now, assigning each tile's tasks to a render
-            // pass and target as required.
-            for _ in 0 .. required_pass_count - 1 {
-                passes.push(RenderPass::new_off_screen(screen_size));
-            }
             passes.push(RenderPass::new_main_framebuffer(screen_size));
-
             render_tasks.assign_to_passes(
                 main_render_task_id,
-                required_pass_count - 1,
-                &mut passes[passes_start..],
+                passes_start,
+                screen_size,
+                &mut passes,
             );
+            passes[passes_start..].reverse();
         }
+
 
         let mut deferred_resolves = vec![];
         let mut has_texture_cache_tasks = false;

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -710,8 +710,6 @@ mod test_glyph_rasterizer {
         use texture_cache::TextureCache;
         use glyph_cache::GlyphCache;
         use gpu_cache::GpuCache;
-        use tiling::SpecialRenderPasses;
-        use api::DeviceIntSize;
         use render_task::{RenderTaskCache, RenderTaskTree};
         use profiler::TextureCacheProfileCounters;
         use api::{FontKey, FontTemplate, FontRenderMode,
@@ -735,8 +733,6 @@ mod test_glyph_rasterizer {
         let mut texture_cache = TextureCache::new_for_testing(2048, 1024);
         let mut render_task_cache = RenderTaskCache::new();
         let mut render_task_tree = RenderTaskTree::new(FrameId::INVALID);
-        let mut special_render_passes = SpecialRenderPasses::new(&DeviceIntSize::new(1366, 768));
-
         let mut font_file =
             File::open("../wrench/reftests/text/VeraBd.ttf").expect("Couldn't open font file");
         let mut font_data = vec![];
@@ -778,7 +774,6 @@ mod test_glyph_rasterizer {
                 &mut gpu_cache,
                 &mut render_task_cache,
                 &mut render_task_tree,
-                &mut special_render_passes,
             );
         }
 

--- a/webrender/src/glyph_rasterizer/no_pathfinder.rs
+++ b/webrender/src/glyph_rasterizer/no_pathfinder.rs
@@ -19,7 +19,6 @@ use resource_cache::CachedImageData;
 use texture_cache::{TextureCache, TextureCacheHandle, Eviction};
 use gpu_cache::GpuCache;
 use render_task::{RenderTaskTree, RenderTaskCache};
-use tiling::SpecialRenderPasses;
 use profiler::TextureCacheProfileCounters;
 use std::collections::hash_map::Entry;
 
@@ -46,7 +45,6 @@ impl GlyphRasterizer {
         gpu_cache: &mut GpuCache,
         _: &mut RenderTaskCache,
         _: &mut RenderTaskTree,
-        _: &mut SpecialRenderPasses,
     ) {
         assert!(
             self.font_contexts

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -2340,7 +2340,6 @@ impl PrimitiveStore {
                     frame_state.resource_cache,
                     frame_state.gpu_cache,
                     frame_state.render_tasks,
-                    frame_state.special_render_passes,
                     scratch,
                 );
             }

--- a/webrender/src/prim_store/text_run.rs
+++ b/webrender/src/prim_store/text_run.rs
@@ -15,7 +15,6 @@ use prim_store::{PrimitiveStore, PrimKeyCommonData, PrimTemplateCommonData, Vect
 use render_task::{RenderTaskTree};
 use renderer::{MAX_VERTEX_TEXTURE_WIDTH};
 use resource_cache::{ResourceCache};
-use tiling::SpecialRenderPasses;
 use util::{MatrixHelpers};
 use prim_store::PrimitiveInstanceKind;
 use std::ops;
@@ -298,7 +297,6 @@ impl TextRunPrimitive {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         render_tasks: &mut RenderTaskTree,
-        special_render_passes: &mut SpecialRenderPasses,
         scratch: &mut PrimitiveScratchBuffer,
     ) {
         let cache_dirty = self.update_font_instance(
@@ -326,7 +324,6 @@ impl TextRunPrimitive {
             &scratch.glyph_keys[self.glyph_keys_range],
             gpu_cache,
             render_tasks,
-            special_render_passes,
         );
     }
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -45,7 +45,6 @@ use std::os::raw::c_void;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use texture_cache::{TextureCache, TextureCacheHandle, Eviction};
-use tiling::SpecialRenderPasses;
 use util::drain_filter;
 
 const DEFAULT_TILE_SIZE: TileSize = 512;
@@ -1296,7 +1295,6 @@ impl ResourceCache {
         glyph_keys: &[GlyphKey],
         gpu_cache: &mut GpuCache,
         render_task_tree: &mut RenderTaskTree,
-        render_passes: &mut SpecialRenderPasses,
     ) {
         debug_assert_eq!(self.state, State::AddResources);
 
@@ -1309,7 +1307,6 @@ impl ResourceCache {
             gpu_cache,
             &mut self.cached_render_tasks,
             render_task_tree,
-            render_passes,
         );
     }
 

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -1159,17 +1159,3 @@ impl ScalingTask {
         instances.push(instance);
     }
 }
-
-pub struct SpecialRenderPasses {
-    pub alpha_glyph_pass: RenderPass,
-    pub color_glyph_pass: RenderPass,
-}
-
-impl SpecialRenderPasses {
-    pub fn new(screen_size: &DeviceIntSize) -> SpecialRenderPasses {
-        SpecialRenderPasses {
-            alpha_glyph_pass: RenderPass::new_off_screen(*screen_size),
-            color_glyph_pass: RenderPass::new_off_screen(*screen_size),
-        }
-    }
-}


### PR DESCRIPTION
Right now creating render passes is a three-step process:

 * You first go through the render task tree and figure out the max depth.
 * You allocate as many passes as needed.
 * You traverse the whole tree again assigning to those passes.

This patch makes it so that assign_to_passes is responsible to grow the passes
vector with offscreen passes lazily as needed, and its caller is responsible to
reverse the array so that the passes end up in order.

Thus so that we can build the pass list in a single pass (no pun intended) as we
traverse down the tree.

This also removes the SpecialRenderPasses because now that cached render tasks
know how to create passes as needed I'm pretty sure it's not needed. There's no
dependency between the two passes I could think of, looking at the code, and all
the tasks use color render targets, so I think they're unnecessary.

And in any case they should be easy to add back, should pathfinder really needed
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3445)
<!-- Reviewable:end -->
