### PR TITLE
Make picture caching more performant, and fix some bugs.

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -41,10 +41,18 @@ impl App {
         color: ColorF,
         builder: &mut DisplayListBuilder,
         property_key: PropertyBindingKey<LayoutTransform>,
+        opacity_key: Option<PropertyBindingKey<f32>>,
     ) {
-        let filters = [
-            FilterOp::Opacity(PropertyBinding::Binding(self.opacity_key, self.opacity), self.opacity),
-        ];
+        let filters = match opacity_key {
+            Some(opacity_key) => {
+                vec![
+                    FilterOp::Opacity(PropertyBinding::Binding(opacity_key, self.opacity), self.opacity),
+                ]
+            }
+            None => {
+                vec![]
+            }
+        };
 
         let reference_frame_id = builder.push_reference_frame(
             &LayoutPrimitiveInfo::new(LayoutRect::new(bounds.origin, LayoutSize::zero())),
@@ -89,8 +97,8 @@ impl App {
 }
 
 impl Example for App {
-    const WIDTH: u32 = 1024;
-    const HEIGHT: u32 = 1024;
+    const WIDTH: u32 = 2048;
+    const HEIGHT: u32 = 1536;
 
     fn render(
         &mut self,
@@ -101,17 +109,19 @@ impl Example for App {
         _pipeline_id: PipelineId,
         _document_id: DocumentId,
     ) {
+        let opacity_key = self.opacity_key;
+
         let bounds = (150, 150).to(250, 250);
         let key0 = self.property_key0;
-        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, key0);
+        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, key0, Some(opacity_key));
 
         let bounds = (400, 400).to(600, 600);
         let key1 = self.property_key1;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, key1);
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, key1, None);
 
         let bounds = (200, 500).to(350, 580);
         let key2 = self.property_key2;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, key2);
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, key2, None);
     }
 
     fn on_event(&mut self, win_event: winit::WindowEvent, api: &RenderApi, document_id: DocumentId) -> bool {

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -988,76 +988,95 @@ impl AlphaBatchBuilder {
 
                                 let tile_cache = picture.tile_cache.as_ref().unwrap();
 
-                                for y in 0 .. tile_cache.tile_rect.size.height {
-                                    for x in 0 .. tile_cache.tile_rect.size.width {
-                                        let i = y * tile_cache.tile_rect.size.width + x;
-                                        let tile = &tile_cache.tiles[i as usize];
+                                // If there is a dirty rect for the tile cache, recurse into the
+                                // main picture primitive list, and draw them first.
+                                if let Some(_) = tile_cache.dirty_region {
+                                    self.add_pic_to_batch(
+                                        picture,
+                                        task_id,
+                                        ctx,
+                                        gpu_cache,
+                                        render_tasks,
+                                        deferred_resolves,
+                                        prim_headers,
+                                        transforms,
+                                        root_spatial_node_index,
+                                        z_generator,
+                                    );
+                                }
 
-                                        // Check if the tile is visible.
-                                        if !tile.is_visible || !tile.in_use {
-                                            continue;
-                                        }
+                                // After drawing the dirty rect, now draw any of the valid tiles that
+                                // will make up the rest of the scene.
 
-                                        // Get the local rect of the tile.
-                                        let tile_rect = tile_cache.get_tile_rect(x, y);
+                                // Generate a new z id for the tiles, that will place them *after*
+                                // any opaque overdraw from the dirty rect above.
+                                // TODO(gw): We should remove this hack, and also remove some
+                                //           (potential opaque) overdraw by adding support for
+                                //           setting a scissor rect for the dirty rect above.
+                                let tile_zid = z_generator.next();
 
-                                        // Construct a local clip rect that ensures we only draw pixels where
-                                        // the local bounds of the picture extend to within the edge tiles.
-                                        let local_clip_rect = prim_instance
-                                            .combined_local_clip_rect
-                                            .intersection(&picture.local_rect)
-                                            .expect("bug: invalid picture local rect");
+                                for i in &tile_cache.tiles_to_draw {
+                                    let tile = &tile_cache.tiles[*i as usize];
 
-                                        let prim_header = PrimitiveHeader {
-                                            local_rect: tile_rect,
-                                            local_clip_rect,
-                                            task_address,
-                                            specific_prim_address: prim_cache_address,
-                                            clip_task_address,
-                                            transform_id,
-                                        };
+                                    // Get the local rect of the tile.
+                                    let tile_rect = tile.local_rect;
 
-                                        let prim_header_index = prim_headers.push(&prim_header, z_id, [
-                                            ShaderColorMode::Image as i32 | ((AlphaType::PremultipliedAlpha as i32) << 16),
-                                            RasterizationSpace::Local as i32,
-                                            get_shader_opacity(1.0),
-                                        ]);
+                                    // Construct a local clip rect that ensures we only draw pixels where
+                                    // the local bounds of the picture extend to within the edge tiles.
+                                    let local_clip_rect = prim_instance
+                                        .combined_local_clip_rect
+                                        .intersection(&picture.local_rect)
+                                        .expect("bug: invalid picture local rect");
 
-                                        let cache_item = ctx
-                                            .resource_cache
-                                            .get_texture_cache_item(&tile.handle);
+                                    let prim_header = PrimitiveHeader {
+                                        local_rect: tile_rect,
+                                        local_clip_rect,
+                                        task_address,
+                                        specific_prim_address: prim_cache_address,
+                                        clip_task_address,
+                                        transform_id,
+                                    };
 
-                                        let key = BatchKey::new(
-                                            kind,
-                                            BlendMode::None,
-                                            BatchTextures::color(cache_item.texture_id),
-                                        );
+                                    let prim_header_index = prim_headers.push(&prim_header, tile_zid, [
+                                        ShaderColorMode::Image as i32 | ((AlphaType::PremultipliedAlpha as i32) << 16),
+                                        RasterizationSpace::Local as i32,
+                                        get_shader_opacity(1.0),
+                                    ]);
 
-                                        let uv_rect_address = gpu_cache
-                                            .get_address(&cache_item.uv_rect_handle)
-                                            .as_int();
+                                    let cache_item = ctx
+                                        .resource_cache
+                                        .get_texture_cache_item(&tile.handle);
 
-                                        let instance = BrushInstance {
-                                            prim_header_index,
-                                            clip_task_address,
-                                            segment_index: INVALID_SEGMENT_INDEX,
-                                            edge_flags: EdgeAaSegmentMask::empty(),
-                                            brush_flags: BrushFlags::empty(),
-                                            user_data: uv_rect_address,
-                                        };
+                                    let key = BatchKey::new(
+                                        kind,
+                                        BlendMode::None,
+                                        BatchTextures::color(cache_item.texture_id),
+                                    );
 
-                                        // Instead of retrieving the batch once and adding each tile instance,
-                                        // use this API to get an appropriate batch for each tile, since
-                                        // the batch textures may be different. The batch list internally
-                                        // caches the current batch if the key hasn't changed.
-                                        let batch = self.batch_list.set_params_and_get_batch(
-                                            key,
-                                            bounding_rect,
-                                            z_id,
-                                        );
+                                    let uv_rect_address = gpu_cache
+                                        .get_address(&cache_item.uv_rect_handle)
+                                        .as_int();
 
-                                        batch.push(PrimitiveInstanceData::from(instance));
-                                    }
+                                    let instance = BrushInstance {
+                                        prim_header_index,
+                                        clip_task_address,
+                                        segment_index: INVALID_SEGMENT_INDEX,
+                                        edge_flags: EdgeAaSegmentMask::empty(),
+                                        brush_flags: BrushFlags::empty(),
+                                        user_data: uv_rect_address,
+                                    };
+
+                                    // Instead of retrieving the batch once and adding each tile instance,
+                                    // use this API to get an appropriate batch for each tile, since
+                                    // the batch textures may be different. The batch list internally
+                                    // caches the current batch if the key hasn't changed.
+                                    let batch = self.batch_list.set_params_and_get_batch(
+                                        key,
+                                        bounding_rect,
+                                        tile_zid,
+                                    );
+
+                                    batch.push(PrimitiveInstanceData::from(instance));
                                 }
                             }
                             PictureCompositeMode::Filter(filter) => {

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -1015,8 +1015,8 @@ impl AlphaBatchBuilder {
                                 //           setting a scissor rect for the dirty rect above.
                                 let tile_zid = z_generator.next();
 
-                                for i in &tile_cache.tiles_to_draw {
-                                    let tile = &tile_cache.tiles[*i as usize];
+                                for tile_index in &tile_cache.tiles_to_draw {
+                                    let tile = &tile_cache.tiles[tile_index.0];
 
                                     // Get the local rect of the tile.
                                     let tile_rect = tile.local_rect;

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -23,7 +23,7 @@ use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use std::{cmp, u32};
 use std::os::raw::c_void;
-use util::{extract_inner_rect_safe, project_rect, ScaleOffset};
+use util::{extract_inner_rect_safe, project_rect, ScaleOffset, MaxRect};
 
 /*
 
@@ -1360,6 +1360,49 @@ impl ClipNodeCollector {
         clip_chain_id: ClipChainId,
     ) {
         self.clips.insert(clip_chain_id);
+    }
+
+    pub fn clear(
+        &mut self,
+    ) {
+        self.clips.clear();
+    }
+
+    /// Build the world clip rect for this clip node collector.
+    // NOTE: This ignores any complex clips that may be present.
+    pub fn get_world_clip_rect(
+        &self,
+        clip_store: &ClipStore,
+        clip_data_store: &ClipDataStore,
+        clip_scroll_tree: &ClipScrollTree,
+    ) -> Option<WorldRect> {
+        let mut clip_rect = WorldRect::max_rect();
+
+        let mut map_local_to_world = SpaceMapper::new(
+            ROOT_SPATIAL_NODE_INDEX,
+            WorldRect::zero(),
+        );
+
+        for clip_chain_id in &self.clips {
+            let node = clip_store.get_clip_chain(*clip_chain_id);
+            let clip_node = &clip_data_store[node.handle];
+
+            if let Some(local_rect) = clip_node.item.get_local_clip_rect(node.local_pos) {
+                map_local_to_world.set_target_spatial_node(
+                    node.spatial_node_index,
+                    clip_scroll_tree,
+                );
+
+                if let Some(world_rect) = map_local_to_world.map(&local_rect) {
+                    clip_rect = match clip_rect.intersection(&world_rect) {
+                        Some(rect) => rect,
+                        None => return None,
+                    };
+                }
+            }
+        }
+
+        Some(clip_rect)
     }
 }
 

--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -1384,20 +1384,17 @@ impl ClipNodeCollector {
         );
 
         for clip_chain_id in &self.clips {
-            let node = clip_store.get_clip_chain(*clip_chain_id);
-            let clip_node = &clip_data_store[node.handle];
+            let clip_chain_node = clip_store.get_clip_chain(*clip_chain_id);
+            let clip_node = &clip_data_store[clip_chain_node.handle];
 
-            if let Some(local_rect) = clip_node.item.get_local_clip_rect(node.local_pos) {
+            if let Some(local_rect) = clip_node.item.get_local_clip_rect(clip_chain_node.local_pos) {
                 map_local_to_world.set_target_spatial_node(
-                    node.spatial_node_index,
+                    clip_chain_node.spatial_node_index,
                     clip_scroll_tree,
                 );
 
                 if let Some(world_rect) = map_local_to_world.map(&local_rect) {
-                    clip_rect = match clip_rect.intersection(&world_rect) {
-                        Some(rect) => rect,
-                        None => return None,
-                    };
+                    clip_rect = clip_rect.intersection(&world_rect)?;
                 }
             }
         }

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -291,14 +291,6 @@ impl FrameBuilder {
             &mut retained_tiles,
         );
 
-        // If we had any retained tiles from the last scene that were not picked
-        // up by the new frame, then just discard them eagerly.
-        // TODO(gw): Maybe it's worth keeping them around for a bit longer in
-        //           some cases?
-        for (_, handle) in retained_tiles.tiles.drain() {
-            resource_cache.texture_cache.mark_unused(&handle);
-        }
-
         let mut frame_state = FrameBuildingState {
             render_tasks,
             profile_counters,
@@ -321,6 +313,7 @@ impl FrameBuilder {
                 true,
                 &mut frame_state,
                 &frame_context,
+                screen_world_rect,
             )
             .unwrap();
 
@@ -346,6 +339,11 @@ impl FrameBuilder {
             .surfaces[ROOT_SURFACE_INDEX.0]
             .take_render_tasks();
 
+        let tile_blits = mem::replace(
+            &mut frame_state.surfaces[ROOT_SURFACE_INDEX.0].tile_blits,
+            Vec::new(),
+        );
+
         let root_render_task = RenderTask::new_picture(
             RenderTaskLocation::Fixed(self.screen_rect.to_i32()),
             self.screen_rect.size.to_f32(),
@@ -355,7 +353,7 @@ impl FrameBuilder {
             UvRectKind::Rect,
             root_spatial_node_index,
             None,
-            Vec::new(),
+            tile_blits,
         );
 
         let render_task_id = frame_state.render_tasks.add(root_render_task);

--- a/webrender/src/frame_builder.rs
+++ b/webrender/src/frame_builder.rs
@@ -26,7 +26,7 @@ use segment::SegmentBuilder;
 use spatial_node::SpatialNode;
 use std::{f32, mem};
 use std::sync::Arc;
-use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext};
+use tiling::{Frame, RenderPass, RenderPassKind, RenderTargetContext, RenderTarget};
 
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -487,9 +487,14 @@ impl FrameBuilder {
                 &mut z_generator,
             );
 
-            if let RenderPassKind::OffScreen { ref texture_cache, ref color, .. } = pass.kind {
-                has_texture_cache_tasks |= !texture_cache.is_empty();
-                has_texture_cache_tasks |= color.must_be_drawn();
+            match pass.kind {
+                RenderPassKind::MainFramebuffer(ref color) => {
+                    has_texture_cache_tasks |= color.must_be_drawn();
+                }
+                RenderPassKind::OffScreen { ref texture_cache, ref color, .. } => {
+                    has_texture_cache_tasks |= !texture_cache.is_empty();
+                    has_texture_cache_tasks |= color.must_be_drawn();
+                }
             }
         }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -73,6 +73,7 @@ pub struct TileCoordinate;
 // Geometry types for tile coordinates.
 pub type TileOffset = TypedPoint2D<i32, TileCoordinate>;
 pub type TileSize = TypedSize2D<i32, TileCoordinate>;
+pub struct TileIndex(pub usize);
 
 /// The size in device pixels of a cached tile. The currently chosen
 /// size is arbitrary. We should do some profiling to find the best
@@ -218,7 +219,7 @@ pub struct TileCache {
     /// A helper struct to map local rects into world coords.
     map_local_to_world: SpaceMapper<LayoutPixel, WorldPixel>,
     /// A list of tiles to draw during batching.
-    pub tiles_to_draw: Vec<usize>,
+    pub tiles_to_draw: Vec<TileIndex>,
     /// List of transform keys - used to check if transforms
     /// have changed.
     transforms: Vec<GlobalTransformInfo>,
@@ -485,10 +486,7 @@ impl TileCache {
                         px / frame_context.device_pixel_scale.0,
                         py / frame_context.device_pixel_scale.0,
                     ),
-                    WorldSize::new(
-                        TILE_SIZE_WIDTH as f32 / frame_context.device_pixel_scale.0,
-                        TILE_SIZE_HEIGHT as f32 / frame_context.device_pixel_scale.0,
-                    ),
+                    self.world_tile_size,
                 );
 
                 tile.local_rect = world_mapper
@@ -512,7 +510,7 @@ impl TileCache {
         // Do tile invalidation for any dependencies that we know now.
         for tile in &mut self.tiles {
             // Invalidate the tile if any images have changed
-            for image_key in &tile.descriptor.image_keys.items {
+            for image_key in tile.descriptor.image_keys.items() {
                 if resource_cache.is_image_dirty(*image_key) {
                     tile.is_valid = false;
                     break;
@@ -520,7 +518,7 @@ impl TileCache {
             }
 
             // Invalidate the tile if any opacity bindings changed.
-            for id in &tile.descriptor.opacity_bindings.items {
+            for id in tile.descriptor.opacity_bindings.items() {
                 let changed = match self.opacity_bindings.get(id) {
                     Some(info) => info.changed,
                     None => true,
@@ -539,6 +537,7 @@ impl TileCache {
         }
     }
 
+    /// Update the dependencies for each tile for a given primitive instance.
     pub fn update_prim_dependencies(
         &mut self,
         prim_instance: &PrimitiveInstance,
@@ -763,17 +762,21 @@ impl TileCache {
 
         // Get the world clip rect that we will use to determine
         // which parts of the tiles are valid / required.
-        let clip_rect = self
+        let clip_rect = match self
             .clip_node_collector
             .get_world_clip_rect(
                 clip_store,
                 &resources.clip_data_store,
                 frame_context.clip_scroll_tree,
-            ).expect("bug: no world clip rect");
+            ) {
+            Some(clip_rect) => clip_rect,
+            None => return,
+        };
 
-        let clip_rect = clip_rect
-            .intersection(&frame_context.screen_world_rect)
-            .expect("bug: clip rect is off-screen");
+        let clip_rect = match clip_rect.intersection(&frame_context.screen_world_rect) {
+            Some(clip_rect) => clip_rect,
+            None => return,
+        };
 
         let clipped = (clip_rect * frame_context.device_pixel_scale).round().to_i32();
 
@@ -824,7 +827,7 @@ impl TileCache {
                 // on screen. However, if there are no primitives there is
                 // no need to draw it.
                 if !tile.descriptor.prims.is_empty() {
-                    self.tiles_to_draw.push(i);
+                    self.tiles_to_draw.push(TileIndex(i));
                 }
             } else {
                 // Add the tile rect to the dirty rect.

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint};
+use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint, WorldPoint};
 use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel, PropertyBinding, PropertyBindingId};
-use api::{DevicePixelScale, RasterRect, RasterSpace, DeviceIntPoint, ColorF, ImageKey, DirtyRect};
-use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor, LayoutSize, LayoutPoint};
+use api::{DevicePixelScale, RasterRect, RasterSpace, ColorF, ImageKey, DirtyRect, WorldSize};
+use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor, WorldVector2D};
 use box_shadow::{BLUR_SAMPLE_SCALE};
 use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode};
 use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
@@ -17,11 +17,10 @@ use internal_types::{FastHashMap, PlaneSplitter};
 use frame_builder::{FrameBuildingContext, FrameBuildingState, PictureState, PictureContext};
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle};
 use gpu_types::{TransformPalette, TransformPaletteId, UvRectKind};
-use internal_types::FastHashSet;
 use plane_split::{Clipper, Polygon, Splitter};
 use prim_store::{PictureIndex, PrimitiveInstance, SpaceMapper, VisibleFace, PrimitiveInstanceKind};
-use prim_store::{get_raster_rects, CoordinateSpaceMapping, PointKey};
-use prim_store::{OpacityBindingStorage, ImageInstanceStorage, OpacityBindingIndex, SizeKey};
+use prim_store::{get_raster_rects, CoordinateSpaceMapping};
+use prim_store::{OpacityBindingStorage, ImageInstanceStorage, OpacityBindingIndex};
 use print_tree::PrintTreePrinter;
 use render_backend::FrameResources;
 use render_task::{ClearMode, RenderTask, RenderTaskCacheEntryHandle, TileBlit};
@@ -34,7 +33,7 @@ use surface::{SurfaceDescriptor, TransformKey};
 use std::{mem, u16};
 use texture_cache::{Eviction, TextureCacheHandle};
 use tiling::RenderTargetKind;
-use util::{TransformedRectKind, MatrixHelpers, MaxRect, RectHelpers};
+use util::{ComparableVec, TransformedRectKind, MatrixHelpers, MaxRect};
 
 /*
  A picture represents a dynamically rendered image. It consists of:
@@ -53,16 +52,16 @@ struct PictureInfo {
     spatial_node_index: SpatialNodeIndex,
 }
 
-/// Stores a map of cached picture tiles that are retained
+/// Stores a list of cached picture tiles that are retained
 /// between new scenes.
 pub struct RetainedTiles {
-    pub tiles: FastHashMap<TileDescriptor, TextureCacheHandle>,
+    pub tiles: Vec<Tile>,
 }
 
 impl RetainedTiles {
     pub fn new() -> Self {
         RetainedTiles {
-            tiles: FastHashMap::default(),
+            tiles: Vec::new(),
         }
     }
 }
@@ -74,26 +73,12 @@ pub struct TileCoordinate;
 // Geometry types for tile coordinates.
 pub type TileOffset = TypedPoint2D<i32, TileCoordinate>;
 pub type TileSize = TypedSize2D<i32, TileCoordinate>;
-pub type TileRect = TypedRect<i32, TileCoordinate>;
 
 /// The size in device pixels of a cached tile. The currently chosen
 /// size is arbitrary. We should do some profiling to find the best
 /// size for real world pages.
 pub const TILE_SIZE_WIDTH: i32 = 1024;
 pub const TILE_SIZE_HEIGHT: i32 = 256;
-
-/// The maximum size of a picture before we disable tile caching.
-const MAX_PICTURE_SIZE: f32 = 65536.0;
-
-/// Information about the state of a transform dependency.
-#[derive(Debug)]
-pub struct TileTransformInfo {
-    /// The spatial node in the current clip-scroll tree that
-    /// this transform maps to.
-    spatial_node_index: SpatialNodeIndex,
-    /// Tiles check this to see if the dependencies have changed.
-    changed: bool,
-}
 
 #[derive(Debug)]
 pub struct GlobalTransformInfo {
@@ -117,148 +102,50 @@ pub struct OpacityBindingInfo {
 /// Information about a cached tile.
 #[derive(Debug)]
 pub struct Tile {
-    /// The set of opacity bindings that this tile depends on.
-    opacity_bindings: FastHashSet<PropertyBindingId>,
-    /// Set of image keys that this tile depends on.
-    image_keys: FastHashSet<ImageKey>,
+    /// The current world rect of thie tile.
+    world_rect: WorldRect,
+    /// The current local rect of this tile.
+    pub local_rect: LayoutRect,
+    /// The valid rect within this tile.
+    pixel_rect: Option<DeviceIntRect>,
+    /// Uniquely describes the content of this tile, in a way that can be
+    /// (reasonably) efficiently hashed and compared.
+    descriptor: TileDescriptor,
+    /// Handle to the cached texture for this tile.
+    pub handle: TextureCacheHandle,
     /// If true, this tile is marked valid, and the existing texture
     /// cache handle can be used. Tiles are invalidated during the
     /// build_dirty_regions method.
     is_valid: bool,
-    /// If false, this tile cannot be cached (e.g. it has an external
-    /// video image attached to it). In future, we could add an API
-    /// for the embedder to tell us if the external image changed.
-    /// This is set during primitive dependency updating.
-    is_cacheable: bool,
-    /// If true, this tile is currently in use by the cache. It
-    /// may be false if the tile is outside the bounding rect of
-    /// the current picture, but hasn't been discarded yet. This
-    /// is calculated during primitive dependency updating.
-    pub in_use: bool,
-    /// If true, this tile is currently visible on screen. This
-    /// is calculated during build_dirty_regions.
-    pub is_visible: bool,
-    /// Handle to the cached texture for this tile.
-    pub handle: TextureCacheHandle,
-    /// A map from clip-scroll tree spatial node indices to the tile
-    /// transforms. This allows the tile transforms to be stable
-    /// if the content of the tile is the same, but the shape of the
-    /// clip-scroll tree changes between scenes in other areas.
-    tile_transform_map: FastHashMap<SpatialNodeIndex, TileTransformIndex>,
-    /// Information about the transforms that is not part of the cache key.
-    transform_info: Vec<TileTransformInfo>,
-    /// Uniquely describes the content of this tile, in a way that can be
-    /// (reasonably) efficiently hashed and compared.
-    descriptor: TileDescriptor,
 }
 
 impl Tile {
     /// Construct a new, invalid tile.
     fn new(
-        tile_offset: TileOffset,
-        local_tile_size: SizeKey,
-        raster_transform: TransformKey,
     ) -> Self {
         Tile {
-            opacity_bindings: FastHashSet::default(),
-            image_keys: FastHashSet::default(),
-            is_valid: false,
-            is_visible: false,
-            is_cacheable: true,
-            in_use: false,
             handle: TextureCacheHandle::invalid(),
-            descriptor: TileDescriptor::new(
-                tile_offset,
-                local_tile_size,
-                raster_transform,
-            ),
-            tile_transform_map: FastHashMap::default(),
-            transform_info: Vec::new(),
+            local_rect: LayoutRect::zero(),
+            world_rect: WorldRect::zero(),
+            descriptor: TileDescriptor::new(),
+            is_valid: false,
+            pixel_rect: None,
         }
     }
 
-    /// Add a (possibly) new transform dependency to this tile.
-    fn push_transform_dependency(
-        &mut self,
-        spatial_node_index: SpatialNodeIndex,
-        surface_spatial_node_index: SpatialNodeIndex,
-        clip_scroll_tree: &ClipScrollTree,
-        global_transforms: &mut [GlobalTransformInfo],
-    ) {
-        // If the primitive is positioned by the same spatial
-        // node as the surface, we don't care about it since
-        // the primitive can never move to a different position
-        // relative to the surface.
-        if spatial_node_index == surface_spatial_node_index {
-            return;
-        }
-
-        let transform_info = &mut self.transform_info;
-        let descriptor = &mut self.descriptor;
-
-        // Get the mapping from unstable spatial node index to
-        // a local transform index within this tile.
-        let tile_transform_index = self
-            .tile_transform_map
-            .entry(spatial_node_index)
-            .or_insert_with(|| {
-                let index = transform_info.len();
-
-                let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
-                    surface_spatial_node_index,
-                    spatial_node_index,
-                    clip_scroll_tree,
-                ).expect("todo: handle invalid mappings");
-
-                // See if the transform changed, and cache the current
-                // transform if not set before.
-                let changed = get_global_transform_changed(
-                    global_transforms,
-                    spatial_node_index,
-                    clip_scroll_tree,
-                    surface_spatial_node_index,
-                );
-
-                transform_info.push(TileTransformInfo {
-                    changed,
-                    spatial_node_index,
-                });
-
-                let key = mapping.into();
-
-                descriptor.transforms.push(key);
-
-                TileTransformIndex(index as u32)
-            });
-
-        // Record the transform for this primitive / clip node.
-        // TODO(gw): It might be worth storing these in runs, since they
-        //           probably don't change very often between prims.
-        descriptor.transform_ids.push(*tile_transform_index);
-    }
-
-    /// Destroy a tile, optionally returning a handle and cache descriptor,
-    /// if this surface was valid and may be useful on the next scene.
-    fn destroy(self) -> Option<(TileDescriptor, TextureCacheHandle)> {
-        if self.is_valid {
-            Some((self.descriptor, self.handle))
-        } else {
-            None
-        }
+    /// Clear the dependencies for a tile.
+    fn clear(&mut self) {
+        self.descriptor.clear();
     }
 }
 
-/// Index of a transform array local to the tile.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct TileTransformIndex(u32);
-
 /// Defines a key that uniquely identifies a primitive instance.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveDescriptor {
     /// Uniquely identifies the content of the primitive template.
     prim_uid: ItemUid,
-    /// The origin in local space of this primitive.
-    origin: PointKey,
+    /// The origin in world space of this primitive.
+    origin: WorldPoint,
     /// The first clip in the clip_uids array of clips that affect this tile.
     first_clip: u16,
     /// The number of clips that affect this primitive instance.
@@ -267,65 +154,50 @@ pub struct PrimitiveDescriptor {
 
 /// Uniquely describes the content of this tile, in a way that can be
 /// (reasonably) efficiently hashed and compared.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 pub struct TileDescriptor {
     /// List of primitive instance unique identifiers. The uid is guaranteed
     /// to uniquely describe the content of the primitive template, while
     /// the other parameters describe the clip chain and instance params.
-    pub prims: Vec<PrimitiveDescriptor>,
+    prims: ComparableVec<PrimitiveDescriptor>,
 
     /// List of clip node unique identifiers. The uid is guaranteed
     /// to uniquely describe the content of the clip node.
-    pub clip_uids: Vec<ItemUid>,
+    clip_uids: ComparableVec<ItemUid>,
 
-    /// List of local tile transform ids that are used to position
-    /// the primitive and clip items above.
-    pub transform_ids: Vec<TileTransformIndex>,
-
-    /// List of transforms used by this tile, along with the current
-    /// quantized value.
-    pub transforms: Vec<TransformKey>,
+    /// List of image keys that this tile depends on.
+    image_keys: ComparableVec<ImageKey>,
 
     /// The set of opacity bindings that this tile depends on.
     // TODO(gw): Ugh, get rid of all opacity binding support!
-    pub opacity_bindings: Vec<PropertyBindingId>,
-
-    /// Ensures that we hash to a tile in the same local position.
-    pub tile_offset: TileOffset,
-    pub local_tile_size: SizeKey,
-
-    /// Identifies the raster configuration of the rasterization
-    /// root, to ensure tiles are invalidated if they are drawn in
-    /// screen-space with an incompatible transform.
-    pub raster_transform: TransformKey,
+    opacity_bindings: ComparableVec<PropertyBindingId>,
 }
 
 impl TileDescriptor {
-    fn new(
-        tile_offset: TileOffset,
-        local_tile_size: SizeKey,
-        raster_transform: TransformKey,
-    ) -> Self {
+    fn new() -> Self {
         TileDescriptor {
-            prims: Vec::new(),
-            clip_uids: Vec::new(),
-            transform_ids: Vec::new(),
-            opacity_bindings: Vec::new(),
-            transforms: Vec::new(),
-            tile_offset,
-            raster_transform,
-            local_tile_size,
+            prims: ComparableVec::new(),
+            clip_uids: ComparableVec::new(),
+            opacity_bindings: ComparableVec::new(),
+            image_keys: ComparableVec::new(),
         }
     }
 
     /// Clear the dependency information for a tile, when the dependencies
     /// are being rebuilt.
     fn clear(&mut self) {
-        self.prims.clear();
-        self.clip_uids.clear();
-        self.transform_ids.clear();
-        self.transforms.clear();
-        self.opacity_bindings.clear();
+        self.prims.reset();
+        self.clip_uids.reset();
+        self.opacity_bindings.reset();
+        self.image_keys.reset();
+    }
+
+    /// Check if the dependencies of this tile are valid.
+    fn is_valid(&self) -> bool {
+        self.image_keys.is_valid() &&
+        self.opacity_bindings.is_valid() &&
+        self.clip_uids.is_valid() &&
+        self.prims.is_valid()
     }
 }
 
@@ -334,129 +206,136 @@ impl TileDescriptor {
 /// regions.
 #[derive(Debug)]
 pub struct DirtyRegion {
-    tile_offset: DeviceIntPoint,
-    dirty_rect: LayoutRect,
     dirty_world_rect: WorldRect,
 }
 
 /// Represents a cache of tiles that make up a picture primitives.
 pub struct TileCache {
-    /// The size of each tile in local-space coordinates of the picture.
-    pub local_tile_size: LayoutSize,
+    /// The positioning node for this tile cache.
+    spatial_node_index: SpatialNodeIndex,
     /// List of tiles present in this picture (stored as a 2D array)
     pub tiles: Vec<Tile>,
-    /// A set of tiles that were used last time we built
-    /// the tile grid, that may be reused or discarded next time.
-    pub old_tiles: FastHashMap<TileOffset, Tile>,
-    /// The current size of the rect in tile coordinates.
-    pub tile_rect: TileRect,
+    /// A helper struct to map local rects into world coords.
+    map_local_to_world: SpaceMapper<LayoutPixel, WorldPixel>,
+    /// A list of tiles to draw during batching.
+    pub tiles_to_draw: Vec<usize>,
     /// List of transform keys - used to check if transforms
     /// have changed.
-    pub transforms: Vec<GlobalTransformInfo>,
+    transforms: Vec<GlobalTransformInfo>,
     /// List of opacity bindings, with some extra information
     /// about whether they changed since last frame.
-    pub opacity_bindings: FastHashMap<PropertyBindingId, OpacityBindingInfo>,
-    /// A helper struct to map local rects into picture coords.
-    pub space_mapper: SpaceMapper<LayoutPixel, LayoutPixel>,
+    opacity_bindings: FastHashMap<PropertyBindingId, OpacityBindingInfo>,
+    /// If Some(..) the region that is dirty in this picture.
+    pub dirty_region: Option<DirtyRegion>,
     /// If true, we need to update the prim dependencies, due
     /// to relative transforms changing. The dependencies are
     /// stored in each tile, and are a list of things that
     /// force the tile to re-rasterize if they change (e.g.
     /// images, transforms).
-    pub needs_update: bool,
-    /// If Some(..) the region that is dirty in this picture.
-    pub dirty_region: Option<DirtyRegion>,
-    /// The current transform of the surface itself, to allow
-    /// invalidating tiles if the surface transform changes.
-    /// This is only relevant when raster_space == RasterSpace::Screen.
-    raster_transform: TransformKey,
-
-    /// Contains the offset between the local picture rect that this
-    /// tile cache covers, and the aligned origin where tiles are
-    /// placed. This ensures that tiles are placed on correctly
-    /// aligned locations between new scenes when the enclosing
-    /// picture rect has a different local origin.
-    local_origin: LayoutPoint,
+    needs_update: bool,
+    /// The current world reference point that tiles are created around.
+    world_origin: WorldPoint,
+    /// Current size of tiles in world units.
+    world_tile_size: WorldSize,
+    /// Current number of tiles in the allocated grid.
+    tile_count: TileSize,
+    /// The current scroll offset for this frame builder. Reset when
+    /// a new scene arrives.
+    scroll_offset: Option<WorldVector2D>,
+    /// A list of blits from the framebuffer to be applied during this frame.
+    pending_blits: Vec<TileBlit>,
+    /// Collects the clips that apply to this surface.
+    clip_node_collector: ClipNodeCollector,
 }
 
 impl TileCache {
-    /// Construct a new tile cache.
-    pub fn new() -> Self {
+    pub fn new(spatial_node_index: SpatialNodeIndex) -> Self {
         TileCache {
+            spatial_node_index,
             tiles: Vec::new(),
-            old_tiles: FastHashMap::default(),
-            tile_rect: TileRect::zero(),
-            local_tile_size: LayoutSize::zero(),
+            map_local_to_world: SpaceMapper::new(
+                ROOT_SPATIAL_NODE_INDEX,
+                WorldRect::zero(),
+            ),
+            tiles_to_draw: Vec::new(),
             transforms: Vec::new(),
             opacity_bindings: FastHashMap::default(),
-            needs_update: true,
             dirty_region: None,
-            space_mapper: SpaceMapper::new(
-                ROOT_SPATIAL_NODE_INDEX,
-                LayoutRect::zero(),
-            ),
-            raster_transform: TransformKey::Local,
-            local_origin: LayoutPoint::zero(),
+            needs_update: true,
+            world_origin: WorldPoint::zero(),
+            world_tile_size: WorldSize::zero(),
+            tile_count: TileSize::zero(),
+            scroll_offset: None,
+            pending_blits: Vec::new(),
+            clip_node_collector: ClipNodeCollector::new(spatial_node_index),
         }
     }
 
-    /// Update the transforms array for this tile cache from the clip-scroll
-    /// tree. This marks each transform as changed for later use during
-    /// tile invalidation.
-    pub fn update_transforms(
+    /// Get the tile coordinates for a given rectangle.
+    fn get_tile_coords_for_rect(
+        &self,
+        rect: &WorldRect,
+    ) -> (TileOffset, TileOffset) {
+        // Translate the rectangle into the virtual tile space
+        let origin = rect.origin - self.world_origin;
+
+        // Get the tile coordinates in the picture space.
+        let p0 = TileOffset::new(
+            (origin.x / self.world_tile_size.width).floor() as i32,
+            (origin.y / self.world_tile_size.height).floor() as i32,
+        );
+
+        let p1 = TileOffset::new(
+            ((origin.x + rect.size.width) / self.world_tile_size.width).ceil() as i32,
+            ((origin.y + rect.size.height) / self.world_tile_size.height).ceil() as i32,
+        );
+
+        (p0, p1)
+    }
+
+    /// Update transforms, opacity bindings and tile rects.
+    pub fn pre_update(
         &mut self,
-        surface_spatial_node_index: SpatialNodeIndex,
-        raster_spatial_node_index: SpatialNodeIndex,
-        raster_space: RasterSpace,
-        frame_context: &FrameBuildingContext,
         pic_rect: LayoutRect,
+        frame_context: &FrameBuildingContext,
+        resource_cache: &ResourceCache,
+        retained_tiles: &mut RetainedTiles,
     ) {
-        // If we previously disabled the tile cache due to an invalid
-        // picture rect, and then we re-enable it, force an update
-        // of all primitive dependencies.
-        if self.tile_rect.size.is_empty_or_negative() {
-            self.needs_update = true;
+        // Work out the scroll offset to apply to the world reference point.
+        let scroll_transform = frame_context.clip_scroll_tree.get_relative_transform(
+            ROOT_SPATIAL_NODE_INDEX,
+            self.spatial_node_index,
+        ).expect("bug: unable to get scroll transform");
+        let scroll_offset = WorldVector2D::new(
+            scroll_transform.m41,
+            scroll_transform.m42,
+        );
+        let scroll_delta = match self.scroll_offset {
+            Some(prev) => prev - scroll_offset,
+            None => WorldVector2D::zero(),
+        };
+        self.scroll_offset = Some(scroll_offset);
+
+        // Pull any retained tiles from the previous scene.
+        if !retained_tiles.tiles.is_empty() {
+            assert!(self.tiles.is_empty());
+            self.tiles = mem::replace(&mut retained_tiles.tiles, Vec::new());
         }
 
-        // Initialize the space mapper with current bounds,
-        // which is used during primitive dependency updates.
+        // Assume no tiles are valid to draw by default
+        self.tiles_to_draw.clear();
+
+        self.map_local_to_world = SpaceMapper::new(
+            ROOT_SPATIAL_NODE_INDEX,
+            frame_context.screen_world_rect,
+        );
+
         let world_mapper = SpaceMapper::new_with_target(
             ROOT_SPATIAL_NODE_INDEX,
-            surface_spatial_node_index,
+            self.spatial_node_index,
             frame_context.screen_world_rect,
             frame_context.clip_scroll_tree,
         );
-
-        let pic_bounds = world_mapper
-            .unmap(&frame_context.screen_world_rect)
-            .unwrap_or(LayoutRect::max_rect());
-
-        self.space_mapper = SpaceMapper::new(
-            surface_spatial_node_index,
-            pic_bounds,
-        );
-
-        // Work out the local space size of each tile, based on the
-        // device pixel size of tiles.
-        // TODO(gw): Perhaps add a map_point API to SpaceMapper.
-        let world_tile_rect = WorldRect::from_floats(
-            0.0,
-            0.0,
-            TILE_SIZE_WIDTH as f32 / frame_context.device_pixel_scale.0,
-            TILE_SIZE_HEIGHT as f32 / frame_context.device_pixel_scale.0,
-        );
-        let local_tile_rect = world_mapper
-            .unmap(&world_tile_rect)
-            .expect("bug: unable to get local tile size");
-        self.local_tile_size = local_tile_rect.size;
-
-        // Round the local reference point down to a whole number. This ensures
-        // that the bounding rect of the tile corresponds to a pixel boundary, and
-        // the content is offset by a fractional amount inside the surface itself.
-        // This means that when drawing the tile it's fine to use a simple 0-1
-        // UV mapping, instead of trying to determine a fractional UV rect that
-        // is slightly inside the allocated tile surface.
-        self.local_origin = pic_rect.origin.floor();
 
         // Walk the transforms and see if we need to rebuild the primitive
         // dependencies for each tile.
@@ -469,7 +348,7 @@ impl TileCache {
                 // tile invalidation later.
                 if let Some(ref mut current) = transform.current {
                     let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
-                        surface_spatial_node_index,
+                        self.spatial_node_index,
                         SpatialNodeIndex(i),
                         frame_context.clip_scroll_tree,
                     ).expect("todo: handle invalid mappings");
@@ -507,193 +386,163 @@ impl TileCache {
             });
         }
 
-        // Update the state of the transform for compositing this picture.
-        self.raster_transform = match raster_space {
-            RasterSpace::Screen => {
-                // In general cases, if we're rasterizing a picture in screen space, then the
-                // value of the surface spatial node will affect the contents of the picture
-                // itself. However, if the surface and raster spatial nodes are in the same
-                // coordinate system (which is the common case!) then we are effectively drawing
-                // in a local space anyway, so don't care about that transform for the purposes
-                // of validating the surface cache contents.
+        // Map the picture rect to world space and work out the tiles that we need
+        // in order to ensure the screen is covered.
+        let pic_world_rect = world_mapper
+            .map(&pic_rect)
+            .expect("bug: unable to map picture rect to world");
 
-                let mut key = CoordinateSpaceMapping::<LayoutPixel, PicturePixel>::new(
-                    raster_spatial_node_index,
-                    surface_spatial_node_index,
-                    frame_context.clip_scroll_tree,
-                ).expect("bug: unable to get coord mapping").into();
+        // TODO(gw): Inflate the world rect a bit, to ensure that we keep tiles in
+        //           the cache for a while after they disappear off-screen.
+        let needed_world_rect = frame_context
+            .screen_world_rect
+            .intersection(&pic_world_rect);
 
-                if let TransformKey::ScaleOffset(ref mut key) = key {
-                    key.offset_x = 0.0;
-                    key.offset_y = 0.0;
-                }
-
-                key
-            }
-            RasterSpace::Local(..) => {
-                TransformKey::local()
+        let needed_world_rect = match needed_world_rect {
+            Some(rect) => rect,
+            None => {
+                // TODO(gw): Should we explicitly drop any existing cache handles here?
+                self.tiles.clear();
+                return;
             }
         };
 
-        // Walk the transforms and see if we need to rebuild the primitive
-        // dependencies for each tile.
-        // TODO(gw): We could be smarter here and only rebuild for the primitives
-        //           which are affected by transforms that have changed.
-        for tile in &mut self.tiles {
-            tile.descriptor.local_tile_size = self.local_tile_size.into();
-            tile.descriptor.raster_transform = self.raster_transform.clone();
+        // Get a reference point that serves as an origin that all tiles we create
+        // must be aligned to. This ensures that tiles get reused correctly between
+        // scrolls and display list changes, even with the different local coord
+        // systems that gecko supplies.
+        let mut world_ref_point = if self.tiles.is_empty() {
+            needed_world_rect.origin.floor()
+        } else {
+            self.tiles[0].world_rect.origin
+        };
 
-            debug_assert_eq!(tile.transform_info.len(), tile.descriptor.transforms.len());
-            for (info, transform) in tile.transform_info.iter_mut().zip(tile.descriptor.transforms.iter_mut()) {
-                let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
-                    surface_spatial_node_index,
-                    info.spatial_node_index,
-                    frame_context.clip_scroll_tree,
-                ).expect("todo: handle invalid mappings");
-                let new_transform = mapping.into();
+        // Apply the scroll delta so that existing tiles still get used.
+        world_ref_point += scroll_delta;
 
-                info.changed = *transform != new_transform;
-                *transform = new_transform;
+        // Work out the required device rect that we need to cover the screen,
+        // given the world reference point constraint.
+        let device_ref_point = world_ref_point * frame_context.device_pixel_scale;
+        let device_world_rect = frame_context.screen_world_rect * frame_context.device_pixel_scale;
+        let pic_device_rect = pic_world_rect * frame_context.device_pixel_scale;
+        let needed_device_rect = pic_device_rect
+            .intersection(&device_world_rect)
+            .expect("todo: handle clipped device rect");
 
-                self.needs_update |= info.changed;
-            }
-        }
+        let p0 = needed_device_rect.origin;
+        let p1 = needed_device_rect.bottom_right();
 
-        // If we need to update the dependencies for tiles, walk each tile
-        // and clear the transforms and opacity bindings arrays.
-        if self.needs_update {
-            debug_assert!(self.old_tiles.is_empty());
-
-            // Clear any dependencies on the set of existing tiles, since
-            // they are going to be rebuilt. Drain the tiles list and add
-            // them to the old_tiles hash, for re-use next frame build.
-            for (i, mut tile) in self.tiles.drain(..).enumerate() {
-                let y = i as i32 / self.tile_rect.size.width;
-                let x = i as i32 % self.tile_rect.size.width;
-                tile.descriptor.clear();
-                tile.transform_info.clear();
-                tile.tile_transform_map.clear();
-                tile.opacity_bindings.clear();
-                tile.image_keys.clear();
-                tile.in_use = false;
-                let key = TileOffset::new(
-                    x + self.tile_rect.origin.x,
-                    y + self.tile_rect.origin.y,
-                );
-                self.old_tiles.insert(key, tile);
-            }
-
-            // Reset the size of the tile grid.
-            self.tile_rect = TileRect::zero();
-        }
-
-        // Get the tile coordinates in the picture space.
-        let pic_rect = TypedRect::from_untyped(&pic_rect.to_untyped());
-        let (p0, p1) = self.get_tile_coords_for_rect(&pic_rect);
-
-        // Update the tile array allocation if needed.
-        self.reconfigure_tiles_if_required(p0.x, p0.y, p1.x, p1.y);
-    }
-
-    /// Get the tile coordinates for a given rectangle.
-    fn get_tile_coords_for_rect(
-        &self,
-        rect: &LayoutRect,
-    ) -> (TileOffset, TileOffset) {
-        // Translate the rectangle into the virtual tile space
-        let origin = rect.origin - self.local_origin;
-
-        // Get the tile coordinates in the picture space.
-        let p0 = TileOffset::new(
-            (origin.x / self.local_tile_size.width).floor() as i32,
-            (origin.y / self.local_tile_size.height).floor() as i32,
+        let p0 = DevicePoint::new(
+            device_ref_point.x + ((p0.x - device_ref_point.x) / TILE_SIZE_WIDTH as f32).floor() * TILE_SIZE_WIDTH as f32,
+            device_ref_point.y + ((p0.y - device_ref_point.y) / TILE_SIZE_HEIGHT as f32).floor() * TILE_SIZE_HEIGHT as f32,
         );
 
-        let p1 = TileOffset::new(
-            ((origin.x + rect.size.width) / self.local_tile_size.width).ceil() as i32,
-            ((origin.y + rect.size.height) / self.local_tile_size.height).ceil() as i32,
+        let p1 = DevicePoint::new(
+            device_ref_point.x + ((p1.x - device_ref_point.x) / TILE_SIZE_WIDTH as f32).ceil() * TILE_SIZE_WIDTH as f32,
+            device_ref_point.y + ((p1.y - device_ref_point.y) / TILE_SIZE_HEIGHT as f32).ceil() * TILE_SIZE_HEIGHT as f32,
         );
 
-        (p0, p1)
-    }
+        // And now the number of tiles from that device rect.
+        let x_tiles = ((p1.x - p0.x) / TILE_SIZE_WIDTH as f32).round() as i32;
+        let y_tiles = ((p1.y - p0.y) / TILE_SIZE_HEIGHT as f32).round() as i32;
 
-    /// Resize the 2D tiles array if needed in order to fit dependencies
-    /// for a given primitive.
-    fn reconfigure_tiles_if_required(
-        &mut self,
-        mut x0: i32,
-        mut y0: i32,
-        mut x1: i32,
-        mut y1: i32,
-    ) {
-        // Determine and store the tile bounds that are now required.
-        if self.tile_rect.size.width > 0 {
-            x0 = x0.min(self.tile_rect.origin.x);
-            x1 = x1.max(self.tile_rect.origin.x + self.tile_rect.size.width);
-        }
-        if self.tile_rect.size.height > 0 {
-            y0 = y0.min(self.tile_rect.origin.y);
-            y1 = y1.max(self.tile_rect.origin.y + self.tile_rect.size.height);
+        // Step through any old tiles, and retain them if we can. They are keyed only on
+        // the (scroll adjusted) world position, relying on the descriptor content checks
+        // later to invalidate them if the content has changed.
+        let mut old_tiles = FastHashMap::default();
+        for tile in self.tiles.drain(..) {
+            let tile_device_pos = (tile.world_rect.origin + scroll_delta) * frame_context.device_pixel_scale;
+            let key = (tile_device_pos.x.round() as i32, tile_device_pos.y.round() as i32);
+            old_tiles.insert(key, tile);
         }
 
-        // See how many tiles are now required, and if that's different from current config.
-        let x_tiles = x1 - x0;
-        let y_tiles = y1 - y0;
+        // Store parameters about the current tiling rect for use during dependency updates.
+        self.world_origin = WorldPoint::new(
+            p0.x / frame_context.device_pixel_scale.0,
+            p0.y / frame_context.device_pixel_scale.0,
+        );
+        self.world_tile_size = WorldSize::new(
+            TILE_SIZE_WIDTH as f32 / frame_context.device_pixel_scale.0,
+            TILE_SIZE_HEIGHT as f32 / frame_context.device_pixel_scale.0,
+        );
+        self.tile_count = TileSize::new(x_tiles, y_tiles);
 
-        // Early exit if the tile configuration is the same.
-        if self.tile_rect.size.width == x_tiles &&
-           self.tile_rect.size.height == y_tiles &&
-           self.tile_rect.origin.x == x0 &&
-           self.tile_rect.origin.y == y0 {
-            return;
-        }
-
-        // We will need to create a new tile array.
-        let mut new_tiles = Vec::with_capacity((x_tiles * y_tiles) as usize);
-
+        // Step through each tile and try to retain an old tile from the
+        // previous frame, and update bounding rects.
         for y in 0 .. y_tiles {
             for x in 0 .. x_tiles {
-                // See if we can re-use an existing tile from the old array, by mapping
-                // the tile address. This saves invalidating existing tiles when we
-                // just resize the picture by adding / remove primitives.
-                let tx = x0 - self.tile_rect.origin.x + x;
-                let ty = y0 - self.tile_rect.origin.y + y;
-                let tile_offset = TileOffset::new(x + x0, y + y0);
+                let px = p0.x + x as f32 * TILE_SIZE_WIDTH as f32;
+                let py = p0.y + y as f32 * TILE_SIZE_HEIGHT as f32;
+                let key = (px.round() as i32, py.round() as i32);
 
-                let tile = if tx >= 0 && ty >= 0 && tx < self.tile_rect.size.width && ty < self.tile_rect.size.height {
-                    let index = (ty * self.tile_rect.size.width + tx) as usize;
-                    mem::replace(
-                        &mut self.tiles[index],
-                        Tile::new(
-                            tile_offset,
-                            self.local_tile_size.into(),
-                            self.raster_transform.clone(),
-                        )
-                    )
-                } else {
-                    self.old_tiles.remove(&tile_offset).unwrap_or_else(|| {
-                        Tile::new(
-                            tile_offset,
-                            self.local_tile_size.into(),
-                            self.raster_transform.clone(),
-                        )
-                    })
+                let mut tile = match old_tiles.remove(&key) {
+                    Some(tile) => tile,
+                    None => Tile::new(),
                 };
-                new_tiles.push(tile);
+
+                tile.world_rect = WorldRect::new(
+                    WorldPoint::new(
+                        px / frame_context.device_pixel_scale.0,
+                        py / frame_context.device_pixel_scale.0,
+                    ),
+                    WorldSize::new(
+                        TILE_SIZE_WIDTH as f32 / frame_context.device_pixel_scale.0,
+                        TILE_SIZE_HEIGHT as f32 / frame_context.device_pixel_scale.0,
+                    ),
+                );
+
+                tile.local_rect = world_mapper
+                    .unmap(&tile.world_rect)
+                    .expect("bug: can't unmap world rect");
+
+                self.tiles.push(tile);
             }
         }
 
-        self.tiles = new_tiles;
-        self.tile_rect.origin = TileOffset::new(x0, y0);
-        self.tile_rect.size = TileSize::new(x_tiles, y_tiles);
+        if !old_tiles.is_empty() {
+            // TODO(gw): Should we explicitly drop the tile texture cache handles here?
+        }
+
+        // TODO(gw): We don't actually need to update the prim dependencies each frame.
+        //           For common cases, such as only being one main scroll root, we could
+        //           detect this and skip the dependency update on scroll frames.
+        self.needs_update = true;
+        self.clip_node_collector.clear();
+
+        // Do tile invalidation for any dependencies that we know now.
+        for tile in &mut self.tiles {
+            // Invalidate the tile if any images have changed
+            for image_key in &tile.descriptor.image_keys.items {
+                if resource_cache.is_image_dirty(*image_key) {
+                    tile.is_valid = false;
+                    break;
+                }
+            }
+
+            // Invalidate the tile if any opacity bindings changed.
+            for id in &tile.descriptor.opacity_bindings.items {
+                let changed = match self.opacity_bindings.get(id) {
+                    Some(info) => info.changed,
+                    None => true,
+                };
+                if changed {
+                    tile.is_valid = false;
+                    break;
+                }
+            }
+
+            if self.needs_update {
+                // Clear any dependencies so that when we rebuild them we
+                // can compare if the tile has the same content.
+                tile.clear();
+            }
+        }
     }
 
-    /// Update the dependencies for each tile for a given primitive instance.
     pub fn update_prim_dependencies(
         &mut self,
         prim_instance: &PrimitiveInstance,
         prim_list: &PrimitiveList,
-        surface_spatial_node_index: SpatialNodeIndex,
         clip_scroll_tree: &ClipScrollTree,
         resources: &FrameResources,
         clip_chain_nodes: &[ClipChainNode],
@@ -714,7 +563,7 @@ impl TileCache {
             return;
         }
 
-        self.space_mapper.set_target_spatial_node(
+        self.map_local_to_world.set_target_spatial_node(
             prim_instance.spatial_node_index,
             clip_scroll_tree,
         );
@@ -748,7 +597,7 @@ impl TileCache {
             None => return,
         };
 
-        let rect = match self.space_mapper.map(&culling_rect) {
+        let world_rect = match self.map_local_to_world.map(&culling_rect) {
             Some(rect) => rect,
             None => {
                 return;
@@ -757,12 +606,12 @@ impl TileCache {
 
         // If the rect is invalid, no need to create dependencies.
         // TODO(gw): Need to handle pictures with filters here.
-        if rect.size.width <= 0.0 || rect.size.height <= 0.0 {
+        if world_rect.size.width <= 0.0 || world_rect.size.height <= 0.0 {
             return;
         }
 
         // Get the tile coordinates in the picture space.
-        let (p0, p1) = self.get_tile_coords_for_rect(&rect);
+        let (p0, p1) = self.get_tile_coords_for_rect(&world_rect);
 
         // Build the list of resources that this primitive has dependencies on.
         let mut opacity_bindings: SmallVec<[PropertyBindingId; 4]> = SmallVec::new();
@@ -835,7 +684,9 @@ impl TileCache {
             // We only care about clip nodes that have transforms that are children
             // of the surface, since clips that are positioned by parents will be
             // handled by the clip collector when these tiles are composited.
-            if clip_chain_node.spatial_node_index >= surface_spatial_node_index {
+            if clip_chain_node.spatial_node_index < self.spatial_node_index {
+                self.clip_node_collector.insert(current_clip_chain_id)
+            } else {
                 clip_chain_spatial_nodes.push(clip_chain_node.spatial_node_index);
                 clip_chain_uids.push(clip_chain_node.handle.uid());
             }
@@ -844,57 +695,38 @@ impl TileCache {
 
         // Normalize the tile coordinates before adding to tile dependencies.
         // For each affected tile, mark any of the primitive dependencies.
-        for y in p0.y - self.tile_rect.origin.y .. p1.y - self.tile_rect.origin.y {
-            for x in p0.x - self.tile_rect.origin.x .. p1.x - self.tile_rect.origin.x {
-                let index = (y * self.tile_rect.size.width + x) as usize;
+        for y in p0.y .. p1.y {
+            for x in p0.x .. p1.x {
+                // If the primitive exists on tiles outside the selected tile cache
+                // area, just ignore those.
+                if x < 0 || x >= self.tile_count.width || y < 0 || y >= self.tile_count.height {
+                    continue;
+                }
+
+                let index = (y * self.tile_count.width + x) as usize;
                 let tile = &mut self.tiles[index];
 
                 // Mark if the tile is cacheable at all.
-                tile.is_cacheable &= is_cacheable;
-                tile.in_use = true;
+                tile.is_valid &= is_cacheable;
 
                 // Include any image keys this tile depends on.
-                for image_key in &image_keys {
-                    tile.image_keys.insert(*image_key);
-                }
+                tile.descriptor.image_keys.extend_from_slice(&image_keys);
 
-                // Include the transform of the primitive itself.
-                tile.push_transform_dependency(
-                    prim_instance.spatial_node_index,
-                    surface_spatial_node_index,
-                    clip_scroll_tree,
-                    &mut self.transforms,
-                );
+                // // Include any opacity bindings this primitive depends on.
+                tile.descriptor.opacity_bindings.extend_from_slice(&opacity_bindings);
 
-                // Include the transforms of any relevant clip nodes for this primitive.
-                for clip_chain_spatial_node in &clip_chain_spatial_nodes {
-                    tile.push_transform_dependency(
-                        *clip_chain_spatial_node,
-                        surface_spatial_node_index,
-                        clip_scroll_tree,
-                        &mut self.transforms,
-                    );
-                }
-
-                // Include any opacity bindings this primitive depends on.
-                for id in &opacity_bindings {
-                    if tile.opacity_bindings.insert(*id) {
-                        tile.descriptor.opacity_bindings.push(*id);
-                    }
-                }
-
-                // For the primitive origin, store the local origin relative to
-                // the local origin of the containing picture. This ensures that
+                // For the primitive origin, store the world origin relative to
+                // the world origin of the containing picture. This ensures that
                 // a tile with primitives in the same coordinate system as the
                 // container picture itself, but different offsets relative to
                 // the containing picture are correctly invalidated. It does this
                 // while still maintaining the property of keeping the same hash
                 // for different display lists where the local origin is different
                 // but the primitives themselves are at the same relative position.
-                let origin = PointKey {
-                    x: prim_rect.origin.x - self.local_origin.x,
-                    y: prim_rect.origin.y - self.local_origin.y,
-                };
+                let origin = WorldPoint::new(
+                    world_rect.origin.x - tile.world_rect.origin.x,
+                    world_rect.origin.y - tile.world_rect.origin.y
+                );
 
                 // Update the tile descriptor, used for tile comparison during scene swaps.
                 tile.descriptor.prims.push(PrimitiveDescriptor {
@@ -908,152 +740,136 @@ impl TileCache {
         }
     }
 
-    /// Get a local space rectangle for a given tile coordinate.
-    pub fn get_tile_rect(&self, x: i32, y: i32) -> LayoutRect {
-        LayoutRect::new(
-            LayoutPoint::new(
-                self.local_origin.x + (self.tile_rect.origin.x + x) as f32 * self.local_tile_size.width,
-                self.local_origin.y + (self.tile_rect.origin.y + y) as f32 * self.local_tile_size.height,
-            ),
-            self.local_tile_size,
-        )
-    }
-
-    /// Build the dirty region(s) for the tile cache after all primitive
-    /// dependencies have been updated.
-    pub fn build_dirty_regions(
+    /// Apply any updates after prim dependency updates. This applies
+    /// any late tile invalidations, and sets up the dirty rect and
+    /// set of tile blits.
+    pub fn post_update(
         &mut self,
-        surface_spatial_node_index: SpatialNodeIndex,
-        frame_context: &FrameBuildingContext,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
-        retained_tiles: &mut RetainedTiles,
+        clip_store: &ClipStore,
+        frame_context: &FrameBuildingContext,
+        resources: &FrameResources,
     ) {
-        self.needs_update = false;
+        let mut dirty_world_rect = WorldRect::zero();
 
-        for (_, tile) in self.old_tiles.drain() {
-            resource_cache.texture_cache.mark_unused(&tile.handle);
-        }
-
-        let world_mapper = SpaceMapper::new_with_target(
-            ROOT_SPATIAL_NODE_INDEX,
-            surface_spatial_node_index,
-            frame_context.screen_world_rect,
-            frame_context.clip_scroll_tree,
+        let descriptor = ImageDescriptor::new(
+            TILE_SIZE_WIDTH,
+            TILE_SIZE_HEIGHT,
+            ImageFormat::BGRA8,
+            true,
+            false,
         );
 
-        let mut tile_offset = DeviceIntPoint::new(
-            self.tile_rect.size.width,
-            self.tile_rect.size.height,
-        );
+        // Get the world clip rect that we will use to determine
+        // which parts of the tiles are valid / required.
+        let clip_rect = self
+            .clip_node_collector
+            .get_world_clip_rect(
+                clip_store,
+                &resources.clip_data_store,
+                frame_context.clip_scroll_tree,
+            ).expect("bug: no world clip rect");
 
-        let mut dirty_rect = LayoutRect::zero();
+        let clip_rect = clip_rect
+            .intersection(&frame_context.screen_world_rect)
+            .expect("bug: clip rect is off-screen");
+
+        let clipped = (clip_rect * frame_context.device_pixel_scale).round().to_i32();
 
         // Step through each tile and invalidate if the dependencies have changed.
-        for y in 0 .. self.tile_rect.size.height {
-            for x in 0 .. self.tile_rect.size.width {
-                let i = y * self.tile_rect.size.width + x;
-                let tile_rect = self.get_tile_rect(x, y);
-                let tile = &mut self.tiles[i as usize];
+        for (i, tile) in self.tiles.iter_mut().enumerate() {
+            // Check the content of the tile is the same
+            tile.is_valid &= tile.descriptor.is_valid();
 
-                // If this tile is unused (has no primitives on it), we can just
-                // skip any invalidation / dirty region work for it.
-                if !tile.in_use {
+            // Invalidate if the backing texture was evicted.
+            if !resource_cache.texture_cache.is_allocated(&tile.handle) {
+                tile.is_valid = false;
+            }
+
+            // Work out which part of the tile rect is valid.
+            let tile_device_rect = (tile.world_rect * frame_context.device_pixel_scale).round().to_i32();
+
+            // Get the part of the tile rect that is actually going to be rendered on screen.
+            let src_rect = clipped.intersection(&tile_device_rect);
+
+            // If that was completely off-screen, nothing to do.
+            let src_rect = match src_rect {
+                Some(rect) => rect,
+                None => {
                     continue;
                 }
+            };
 
-                // Check if this tile is actually visible.
-                let tile_world_rect = world_mapper
-                    .map(&tile_rect)
-                    .expect("bug: unable to map tile to world coords");
-                tile.is_visible = frame_context.screen_world_rect.intersects(&tile_world_rect);
+            // Get this space relative to the tile itself.
+            let unit_rect = src_rect
+                .translate(&-tile_device_rect.origin.to_vector());
 
-                // Try to reuse cached tiles from the previous scene in this new
-                // scene, if possible.
-                if tile.is_visible && !resource_cache.texture_cache.is_allocated(&tile.handle) {
-                    // See if we have a retained tile from last scene that matches the
-                    // exact content of this tile.
+            // Work out if the currently valid rect of this tile is large
+            // enough for what we need to draw.
+            let valid_pixel_rect = match tile.pixel_rect {
+                Some(pixel_rect) => pixel_rect.contains_rect(&unit_rect),
+                None => false,
+            };
+            if !valid_pixel_rect {
+                tile.is_valid = false;
+            }
 
-                    if let Some(retained_handle) = retained_tiles.tiles.remove(&tile.descriptor) {
-                        // Only use if not evicted from texture cache in the meantime.
-                        if resource_cache.texture_cache.is_allocated(&retained_handle) {
-                            // We found a matching tile from the previous scene, so use it!
-                            tile.handle = retained_handle;
-                            tile.is_valid = true;
-                            // We know that the hash key of the descriptor validates that
-                            // the local transforms in this tile exactly match the value
-                            // of the current relative transforms needed for this tile,
-                            // so we can mark those transforms as valid to avoid the
-                            // retained tile being invalidated below.
-                            for info in &mut tile.transform_info {
-                                info.changed = false;
-                            }
-                        }
-                    }
+            // Request the backing texture so it won't get evicted this frame.
+            resource_cache.texture_cache.request(&tile.handle, gpu_cache);
+
+            // Decide how to handle this tile when drawing this frame.
+            if tile.is_valid {
+                // If the tile is valid, we will generally want to draw it
+                // on screen. However, if there are no primitives there is
+                // no need to draw it.
+                if !tile.descriptor.prims.is_empty() {
+                    self.tiles_to_draw.push(i);
                 }
+            } else {
+                // Add the tile rect to the dirty rect.
+                dirty_world_rect = dirty_world_rect.union(&tile.world_rect);
 
-                // Invalidate the tile if not cacheable
-                if !tile.is_cacheable {
-                    tile.is_valid = false;
-                }
+                // Store the currently valid rect for this tile.
+                tile.pixel_rect = Some(unit_rect);
 
-                // Invalidate the tile if any images have changed
-                for image_key in &tile.image_keys {
-                    if resource_cache.is_image_dirty(*image_key) {
-                        tile.is_valid = false;
-                        break;
-                    }
-                }
+                // Ensure that this texture is allocated.
+                resource_cache.texture_cache.update(
+                    &mut tile.handle,
+                    descriptor,
+                    TextureFilter::Linear,
+                    None,
+                    [0.0; 3],
+                    DirtyRect::All,
+                    gpu_cache,
+                    None,
+                    UvRectKind::Rect,
+                    Eviction::Eager,
+                );
 
-                // Invalidate the tile if any opacity bindings changed.
-                for id in &tile.opacity_bindings {
-                    let changed = match self.opacity_bindings.get(id) {
-                        Some(info) => info.changed,
-                        None => true,
-                    };
-                    if changed {
-                        tile.is_valid = false;
-                        break;
-                    }
-                }
+                let cache_item = resource_cache
+                    .get_texture_cache_item(&tile.handle);
 
-                // Invalidate the tile if any dependent transforms changed
-                for info in &tile.transform_info {
-                    if info.changed {
-                        tile.is_valid = false;
-                        break;
-                    }
-                }
+                // Store a blit operation to be done after drawing the
+                // frame in order to update the cached texture tile.
+                let dest_offset = unit_rect.origin;
+                self.pending_blits.push(TileBlit {
+                    target: cache_item,
+                    src_offset: src_rect.origin,
+                    dest_offset,
+                    size: unit_rect.size,
+                });
 
-                // Invalidate the tile if it was evicted by the texture cache.
-                if !resource_cache.texture_cache.is_allocated(&tile.handle) {
-                    tile.is_valid = false;
-                }
-
-                if tile.is_visible {
-                    // Ensure we request the texture cache handle for this tile
-                    // each frame it will be used so the texture cache doesn't
-                    // decide to evict tiles that we currently want to use.
-                    resource_cache.texture_cache.request(&tile.handle, gpu_cache);
-
-                    // If we have an invalid tile, which is also visible, add it to the
-                    // dirty rect we will need to draw.
-                    if !tile.is_valid {
-                        dirty_rect = dirty_rect.union(&tile_rect);
-                        tile_offset.x = tile_offset.x.min(x);
-                        tile_offset.y = tile_offset.y.min(y);
-                    }
-                }
+                // We can consider this tile valid now.
+                tile.is_valid = true;
             }
         }
 
-        self.dirty_region = if dirty_rect.is_empty() {
+        // Store the dirty region for drawing the main scene.
+        self.dirty_region = if dirty_world_rect.is_empty() {
             None
         } else {
-            let dirty_world_rect = world_mapper.map(&dirty_rect).expect("todo");
             Some(DirtyRegion {
-                dirty_rect,
-                tile_offset,
                 dirty_world_rect,
             })
         };
@@ -1062,7 +878,7 @@ impl TileCache {
 
 /// State structure that is used during the tile cache update picture traversal.
 pub struct TileCacheUpdateState {
-    pub tile_cache: Option<(TileCache, SpatialNodeIndex)>,
+    pub tile_cache: Option<TileCache>,
 }
 
 impl TileCacheUpdateState {
@@ -1168,6 +984,8 @@ pub struct SurfaceInfo {
     pub tasks: Vec<RenderTaskId>,
     /// How much the local surface rect should be inflated (for blur radii).
     pub inflation_factor: f32,
+    /// A list of tile blits to be done after drawing this surface.
+    pub tile_blits: Vec<TileBlit>,
 }
 
 impl SurfaceInfo {
@@ -1202,6 +1020,7 @@ impl SurfaceInfo {
             surface_spatial_node_index,
             tasks: Vec::new(),
             inflation_factor,
+            tile_blits: Vec::new(),
         }
     }
 
@@ -1592,14 +1411,8 @@ impl PicturePrimitive {
         retained_tiles: &mut RetainedTiles,
     ) {
         if let Some(tile_cache) = self.tile_cache.take() {
-            debug_assert!(tile_cache.old_tiles.is_empty());
             for tile in tile_cache.tiles {
-                if let Some((descriptor, handle)) = tile.destroy() {
-                    retained_tiles.tiles.insert(
-                        descriptor,
-                        handle,
-                    );
-                }
+                retained_tiles.tiles.push(tile);
             }
         }
     }
@@ -1640,7 +1453,7 @@ impl PicturePrimitive {
 
         let tile_cache = match requested_composite_mode {
             Some(PictureCompositeMode::TileCache { .. }) => {
-                Some(TileCache::new())
+                Some(TileCache::new(spatial_node_index))
             }
             Some(_) | None => {
                 None
@@ -1677,6 +1490,7 @@ impl PicturePrimitive {
         parent_allows_subpixel_aa: bool,
         frame_state: &mut FrameBuildingState,
         frame_context: &FrameBuildingContext,
+        dirty_world_rect: WorldRect,
     ) -> Option<(PictureContext, PictureState, PrimitiveList)> {
         if !self.is_visible() {
             return None;
@@ -1697,8 +1511,8 @@ impl PicturePrimitive {
                     })
             }
             None => {
-                // No tile cache - just assume the world rect of the screen.
-                frame_context.screen_world_rect
+                // No tile cache - just assume the current dirty world rect.
+                dirty_world_rect
             }
         };
 
@@ -2037,7 +1851,6 @@ impl PicturePrimitive {
     pub fn update_prim_dependencies(
         &self,
         tile_cache: &mut TileCache,
-        surface_spatial_node_index: SpatialNodeIndex,
         frame_context: &FrameBuildingContext,
         resource_cache: &mut ResourceCache,
         resources: &FrameResources,
@@ -2050,7 +1863,6 @@ impl PicturePrimitive {
             tile_cache.update_prim_dependencies(
                 prim_instance,
                 &self.prim_list,
-                surface_spatial_node_index,
                 &frame_context.clip_scroll_tree,
                 resources,
                 &clip_store.clip_chain_nodes,
@@ -2153,25 +1965,6 @@ impl PicturePrimitive {
         // to the parent.
         if let Some(ref mut raster_config) = self.raster_config {
             let surface_rect = state.current_surface().rect;
-
-            // Sometimes, Gecko supplies a huge picture rect. This is typically
-            // due to some weird startup condition, or a reftest that has an
-            // extreme scale in it. In these cases, disable the tile cache and
-            // just use the normal Blit composite mode for this picture. This
-            // is not ideal (we could skip the surface altogether in the future)
-            // but it's simple and works around this edge case for now.
-            if let Some(ref mut tile_cache) = self.tile_cache {
-                if surface_rect.size.width > MAX_PICTURE_SIZE ||
-                   surface_rect.size.height > MAX_PICTURE_SIZE ||
-                   surface_rect.size.width <= 0.0 ||
-                   surface_rect.size.height <= 0.0
-                {
-                    tile_cache.needs_update = false;
-                    tile_cache.tiles.clear();
-                    tile_cache.tile_rect = TileRect::zero();
-                    raster_config.composite_mode = PictureCompositeMode::Blit;
-                }
-            }
 
             let mut surface_rect = TypedRect::from_untyped(&surface_rect.to_untyped());
 
@@ -2277,124 +2070,16 @@ impl PicturePrimitive {
         //           it's not used by that shader.
 
         let surface = match raster_config.composite_mode {
-            PictureCompositeMode::TileCache { clear_color, .. } => {
+            PictureCompositeMode::TileCache { .. } => {
                 let tile_cache = self.tile_cache.as_mut().unwrap();
 
-                // Build the render task for a tile cache picture, if there is
-                // any dirty rect.
+                // For a picture surface, just push any child tasks and tile
+                // blits up to the parent surface.
+                let surface = &mut surfaces[surface_index.0];
+                surface.tasks.extend(child_tasks);
+                surface.tile_blits.extend(tile_cache.pending_blits.drain(..));
 
-                match tile_cache.dirty_region {
-                    Some(ref dirty_region) => {
-                        // Texture cache descriptor for each tile.
-                        // TODO(gw): If / when we start to use tile caches with
-                        //           clip masks and/or transparent backgrounds,
-                        //           we will need to correctly select an opacity
-                        //           here and a blend mode in batch.rs.
-                        let descriptor = ImageDescriptor::new(
-                            TILE_SIZE_WIDTH,
-                            TILE_SIZE_HEIGHT,
-                            ImageFormat::BGRA8,
-                            true,
-                            false,
-                        );
-
-                        // Get a picture rect, expanded to tile boundaries.
-                        let p0 = pic_rect.origin;
-                        let p1 = pic_rect.bottom_right();
-                        let local_tile_size = tile_cache.local_tile_size;
-                        let aligned_pic_rect = PictureRect::from_floats(
-                            (p0.x / local_tile_size.width).floor() * local_tile_size.width,
-                            (p0.y / local_tile_size.height).floor() * local_tile_size.height,
-                            (p1.x / local_tile_size.width).ceil() * local_tile_size.width,
-                            (p1.y / local_tile_size.height).ceil() * local_tile_size.height,
-                        );
-
-                        let mut blits = Vec::new();
-
-                        // Step through each tile and build the dirty rect
-                        for y in 0 .. tile_cache.tile_rect.size.height {
-                            for x in 0 .. tile_cache.tile_rect.size.width {
-                                let i = y * tile_cache.tile_rect.size.width + x;
-                                let tile = &mut tile_cache.tiles[i as usize];
-
-                                // If tile is invalidated, and on-screen, then we will
-                                // need to rasterize it.
-                                if !tile.is_valid && tile.is_visible && tile.in_use {
-                                    // Notify the texture cache that we want to use this handle
-                                    // and make sure it is allocated.
-                                    frame_state.resource_cache.texture_cache.update(
-                                        &mut tile.handle,
-                                        descriptor,
-                                        TextureFilter::Linear,
-                                        None,
-                                        [0.0; 3],
-                                        DirtyRect::All,
-                                        frame_state.gpu_cache,
-                                        None,
-                                        UvRectKind::Rect,
-                                        Eviction::Eager,
-                                    );
-
-                                    let cache_item = frame_state
-                                        .resource_cache
-                                        .get_texture_cache_item(&tile.handle);
-
-                                    // Set up the blit command now that we know where the dest
-                                    // rect is in the texture cache.
-                                    let offset = DeviceIntPoint::new(
-                                        (x - dirty_region.tile_offset.x) * TILE_SIZE_WIDTH,
-                                        (y - dirty_region.tile_offset.y) * TILE_SIZE_HEIGHT,
-                                    );
-
-                                    blits.push(TileBlit {
-                                        target: cache_item,
-                                        offset,
-                                    });
-
-                                    tile.is_valid = true;
-                                }
-                            }
-                        }
-
-                        // We want to clip the drawing of this and any children to the
-                        // dirty rect.
-                        let clipped_rect = dirty_region.dirty_world_rect;
-
-                        let (clipped, unclipped) = match get_raster_rects(
-                            aligned_pic_rect,
-                            &map_pic_to_raster,
-                            &map_raster_to_world,
-                            clipped_rect,
-                            frame_context.device_pixel_scale,
-                        ) {
-                            Some(info) => info,
-                            None => {
-                                return false;
-                            }
-                        };
-
-                        let picture_task = RenderTask::new_picture(
-                            RenderTaskLocation::Dynamic(None, clipped.size),
-                            unclipped.size,
-                            pic_index,
-                            clipped.origin,
-                            child_tasks,
-                            UvRectKind::Rect,
-                            pic_context.raster_spatial_node_index,
-                            Some(clear_color),
-                            blits,
-                        );
-
-                        let render_task_id = frame_state.render_tasks.add(picture_task);
-                        surfaces[surface_index.0].tasks.push(render_task_id);
-
-                        PictureSurface::RenderTask(render_task_id)
-                    }
-                    None => {
-                        // None of the tiles have changed, so we can skip any drawing!
-                        return true;
-                    }
-                }
+                return true;
             }
             PictureCompositeMode::Filter(FilterOp::Blur(blur_radius)) => {
                 let blur_std_deviation = blur_radius * frame_context.device_pixel_scale.0;
@@ -2837,29 +2522,4 @@ fn create_raster_mappers(
     );
 
     (map_raster_to_world, map_pic_to_raster)
-}
-
-// Check whether a relative transform between two spatial nodes has changed
-// since last frame. If that relative transform hasn't been calculated, then
-// do that now and store it for later use.
-fn get_global_transform_changed(
-    global_transforms: &mut [GlobalTransformInfo],
-    spatial_node_index: SpatialNodeIndex,
-    clip_scroll_tree: &ClipScrollTree,
-    surface_spatial_node_index: SpatialNodeIndex,
-) -> bool {
-    let transform = &mut global_transforms[spatial_node_index.0];
-
-    if transform.current.is_none() {
-        let mapping: CoordinateSpaceMapping<LayoutPixel, PicturePixel> = CoordinateSpaceMapping::new(
-            surface_spatial_node_index,
-            spatial_node_index,
-            clip_scroll_tree,
-        ).expect("todo: handle invalid mappings");
-
-        transform.current = Some(mapping.into());
-        transform.changed = true;
-    }
-
-    transform.changed
 }

--- a/webrender/src/render_task.rs
+++ b/webrender/src/render_task.rs
@@ -255,7 +255,9 @@ pub struct ClipRegionTask {
 #[cfg_attr(feature = "replay", derive(Deserialize))]
 pub struct TileBlit {
     pub target: CacheItem,
-    pub offset: DeviceIntPoint,
+    pub src_offset: DeviceIntPoint,
+    pub dest_offset: DeviceIntPoint,
+    pub size: DeviceIntSize,
 }
 
 #[derive(Debug)]

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -3495,19 +3495,35 @@ impl Renderer {
                     with_depth: false,
                 });
 
-                let src_rect = DeviceIntRect::new(
-                    blit.offset,
-                    blit.target.uv_rect.size.to_i32(),
+                let mut src_rect = DeviceIntRect::new(
+                    blit.src_offset,
+                    blit.size,
                 );
 
-                let dest_rect = blit.target.uv_rect.to_i32();
+                let target_rect = blit.target.uv_rect.to_i32();
+
+                let mut dest_rect = DeviceIntRect::new(
+                    DeviceIntPoint::new(
+                        blit.dest_offset.x + target_rect.origin.x,
+                        blit.dest_offset.y + target_rect.origin.y,
+                    ),
+                    blit.size,
+                );
+
+                // Modify the src/dest rects since we are blitting from the framebuffer
+                src_rect.origin.y = draw_target.dimensions().height as i32 - src_rect.size.height - src_rect.origin.y;
+                dest_rect.origin.y += dest_rect.size.height;
+                dest_rect.size.height = -dest_rect.size.height;
 
                 self.device.blit_render_target(
                     src_rect,
                     dest_rect,
                 );
             }
+
+            self.device.bind_draw_target(draw_target);
         }
+
     }
 
     fn draw_alpha_target(

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -1602,6 +1602,8 @@ pub struct Renderer {
     /// Notification requests to be fulfilled after rendering.
     notifications: Vec<NotificationRequest>,
 
+    framebuffer_size: Option<DeviceIntSize>,
+
     #[cfg(feature = "capture")]
     read_fbo: FBOId,
     #[cfg(feature = "replay")]
@@ -2048,6 +2050,7 @@ impl Renderer {
             #[cfg(feature = "replay")]
             owned_external_images: FastHashMap::default(),
             notifications: Vec::new(),
+            framebuffer_size: None,
         };
 
         renderer.set_debug_flags(options.debug_flags);
@@ -2116,7 +2119,8 @@ impl Renderer {
                             // (in order to update the texture cache), issue
                             // a render just to off-screen targets.
                             if self.active_documents[pos].1.frame.must_be_drawn() {
-                                self.render_impl(None).ok();
+                                let framebuffer_size = self.framebuffer_size;
+                                self.render_impl(framebuffer_size).ok();
                             }
                             self.active_documents[pos].1 = doc;
                         }
@@ -2483,6 +2487,8 @@ impl Renderer {
         &mut self,
         framebuffer_size: DeviceIntSize,
     ) -> Result<RendererStats, Vec<RendererError>> {
+        self.framebuffer_size = Some(framebuffer_size);
+
         let result = self.render_impl(Some(framebuffer_size));
 
         drain_filter(

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -424,10 +424,12 @@ impl RenderTarget for ColorRenderTarget {
 
                     for blit in &pic_task.blits {
                         self.tile_blits.push(TileBlit {
+                            dest_offset: blit.dest_offset,
+                            size: blit.size,
                             target: blit.target.clone(),
-                            offset: DeviceIntPoint::new(
-                                blit.offset.x + target_rect.origin.x,
-                                blit.offset.y + target_rect.origin.y,
+                            src_offset: DeviceIntPoint::new(
+                                blit.src_offset.x + target_rect.origin.x,
+                                blit.src_offset.y + target_rect.origin.y,
                             ),
                         })
                     }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -893,7 +893,7 @@ pub fn recycle_vec<T>(vec: &mut Vec<T>) {
 #[derive(Debug)]
 pub struct ComparableVec<T> {
     /// The items to be stored and compared
-    pub items: Vec<T>,
+    items: Vec<T>,
     /// The current index to add the next item to
     current_index: usize,
     /// The previous length of the array
@@ -913,9 +913,15 @@ impl<T> ComparableVec<T> where T: PartialEq + Clone + fmt::Debug {
         }
     }
 
+    /// Retrieve a reference to the current items array
+    pub fn items(&self) -> &[T] {
+        &self.items[.. self.current_index]
+    }
+
     /// Clear the contents of the vec, ready for adding new items.
     pub fn reset(&mut self) {
-        self.prev_len = self.items.len();
+        self.items.truncate(self.current_index);
+        self.prev_len = self.current_index;
         self.current_index = 0;
         self.is_same = true;
     }
@@ -968,6 +974,6 @@ impl<T> ComparableVec<T> where T: PartialEq + Clone + fmt::Debug {
 
     /// Return true if the contents of the vec are the same as the previous time.
     pub fn is_valid(&self) -> bool {
-        self.is_same && self.prev_len == self.items.len()
+        self.is_same && self.prev_len == self.current_index
     }
 }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -884,3 +884,90 @@ pub fn recycle_vec<T>(vec: &mut Vec<T>) {
     }
     vec.clear();
 }
+
+/// A specialized array container for comparing equality between the current
+/// contents and the new contents, incrementally. As each item is added, the
+/// container maintains track of whether this is the same as last time items
+/// were added, or if the contents have diverged. After each reset, the memory
+/// of the vec is retained, which means that memory allocation is rare.
+#[derive(Debug)]
+pub struct ComparableVec<T> {
+    /// The items to be stored and compared
+    pub items: Vec<T>,
+    /// The current index to add the next item to
+    current_index: usize,
+    /// The previous length of the array
+    prev_len: usize,
+    /// Whether the contents of the vec is the same as last time.
+    is_same: bool,
+}
+
+impl<T> ComparableVec<T> where T: PartialEq + Clone + fmt::Debug {
+    /// Construct a new comparable vec
+    pub fn new() -> Self {
+        ComparableVec {
+            items: Vec::new(),
+            current_index: 0,
+            prev_len: 0,
+            is_same: false,
+        }
+    }
+
+    /// Clear the contents of the vec, ready for adding new items.
+    pub fn reset(&mut self) {
+        self.prev_len = self.items.len();
+        self.current_index = 0;
+        self.is_same = true;
+    }
+
+    /// Return the current length of the container
+    pub fn len(&self) -> usize {
+        self.current_index
+    }
+
+    /// Return true if the container has no items
+    pub fn is_empty(&self) -> bool {
+        self.current_index == 0
+    }
+
+    /// Push a number of items into the container
+    pub fn extend_from_slice(&mut self, items: &[T]) {
+        for item in items {
+            self.push(item.clone());
+        }
+    }
+
+    /// Push a single item into the container.
+    pub fn push(&mut self, item: T) {
+        // If this item extends the real length of the vec, it's clearly not
+        // the same as last time.
+        if self.current_index < self.items.len() {
+            // If the vec is currently considered equal, we need to compare
+            // the item being pushed.
+            if self.is_same {
+                let existing_item = &mut self.items[self.current_index];
+                if *existing_item != item {
+                    // Overwrite the current item with the new one and
+                    // mark the vec as different.
+                    *existing_item = item;
+                    self.is_same = false;
+                }
+            } else {
+                // The vec is already not equal, so just push the item.
+                self.items[self.current_index] = item;
+            }
+        } else {
+            // In this case, mark the vec as different and store the new item.
+            self.is_same = false;
+            self.items.push(item);
+        }
+
+        // Increment where the next item will be pushed.
+        self.current_index += 1;
+    }
+
+    /// Return true if the contents of the vec are the same as the previous time.
+    pub fn is_valid(&self) -> bool {
+        self.is_same && self.prev_len == self.items.len()
+    }
+}


### PR DESCRIPTION
One the remaining issues with enabling picture caching is that
it was a noticeable performance regression on sites that don't
benefit from picture caching, due to the extra render targets
and blits. Instead, we now draw to the main framebuffer and
blit those results into tiles for caching, as appropriate.

There is still a bit of work to be done here (specifically,
detecting when a tile isn't opaque, and disabling the cache blit
if we decide the tile is changing too often), but this is in
general a much faster solution than before. It's also faster
on pages that *do* benefit from picture caching, removing
one extra blit step during cache creation.

This also changes how we handle the way gecko supplies different
display lists with different local coordinate systems. Now, we
cache based on the world rect of the tile, and verify the content
with the new ComparableVec type. This is much more robust and
fixes a number of existing bugzilla bugs related to picture caching.

This patch also removes much of the hashing required, which is a
performance win on the sites I tested (even with the vec comparison
that we now use instead). We do currently update prim deps each
scroll frame, which can be improved / optimized in the future.

Finally, this implementation only allocates and stores tiles for
the current viewport, which is much better for performance and
scaling of content where the picture rect is very large.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3446)
<!-- Reviewable:end -->
