### PR TITLE
Avoid overflowing or OOMing when given a nonsensical blob image request

### DIFF
--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -1150,6 +1150,19 @@ impl ResourceCache {
                 // nonsensical blob image requests.
                 // Constant here definitely needs to be tweaked.
                 const MAX_TILES_PER_REQUEST: i32 = 64;
+                // For truly nonsensical requests, we might run into overflow
+                // when computing width * height. Even if we don't, the loop
+                // below to reduce the number of tiles is linear and can take
+                // a long time to complete. These preliminary conditions help
+                // get us there faster and avoid the overflow.
+                if tiles.size.width > MAX_TILES_PER_REQUEST {
+                    tiles.origin.x += (tiles.size.width - MAX_TILES_PER_REQUEST) / 2;
+                    tiles.size.width = MAX_TILES_PER_REQUEST;
+                }
+                if tiles.size.height > MAX_TILES_PER_REQUEST {
+                    tiles.origin.y += (tiles.size.height - MAX_TILES_PER_REQUEST) / 2;
+                    tiles.size.height = MAX_TILES_PER_REQUEST;
+                }
                 while tiles.size.width as i32 * tiles.size.height as i32 > MAX_TILES_PER_REQUEST {
                     // Remove tiles in the largest dimension.
                     if tiles.size.width > tiles.size.height {


### PR DESCRIPTION
This fixes the test case in https://bugzilla.mozilla.org/show_bug.cgi?id=1509123

Try push is at https://treeherder.mozilla.org/#/jobs?repo=try&group_state=expanded&revision=b3e1f1e97f16943e4cfc41834371ccb6c00a39c0 and I'll add the testcase from the bug as a crashtest in gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3449)
<!-- Reviewable:end -->
