### PR TITLE
Fix picture caching on sites with multiple scroll roots.

### DIFF
--- a/webrender/src/display_list_flattener.rs
+++ b/webrender/src/display_list_flattener.rs
@@ -263,21 +263,36 @@ impl<'a> DisplayListFlattener<'a> {
         //
 
         // Find the first primitive which has the desired scroll root.
+        let mut first_index = None;
         let mut main_scroll_root = None;
 
-        let first_index = primitives.iter().position(|instance| {
+        for (i, instance) in primitives.iter().enumerate() {
             let scroll_root = self.find_scroll_root(
                 instance.spatial_node_index,
             );
 
-            if scroll_root == ROOT_SPATIAL_NODE_INDEX {
-                false
-            } else {
-                debug_assert!(main_scroll_root.is_none());
-                main_scroll_root = Some(scroll_root);
-                true
+            if scroll_root != ROOT_SPATIAL_NODE_INDEX {
+                // If we find multiple scroll roots in this page, then skip
+                // picture caching for now. In future, we can handle picture
+                // caching on these sites by creating a tile cache per
+                // scroll root, or (more likely) selecting the common parent
+                // scroll root between the detected scroll roots.
+                match main_scroll_root {
+                    Some(main_scroll_root) => {
+                        if main_scroll_root != scroll_root {
+                            return;
+                        }
+                    }
+                    None => {
+                        main_scroll_root = Some(scroll_root);
+                    }
+                }
+
+                if first_index.is_none() {
+                    first_index = Some(i);
+                }
             }
-        });
+        }
 
         let main_scroll_root = match main_scroll_root {
             Some(main_scroll_root) => main_scroll_root,


### PR DESCRIPTION
For now, we simply disable picture caching when we encounter a
display list with content that has multiple scroll roots (other
than the root scroll node) - this still handles the majority of
sites. In future, we can expand this to support more cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3454)
<!-- Reviewable:end -->
