### PR TITLE
Version 0.58.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
  "euclid 0.19.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.57.2",
+ "webrender 0.58.0",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.57.2"
+version = "0.58.0"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1570,7 +1570,7 @@ dependencies = [
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_api 0.57.2",
+ "webrender_api 0.58.0",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1584,13 +1584,13 @@ dependencies = [
  "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.57.2",
+ "webrender 0.58.0",
  "winit 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.57.2"
+version = "0.58.0"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1693,8 +1693,8 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.57.2",
- "webrender_api 0.57.2",
+ "webrender 0.58.0",
+ "webrender_api 0.58.0",
  "winit 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.57.2"
+version = "0.58.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
@@ -41,7 +41,7 @@ sha2 = "0.8"
 smallvec = "0.6"
 thread_profiler = "0.1.1"
 time = "0.1"
-webrender_api = { version = "0.57.2", path = "../webrender_api" }
+webrender_api = { version = "0.58.0", path = "../webrender_api" }
 ws = { optional = true, version = "0.7.3" }
 
 [dependencies.pathfinder_font_renderer]

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.57.2"
+version = "0.58.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"


### PR DESCRIPTION
I have a local [branch](https://github.com/nical/webrender/tree/no-pathfinder) that removes the pathfinder dependencies in order be able to push to crates.io. I plan to publish from that branch without merging it into master, but I also need to bump the version of webrender_api to be able to do the package/publish dance.

Having pathfinder in webrender's crates.io version is pending on getting the remaining bits of pathfinder published as well as updating webrender to use fontkit and pathfinder's more recent API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3457)
<!-- Reviewable:end -->
