### PR TITLE
Fix picture caching on pages with fixed position clips.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -23,7 +23,7 @@ use render_task::to_cache_size;
 use resource_cache::{ImageRequest, ResourceCache};
 use std::{cmp, u32};
 use std::os::raw::c_void;
-use util::{extract_inner_rect_safe, project_rect, ScaleOffset, MaxRect};
+use util::{extract_inner_rect_safe, project_rect, ScaleOffset};
 
 /*
 
@@ -1360,46 +1360,6 @@ impl ClipNodeCollector {
         clip_chain_id: ClipChainId,
     ) {
         self.clips.insert(clip_chain_id);
-    }
-
-    pub fn clear(
-        &mut self,
-    ) {
-        self.clips.clear();
-    }
-
-    /// Build the world clip rect for this clip node collector.
-    // NOTE: This ignores any complex clips that may be present.
-    pub fn get_world_clip_rect(
-        &self,
-        clip_store: &ClipStore,
-        clip_data_store: &ClipDataStore,
-        clip_scroll_tree: &ClipScrollTree,
-    ) -> Option<WorldRect> {
-        let mut clip_rect = WorldRect::max_rect();
-
-        let mut map_local_to_world = SpaceMapper::new(
-            ROOT_SPATIAL_NODE_INDEX,
-            WorldRect::zero(),
-        );
-
-        for clip_chain_id in &self.clips {
-            let clip_chain_node = clip_store.get_clip_chain(*clip_chain_id);
-            let clip_node = &clip_data_store[clip_chain_node.handle];
-
-            if let Some(local_rect) = clip_node.item.get_local_clip_rect(clip_chain_node.local_pos) {
-                map_local_to_world.set_target_spatial_node(
-                    clip_chain_node.spatial_node_index,
-                    clip_scroll_tree,
-                );
-
-                if let Some(world_rect) = map_local_to_world.map(&local_rect) {
-                    clip_rect = clip_rect.intersection(&world_rect)?;
-                }
-            }
-        }
-
-        Some(clip_rect)
     }
 }
 

--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -4,11 +4,11 @@
 
 use api::{DeviceRect, FilterOp, MixBlendMode, PipelineId, PremultipliedColorF, PictureRect, PicturePoint, WorldPoint};
 use api::{DeviceIntRect, DevicePoint, LayoutRect, PictureToRasterTransform, LayoutPixel, PropertyBinding, PropertyBindingId};
-use api::{DevicePixelScale, RasterRect, RasterSpace, ColorF, ImageKey, DirtyRect, WorldSize, LayoutSize};
+use api::{DevicePixelScale, RasterRect, RasterSpace, ColorF, ImageKey, DirtyRect, WorldSize, LayoutSize, ClipMode};
 use api::{PicturePixel, RasterPixel, WorldPixel, WorldRect, ImageFormat, ImageDescriptor, WorldVector2D};
 use box_shadow::{BLUR_SAMPLE_SCALE};
-use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode};
-use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex};
+use clip::{ClipNodeCollector, ClipStore, ClipChainId, ClipChainNode, ClipItem};
+use clip_scroll_tree::{ROOT_SPATIAL_NODE_INDEX, ClipScrollTree, SpatialNodeIndex, CoordinateSystemId};
 use device::TextureFilter;
 use euclid::{TypedScale, vec3, TypedRect, TypedPoint2D, TypedSize2D};
 use euclid::approxeq::ApproxEq;
@@ -108,7 +108,7 @@ pub struct Tile {
     /// The current local rect of this tile.
     pub local_rect: LayoutRect,
     /// The valid rect within this tile.
-    pixel_rect: Option<DeviceIntRect>,
+    valid_rect: WorldRect,
     /// Uniquely describes the content of this tile, in a way that can be
     /// (reasonably) efficiently hashed and compared.
     descriptor: TileDescriptor,
@@ -125,12 +125,12 @@ impl Tile {
     fn new(
     ) -> Self {
         Tile {
-            handle: TextureCacheHandle::invalid(),
             local_rect: LayoutRect::zero(),
             world_rect: WorldRect::zero(),
+            valid_rect: WorldRect::zero(),
+            handle: TextureCacheHandle::invalid(),
             descriptor: TileDescriptor::new(),
             is_valid: false,
-            pixel_rect: None,
         }
     }
 
@@ -177,6 +177,12 @@ pub struct TileDescriptor {
     /// The set of opacity bindings that this tile depends on.
     // TODO(gw): Ugh, get rid of all opacity binding support!
     opacity_bindings: ComparableVec<PropertyBindingId>,
+
+    /// List of the required valid rectangles for each primitive.
+    needed_rects: Vec<WorldRect>,
+
+    /// List of the currently valid rectangles for each primitive.
+    current_rects: Vec<WorldRect>,
 }
 
 impl TileDescriptor {
@@ -187,6 +193,8 @@ impl TileDescriptor {
             clip_vertices: ComparableVec::new(),
             opacity_bindings: ComparableVec::new(),
             image_keys: ComparableVec::new(),
+            needed_rects: Vec::new(),
+            current_rects: Vec::new(),
         }
     }
 
@@ -198,15 +206,37 @@ impl TileDescriptor {
         self.clip_vertices.reset();
         self.opacity_bindings.reset();
         self.image_keys.reset();
+        self.needed_rects.clear();
     }
 
     /// Check if the dependencies of this tile are valid.
     fn is_valid(&self) -> bool {
+        // For a tile to be valid, it needs to ensure that the currently valid
+        // rect of each primitive encloses the required valid rect.
+        // TODO(gw): This is only needed for tiles that are partially rendered
+        //           (i.e. those clipped to edge of screen). We can make this much
+        //           faster by skipping this step for tiles that are not clipped!
+        // TODO(gw): For partial tiles that *do* need this test, we can probably
+        //           make it faster again by caching and checking the relative
+        //           transforms of primitives on this tile.
+        let rects_valid = if self.needed_rects.len() == self.current_rects.len() {
+            for (needed, current) in self.needed_rects.iter().zip(self.current_rects.iter()) {
+                if !current.contains_rect(needed) {
+                    return false;
+                }
+            }
+
+            true
+        } else {
+            false
+        };
+
         self.image_keys.is_valid() &&
         self.opacity_bindings.is_valid() &&
         self.clip_uids.is_valid() &&
         self.clip_vertices.is_valid() &&
-        self.prims.is_valid()
+        self.prims.is_valid() &&
+        rects_valid
     }
 }
 
@@ -254,8 +284,12 @@ pub struct TileCache {
     scroll_offset: Option<WorldVector2D>,
     /// A list of blits from the framebuffer to be applied during this frame.
     pub pending_blits: Vec<TileBlit>,
-    /// Collects the clips that apply to this surface.
-    clip_node_collector: ClipNodeCollector,
+    /// The current world bounding rect of this tile cache. This is used
+    /// to derive a local clip rect, such that we don't obscure in the
+    /// z-buffer any items placed earlier in the render order (such as
+    /// scroll bars in gecko, when the content overflows under the
+    /// scroll bar).
+    world_bounding_rect: WorldRect,
 }
 
 impl TileCache {
@@ -277,7 +311,7 @@ impl TileCache {
             tile_count: TileSize::zero(),
             scroll_offset: None,
             pending_blits: Vec::new(),
-            clip_node_collector: ClipNodeCollector::new(spatial_node_index),
+            world_bounding_rect: WorldRect::zero(),
         }
     }
 
@@ -514,7 +548,7 @@ impl TileCache {
         //           For common cases, such as only being one main scroll root, we could
         //           detect this and skip the dependency update on scroll frames.
         self.needs_update = true;
-        self.clip_node_collector.clear();
+        self.world_bounding_rect = WorldRect::zero();
 
         // Do tile invalidation for any dependencies that we know now.
         for tile in &mut self.tiles {
@@ -558,6 +592,7 @@ impl TileCache {
         resource_cache: &ResourceCache,
         opacity_binding_store: &OpacityBindingStorage,
         image_instances: &ImageInstanceStorage,
+        screen_world_rect: &WorldRect,
     ) {
         if !self.needs_update {
             return;
@@ -687,14 +722,52 @@ impl TileCache {
 
         // The transforms of any clips that are relative to the picture may affect
         // the content rendered by this primitive.
+        let mut world_clip_rect = world_rect;
         while current_clip_chain_id != ClipChainId::NONE {
             let clip_chain_node = &clip_chain_nodes[current_clip_chain_id.0 as usize];
-            // We only care about clip nodes that have transforms that are children
-            // of the surface, since clips that are positioned by parents will be
-            // handled by the clip collector when these tiles are composited.
-            if clip_chain_node.spatial_node_index < self.spatial_node_index {
-                self.clip_node_collector.insert(current_clip_chain_id)
-            } else {
+            let clip_node = &resources.clip_data_store[clip_chain_node.handle];
+
+            self.map_local_to_world.set_target_spatial_node(
+                clip_chain_node.spatial_node_index,
+                clip_scroll_tree,
+            );
+
+            // Clips that are simple rects and handled by collapsing them into a single
+            // clip rect. This avoids the need to store vertices for these cases, and also
+            // allows easy calculation of the overall bounds of the tile cache.
+            let add_to_clip_deps = match clip_node.item {
+                ClipItem::Rectangle(size, ClipMode::Clip) => {
+                    let clip_spatial_node = &clip_scroll_tree.spatial_nodes[clip_chain_node.spatial_node_index.0 as usize];
+
+                    // Clips that are not in the root coordinate system are not axis-aligned,
+                    // so we need to treat them as normal style clips with vertices.
+                    if clip_spatial_node.coordinate_system_id == CoordinateSystemId(0) {
+                        let local_rect = LayoutRect::new(
+                            clip_chain_node.local_pos,
+                            size,
+                        );
+
+                        if let Some(clip_world_rect) = self.map_local_to_world.map(&local_rect) {
+                            world_clip_rect = match world_clip_rect.intersection(&clip_world_rect) {
+                                Some(rect) => rect,
+                                None => return,
+                            };
+                        }
+
+                        false
+                    } else {
+                        true
+                    }
+                }
+                ClipItem::Rectangle(_, ClipMode::ClipOut) |
+                ClipItem::RoundedRectangle(..) |
+                ClipItem::Image { .. } |
+                ClipItem::BoxShadow(..) => {
+                    true
+                }
+            };
+
+            if add_to_clip_deps {
                 // TODO(gw): Constructing a rect here rather than mapping a point
                 //           is wasteful. We can optimize this by extending the
                 //           SpaceMapper struct to support mapping a point.
@@ -703,21 +776,17 @@ impl TileCache {
                     LayoutSize::zero(),
                 );
 
-                self.map_local_to_world.set_target_spatial_node(
-                    clip_chain_node.spatial_node_index,
-                    clip_scroll_tree,
-                );
+                if let Some(clip_world_rect) = self.map_local_to_world.map(&local_rect) {
+                    clip_vertices.push(clip_world_rect.origin);
+                }
 
-                let clip_world_rect = self
-                    .map_local_to_world
-                    .map(&local_rect)
-                    .expect("bug: unable to map clip rect to world");
-
-                clip_vertices.push(clip_world_rect.origin);
                 clip_chain_uids.push(clip_chain_node.handle.uid());
             }
+
             current_clip_chain_id = clip_chain_node.parent_clip_chain_id;
         }
+
+        self.world_bounding_rect = self.world_bounding_rect.union(&world_clip_rect);
 
         // Normalize the tile coordinates before adding to tile dependencies.
         // For each affected tile, mark any of the primitive dependencies.
@@ -731,6 +800,17 @@ impl TileCache {
 
                 let index = (y * self.tile_count.width + x) as usize;
                 let tile = &mut self.tiles[index];
+
+                // Work out the needed rect for the primitive on this tile.
+                // TODO(gw): We should be able to remove this for any tile that is not
+                //           a partially clipped tile, which would be a significant
+                //           optimization for the common case (non-clipped tiles).
+                let needed_rect = match world_clip_rect.intersection(&tile.world_rect).and_then(|r| r.intersection(screen_world_rect)) {
+                    Some(rect) => rect.translate(&-tile.world_rect.origin.to_vector()),
+                    None => continue,
+                };
+
+                tile.descriptor.needed_rects.push(needed_rect);
 
                 // Mark if the tile is cacheable at all.
                 tile.is_valid &= is_cacheable;
@@ -784,9 +864,7 @@ impl TileCache {
         &mut self,
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
-        clip_store: &ClipStore,
         frame_context: &FrameBuildingContext,
-        resources: &FrameResources,
     ) -> LayoutRect {
         let mut dirty_world_rect = WorldRect::zero();
 
@@ -801,18 +879,10 @@ impl TileCache {
             false,
         );
 
-        // Get the world clip rect that we will use to determine
-        // which parts of the tiles are valid / required.
-        let clip_rect = match self
-            .clip_node_collector
-            .get_world_clip_rect(
-                clip_store,
-                &resources.clip_data_store,
-                frame_context.clip_scroll_tree,
-            ) {
-            Some(clip_rect) => clip_rect,
-            None => return LayoutRect::zero(),
-        };
+        // Skip all tiles if completely off-screen.
+        if !self.world_bounding_rect.intersects(&frame_context.screen_world_rect) {
+            return LayoutRect::zero();
+        }
 
         let map_surface_to_world: SpaceMapper<LayoutPixel, WorldPixel> = SpaceMapper::new_with_target(
             ROOT_SPATIAL_NODE_INDEX,
@@ -822,51 +892,24 @@ impl TileCache {
         );
 
         let local_clip_rect = map_surface_to_world
-            .unmap(&clip_rect)
+            .unmap(&self.world_bounding_rect)
             .expect("bug: unable to map local clip rect");
-
-        let clip_rect = match clip_rect.intersection(&frame_context.screen_world_rect) {
-            Some(clip_rect) => clip_rect,
-            None => return LayoutRect::zero(),
-        };
-
-        let clipped = (clip_rect * frame_context.device_pixel_scale).round().to_i32();
 
         // Step through each tile and invalidate if the dependencies have changed.
         for (i, tile) in self.tiles.iter_mut().enumerate() {
+            let visible_rect = match tile
+                .world_rect
+                .intersection(&frame_context.screen_world_rect)
+            {
+                Some(rect) => rect,
+                None => continue,
+            };
+
             // Check the content of the tile is the same
             tile.is_valid &= tile.descriptor.is_valid();
 
             // Invalidate if the backing texture was evicted.
             if !resource_cache.texture_cache.is_allocated(&tile.handle) {
-                tile.is_valid = false;
-            }
-
-            // Work out which part of the tile rect is valid.
-            let tile_device_rect = (tile.world_rect * frame_context.device_pixel_scale).round().to_i32();
-
-            // Get the part of the tile rect that is actually going to be rendered on screen.
-            let src_rect = clipped.intersection(&tile_device_rect);
-
-            // If that was completely off-screen, nothing to do.
-            let src_rect = match src_rect {
-                Some(rect) => rect,
-                None => {
-                    continue;
-                }
-            };
-
-            // Get this space relative to the tile itself.
-            let unit_rect = src_rect
-                .translate(&-tile_device_rect.origin.to_vector());
-
-            // Work out if the currently valid rect of this tile is large
-            // enough for what we need to draw.
-            let valid_pixel_rect = match tile.pixel_rect {
-                Some(pixel_rect) => pixel_rect.contains_rect(&unit_rect),
-                None => false,
-            };
-            if !valid_pixel_rect {
                 tile.is_valid = false;
             }
 
@@ -885,9 +928,6 @@ impl TileCache {
                 // Add the tile rect to the dirty rect.
                 dirty_world_rect = dirty_world_rect.union(&tile.world_rect);
 
-                // Store the currently valid rect for this tile.
-                tile.pixel_rect = Some(unit_rect);
-
                 // Ensure that this texture is allocated.
                 resource_cache.texture_cache.update(
                     &mut tile.handle,
@@ -905,18 +945,25 @@ impl TileCache {
                 let cache_item = resource_cache
                     .get_texture_cache_item(&tile.handle);
 
+                let src_origin = (visible_rect.origin * frame_context.device_pixel_scale).round().to_i32();
+                tile.valid_rect = visible_rect.translate(&-tile.world_rect.origin.to_vector());
+
                 // Store a blit operation to be done after drawing the
                 // frame in order to update the cached texture tile.
-                let dest_offset = unit_rect.origin;
+                let dest_rect = (tile.valid_rect * frame_context.device_pixel_scale).round().to_i32();
                 self.pending_blits.push(TileBlit {
                     target: cache_item,
-                    src_offset: src_rect.origin,
-                    dest_offset,
-                    size: unit_rect.size,
+                    src_offset: src_origin,
+                    dest_offset: dest_rect.origin,
+                    size: dest_rect.size,
                 });
 
                 // We can consider this tile valid now.
                 tile.is_valid = true;
+                tile.descriptor.current_rects = mem::replace(
+                    &mut tile.descriptor.needed_rects,
+                    Vec::new(),
+                );
             }
         }
 
@@ -1938,6 +1985,7 @@ impl PicturePrimitive {
                 resource_cache,
                 opacity_binding_store,
                 image_instances,
+                &frame_context.screen_world_rect,
             );
         }
     }

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -1734,9 +1734,7 @@ impl PrimitiveStore {
             pic.local_clip_rect = tile_cache.post_update(
                 resource_cache,
                 gpu_cache,
-                clip_store,
                 frame_context,
-                resources,
             );
 
             pic.tile_cache = Some(tile_cache);


### PR DESCRIPTION
Previously, the code used a clip node collector to build an
overall (clipped) bounding rect for the tile cache.

This is needed to ensure that the tiles don't write into the
z-buffer where primitives don't exist on the tiles, so that
primitives earlier in the render order (e.g. scroll bars)
still draw correctly in cases where the content overflows the
scroll region and is clipped.

The clip node collector code handles common cases, but it fails
when there are fixed position clips on small items within the
primitive instance list.

Instead, build the overall clipped world rect and per-primitive
required rects to handle partial tiles. This is quite a
conservative approach, for now. In future we should be able
to optimize these changes quite significantly.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1517117