### PR TITLE
[WIP] hook up the blob visible area in tile-decomposition

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -297,7 +297,6 @@ impl ClipNodeInfo {
                     let mut mask_tiles = Vec::new();
                     let mask_rect = LayoutRect::new(self.local_pos, size);
 
-                    let device_image_size = props.descriptor.size;
                     let visible_rect = if repeat {
                         *clipped_rect
                     } else {
@@ -310,15 +309,19 @@ impl ClipNodeInfo {
                         size,
                     );
 
+                    // TODO: As a followup, if the image is a tiled blob, the device_image_rect below
+                    // will be set to the blob's visible area.
+                    let device_image_rect = DeviceIntRect::from_size(props.descriptor.size);
+
                     for Repetition { origin, .. } in repetitions {
-                        let image_rect = LayoutRect {
+                        let layout_image_rect = LayoutRect {
                             origin,
                             size,
                         };
                         let tiles = image::tiles(
-                            &image_rect,
+                            &layout_image_rect,
                             &visible_rect,
-                            &device_image_size,
+                            &device_image_rect,
                             tile_size as i32,
                         );
                         for tile in tiles {

--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use api::{TileOffset, TileRange, LayoutRect, LayoutSize, LayoutPoint};
-use api::{DeviceIntSize, DeviceIntRect};
-use euclid::{vec2, point2};
+use api::{DeviceIntSize, DeviceIntRect, TileSize};
+use euclid::{point2, size2};
 use prim_store::EdgeAaSegmentMask;
+
+use std::i32;
+use std::ops::Range;
 
 /// If repetitions are far enough apart that only one is within
 /// the primitive rect, then we can simplify the parameters and
@@ -155,15 +158,22 @@ pub struct Tile {
     pub edge_flags: EdgeAaSegmentMask,
 }
 
+#[derive(Debug)]
+pub struct TileIteratorExtent {
+    /// Range of tiles to iterate over in number of tiles.
+    tile_range: Range<i32>,
+    /// Size of the first tile in layout space.
+    first_tile_layout_size: f32,
+    /// Size of the last tile in layout space.
+    last_tile_layout_size: f32,
+}
+
+#[derive(Debug)]
 pub struct TileIterator {
-    current_x: i32,
-    x_count: i32,
-    current_y: i32,
-    y_count: i32,
-    origin: TileOffset,
-    tile_size: LayoutSize,
-    leftover_offset: TileOffset,
-    leftover_size: LayoutSize,
+    current_tile: TileOffset,
+    x: TileIteratorExtent,
+    y: TileIteratorExtent,
+    regular_tile_size: LayoutSize,
     local_origin: LayoutPoint,
     row_flags: EdgeAaSegmentMask,
 }
@@ -172,52 +182,53 @@ impl Iterator for TileIterator {
     type Item = Tile;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_x == self.x_count {
-            self.current_y += 1;
-            if self.current_y >= self.y_count {
+        if self.current_tile.x == self.x.tile_range.end {
+            self.current_tile.y += 1;
+            if self.current_tile.y >= self.y.tile_range.end {
                 return None;
             }
-            self.current_x = 0;
+            self.current_tile.x = self.x.tile_range.start;
             self.row_flags = EdgeAaSegmentMask::empty();
-            if self.current_y == self.y_count - 1 {
+            if self.current_tile.y == self.y.tile_range.end - 1 {
                 self.row_flags |= EdgeAaSegmentMask::BOTTOM;
             }
         }
 
-        let tile_offset = self.origin + vec2(self.current_x, self.current_y);
+        let tile_offset = self.current_tile;
 
         let mut segment_rect = LayoutRect {
             origin: LayoutPoint::new(
-                self.local_origin.x + tile_offset.x as f32 * self.tile_size.width,
-                self.local_origin.y + tile_offset.y as f32 * self.tile_size.height,
+                self.local_origin.x + tile_offset.x as f32 * self.regular_tile_size.width,
+                self.local_origin.y + tile_offset.y as f32 * self.regular_tile_size.height,
             ),
-            size: self.tile_size,
+            size: self.regular_tile_size,
         };
 
-        if tile_offset.x == self.leftover_offset.x {
-            segment_rect.size.width = self.leftover_size.width;
-        }
-
-        if tile_offset.y == self.leftover_offset.y {
-            segment_rect.size.height = self.leftover_size.height;
-        }
-
         let mut edge_flags = self.row_flags;
-        if self.current_x == 0 {
+
+        if tile_offset.x == self.x.tile_range.start {
             edge_flags |= EdgeAaSegmentMask::LEFT;
+            segment_rect.size.width = self.x.first_tile_layout_size;
         }
-
-        if self.current_x == self.x_count - 1 {
+        if tile_offset.x == self.x.tile_range.end - 1 {
             edge_flags |= EdgeAaSegmentMask::RIGHT;
+            segment_rect.size.width = self.x.last_tile_layout_size;
         }
 
+        if tile_offset.y == self.y.tile_range.start {
+            segment_rect.size.height = self.y.first_tile_layout_size;
+        } else if tile_offset.y == self.y.tile_range.end - 1 {
+            segment_rect.size.height = self.y.last_tile_layout_size;
+        }
+        assert!(tile_offset.y < self.y.tile_range.end);
         let tile = Tile {
             rect: segment_rect,
             offset: tile_offset,
             edge_flags,
         };
 
-        self.current_x += 1;
+        self.current_tile.x += 1;
+
         Some(tile)
     }
 }
@@ -235,128 +246,313 @@ pub fn tiles(
 
     // The tiling logic works as follows:
     //
-    //  ###################-+  -+
-    //  #    |    |    |//# |   | image size
-    //  #    |    |    |//# |   |
-    //  #----+----+----+--#-+   |  -+
-    //  #    |    |    |//# |   |   | regular tile size
-    //  #    |    |    |//# |   |   |
-    //  #----+----+----+--#-+   |  -+-+
-    //  #////|////|////|//# |   |     | "leftover" height
-    //  ################### |  -+  ---+
-    //  #----+----+----+----+
+    //  +-#################-+  -+
+    //  | #//|    |    |//# |   | image size
+    //  | #//|    |    |//# |   |
+    //  +-#--+----+----+--#-+   |  -+
+    //  | #//|    |    |//# |   |   | regular tile size
+    //  | #//|    |    |//# |   |   |
+    //  +-#--+----+----+--#-+   |  -+-+
+    //  | #//|////|////|//# |   |     | "leftover" height
+    //  | ################# |  -+  ---+
+    //  +----+----+----+----+
     //
     // In the ascii diagram above, a large image is split into tiles of almost regular size.
-    // The tiles on the right and bottom edges (hatched in the diagram) are smaller than
-    // the regular tiles and are handled separately in the code see leftover_width/height.
-    // each generated segment corresponds to a tile in the texture cache, with the
-    // assumption that the smaller tiles with leftover sizes are sized to fit their own
-    // irregular size in the texture cache.
-
+    // The tiles on the edges (hatched in the diagram) can be smaller than the regular tiles
+    // and are handled separately in the code (we'll call them boundary tiles).
+    //
+    // Each generated segment corresponds to a tile in the texture cache, with the
+    // assumption that the boundary tiles are sized to fit their own irregular size in the
+    // texture cache.
+    //
     // Because we can have very large virtual images we iterate over the visible portion of
-    // the image in layer space intead of iterating over device tiles.
+    // the image in layer space intead of iterating over all device tiles.
 
     let visible_rect = match prim_rect.intersection(&visible_rect) {
         Some(rect) => rect,
         None => {
             return TileIterator {
-                current_x: 0,
-                current_y: 0,
-                x_count: 0,
-                y_count: 0,
+                current_tile: TileOffset::zero(),
+                x: TileIteratorExtent {
+                    tile_range: 0..0,
+                    first_tile_layout_size: 0.0,
+                    last_tile_layout_size: 0.0,
+                },
+                y: TileIteratorExtent {
+                    tile_range: 0..0,
+                    first_tile_layout_size: 0.0,
+                    last_tile_layout_size: 0.0,
+                },
                 row_flags: EdgeAaSegmentMask::empty(),
-                origin: TileOffset::zero(),
-                tile_size: LayoutSize::zero(),
-                leftover_offset: TileOffset::zero(),
-                leftover_size: LayoutSize::zero(),
+                regular_tile_size: LayoutSize::zero(),
                 local_origin: LayoutPoint::zero(),
             }
         }
     };
 
-    let device_tile_size_f32 = device_tile_size as f32;
+    // TODO: these values hold for regular images but not necessarily for blobs.
+    // the latters can have image bounds with negative values (the blob image's
+    // visible area provided by gecko).
+    //
+    // Likewise, the alyout space tiling origin (layout position of tile offset
+    // (0, 0)) for blobs can be different from the top-left corner of the primitive
+    // rect.
+    //
+    // This info needs to be patched through.
+    let layout_tiling_origin = prim_rect.origin;
+    let device_image_range_x = 0..device_image_size.width;
+    let device_image_range_y = 0..device_image_size.height;
 
-    // Ratio between (image space) tile size and image size .
-    let tile_dw = device_tile_size_f32 / (device_image_size.width as f32);
-    let tile_dh = device_tile_size_f32 / (device_image_size.height as f32);
-
-    // size of regular tiles in layout space.
-    let layer_tile_size = LayoutSize::new(
-        tile_dw * prim_rect.size.width,
-        tile_dh * prim_rect.size.height,
+    // Size of regular tiles in layout space.
+    let layout_tile_size = LayoutSize::new(
+        device_tile_size as f32 / device_image_size.width as f32 * prim_rect.size.width,
+        device_tile_size as f32 / device_image_size.height as f32 * prim_rect.size.height,
     );
 
-    // The size in pixels of the tiles on the right and bottom edges, smaller
-    // than the regular tile size if the image is not a multiple of the tile size.
-    // Zero means the image size is a multiple of the tile size.
-    let leftover_device_size = DeviceIntSize::new(
-        device_image_size.width % device_tile_size,
-        device_image_size.height % device_tile_size
+    // The decomposition logic is exactly the same on each axis so we reduce
+    // this to a 1-dimmensional problem in an attempt to make the code simpler.
+
+    let x_extent = tiles_1d(
+        layout_tile_size.width,
+        visible_rect.min_x()..visible_rect.max_x(),
+        device_image_range_x,
+        device_tile_size,
+        layout_tiling_origin.x,
     );
 
-    // The size in layer space of the tiles on the right and bottom edges.
-    let leftover_layer_size = LayoutSize::new(
-        layer_tile_size.width * leftover_device_size.width as f32 / device_tile_size_f32,
-        layer_tile_size.height * leftover_device_size.height as f32 / device_tile_size_f32,
+    let y_extent = tiles_1d(
+        layout_tile_size.height,
+        visible_rect.min_y()..visible_rect.max_y(),
+        device_image_range_y,
+        device_tile_size,
+        layout_tiling_origin.y,
     );
-
-    // Offset of the row and column of tiles with leftover size.
-    let leftover_offset = TileOffset::new(
-        device_image_size.width / device_tile_size,
-        device_image_size.height / device_tile_size,
-    );
-
-    // Number of culled out tiles to skip before the first visible tile.
-    let t0 = TileOffset::new(
-        if visible_rect.origin.x > prim_rect.origin.x {
-            f32::floor((visible_rect.origin.x - prim_rect.origin.x) / layer_tile_size.width) as i32
-        } else {
-            0
-        },
-        if visible_rect.origin.y > prim_rect.origin.y {
-            f32::floor((visible_rect.origin.y - prim_rect.origin.y) / layer_tile_size.height) as i32
-        } else {
-            0
-        },
-    );
-
-    // Since we're working in layer space, we can end up computing leftover tiles with an empty
-    // size due to floating point precision issues. Detect this case so that we don't return
-    // tiles with an empty size.
-    let x_max = {
-        let result = f32::ceil((visible_rect.max_x() - prim_rect.origin.x) / layer_tile_size.width) as i32;
-        if result == leftover_offset.x + 1 && leftover_layer_size.width == 0.0f32 {
-            leftover_offset.x
-        } else {
-            result
-        }
-    };
-    let y_max = {
-        let result = f32::ceil((visible_rect.max_y() - prim_rect.origin.y) / layer_tile_size.height) as i32;
-        if result == leftover_offset.y + 1 && leftover_layer_size.height == 0.0f32 {
-            leftover_offset.y
-        } else {
-            result
-        }
-    };
 
     let mut row_flags = EdgeAaSegmentMask::TOP;
-    if y_max - t0.y == 1 {
+    if y_extent.tile_range.end == y_extent.tile_range.start + 1 {
+        // Single row of tiles (both top and bottom edge).
         row_flags |= EdgeAaSegmentMask::BOTTOM;
     }
+
     TileIterator {
-        current_x: 0,
-        current_y: 0,
-        x_count: x_max - t0.x,
-        y_count: y_max - t0.y,
+        current_tile: point2(
+            x_extent.tile_range.start,
+            y_extent.tile_range.start,
+        ),
+        x: x_extent,
+        y: y_extent,
         row_flags,
-        origin: t0,
-        tile_size: layer_tile_size,
-        leftover_offset,
-        leftover_size: leftover_layer_size,
+        regular_tile_size: layout_tile_size,
         local_origin: prim_rect.origin,
     }
 }
+
+/// Decompose tiles along an arbitray axis.
+///
+/// Considering the 2d problem below:
+///
+///   +----+----+----+----+
+///   | ################# |  -+
+///   | #//|////|////|//# |   | image size
+///   +-#--+----+----+--#-+   |  -+
+///   | #//|    |    |//# |   |   | regular tile size
+///   | #//|    |    |//# |   |   |
+///   +-#--+----+----+--#-+   |  -+-+
+///   | #//|////|////|//# |   |     | "leftover" height
+///   | ################# |  -+  ---+
+///   +----+----+----+----+
+///
+/// This function only treats the problem in one dimmension,
+/// so either:
+///
+///   +----+----+----+----+
+///   | ...|....|....|... |
+///   | .  |    |    |  . |
+///   +-#--+----+----+--#-+
+///___| #//|    |    |//# |____
+///   | #//|    |    |//# |
+///   +-#--+----+----+--#-+
+///   | .  |    |    |  . |
+///   | ...|....|....|... |
+///   +----+----+----+----+
+///
+/// Or:
+///           |
+///   +----+----+----+----+
+///   | ...######....|... |
+///   | .  |////|    |  . |
+///   +----+----+----+----+
+///   | .  |    |    |  . |
+///   | .  |    |    |  . |
+///   +----+----+----+----+
+///   | .  |////|    |  . |
+///   | ...######....|... |
+///   +----+----+----+----+
+//            |
+fn tiles_1d(
+    layout_tile_size: f32,
+    layout_visible_range: Range<f32>,
+    device_image_range: Range<i32>,
+    device_tile_size: i32,
+    layout_tiling_origin: f32,
+) -> TileIteratorExtent {
+    // Sizes of the boundary tiles in pixels.
+    let first_tile_device_size = first_tile_size_1d(&device_image_range, device_tile_size);
+    let last_tile_device_size = last_tile_size_1d(&device_image_range, device_tile_size);
+
+    // Offsets of first and last tiles of this row/column (in number of tiles) without
+    // taking culling into account.
+    let (first_image_tile, last_image_tile) = first_and_last_tile_1d(&device_image_range, device_tile_size);
+
+    // The visible tiles (because of culling).
+    //
+    // Here we don't need to do the off by one dance we did above because f32::floor
+    // behaves the way we want.
+    let first_visible_tile = f32::floor((layout_visible_range.start - layout_tiling_origin) / layout_tile_size) as i32;
+    let last_visible_tile = f32::floor((layout_visible_range.end - layout_tiling_origin) / layout_tile_size) as i32;
+
+    // Combine the above two to get the tiles in the image that are visible this frame.
+
+    let first_tile = i32::max(first_image_tile, first_visible_tile);
+    let last_tile = i32::min(last_image_tile, last_visible_tile);
+
+    // The size in layout space of the boundary tiles.
+    let first_tile_layout_size = if first_tile == first_image_tile {
+        first_tile_device_size as f32 * layout_tile_size / device_tile_size as f32
+    } else {
+        // boundary tile was culled out, so the new first tile is a regularly sized tile.
+        layout_tile_size
+    };
+
+    // Idem.
+    let last_tile_layout_size = if last_tile == last_image_tile {
+        last_tile_device_size as f32 * layout_tile_size / device_tile_size as f32
+    } else {
+        layout_tile_size
+    };
+
+    TileIteratorExtent {
+        tile_range: first_tile..(last_tile + 1),
+        first_tile_layout_size,
+        last_tile_layout_size,
+    }
+}
+
+/// Compute the tile offsets of teh first and last tiles in an arbitrary dimmension.
+///
+///        0
+///        :
+///  #-+---+---+---+---+---+--#
+///  # |   |   |   |   |   |  #
+///  #-+---+---+---+---+---+--#
+///  ^     :               ^
+///
+///  +------------------------+  image_range
+///        +---+  regular_tile_size
+///
+fn first_and_last_tile_1d(
+    image_range: &Range<i32>,
+    regular_tile_size: i32,
+) -> (i32, i32) {
+    // Integer division truncates towards zero so with negative values if the first/last
+    // tile isn't a full tile we can get offset by one which we account for here.
+
+    let mut first_image_tile = image_range.start / regular_tile_size;
+    if image_range.start % regular_tile_size != 0 && image_range.start < 0 {
+        first_image_tile -= 1;
+    }
+
+    let mut last_image_tile = image_range.end / regular_tile_size;
+    if image_range.end % regular_tile_size == 0 || image_range.end < 0 {
+        last_image_tile -= 1;
+    }
+
+    (first_image_tile, last_image_tile)
+}
+
+// Sizes of the first boundary tile in pixels.
+//
+// It can be smaller than the regular tile size if the image is not a multiple
+// of the regular tile size.
+fn first_tile_size_1d(
+    image_range: &Range<i32>,
+    regular_tile_size: i32,
+) -> i32 {
+    // We have to account for how the modulo operation behaves for negative values.
+    let image_size = image_range.end - image_range.start;
+    match image_range.start % regular_tile_size {
+        //             .      #------+------+      .
+        //             .      #//////|      |      .
+        0 => i32::min(regular_tile_size, image_size),
+        //   (zero) -> 0      .   #--+------+      .
+        //             .      .   #//|      |      .
+        // modulo(m):          ~~~
+        m if m > 0 => regular_tile_size - m,
+        //             .      .   #--+------+      0 <- (zero)
+        //             .      .   #//|      |      .
+        // modulo(m):             ~~~
+        m => m,
+    }
+}
+
+// Sizes of the last boundary tile in pixels.
+//
+// It can be smaller than the regular tile size if the image is not a multiple
+// of the regular tile size.
+fn last_tile_size_1d(
+    image_range: &Range<i32>,
+    regular_tile_size: i32,
+) -> i32 {
+    // We have to account for how the modulo operation behaves for negative values.
+    let image_size = image_range.end - image_range.start;
+    match image_range.end % regular_tile_size {
+        //                    +------+------#      .
+        // tiles:      .      |      |//////#      .
+        0 => i32::min(regular_tile_size, image_size),
+        //             .      +------+--#   .      0 <- (zero)
+        //             .      |      |//#   .      .
+        // modulo (m):                   ~~~
+        m if m < 0 => regular_tile_size - m,
+        //   (zero) -> 0      +------+--#   .      .
+        //             .      |      |//#   .      .
+        // modulo (m):                ~~~
+        m => m,
+    }
+}
+
+// Compute the width and height in pixels of a tile depending on its position in the image.
+pub fn compute_tile_size(
+    image_rect: &DeviceIntRect,
+    regular_tile_size: TileSize,
+    tile: TileOffset,
+) -> DeviceIntSize {
+    let regular_tile_size = regular_tile_size as i32;
+    let img_range_x = image_rect.min_x()..image_rect.max_x();
+    let img_range_y = image_rect.min_y()..image_rect.max_y();
+    let (x_first, x_last) = first_and_last_tile_1d(&img_range_x, regular_tile_size);
+    let (y_first, y_last) = first_and_last_tile_1d(&img_range_y, regular_tile_size);
+
+    // Most tiles are going to have base_size as width and height,
+    // except for tiles around the edges that are shrunk to fit the mage data
+    // (See decompose_tiled_image in frame.rs).
+    let actual_width = match tile.x as i32 {
+        x if x == x_first => first_tile_size_1d(&img_range_x, regular_tile_size),
+        x if x == x_last => last_tile_size_1d(&img_range_x, regular_tile_size),
+        _ => regular_tile_size,
+    };
+
+    let actual_height = match tile.y as i32 {
+        y if y == y_first => first_tile_size_1d(&img_range_y, regular_tile_size),
+        y if y == y_last => last_tile_size_1d(&img_range_y, regular_tile_size),
+        _ => regular_tile_size,
+    };
+
+    assert!(actual_width > 0);
+    assert!(actual_height > 0);
+
+    size2(actual_width, actual_height)
+}
+
 
 pub fn compute_tile_range(
     visible_area: &DeviceIntRect,
@@ -386,9 +582,9 @@ pub fn for_each_tile_in_range(
     range: &TileRange,
     mut callback: impl FnMut(TileOffset),
 ) {
-    for y in 0..range.size.height {
-        for x in 0..range.size.width {
-            callback(range.origin + vec2(x, y));
+    for y in range.min_y()..range.max_y() {
+        for x in range.min_x()..range.max_x() {
+            callback(point2(x, y));
         }
     }
 }

--- a/webrender/src/image.rs
+++ b/webrender/src/image.rs
@@ -236,7 +236,7 @@ impl Iterator for TileIterator {
 pub fn tiles(
     prim_rect: &LayoutRect,
     visible_rect: &LayoutRect,
-    device_image_size: &DeviceIntSize,
+    image_rect: &DeviceIntRect,
     device_tile_size: i32,
 ) -> TileIterator {
     // The image resource is tiled. We have to generate an image primitive
@@ -290,23 +290,13 @@ pub fn tiles(
         }
     };
 
-    // TODO: these values hold for regular images but not necessarily for blobs.
-    // the latters can have image bounds with negative values (the blob image's
-    // visible area provided by gecko).
-    //
-    // Likewise, the alyout space tiling origin (layout position of tile offset
-    // (0, 0)) for blobs can be different from the top-left corner of the primitive
-    // rect.
-    //
-    // This info needs to be patched through.
-    let layout_tiling_origin = prim_rect.origin;
-    let device_image_range_x = 0..device_image_size.width;
-    let device_image_range_y = 0..device_image_size.height;
+    let device_image_range_x = image_rect.min_x()..image_rect.max_x();
+    let device_image_range_y = image_rect.min_y()..image_rect.max_y();
 
     // Size of regular tiles in layout space.
     let layout_tile_size = LayoutSize::new(
-        device_tile_size as f32 / device_image_size.width as f32 * prim_rect.size.width,
-        device_tile_size as f32 / device_image_size.height as f32 * prim_rect.size.height,
+        device_tile_size as f32 / image_rect.size.width as f32 * prim_rect.size.width,
+        device_tile_size as f32 / image_rect.size.height as f32 * prim_rect.size.height,
     );
 
     // The decomposition logic is exactly the same on each axis so we reduce
@@ -315,17 +305,17 @@ pub fn tiles(
     let x_extent = tiles_1d(
         layout_tile_size.width,
         visible_rect.min_x()..visible_rect.max_x(),
+        prim_rect.min_x(),
         device_image_range_x,
         device_tile_size,
-        layout_tiling_origin.x,
     );
 
     let y_extent = tiles_1d(
         layout_tile_size.height,
         visible_rect.min_y()..visible_rect.max_y(),
+        prim_rect.min_y(),
         device_image_range_y,
         device_tile_size,
-        layout_tiling_origin.y,
     );
 
     let mut row_flags = EdgeAaSegmentMask::TOP;
@@ -392,9 +382,9 @@ pub fn tiles(
 fn tiles_1d(
     layout_tile_size: f32,
     layout_visible_range: Range<f32>,
+    layout_prim_start: f32,
     device_image_range: Range<i32>,
     device_tile_size: i32,
-    layout_tiling_origin: f32,
 ) -> TileIteratorExtent {
     // A few sanity checks.
     debug_assert!(layout_tile_size > 0.0);
@@ -409,6 +399,11 @@ fn tiles_1d(
     // Offsets of first and last tiles of this row/column (in number of tiles) without
     // taking culling into account.
     let (first_image_tile, last_image_tile) = first_and_last_tile_1d(&device_image_range, device_tile_size);
+
+    // Layout offset of tile (0, 0) with respect to the top-left corner of the display item.
+    let layout_offset = device_image_range.start as f32 * layout_tile_size / device_tile_size as f32;
+    // Position in layout space of tile (0, 0).
+    let layout_tiling_origin = layout_prim_start - layout_offset;
 
     // The visible tiles (because of culling).
     //
@@ -602,14 +597,14 @@ pub fn for_each_tile_in_range(
 mod tests {
     use super::*;
     use std::collections::HashSet;
-    use api::{LayoutRect, DeviceIntSize};
-    use euclid::{rect, size2};
+    use api::LayoutRect;
+    use euclid::rect;
 
     // this checks some additional invariants
     fn checked_for_each_tile(
         prim_rect: &LayoutRect,
         visible_rect: &LayoutRect,
-        device_image_size: &DeviceIntSize,
+        device_image_rect: &DeviceIntRect,
         device_tile_size: i32,
         callback: &mut FnMut(&LayoutRect, TileOffset, EdgeAaSegmentMask),
     ) {
@@ -618,7 +613,7 @@ mod tests {
         for tile in tiles(
             prim_rect,
             visible_rect,
-            device_image_size,
+            device_image_rect,
             device_tile_size,
         ) {
             // make sure we don't get sent duplicate tiles
@@ -637,7 +632,7 @@ mod tests {
         let mut count = 0;
         checked_for_each_tile(&rect(0., 0., 1000., 1000.),
             &rect(75., 75., 400., 400.),
-            &size2(400, 400),
+            &rect(0, 0, 400, 400),
             36,
             &mut |_tile_rect, _tile_offset, _tile_flags| {
                 count += 1;
@@ -651,7 +646,7 @@ mod tests {
         let mut count = 0;
         checked_for_each_tile(&rect(0., 0., 74., 74.),
               &rect(75., 75., 400., 400.),
-              &size2(400, 400),
+              &rect(0, 0, 400, 400),
               36,
               &mut |_tile_rect, _tile_offset, _tile_flags| {
                 count += 1;
@@ -663,38 +658,38 @@ mod tests {
     #[test]
     fn test_tiles_1d() {
         // Exactly one full tile at positive offset.
-        let result = tiles_1d(64.0, -10000.0..10000.0, 0..64, 64, 0.0);
+        let result = tiles_1d(64.0, -10000.0..10000.0, 0.0, 0..64, 64);
         assert_eq!(result.tile_range.start, 0);
         assert_eq!(result.tile_range.end, 1);
         assert_eq!(result.first_tile_layout_size, 64.0);
         assert_eq!(result.last_tile_layout_size, 64.0);
 
         // Exactly one full tile at negative offset.
-        let result = tiles_1d(64.0, -10000.0..10000.0, -64..0, 64, 0.0);
+        let result = tiles_1d(64.0, -10000.0..10000.0, -64.0, -64..0, 64);
         assert_eq!(result.tile_range.start, -1);
         assert_eq!(result.tile_range.end, 0);
         assert_eq!(result.first_tile_layout_size, 64.0);
         assert_eq!(result.last_tile_layout_size, 64.0);
 
         // Two full tiles at negative and positive offsets.
-        let result = tiles_1d(64.0, -10000.0..10000.0, -64..64, 64, 0.0);
+        let result = tiles_1d(64.0, -10000.0..10000.0, -64.0, -64..64, 64);
         assert_eq!(result.tile_range.start, -1);
         assert_eq!(result.tile_range.end, 1);
         assert_eq!(result.first_tile_layout_size, 64.0);
         assert_eq!(result.last_tile_layout_size, 64.0);
 
         // One partial tile at positve offset, non-zero origin, culled out.
-        let result = tiles_1d(64.0, -100.0..10.0, 64..310, 64, 0.0);
+        let result = tiles_1d(64.0, -100.0..10.0, 64.0, 64..310, 64);
         assert_eq!(result.tile_range.start, result.tile_range.end);
 
         // Two tiles at negative and positive offsets, one of which is culled out.
         // The remaining tile is partially culled but it should still generate a full tile.
-        let result = tiles_1d(64.0, 10.0..10000.0, -64..64, 64, 0.0);
+        let result = tiles_1d(64.0, 10.0..10000.0, -64.0, -64..64, 64);
         assert_eq!(result.tile_range.start, 0);
         assert_eq!(result.tile_range.end, 1);
         assert_eq!(result.first_tile_layout_size, 64.0);
         assert_eq!(result.last_tile_layout_size, 64.0);
-        let result = tiles_1d(64.0, -10000.0..-10.0, -64..64, 64, 0.0);
+        let result = tiles_1d(64.0, -10000.0..-10.0, -64.0, -64..64, 64);
         assert_eq!(result.tile_range.start, -1);
         assert_eq!(result.tile_range.end, 0);
         assert_eq!(result.first_tile_layout_size, 64.0);
@@ -702,7 +697,7 @@ mod tests {
 
         // Stretched tile in layout space device tile size is 64 and layout tile size is 128.
         // So the resulting tile sizes in layout space should be multiplied by two.
-        let result = tiles_1d(128.0, -10000.0..10000.0, -64..32, 64, 0.0);
+        let result = tiles_1d(128.0, -10000.0..10000.0, -64.0, -64..32, 64);
         assert_eq!(result.tile_range.start, -1);
         assert_eq!(result.tile_range.end, 1);
         assert_eq!(result.first_tile_layout_size, 128.0);
@@ -759,7 +754,7 @@ mod tests {
 
 
         // One partial tile at positve offset, non-zero origin.
-        let result = tiles_1d(64.0, -10000.0..10000.0, 300..310, 64, 0.0);
+        let result = tiles_1d(64.0, -10000.0..10000.0, 0.0, 300..310, 64);
         assert_eq!(result.tile_range.start, 4);
         assert_eq!(result.tile_range.end, 5);
         assert_eq!(result.first_tile_layout_size, 10.0);

--- a/webrender/src/prim_store/mod.rs
+++ b/webrender/src/prim_store/mod.rs
@@ -2466,7 +2466,9 @@ impl PrimitiveStore {
 
                 if let Some(image_properties) = image_properties {
                     if let Some(tile_size) = image_properties.tiling {
-                        let device_image_size = image_properties.descriptor.size;
+                        // TODO: As a followup, if the image is a tiled blob, the device_image_rect below
+                        // will be set to the blob's visible area.
+                        let device_image_rect = DeviceIntRect::from_size(image_properties.descriptor.size);
 
                         // Tighten the clip rect because decomposing the repeated image can
                         // produce primitives that are partially covering the original image
@@ -2500,15 +2502,15 @@ impl PrimitiveStore {
                         for Repetition { origin, edge_flags } in repetitions {
                             let edge_flags = base_edge_flags | edge_flags;
 
-                            let image_rect = LayoutRect {
+                            let layout_image_rect = LayoutRect {
                                 origin,
                                 size: image_data.stretch_size,
                             };
 
                             let tiles = ::image::tiles(
-                                &image_rect,
+                                &layout_image_rect,
                                 &visible_rect,
-                                &device_image_size,
+                                &device_image_rect,
                                 tile_size as i32,
                             );
 

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -27,7 +27,7 @@ use glyph_cache::GlyphCacheEntry;
 use glyph_rasterizer::{FontInstance, GlyphFormat, GlyphKey, GlyphRasterizer};
 use gpu_cache::{GpuCache, GpuCacheAddress, GpuCacheHandle};
 use gpu_types::UvRectKind;
-use image::{compute_tile_range, for_each_tile_in_range};
+use image::{compute_tile_size, compute_tile_range, for_each_tile_in_range};
 use internal_types::{FastHashMap, FastHashSet, TextureSource, TextureUpdateList};
 use profiler::{ResourceProfileCounters, TextureCacheProfileCounters};
 use render_backend::{FrameId, FrameStamp};
@@ -1071,7 +1071,7 @@ impl ResourceCache {
                             LayoutIntRect {
                                 origin: point2(tile.x, tile.y) * tile_size as i32,
                                 size: blob_size(compute_tile_size(
-                                    &template.descriptor,
+                                    &template.descriptor.size.into(),
                                     tile_size,
                                     tile,
                                 )),
@@ -1179,7 +1179,7 @@ impl ResourceCache {
                         rect: LayoutIntRect {
                             origin: point2(tile.x, tile.y) * tile_size as i32,
                             size: blob_size(compute_tile_size(
-                                &template.descriptor,
+                                &template.descriptor.size.into(),
                                 tile_size,
                                 tile,
                             )),
@@ -1620,7 +1620,7 @@ impl ResourceCache {
 
                 if let Some(tile) = request.tile {
                     let tile_size = image_template.tiling.unwrap();
-                    let clipped_tile_size = compute_tile_size(&descriptor, tile_size, tile);
+                    let clipped_tile_size = compute_tile_size(&descriptor.size.into(), tile_size, tile);
 
                     // The tiled image could be stored on the CPU as one large image or be
                     // already broken up into tiles. This affects the way we compute the stride
@@ -1821,32 +1821,6 @@ pub fn get_blob_tiling(
     }
 
     tiling
-}
-
-
-// Compute the width and height of a tile depending on its position in the image.
-pub fn compute_tile_size(
-    descriptor: &ImageDescriptor,
-    base_size: TileSize,
-    tile: TileOffset,
-) -> DeviceIntSize {
-    let base_size = base_size as i32;
-    // Most tiles are going to have base_size as width and height,
-    // except for tiles around the edges that are shrunk to fit the mage data
-    // (See decompose_tiled_image in frame.rs).
-    let actual_width = if (tile.x as i32) < descriptor.size.width / base_size {
-        base_size
-    } else {
-        descriptor.size.width % base_size
-    };
-
-    let actual_height = if (tile.y as i32) < descriptor.size.height / base_size {
-        base_size
-    } else {
-        descriptor.size.height % base_size
-    };
-
-    size2(actual_width, actual_height)
 }
 
 #[cfg(any(feature = "capture", feature = "replay"))]


### PR DESCRIPTION
Store the blob visible areas in yet another hash map (this one being in the bag of post-scene-building state whereas `blob_image_templates` is pre-scene-building info), and pass it along to the tile decomposition code.

This PR needs #3460 and #3409.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3461)
<!-- Reviewable:end -->
