### PR TITLE
Require newer euclid version.

### DIFF
--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -18,7 +18,7 @@ bincode = "1.0"
 bitflags = "1.0"
 byteorder = "1.2.1"
 ipc-channel = {version = "0.11.0", optional = true}
-euclid = { version = "0.19.3", features = ["serde"] }
+euclid = { version = "0.19.4", features = ["serde"] }
 serde = { version = "=1.0.80", features = ["rc"] }
 serde_derive = { version = "=1.0.80", features = ["deserialize_in_place"] }
 serde_bytes = "0.10"


### PR DESCRIPTION
There is code in webrender that relies upon APIs that are only present in 0.19.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3462)
<!-- Reviewable:end -->
