### PR TITLE
Retain tiles just outside the viewport a bit longer.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -113,6 +113,9 @@ pub struct Tile {
     pub local_rect: LayoutRect,
     /// The valid rect within this tile.
     valid_rect: WorldRect,
+    /// The currently visible rect within this tile, updated per frame.
+    /// If None, this tile is not currently visible.
+    visible_rect: Option<WorldRect>,
     /// Uniquely describes the content of this tile, in a way that can be
     /// (reasonably) efficiently hashed and compared.
     descriptor: TileDescriptor,
@@ -136,6 +139,7 @@ impl Tile {
             local_rect: LayoutRect::zero(),
             world_rect: WorldRect::zero(),
             valid_rect: WorldRect::zero(),
+            visible_rect: None,
             handle: TextureCacheHandle::invalid(),
             descriptor: TileDescriptor::new(),
             is_valid: false,
@@ -491,6 +495,17 @@ impl TileCache {
             .intersection(&device_world_rect)
             .expect("todo: handle clipped device rect");
 
+        // Expand the needed device rect vertically by a small number of tiles. This
+        // ensures that as tiles are scrolled in/out of view, they are retained for
+        // a while before being discarded.
+        // TODO(gw): On some pages it might be worth also inflating horizontally.
+        //           (is this locale specific?). It might be possible to make a good
+        //           guess based on the size of the picture rect for the tile cache.
+        let needed_device_rect = needed_device_rect.inflate(
+            0.0,
+            3.0 * TILE_SIZE_HEIGHT as f32,
+        );
+
         let p0 = needed_device_rect.origin;
         let p1 = needed_device_rect.bottom_right();
 
@@ -554,6 +569,8 @@ impl TileCache {
                     .unmap(&tile.world_rect)
                     .expect("bug: can't unmap world rect");
 
+                tile.visible_rect = tile.world_rect.intersection(&frame_context.screen_world_rect);
+
                 self.tiles.push(tile);
             }
         }
@@ -610,7 +627,6 @@ impl TileCache {
         resource_cache: &ResourceCache,
         opacity_binding_store: &OpacityBindingStorage,
         image_instances: &ImageInstanceStorage,
-        screen_world_rect: &WorldRect,
     ) {
         if !self.needs_update {
             return;
@@ -766,10 +782,13 @@ impl TileCache {
                         );
 
                         if let Some(clip_world_rect) = self.map_local_to_world.map(&local_rect) {
-                            world_clip_rect = match world_clip_rect.intersection(&clip_world_rect) {
-                                Some(rect) => rect,
-                                None => return,
-                            };
+                            // Even if this ends up getting clipped out by the current clip
+                            // stack, we want to ensure the primitive gets added to the tiles
+                            // below, to ensure invalidation isn't tripped up by the wrong
+                            // number of primitives that affect this tile.
+                            world_clip_rect = world_clip_rect
+                                .intersection(&clip_world_rect)
+                                .unwrap_or(WorldRect::zero());
                         }
 
                         false
@@ -819,14 +838,31 @@ impl TileCache {
                 let index = (y * self.tile_count.width + x) as usize;
                 let tile = &mut self.tiles[index];
 
+                // TODO(gw): For now, we need to always build the dependencies each
+                //           frame, so can't early exit here. In future, we should
+                //           support retaining the tile descriptor from when the
+                //           tile goes off-screen, which will mean we can then
+                //           compare against that next time it becomes visible.
+                let visible_rect = match tile.visible_rect {
+                    Some(visible_rect) => visible_rect,
+                    None => WorldRect::zero(),
+                };
+
                 // Work out the needed rect for the primitive on this tile.
                 // TODO(gw): We should be able to remove this for any tile that is not
                 //           a partially clipped tile, which would be a significant
                 //           optimization for the common case (non-clipped tiles).
-                let needed_rect = match world_clip_rect.intersection(&tile.world_rect).and_then(|r| r.intersection(screen_world_rect)) {
-                    Some(rect) => rect.translate(&-tile.world_rect.origin.to_vector()),
-                    None => continue,
-                };
+
+                // Get the required tile-local rect that this primitive occupies.
+                // Ensure that even if it's currently clipped out of this tile,
+                // we still insert a rect of zero size, so that the tile descriptor's
+                // needed rects array matches.
+                let needed_rect = world_clip_rect
+                    .intersection(&visible_rect)
+                    .map(|rect| {
+                        rect.translate(&-tile.world_rect.origin.to_vector())
+                    })
+                    .unwrap_or(WorldRect::zero());
 
                 tile.descriptor.needed_rects.push(needed_rect);
 
@@ -930,10 +966,7 @@ impl TileCache {
                 tile.is_valid = false;
             }
 
-            let visible_rect = match tile
-                .world_rect
-                .intersection(&frame_context.screen_world_rect)
-            {
+            let visible_rect = match tile.visible_rect {
                 Some(rect) => rect,
                 None => continue,
             };
@@ -2010,7 +2043,6 @@ impl PicturePrimitive {
                 resource_cache,
                 opacity_binding_store,
                 image_instances,
-                &frame_context.screen_world_rect,
             );
         }
     }


### PR DESCRIPTION
Expand the size of the needed region that active tiles exist
over. This means that as tiles get scrolled just in / out of
the screen we retain them for a bit longer.

Since we only support a single dirty rect (for now), this is
helpful for avoiding the case of creating a large dirty rect
when something in the middle of the screen is animating while
scrolling. In future, once multiple dirty rects are supported,
it will be far less important to retain tiles outside the
viewport.

Also fix a subtle bug with the descriptor dependencies where
clipped out primitives would invalidate the tile due to changing
the length of the descriptor needed_rects array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3467)
<!-- Reviewable:end -->
