### PR TITLE
Allow running headless.py in a debugger.

### DIFF
--- a/wrench/script/headless.py
+++ b/wrench/script/headless.py
@@ -107,6 +107,9 @@ if use_rr():
     dbg_cmd = ['rr', 'record']
 elif use_gdb():
     dbg_cmd = [debugger(), '--args']
+elif debugger():
+    print("Unknown debugger: " + debugger())
+    sys.exit(1)
 
 # TODO(gw): We have an occasional accuracy issue or bug (could be WR or OSMesa)
 #           where the output of a previous test that uses intermediate targets can

--- a/wrench/script/headless.py
+++ b/wrench/script/headless.py
@@ -49,6 +49,20 @@ def is_linux():
     return sys.platform.startswith('linux')
 
 
+def debugger():
+    if "DEBUGGER" in os.environ:
+        return os.environ["DEBUGGER"]
+    return None
+
+
+def use_gdb():
+    return debugger() in ['gdb', 'cgdb', 'rust-gdb']
+
+
+def use_rr():
+    return debugger() == 'rr'
+
+
 def set_osmesa_env(bin_path):
     """Set proper LD_LIBRARY_PATH and DRIVE for software rendering on Linux and OSX"""
     if is_linux():
@@ -69,9 +83,18 @@ extra_flags = os.getenv('CARGOFLAGS', None)
 extra_flags = extra_flags.split(' ') if extra_flags else []
 subprocess.check_call(['cargo', 'build'] + extra_flags + ['--release', '--verbose', '--features', 'headless'])
 set_osmesa_env('../target/release/')
+
+dbg_cmd = []
+if use_rr():
+    dbg_cmd = ['rr', 'record']
+elif use_gdb():
+    dbg_cmd = [debugger(), '--args']
+
 # TODO(gw): We have an occasional accuracy issue or bug (could be WR or OSMesa)
 #           where the output of a previous test that uses intermediate targets can
 #           cause 1.0 / 255.0 pixel differences in a subsequent test. For now, we
 #           run tests with no-scissor mode, which ensures a complete target clear
 #           between test runs. But we should investigate this further...
-subprocess.check_call(['../target/release/wrench', '--no-scissor', '-h'] + sys.argv[1:])
+cmd = dbg_cmd + ['../target/release/wrench', '--no-scissor', '-h'] + sys.argv[1:]
+print('Running: `' + ' '.join(cmd) + '`')
+subprocess.check_call(cmd)


### PR DESCRIPTION
Set the environment variable DEBUGGER to either "gdb", "cgdb", "rust-gdb" or "rr" and run headless.py.
Example: `DEBUGGER=rr ./script/headless.py rawtest`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3468)
<!-- Reviewable:end -->
