### PR TITLE
Fix cached picture content escaping into transparent UI areas.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -458,20 +458,16 @@ impl TileCache {
             .map(&pic_rect)
             .expect("bug: unable to map picture rect to world");
 
-        // TODO(gw): Inflate the world rect a bit, to ensure that we keep tiles in
-        //           the cache for a while after they disappear off-screen.
+        // If the bounding rect of the picture to cache doesn't intersect with
+        // the visible world rect at all, just take the screen world rect as
+        // a reference for the area to create tiles for. This allows existing
+        // tiles to be retained in case they are still valid if / when they
+        // get scrolled back onto the screen.
+
         let needed_world_rect = frame_context
             .screen_world_rect
-            .intersection(&pic_world_rect);
-
-        let needed_world_rect = match needed_world_rect {
-            Some(rect) => rect,
-            None => {
-                // TODO(gw): Should we explicitly drop any existing cache handles here?
-                self.tiles.clear();
-                return;
-            }
-        };
+            .intersection(&pic_world_rect)
+            .unwrap_or(frame_context.screen_world_rect);
 
         // Get a reference point that serves as an origin that all tiles we create
         // must be aligned to. This ensures that tiles get reused correctly between
@@ -493,7 +489,7 @@ impl TileCache {
         let pic_device_rect = pic_world_rect * frame_context.device_pixel_scale;
         let needed_device_rect = pic_device_rect
             .intersection(&device_world_rect)
-            .expect("todo: handle clipped device rect");
+            .unwrap_or(device_world_rect);
 
         // Expand the needed device rect vertically by a small number of tiles. This
         // ensures that as tiles are scrolled in/out of view, they are retained for


### PR DESCRIPTION
Previously, the code would include the world rect of any
off-screen picture surfaces in the overall tile bounding rect.

Because we don't know the clip rect of the picture yet, this
can give incorrect results.

Instead, don't include the picture bounding rect (this is
handled when we recurse into the picture to get the child
bounding rects anyway).

This can result in extra cache invalidations in some edge cases,
but should give correct rendering results. We can fix the
extra invalidations as a follow up by determining the picture
clip rect during the first picture traversal pass.

This is a fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1517805

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3474)
<!-- Reviewable:end -->
