### PR TITLE
 Optimizations to picture caching validation and blits.

### DIFF
--- a/webrender/src/picture.rs
+++ b/webrender/src/picture.rs
@@ -1000,7 +1000,7 @@ impl TileCache {
                 }
             } else {
                 // Add the tile rect to the dirty rect.
-                dirty_world_rect = dirty_world_rect.union(&tile.world_rect);
+                dirty_world_rect = dirty_world_rect.union(&visible_rect);
 
                 // Ensure that this texture is allocated.
                 resource_cache.texture_cache.update(


### PR DESCRIPTION
Reduce the size of blits done to the tile cache, by using only
the valid rect portion, rather than any clipped out parts.

Remove the per-primitive needed/current rect code, in favor
of a single valid pixel rect. This was an attempted fix for
some primitives not having a correct clip rect - but it turns
out this was caused by a bug in how we were accumulating the
clip rect for picture primitives. Now that this is resolved,
we can use the simpler / faster single valid rect method.

This also unblocks a couple of other changes coming - such as
only caching tiles if they have been the same for some time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3477)
<!-- Reviewable:end -->
