### PR TITLE
picture: Only collect clip nodes for raster roots, not all surfaces.

### DIFF
--- a/webrender/src/clip.rs
+++ b/webrender/src/clip.rs
@@ -497,22 +497,21 @@ impl ClipStore {
         &self.clip_node_instances[(node_range.first + index) as usize]
     }
 
-    // Notify the clip store that a new surface has been created.
-    // This means any clips from an earlier root should be collected rather
-    // than applied on the primitive itself.
-    pub fn push_surface(
-        &mut self,
-        spatial_node_index: SpatialNodeIndex,
-    ) {
+    /// Notify the clip store that a new raster root has been created.
+    ///
+    /// This means any clips from an earlier root should be collected rather than
+    /// applied on the primitive itself.
+    ///
+    /// This is sound because raster roots are necessarily reference frames,
+    /// which establish fixed-positioning containing blocks in CSS.
+    pub fn push_raster_root(&mut self, spatial_node_index: SpatialNodeIndex) {
         self.clip_node_collectors.push(
             ClipNodeCollector::new(spatial_node_index),
         );
     }
 
-    // Mark the end of a rendering surface.
-    pub fn pop_surface(
-        &mut self,
-    ) -> ClipNodeCollector {
+    /// Mark the end of a raster root.
+    pub fn pop_raster_root(&mut self) -> ClipNodeCollector {
         self.clip_node_collectors.pop().unwrap()
     }
 


### PR DESCRIPTION
This is effectively a revert of 47242e13a6f88c17186afeaf2545796670e2d078.

The assumption that patch introduces does just not hold for fixed-pos clips,
unless we introduce more complexity to turn them into their own spatial nodes of
course.

Per https://bugzilla.mozilla.org/show_bug.cgi?id=1501111#c11 this is no longer
needed for picture caching, so let's use the clip node collectors when the
assumption they use hold (which is when the picture is a raster root, since
raster roots are reference frames, and reference frames are a containing block
for fixed-pos elements).

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1501111.