### PR TITLE
Don't evict standalone textures when clearing shared cache.

### DIFF
--- a/webrender/src/freelist.rs
+++ b/webrender/src/freelist.rs
@@ -263,6 +263,7 @@ impl<T, M> FreeList<T, M> {
         slot.value.take().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.active_count
     }

--- a/webrender/src/texture_cache.rs
+++ b/webrender/src/texture_cache.rs
@@ -526,7 +526,8 @@ impl TextureCache {
         self.debug_flags = flags;
     }
 
-    pub fn clear(&mut self) {
+    /// Clear all standalone textures in the cache.
+    pub fn clear_standalone(&mut self) {
         let standalone_entry_handles = mem::replace(
             &mut self.handles.standalone,
             Vec::new(),
@@ -537,7 +538,10 @@ impl TextureCache {
             entry.evict();
             self.free(entry);
         }
+    }
 
+    /// Clear all shared textures in the cache.
+    pub fn clear_shared(&mut self) {
         let shared_entry_handles = mem::replace(
             &mut self.handles.shared,
             Vec::new(),
@@ -549,9 +553,14 @@ impl TextureCache {
             self.free(entry);
         }
 
-        assert!(self.entries.len() == 0);
-
         self.shared_textures.clear(&mut self.pending_updates);
+    }
+
+    /// Clear all entries in the texture cache. This is a fairly drastic
+    /// step that should only be called very rarely.
+    pub fn clear(&mut self) {
+        self.clear_standalone();
+        self.clear_shared();
     }
 
     /// Called at the beginning of each frame.
@@ -597,7 +606,7 @@ impl TextureCache {
         if let Some(t) = self.reached_reclaim_threshold {
             let dur = self.now.time().duration_since(t).unwrap_or(Duration::default());
             if dur >= Duration::from_secs(5) {
-                self.clear();
+                self.clear_shared();
                 self.reached_reclaim_threshold = None;
             }
         }


### PR DESCRIPTION
When reclaiming shared texture cache memory, the final step that
can occur is to completely flush the shared cache in order to
shrink it.

However, this was calling clear() which also evicts all the
existing standalone textures, even ones that are in current use.

This results in picture caching tiles being evicted in some cases
when they shouldn't be. Instead, change the code to only clear
the shared texture cache in this code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3488)
<!-- Reviewable:end -->
