### PR TITLE
Mark the hit tester as valid once we rebuild it.

### DIFF
--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -536,6 +536,7 @@ impl Document {
                 &self.clip_scroll_tree,
                 &self.resources.clip_data_store,
             ));
+            self.hit_tester_is_valid = true;
         }
     }
 


### PR DESCRIPTION
This prevent us from rebuilding the hit tester unnecessarily, and partially addresses #3489.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3490)
<!-- Reviewable:end -->
