### PR TITLE
Clear blob_requests on LowPrioritySceneBuilder.

### DIFF
--- a/webrender/src/scene_builder.rs
+++ b/webrender/src/scene_builder.rs
@@ -817,6 +817,7 @@ impl LowPrioritySceneBuilder {
     fn process_transaction(&mut self, mut txn: Box<Transaction>) -> Box<Transaction> {
         let is_low_priority = true;
         txn.rasterize_blobs(is_low_priority);
+        txn.blob_requests = Vec::new();
 
         if self.simulate_slow_ms > 0 {
             thread::sleep(Duration::from_millis(self.simulate_slow_ms as u64));


### PR DESCRIPTION
PR #3398 made it so we weren't clearing txn.blob_requests
on the low priority scene builder. I believe this change was
unintentional. Clearing blob_requests cuts the amount of
blob rasterization that we do in half on hixie-004.xml and
should fix the talos regression that we were seeing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3491)
<!-- Reviewable:end -->
