### PR TITLE
Add basic picture caching debug overlay.

### DIFF
--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -233,6 +233,7 @@ pub fn main_wrapper<E: Example>(
                 winit::VirtualKeyCode::O => debug_flags.toggle(DebugFlags::RENDER_TARGET_DBG),
                 winit::VirtualKeyCode::I => debug_flags.toggle(DebugFlags::TEXTURE_CACHE_DBG),
                 winit::VirtualKeyCode::S => debug_flags.toggle(DebugFlags::COMPACT_PROFILER),
+                winit::VirtualKeyCode::T => debug_flags.toggle(DebugFlags::PICTURE_CACHING_DBG),
                 winit::VirtualKeyCode::Q => debug_flags.toggle(
                     DebugFlags::GPU_TIME_QUERIES | DebugFlags::GPU_SAMPLE_QUERIES
                 ),

--- a/webrender/src/debug_render.rs
+++ b/webrender/src/debug_render.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api::{ColorU, ImageFormat, TextureTarget};
+use api::{ColorU, ColorF, ImageFormat, TextureTarget};
 use api::{DeviceIntRect, DeviceRect, DevicePoint, DeviceSize, DeviceIntSize};
 use debug_font_data;
 use device::{Device, Program, Texture, TextureSlot, VertexDescriptor, ShaderError, VAO};
@@ -10,6 +10,20 @@ use device::{TextureFilter, VertexAttribute, VertexAttributeKind, VertexUsageHin
 use euclid::{Point2D, Rect, Size2D, Transform3D};
 use internal_types::{ORTHO_FAR_PLANE, ORTHO_NEAR_PLANE};
 use std::f32;
+
+#[cfg_attr(feature = "capture", derive(Serialize))]
+#[cfg_attr(feature = "replay", derive(Deserialize))]
+pub enum DebugItem {
+    Text {
+        msg: String,
+        color: ColorF,
+        position: DevicePoint,
+    },
+    Rect {
+        color: ColorF,
+        rect: DeviceRect,
+    },
+}
 
 #[derive(Debug, Copy, Clone)]
 enum DebugSampler {

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -475,6 +475,7 @@ impl Document {
         resource_cache: &mut ResourceCache,
         gpu_cache: &mut GpuCache,
         resource_profile: &mut ResourceProfileCounters,
+        debug_flags: DebugFlags,
     ) -> RenderedDocument {
         let accumulated_scale_factor = self.view.accumulated_scale_factor();
         let pan = self.view.pan.to_f32() / accumulated_scale_factor;
@@ -501,6 +502,7 @@ impl Document {
                 &self.dynamic_properties,
                 &mut self.resources,
                 &mut self.scratch,
+                debug_flags,
             );
             self.hit_tester = Some(frame_builder.create_hit_tester(
                 &self.clip_scroll_tree,
@@ -1379,6 +1381,7 @@ impl RenderBackend {
                     &mut self.resource_cache,
                     &mut self.gpu_cache,
                     &mut profile_counters.resources,
+                    self.debug_flags,
                 );
 
                 debug!("generated frame for document {:?} with {} passes",
@@ -1636,6 +1639,7 @@ impl RenderBackend {
                     &mut self.resource_cache,
                     &mut self.gpu_cache,
                     &mut profile_counters.resources,
+                    self.debug_flags,
                 );
                 //TODO: write down doc's pipeline info?
                 // it has `pipeline_epoch_map`,

--- a/webrender/src/tiling.rs
+++ b/webrender/src/tiling.rs
@@ -8,6 +8,8 @@ use api::{MixBlendMode, PipelineId, DeviceRect, LayoutSize};
 use batch::{AlphaBatchBuilder, AlphaBatchContainer, ClipBatcher, resolve_image};
 use clip::ClipStore;
 use clip_scroll_tree::{ClipScrollTree};
+#[cfg(feature = "debug_renderer")]
+use debug_render::DebugItem;
 use device::{Texture};
 #[cfg(feature = "pathfinder")]
 use euclid::{TypedPoint2D, TypedVector2D};
@@ -1114,6 +1116,10 @@ pub struct Frame {
     /// True if this frame has been drawn by the
     /// renderer.
     pub has_been_rendered: bool,
+
+    /// Debugging information to overlay for this frame.
+    #[cfg(feature = "debug_renderer")]
+    pub debug_items: Vec<DebugItem>,
 }
 
 impl Frame {

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -984,6 +984,8 @@ bitflags! {
         const GPU_CACHE_DBG         = 1 << 12;
         const SLOW_FRAME_INDICATOR  = 1 << 13;
         const TEXTURE_CACHE_DBG_CLEAR_EVICTED = 1 << 14;
+        /// Show picture caching debug overlay
+        const PICTURE_CACHING_DBG   = 1 << 15;
     }
 }
 


### PR DESCRIPTION
Add support for frame building to push debug rects and strings
that are displayed by the debug renderer.

Add a debug flag for toggling the picture caching debug overlay.

Add some basic information to the picture caching overlay:
 - The red rectangle is the current dirty rect.
 - The green rectangles show tile boundaries with per-tile stats.

In future, this will be expanded to include more information about
each cached tile, such as invalidation reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3493)
<!-- Reviewable:end -->
