### PR TITLE
don't snap text position in local raster space

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -63,6 +63,7 @@ TextRun fetch_text_run(int address) {
 
 VertexInfo write_text_vertex(RectWithSize local_clip_rect,
                              float z,
+                             int raster_space,
                              Transform transform,
                              PictureTask task,
                              vec2 text_offset,
@@ -76,7 +77,7 @@ VertexInfo write_text_vertex(RectWithSize local_clip_rect,
 #ifdef WR_FEATURE_GLYPH_TRANSFORM
     bool remove_subpx_offset = true;
 #else
-    bool remove_subpx_offset = transform.is_axis_aligned;
+    bool remove_subpx_offset = transform.is_axis_aligned && raster_space == RASTER_SCREEN;
 #endif
     // Compute the snapping offset only if the scroll node transform is axis-aligned.
     if (remove_subpx_offset) {
@@ -214,6 +215,7 @@ void main(void) {
 
     VertexInfo vi = write_text_vertex(ph.local_clip_rect,
                                       ph.z,
+                                      ph.user_data.x,
                                       transform,
                                       task,
                                       text.offset,

--- a/webrender/src/batch.rs
+++ b/webrender/src/batch.rs
@@ -550,6 +550,7 @@ impl AlphaBatchBuilder {
         // Add each run in this picture to the batch.
         for prim_instance in &pic.prim_list.prim_instances {
             self.add_prim_to_batch(
+                pic,
                 prim_instance,
                 ctx,
                 gpu_cache,
@@ -571,6 +572,7 @@ impl AlphaBatchBuilder {
     // in that picture are being drawn into the same target.
     fn add_prim_to_batch(
         &mut self,
+        cur_pic: &PicturePrimitive,
         prim_instance: &PrimitiveInstance,
         ctx: &RenderTargetContext,
         gpu_cache: &mut GpuCache,
@@ -829,7 +831,8 @@ impl AlphaBatchBuilder {
                             }
                         };
 
-                        let prim_header_index = prim_headers.push(&prim_header, z_id, [0; 3]);
+                        let raster_space = RasterizationSpace::from(cur_pic.requested_raster_space);
+                        let prim_header_index = prim_headers.push(&prim_header, z_id, [raster_space as i32, 0, 0]);
                         let key = BatchKey::new(kind, blend_mode, textures);
                         let base_instance = GlyphInstance::new(
                             prim_header_index,

--- a/webrender/src/gpu_types.rs
+++ b/webrender/src/gpu_types.rs
@@ -5,7 +5,7 @@
 use api::{
     DevicePoint, DeviceSize, DeviceRect, LayoutRect, LayoutToWorldTransform, LayoutTransform,
     PremultipliedColorF, LayoutToPictureTransform, PictureToLayoutTransform, PicturePixel,
-    WorldPixel, WorldToLayoutTransform, LayoutPoint,
+    WorldPixel, WorldToLayoutTransform, LayoutPoint, RasterSpace,
 };
 use clip_scroll_tree::{ClipScrollTree, ROOT_SPATIAL_NODE_INDEX, SpatialNodeIndex};
 use gpu_cache::{GpuCacheAddress, GpuDataRequest};
@@ -57,6 +57,15 @@ impl ZBufferIdGenerator {
 pub enum RasterizationSpace {
     Local = 0,
     Screen = 1,
+}
+
+impl From<RasterSpace> for RasterizationSpace {
+    fn from(raster_space: RasterSpace) -> Self {
+        match raster_space {
+            RasterSpace::Local(..) => RasterizationSpace::Local,
+            RasterSpace::Screen => RasterizationSpace::Screen,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This resolves Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1512010

We don't want to snap text positions in raster space local as this is used to indicate that the text is animated. There are still legitimate non-transform cases where we want to snap (i.e. no scale/rotate, only translation), so that is why this patch goes through some pain to pass in the raster space and make sure we check it before skipping the snapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3500)
<!-- Reviewable:end -->
