### PR TITLE
Update rustdoc documentation on main page of 

### DIFF
--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -12,32 +12,33 @@ but it can also be used as such in a standalone application.
 WebRender currently depends on [FreeType](https://www.freetype.org/)
 
 # Api Structure
-The main entry point to WebRender is the `webrender::Renderer`.
+The main entry point to WebRender is the [`crate::Renderer`].
 
-By calling `Renderer::new(...)` you get a `Renderer`, as well as a `RenderApiSender`.
-Your `Renderer` is responsible to render the previously processed frames onto the screen.
+By calling [`Renderer::new(...)`](crate::Renderer::new) you get a [`Renderer`], as well as
+a [`RenderApiSender`](api::RenderApiSender). Your [`Renderer`] is responsible to render the
+previously processed frames onto the screen.
 
-By calling `yourRenderApiSender.create_api()`, you'll get a `RenderApi` instance,
-which is responsible for managing resources and documents. A worker thread is used internally
-to untie the workload from the application thread and therefore be able to make better use of
-multicore systems.
+By calling [`yourRenderApiSender.create_api()`](api::RenderApiSender::create_api), you'll
+get a [`RenderApi`](api::RenderApi) instance, which is responsible for managing resources
+and documents. A worker thread is used internally to untie the workload from the application
+thread and therefore be able to make better use of multicore systems.
 
 ## Frame
 
 What is referred to as a `frame`, is the current geometry on the screen.
-A new Frame is created by calling [`set_display_list()`][newframe] on the `RenderApi`.
-When the geometry is processed, the application will be informed via a `RenderNotifier`,
-a callback which you employ with [set_render_notifier][notifier] on the `Renderer`
+A new Frame is created by calling [`set_display_list()`](api::Transaction::set_display_list)
+on the [`RenderApi`](api::RenderApi). When the geometry is processed, the application will be
+informed via a [`RenderNotifier`](api::RenderNotifier), a callback which you pass to
+[`Renderer::new`].
 More information about [stacking contexts][stacking_contexts].
 
-`set_display_list()` also needs to be supplied with `BuiltDisplayList`s.
-These are obtained by finalizing a `DisplayListBuilder`. These are used to draw your geometry.
-But it doesn't only contain trivial geometry, it can also store another StackingContext, as
-they're nestable.
+[`set_display_list()`](api::Transaction::set_display_list) also needs to be supplied with
+[`BuiltDisplayList`](api::BuiltDisplayList)s. These are obtained by finalizing a
+[`DisplayListBuilder`](api::DisplayListBuilder). These are used to draw your geometry. But it
+doesn't only contain trivial geometry, it can also store another
+[`StackingContext`](api::StackingContext), as they're nestable.
 
 [stacking_contexts]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-[newframe]: ../webrender_api/struct.RenderApi.html#method.set_display_list
-[notifier]: renderer/struct.Renderer.html#method.set_render_notifier
 */
 
 // Cribbed from the |matches| crate, for simplicity.

--- a/webrender/src/renderer.rs
+++ b/webrender/src/renderer.rs
@@ -2484,8 +2484,7 @@ impl Renderer {
 
     /// Renders the current frame.
     ///
-    /// A Frame is supplied by calling [`generate_frame()`][genframe].
-    /// [genframe]: ../../webrender_api/struct.DocumentApi.html#method.generate_frame
+    /// A Frame is supplied by calling [`generate_frame()`][webrender_api::Transaction::generate_frame].
     pub fn render(
         &mut self,
         framebuffer_size: DeviceIntSize,

--- a/webrender_api/src/api.rs
+++ b/webrender_api/src/api.rs
@@ -147,7 +147,6 @@ impl Transaction {
     ///
     /// Arguments:
     ///
-    /// * `document_id`: Target Document ID.
     /// * `epoch`: The unique Frame ID, monotonically increasing.
     /// * `background`: The background color of this pipeline.
     /// * `viewport_size`: The size of the viewport for this frame.


### PR DESCRIPTION
Today I saw the [webrender newsletter](https://mozillagfx.wordpress.com/2019/01/10/webrender-newsletter-35/) about webrender being on crates.io. However the documentation on [docs.rs](https://docs.rs/webrender/0.58.0/webrender/) contained some broken links and referenced stuff which was moved to another crate. So I decided to make this PR to fix it.

It might also be good to look again at the `set_display_list` bit as it seems the api around that has changed (using a `webrender_api::Transaction`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3502)
<!-- Reviewable:end -->
