### PR TITLE
use switch statement for text snapping decision

### DIFF
--- a/webrender/res/ps_text_run.glsl
+++ b/webrender/res/ps_text_run.glsl
@@ -71,7 +71,7 @@ VertexInfo write_text_vertex(RectWithSize local_clip_rect,
                              vec2 snap_bias) {
     // The offset to snap the glyph rect to a device pixel
     vec2 snap_offset = vec2(0.0);
-    mat2 local_transform;
+    mat2 local_transform = mat2(1.0);
 
 #ifdef WR_FEATURE_GLYPH_TRANSFORM
     bool remove_subpx_offset = true;


### PR DESCRIPTION
Fixes #3538.

@lsalzman this implements your suggestion of switching from an `if` to a `switch` statement, and it really fixes the issue for some puzzling reason! I'd love to put a better description of the issue into the commit message, but this behaviour thoroughly confuses me. Can you offer more insight into why this particular change alleviates the problem?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/webrender/3540)
<!-- Reviewable:end -->
