### PR TITLE
Move external image handler API into webrender_api

### DIFF
--- a/example-compositor/compositor/src/main.rs
+++ b/example-compositor/compositor/src/main.rs
@@ -21,6 +21,73 @@ use webrender::api::units::*;
 #[cfg(target_os = "windows")]
 use compositor_windows as compositor;
 
+#[cfg(not(target_os = "windows"))]
+mod compositor {
+    use std::os::raw::{c_void, c_char};
+
+    pub struct Window;
+
+    pub fn create_surface(
+        _window: *mut Window,
+        _id: u64,
+        _width: i32,
+        _height: i32,
+        _is_opaque: bool,
+    ) {
+    }
+
+    pub fn destroy_surface(
+        _window: *mut Window,
+        _id: u64,
+    ) {
+    }
+
+    pub fn bind_surface(
+        _window: *mut Window,
+        _id: u64,
+        _dirty_x0: i32,
+        _dirty_y0: i32,
+        _dirty_width: i32,
+        _dirty_height: i32,
+    ) -> (i32, i32) {
+        unimplemented!()
+    }
+
+    pub fn add_surface(
+        _window: *mut Window,
+        _id: u64,
+        _x: i32,
+        _y: i32,
+        _clip_x: i32,
+        _clip_y: i32,
+        _clip_w: i32,
+        _clip_h: i32,
+    ) {
+    }
+
+    pub fn begin_transaction(_window: *mut Window) {}
+
+    pub fn unbind_surface(_window: *mut Window) {}
+
+    pub fn end_transaction(_window: *mut Window) {}
+
+    pub fn swap_buffers(_window: *mut Window) {}
+
+    pub fn create_window(_width: i32, _height: i32, _enable_compositor: bool) -> *mut Window {
+        unimplemented!()
+    }
+
+    pub fn get_proc_address(_name: *const c_char) -> *const c_void {
+        unimplemented!()
+    }
+
+    pub fn tick(_window: *mut Window) -> bool {
+        unimplemented!()
+    }
+
+    pub fn destroy_window(_window: *mut Window) {}
+}
+
 // A very hacky integration with DirectComposite. It proxies calls from the compositor
 // interface to a simple C99 library which does the DirectComposition / D3D11 / ANGLE
 // interfacing. This is a very unsafe impl due to the way the window pointer is passed

--- a/examples/common/boilerplate.rs
+++ b/examples/common/boilerplate.rs
@@ -91,8 +91,8 @@ pub trait Example {
     fn get_image_handlers(
         &mut self,
         _gl: &dyn gl::Gl,
-    ) -> (Option<Box<dyn webrender::ExternalImageHandler>>,
-          Option<Box<dyn webrender::OutputImageHandler>>) {
+    ) -> (Option<Box<dyn ExternalImageHandler>>,
+          Option<Box<dyn OutputImageHandler>>) {
         (None, None)
     }
     fn draw_custom(&mut self, _gl: &dyn gl::Gl) {

--- a/examples/frame_output.rs
+++ b/examples/frame_output.rs
@@ -43,7 +43,7 @@ struct ExternalHandler {
     texture_id: gl::GLuint
 }
 
-impl webrender::OutputImageHandler for OutputHandler {
+impl OutputImageHandler for OutputHandler {
     fn lock(&mut self, _id: PipelineId) -> Option<(u32, FramebufferIntSize)> {
         Some((self.texture_id, FramebufferIntSize::new(500, 500)))
     }
@@ -51,16 +51,16 @@ impl webrender::OutputImageHandler for OutputHandler {
     fn unlock(&mut self, _id: PipelineId) {}
 }
 
-impl webrender::ExternalImageHandler for ExternalHandler {
+impl ExternalImageHandler for ExternalHandler {
     fn lock(
         &mut self,
         _key: ExternalImageId,
         _channel_index: u8,
         _rendering: ImageRendering
-    ) -> webrender::ExternalImage {
-        webrender::ExternalImage {
+    ) -> ExternalImage {
+        ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
-            source: webrender::ExternalImageSource::NativeTexture(self.texture_id),
+            source: ExternalImageSource::NativeTexture(self.texture_id),
         }
     }
     fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {}
@@ -182,8 +182,8 @@ impl Example for App {
     fn get_image_handlers(
         &mut self,
         gl: &dyn gl::Gl,
-    ) -> (Option<Box<dyn webrender::ExternalImageHandler>>,
-          Option<Box<dyn webrender::OutputImageHandler>>) {
+    ) -> (Option<Box<dyn ExternalImageHandler>>,
+          Option<Box<dyn OutputImageHandler>>) {
         let texture_id = gl.gen_textures(1)[0];
 
         gl.bind_texture(gl::TEXTURE_2D, texture_id);

--- a/examples/texture_cache_stress.rs
+++ b/examples/texture_cache_stress.rs
@@ -62,17 +62,17 @@ impl ImageGenerator {
     }
 }
 
-impl webrender::ExternalImageHandler for ImageGenerator {
+impl ExternalImageHandler for ImageGenerator {
     fn lock(
         &mut self,
         _key: ExternalImageId,
         channel_index: u8,
         _rendering: ImageRendering
-    ) -> webrender::ExternalImage {
+    ) -> ExternalImage {
         self.generate_image(channel_index as i32);
-        webrender::ExternalImage {
+        ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
-            source: webrender::ExternalImageSource::RawData(&self.current_image),
+            source: ExternalImageSource::RawData(&self.current_image),
         }
     }
     fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {}
@@ -299,8 +299,8 @@ impl Example for App {
     fn get_image_handlers(
         &mut self,
         _gl: &dyn gl::Gl,
-    ) -> (Option<Box<dyn webrender::ExternalImageHandler>>,
-          Option<Box<dyn webrender::OutputImageHandler>>) {
+    ) -> (Option<Box<dyn ExternalImageHandler>>,
+          Option<Box<dyn OutputImageHandler>>) {
         (Some(Box::new(ImageGenerator::new())), None)
     }
 }

--- a/examples/yuv.rs
+++ b/examples/yuv.rs
@@ -61,17 +61,17 @@ impl YuvImageProvider {
     }
 }
 
-impl webrender::ExternalImageHandler for YuvImageProvider {
+impl ExternalImageHandler for YuvImageProvider {
     fn lock(
         &mut self,
         key: ExternalImageId,
         _channel_index: u8,
         _rendering: ImageRendering
-    ) -> webrender::ExternalImage {
+    ) -> ExternalImage {
         let id = self.texture_ids[key.0 as usize];
-        webrender::ExternalImage {
+        ExternalImage {
             uv: TexelRect::new(0.0, 0.0, 1.0, 1.0),
-            source: webrender::ExternalImageSource::NativeTexture(id),
+            source: ExternalImageSource::NativeTexture(id),
         }
     }
     fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {
@@ -198,8 +198,8 @@ impl Example for App {
     fn get_image_handlers(
         &mut self,
         gl: &dyn gl::Gl,
-    ) -> (Option<Box<dyn webrender::ExternalImageHandler>>,
-          Option<Box<dyn webrender::OutputImageHandler>>) {
+    ) -> (Option<Box<dyn ExternalImageHandler>>,
+          Option<Box<dyn OutputImageHandler>>) {
         let provider = YuvImageProvider::new(gl);
         self.texture_id = provider.texture_ids[0];
         (Some(Box::new(provider)), None)

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -209,10 +209,10 @@ pub use crate::frame_builder::ChasePrimitive;
 pub use crate::prim_store::PrimitiveDebugId;
 pub use crate::profiler::{ProfilerHooks, set_profiler_hooks};
 pub use crate::renderer::{
-    AsyncPropertySampler, CpuProfile, DebugFlags, OutputImageHandler, RendererKind, ExternalImage,
-    ExternalImageHandler, ExternalImageSource, GpuProfile, GraphicsApi, GraphicsApiInfo,
-    PipelineInfo, Renderer, RendererError, RendererOptions, RenderResults, RendererStats, SceneBuilderHooks,
-    ThreadListener, ShaderPrecacheFlags, MAX_VERTEX_TEXTURE_WIDTH,
+    AsyncPropertySampler, CpuProfile, DebugFlags, RendererKind, GpuProfile, GraphicsApi,
+    GraphicsApiInfo, PipelineInfo, Renderer, RendererError, RendererOptions, RenderResults,
+    RendererStats, SceneBuilderHooks, ThreadListener, ShaderPrecacheFlags,
+    MAX_VERTEX_TEXTURE_WIDTH,
 };
 pub use crate::screen_capture::{AsyncScreenshotHandle, RecordedFrameHandle};
 pub use crate::shade::{Shaders, WrShaders};

--- a/webrender_api/src/image.rs
+++ b/webrender_api/src/image.rs
@@ -9,7 +9,8 @@ use peek_poke::PeekPoke;
 use std::ops::{Add, Sub};
 use std::sync::Arc;
 // local imports
-use crate::api::{IdNamespace, TileSize};
+use crate::api::{IdNamespace, PipelineId, TileSize};
+use crate::display_item::ImageRendering;
 use crate::font::{FontInstanceKey, FontInstanceData, FontKey, FontTemplate};
 use crate::units::*;
 
@@ -56,6 +57,52 @@ impl BlobImageKey {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ExternalImageId(pub u64);
+
+/// The source for an external image.
+pub enum ExternalImageSource<'a> {
+    /// A raw pixel buffer.
+    RawData(&'a [u8]),
+    /// A gl::GLuint texture handle.
+    NativeTexture(u32),
+}
+
+/// The data that an external client should provide about
+/// an external image. For instance, if providing video frames,
+/// the application could call wr.render() whenever a new
+/// video frame is ready. Note that the UV coords are supplied
+/// in texel-space!
+pub struct ExternalImage<'a> {
+    /// UV coordinates for the image.
+    pub uv: TexelRect,
+    /// The source for this image's contents.
+    pub source: ExternalImageSource<'a>,
+}
+
+/// The interfaces that an application can implement to support providing
+/// external image buffers.
+/// When the application passes an external image to WR, it should keep that
+/// external image life time. People could check the epoch id in RenderNotifier
+/// at the client side to make sure that the external image is not used by WR.
+/// Then, do the clean up for that external image.
+pub trait ExternalImageHandler {
+    /// Lock the external image. Then, WR could start to read the image content.
+    /// The WR client should not change the image content until the unlock()
+    /// call. Provide ImageRendering for NativeTexture external images.
+    fn lock(&mut self, key: ExternalImageId, channel_index: u8, rendering: ImageRendering) -> ExternalImage;
+    /// Unlock the external image. WR should not read the image content
+    /// after this call.
+    fn unlock(&mut self, key: ExternalImageId, channel_index: u8);
+}
+
+/// Allows callers to receive a texture with the contents of a specific
+/// pipeline copied to it.
+pub trait OutputImageHandler {
+    /// Return the native texture handle and the size of the texture.
+    fn lock(&mut self, pipeline_id: PipelineId) -> Option<(u32, FramebufferIntSize)>;
+    /// Unlock will only be called if the lock() call succeeds, when WR has issued
+    /// the GL commands to copy the output to the texture handle.
+    fn unlock(&mut self, pipeline_id: PipelineId);
+}
 
 /// Specifies the type of texture target in driver terms.
 #[repr(u8)]

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -138,17 +138,17 @@ impl LocalExternalImageHandler {
     }
 }
 
-impl webrender::ExternalImageHandler for LocalExternalImageHandler {
+impl ExternalImageHandler for LocalExternalImageHandler {
     fn lock(
         &mut self,
         key: ExternalImageId,
         _channel_index: u8,
         _rendering: ImageRendering,
-    ) -> webrender::ExternalImage {
+    ) -> ExternalImage {
         let (id, desc) = self.texture_ids[key.0 as usize];
-        webrender::ExternalImage {
+        ExternalImage {
             uv: TexelRect::new(0.0, 0.0, desc.size.width as f32, desc.size.height as f32),
-            source: webrender::ExternalImageSource::NativeTexture(id),
+            source: ExternalImageSource::NativeTexture(id),
         }
     }
     fn unlock(&mut self, _key: ExternalImageId, _channel_index: u8) {}


### PR DESCRIPTION
This reduces some unnecessary dependencies on webrender (vs webrender_api) in Servo and makes it more efficient to bisect during webrender upgrades.