### PR TITLE
Update smallvec

### DIFF
--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -45,7 +45,7 @@ ron = { optional = true, version = "0.1.7" }
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 serde_json = { optional = true, version = "1.0" }
 sha2 = "0.8"
-smallvec = "0.6"
+smallvec = "1.0"
 thread_profiler = "0.1.1"
 time = "0.1"
 api = { version = "0.60.0", path = "../webrender_api", package = "webrender_api" }


### PR DESCRIPTION
Wrench still depends on an older smallvec, this can be fixed if we update winit and glutin, but it's a bunch of work.