### PR TITLE
Remove sha256 from dependencies (closes #3586)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,17 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "shared_library"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,7 +1775,6 @@ dependencies = [
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "svg_fmt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1837,7 +1825,6 @@ name = "webrender_build"
 version = "0.0.1"
 dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2176,7 +2163,6 @@ dependencies = [
 "checksum servo-fontconfig-sys 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "38b494f03009ee81914b0e7d387ad7c145cafcd69747c2ec89b0e17bb94f303a"
 "checksum servo-freetype-sys 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4ccb6d0d32d277d3ef7dea86203d8210945eb7a45fba89dd445b3595dd0dfc"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
-"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8254bf098ce4d8d7cc7cc6de438c5488adc5297e5b7ffef88816c0a91bd289c1"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -44,7 +44,6 @@ rayon = "1"
 ron = { optional = true, version = "0.1.7" }
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 serde_json = { optional = true, version = "1.0" }
-sha2 = "0.8"
 smallvec = "0.6"
 thread_profiler = "0.1.1"
 time = "0.1"

--- a/webrender/src/lib.rs
+++ b/webrender/src/lib.rs
@@ -184,7 +184,6 @@ extern crate rayon;
 extern crate ron;
 #[cfg(feature = "debugger")]
 extern crate serde_json;
-extern crate sha2;
 #[macro_use]
 extern crate smallvec;
 extern crate time;

--- a/webrender_build/Cargo.toml
+++ b/webrender_build/Cargo.toml
@@ -12,4 +12,3 @@ serialize_program = ["serde"]
 
 [dependencies]
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
-sha2 = "0.8"

--- a/webrender_build/src/lib.rs
+++ b/webrender_build/src/lib.rs
@@ -6,6 +6,4 @@
 #[macro_use]
 extern crate serde;
 
-extern crate sha2;
-
 pub mod shader;

--- a/webrender_build/src/shader.rs
+++ b/webrender_build/src/shader.rs
@@ -7,31 +7,27 @@
 //! This module is used during precompilation (build.rs) and regular compilation,
 //! so it has minimal dependencies.
 
-pub use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Default)]
 #[cfg_attr(feature = "serialize_program", derive(Deserialize, Serialize))]
-pub struct ProgramSourceDigest([u8; 32]);
+pub struct ProgramSourceDigest(u64);
 
 impl ::std::fmt::Display for ProgramSourceDigest {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        for byte in self.0.iter() {
-            f.write_fmt(format_args!("{:02x}", byte))?;
-        }
-        Ok(())
+        write!(f, "{:02x}", self.0)
     }
 }
 
-impl From<Sha256> for ProgramSourceDigest {
-    fn from(hasher: Sha256) -> Self {
-        let mut digest = Self::default();
-        digest.0.copy_from_slice(hasher.result().as_slice());
-        digest
+impl From<DefaultHasher> for ProgramSourceDigest {
+    fn from(hasher: DefaultHasher) -> Self {
+        use std::hash::Hasher;
+        ProgramSourceDigest(hasher.finish())
     }
 }
 


### PR DESCRIPTION
#3586 - `Sha256::new()` can be safely replaced by `DefaultHasher::new()` since its only used for *verifying* shaders if they use an different source file.

Note that there seems to have been a change in Rust Edition 2018 so that `Hasher::input` was renamed to `Hasher::write`. Not sure if this impacts the supported compiler versions.