### PR TITLE
Gitpod: initial

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+image: gitpod/workspace-full-vnc
+
+ports:
+  - port: 6080
+    onOpen: open-preview
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+
+tasks:
+  - init: cargo build --manifest-path="$GITPOD_REPO_ROOT/examples/Cargo.toml"
+    command: cargo run --bin animation

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,6 @@ To run an example e.g. `basic`, try:
 ```
 cargo run --bin basic
 ```
+
+Alternatively you can try in gitpod<br>
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/servo/webrender)

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -211,5 +211,7 @@ fn main() {
         angle1: 0.0,
         angle2: 0.0,
     };
+
+    println!("Press arrows for the GUI to move");
     boilerplate::main_wrapper(&mut app, None);
 }


### PR DESCRIPTION
**Disclaimer:** i am not affiliated with gitpod. i'm just in their github team that allows me to use the product for free on open-source.

I wanted to try the examples and it did not build correctly on gitpod so i fixed it this way and instead of keeping it on my fork i've decided to push it to upstream.

Gitpod is hosting for Theia which is Online IDE which service is free for open-source.

![image](https://user-images.githubusercontent.com/11302521/76168955-5ba71a80-6174-11ea-87c0-32433c7c67f3.png)

Try it yourself on https://gitpod.io/#https://github.com/Kreyren/webrender/tree/gitpod (github/gitlav account required)

Currently the result caused by `cargo build --manifest-path="$GITPOD_REPO_ROOT/examples/Cargo.toml"` is cached so the environment will be loaded with the target already compiled (this is currently updated after each commit in master)

The noVNC (used in preview for the desktop environment) is currently configured to expect the example on port 8060.