### PR TITLE
Add a reftest to ensure that scroll frames can be defined and used in any order.

### DIFF
--- a/wrench/reftests/scrolling/reftest.list
+++ b/wrench/reftests/scrolling/reftest.list
@@ -17,3 +17,4 @@
 == nested-stickys.yaml nested-stickys-ref.yaml
 == viewport-offset.yaml viewport-offset-ref.yaml
 == ext-scroll-offset-1.yaml ext-scroll-offset-1-ref.yaml
+== scroll-frame-order.yaml scroll-frame-order-ref.yaml

--- a/wrench/reftests/scrolling/scroll-frame-order-ref.yaml
+++ b/wrench/reftests/scrolling/scroll-frame-order-ref.yaml
@@ -1,0 +1,35 @@
+# Tests that scroll frames can be defined and used in any order.
+
+---
+root:
+  items:
+    - type: scroll-frame
+      bounds: [0, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [0, 0, 50, 50]
+      id: 123
+    - type: scroll-frame
+      bounds: [50, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [50, 0, 50, 50]
+      scroll-offset: [0, -25]
+      id: 456
+    - type: scroll-frame
+      bounds: [100, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [100, 0, 50, 50]
+      scroll-offset: [0, -15]
+      id: 789
+    - type: rect
+      bounds: [0, 0, 50, 50]
+      color: red
+      clip-and-scroll: 123
+    - type: rect
+      bounds: [50, 0, 50, 50]
+      color: green
+      clip-and-scroll: 456
+    - type: rect
+      bounds: [100, 0, 50, 50]
+      color: blue
+      clip-and-scroll: 789
+

--- a/wrench/reftests/scrolling/scroll-frame-order.yaml
+++ b/wrench/reftests/scrolling/scroll-frame-order.yaml
@@ -1,0 +1,34 @@
+# Tests that scroll frames can be defined and used in any order.
+
+---
+root:
+  items:
+    - type: scroll-frame
+      bounds: [0, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [0, 0, 50, 50]
+      id: 123
+    - type: rect
+      bounds: [0, 0, 50, 50]
+      color: red
+      clip-and-scroll: 123
+    - type: scroll-frame
+      bounds: [50, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [50, 0, 50, 50]
+      scroll-offset: [0, -25]
+      id: 456
+    - type: rect
+      bounds: [50, 0, 50, 50]
+      color: green
+      clip-and-scroll: 456
+    - type: scroll-frame
+      bounds: [100, 0, 50, 50]
+      content-size: [50, 50]
+      clip-rect: [100, 0, 50, 50]
+      scroll-offset: [0, -15]
+      id: 789
+    - type: rect
+      bounds: [100, 0, 50, 50]
+      color: blue
+      clip-and-scroll: 789


### PR DESCRIPTION
r? @gw3583 

@mrobinson How's this?