### PR TITLE
Use Cow<'static, [u8]> instead of Vec<u8> for ImageData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dwrote"
+version = "0.12.0"
+source = "git+https://github.com/fschutt/dwrote-rs?rev=7ca1b79032519ad4a9711b7ae04acb043aa949f0#7ca1b79032519ad4a9711b7ae04acb043aa949f0"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi 0.3.8",
+ "wio",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,7 +2016,7 @@ dependencies = [
  "core-text",
  "cstr",
  "derive_more",
- "dwrote",
+ "dwrote 0.12.0",
  "etagere",
  "euclid",
  "freetype",
@@ -2175,7 +2188,7 @@ dependencies = [
  "core-foundation 0.9.0",
  "core-graphics 0.22.0",
  "crossbeam",
- "dwrote",
+ "dwrote 0.11.0",
  "env_logger",
  "font-loader",
  "gleam 0.13.1",

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -67,7 +67,7 @@ freetype = { version = "0.7", default-features = false }
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-dwrote = "0.11"
+dwrote = { git = "https://github.com/fschutt/dwrote-rs", rev = "7ca1b79032519ad4a9711b7ae04acb043aa949f0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -24,6 +24,7 @@ use rayon::prelude::*;
 use euclid::approxeq::ApproxEq;
 use euclid::size2;
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::cmp;
 use std::cell::Cell;
 use std::hash::{Hash, Hasher};
@@ -226,8 +227,6 @@ impl GlyphRasterizer {
         gpu_cache: &mut GpuCache,
         profile: &mut TransactionProfile,
     ) {
-        use std::borrow::Cow;
-
         profile.start_time(profiler::GLYPH_RESOLVE_TIME);
 
         // Work around the borrow checker, since we call flush_glyph_requests below

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -226,6 +226,8 @@ impl GlyphRasterizer {
         gpu_cache: &mut GpuCache,
         profile: &mut TransactionProfile,
     ) {
+        use std::borrow::Cow;
+
         profile.start_time(profiler::GLYPH_RESOLVE_TIME);
 
         // Work around the borrow checker, since we call flush_glyph_requests below
@@ -298,7 +300,7 @@ impl GlyphRasterizer {
                                 offset: 0,
                             },
                             TextureFilter::Linear,
-                            Some(CachedImageData::Raw(Arc::new(glyph.bytes))),
+                            Some(CachedImageData::Raw(Arc::new(Cow::Owned(glyph.bytes)))),
                             [glyph.left, -glyph.top, glyph.scale],
                             DirtyRect::All,
                             gpu_cache,

--- a/webrender/src/glyph_rasterizer/mod.rs
+++ b/webrender/src/glyph_rasterizer/mod.rs
@@ -227,6 +227,8 @@ impl GlyphRasterizer {
         gpu_cache: &mut GpuCache,
         profile: &mut TransactionProfile,
     ) {
+        use std::borrow::Cow;
+
         profile.start_time(profiler::GLYPH_RESOLVE_TIME);
 
         // Work around the borrow checker, since we call flush_glyph_requests below

--- a/webrender/src/internal_types.rs
+++ b/webrender/src/internal_types.rs
@@ -22,6 +22,7 @@ use std::f32;
 use std::hash::BuildHasherDefault;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::borrow::Cow;
 
 #[cfg(any(feature = "capture", feature = "replay"))]
 use crate::capture::CaptureConfig;
@@ -311,7 +312,7 @@ pub enum TextureUpdateSource {
         id: ExternalImageId,
         channel_index: u8,
     },
-    Bytes { data: Arc<Vec<u8>> },
+    Bytes { data: Arc<Cow<'static, [u8]>> },
     /// Clears the target area, rather than uploading any pixels. Used when the
     /// texture cache debug display is active.
     DebugClear,

--- a/webrender/src/platform/macos/font.rs
+++ b/webrender/src/platform/macos/font.rs
@@ -26,6 +26,7 @@ use crate::gamma_lut::{ColorLut, GammaLut};
 use crate::glyph_rasterizer::{FontInstance, FontTransform, GlyphKey};
 use crate::glyph_rasterizer::{GlyphFormat, GlyphRasterError, GlyphRasterResult, RasterizedGlyph};
 use crate::internal_types::{FastHashMap, ResourceCacheError};
+use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
@@ -372,7 +373,7 @@ impl FontContext {
         self.desc_or_fonts.contains_key(font_key)
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: Arc<Vec<u8>>, index: u32) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: Arc<Cow<'static, [u8]>>, index: u32) {
         if self.desc_or_fonts.contains_key(font_key) {
             return;
         }

--- a/webrender/src/platform/unix/font.rs
+++ b/webrender/src/platform/unix/font.rs
@@ -26,6 +26,7 @@ use crate::internal_types::{FastHashMap, ResourceCacheError};
 #[cfg(any(not(target_os = "android"), feature = "no_static_freetype"))]
 use libc::{dlsym, RTLD_DEFAULT};
 use libc::free;
+use std::borrow::Cow;
 use std::{cmp, mem, ptr, slice};
 use std::cmp::max;
 use std::collections::hash_map::Entry;
@@ -346,7 +347,7 @@ impl FontContext {
         self.faces.contains_key(font_key)
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: Arc<Vec<u8>>, index: u32) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, bytes: Arc<Cow<'static, [u8]>>, index: u32) {
         if !self.faces.contains_key(font_key) {
             let file = FontFile::Data(bytes);
             if let Some(face) = new_ft_face(font_key, self.lib, &file, index) {

--- a/webrender/src/platform/windows/font.rs
+++ b/webrender/src/platform/windows/font.rs
@@ -10,7 +10,7 @@ use crate::glyph_rasterizer::{FontInstance, FontTransform, GlyphKey};
 use crate::internal_types::{FastHashMap, FastHashSet, ResourceCacheError};
 use crate::glyph_rasterizer::{GlyphFormat, GlyphRasterError, GlyphRasterResult, RasterizedGlyph};
 use crate::gamma_lut::GammaLut;
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
@@ -164,7 +164,7 @@ impl FontContext {
         }
     }
 
-    pub fn add_raw_font(&mut self, font_key: &FontKey, data: Arc<Vec<u8>>, index: u32) {
+    pub fn add_raw_font(&mut self, font_key: &FontKey, data: Arc<Cow<'static, [u8]>>, index: u32) {
         if self.fonts.contains_key(font_key) {
             return;
         }

--- a/webrender/src/render_api.rs
+++ b/webrender/src/render_api.rs
@@ -4,6 +4,7 @@
 
 #![deny(missing_docs)]
 
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
@@ -515,7 +516,7 @@ impl Transaction {
     }
 
     /// See `ResourceUpdate::AddFont`.
-    pub fn add_raw_font(&mut self, key: FontKey, bytes: Vec<u8>, index: u32) {
+    pub fn add_raw_font(&mut self, key: FontKey, bytes: Cow<'static, [u8]>, index: u32) {
         self.resource_updates
             .push(ResourceUpdate::AddFont(AddFont::Raw(key, Arc::new(bytes), index)));
     }
@@ -737,7 +738,7 @@ pub struct UpdateBlobImage {
 #[cfg_attr(any(feature = "serde"), derive(Deserialize, Serialize))]
 pub enum AddFont {
     ///
-    Raw(FontKey, Arc<Vec<u8>>, u32),
+    Raw(FontKey, Arc<Cow<'static, [u8]>>, u32),
     ///
     Native(FontKey, NativeFontHandle),
 }

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -34,6 +34,7 @@ use crate::render_task_cache::{RenderTaskCache, RenderTaskCacheKey, RenderTaskPa
 use crate::render_task_cache::{RenderTaskCacheEntry, RenderTaskCacheEntryHandle};
 use euclid::point2;
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::collections::hash_map::Entry::{self, Occupied, Vacant};
 use std::collections::hash_map::{Iter, IterMut};
 use std::collections::VecDeque;
@@ -1874,7 +1875,7 @@ impl ResourceCache {
                     warn!("Tiled blob images aren't supported yet");
                     let result = RasterizedBlobImage {
                         rasterized_rect: desc.size.into(),
-                        data: Arc::new(vec![0; desc.compute_total_size() as usize])
+                        data: Arc::new(Cow::Owned(vec![0; desc.compute_total_size() as usize]))
                     };
 
                     assert_eq!(result.rasterized_rect.size, desc.size);

--- a/webrender/src/resource_cache.rs
+++ b/webrender/src/resource_cache.rs
@@ -46,6 +46,7 @@ use std::os::raw::c_void;
 #[cfg(any(feature = "capture", feature = "replay"))]
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::borrow::Cow;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::u32;
 use crate::texture_cache::{TextureCache, TextureCacheHandle, Eviction, TargetShader};
@@ -101,7 +102,7 @@ impl CacheItem {
 pub enum CachedImageData {
     /// A simple series of bytes, provided by the embedding and owned by WebRender.
     /// The format is stored out-of-band, currently in ImageDescriptor.
-    Raw(Arc<Vec<u8>>),
+    Raw(Arc<Cow<'static, [u8]>>),
     /// An series of commands that can be rasterized into an image via an
     /// embedding-provided callback.
     ///
@@ -1542,7 +1543,7 @@ impl ResourceCache {
         }
 
         for font in self.resources.weak_fonts.iter() {
-            if !seen_fonts.contains(&font.as_ptr()) { 
+            if !seen_fonts.contains(&font.as_ptr()) {
                 report.weak_fonts += unsafe { op(font.as_ptr() as *const c_void) };
             }
         }

--- a/webrender/src/util.rs
+++ b/webrender/src/util.rs
@@ -449,7 +449,7 @@ impl<Src, Dst> MatrixHelpers<Src, Dst> for Transform3D<f32, Src, Dst> {
      *  a  b  0  1
      */
     fn is_2d_scale_translation(&self) -> bool {
-        (self.m33 - 1.0).abs() < NEARLY_ZERO && 
+        (self.m33 - 1.0).abs() < NEARLY_ZERO &&
             (self.m44 - 1.0).abs() < NEARLY_ZERO &&
             self.m12.abs() < NEARLY_ZERO && self.m13.abs() < NEARLY_ZERO && self.m14.abs() < NEARLY_ZERO &&
             self.m21.abs() < NEARLY_ZERO && self.m23.abs() < NEARLY_ZERO && self.m24.abs() < NEARLY_ZERO &&
@@ -1478,14 +1478,14 @@ fn test_conservative_union_rect() {
 /// This is inspired by the `weak-table` crate.
 /// It holds a Vec of weak pointers that are garbage collected as the Vec
 pub struct WeakTable {
-    inner: Vec<std::sync::Weak<Vec<u8>>>
+    inner: Vec<std::sync::Weak<Cow<'static, [u8]>>>
 }
 
 impl WeakTable {
     pub fn new() -> WeakTable {
         WeakTable { inner: Vec::new() }
     }
-    pub fn insert(&mut self, x: std::sync::Weak<Vec<u8>>) {
+    pub fn insert(&mut self, x: std::sync::Weak<Cow<'static, [u8]>>) {
         if self.inner.len() == self.inner.capacity() {
             self.remove_expired();
 
@@ -1509,7 +1509,7 @@ impl WeakTable {
         self.inner.retain(|x| x.strong_count() > 0)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = Arc<Vec<u8>>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Arc<Cow<'static, [u8]>>> + '_ {
         self.inner.iter().filter_map(|x| x.upgrade())
     }
 }

--- a/webrender_api/src/font.rs
+++ b/webrender_api/src/font.rs
@@ -11,6 +11,7 @@ use peek_poke::PeekPoke;
 use serde::de::{self, Deserialize, Deserializer};
 #[cfg(target_os = "macos")]
 use serde::ser::{Serialize, Serializer};
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 #[cfg(not(target_os = "macos"))]
@@ -280,7 +281,7 @@ impl FontKey {
 /// intended to distinguish this data from instance-specific data.
 #[derive(Clone)]
 pub enum FontTemplate {
-    Raw(Arc<Vec<u8>>, u32),
+    Raw(Arc<Cow<'static, [u8]>>, u32),
     Native(NativeFontHandle),
 }
 


### PR DESCRIPTION
This is a small memory optimization in case the image is allocated / decoded at compile time (useful for embedded images). Since webrender never copies the image data but just reference it, this can avoid a couple of large allocations in the `&'static` case.

NOTE: This is a WIP PR to see if the tests run, I'm currently in the progress of doing the same thing for FontData, but I need to update dwrote-rs for that (since dwrote-rs uses `Arc<Vec<u8>>` instead of `Arc<Cow<'static, [u8]>>`.