### PR TITLE
Port swgl to no_std

### DIFF
--- a/swgl/Cargo.toml
+++ b/swgl/Cargo.toml
@@ -12,4 +12,4 @@ glsl-to-cxx = { path = "../glsl-to-cxx" }
 webrender_build = { path = "../webrender_build" }
 
 [dependencies]
-gleam = "0.13.1"
+gleam = { version = "0.15.0", git = "https://github.com/fschutt/gleam", branch = "no_std", default-features = false }

--- a/swgl/src/lib.rs
+++ b/swgl/src/lib.rs
@@ -4,8 +4,11 @@
 
 #![crate_name = "swgl"]
 #![crate_type = "lib"]
+#![no_std]
 
 extern crate gleam;
+#[macro_use]
+extern crate alloc;
 
 mod swgl_fns;
 

--- a/swgl/src/swgl_fns.rs
+++ b/swgl/src/swgl_fns.rs
@@ -5,9 +5,12 @@
 
 use gleam::gl::*;
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::ptr;
-use std::str;
+use gleam::gl::ffi::__gl_imports::{c_char, c_int, c_void};
+use core::ptr;
+use core::str;
+use alloc::string::ToString;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[allow(unused)]
 macro_rules! debug {


### PR DESCRIPTION
This PR makes webrender / swgl ready to be used on embedded hardware. The only thing that webrender / gleam uses from the entire standard library is `CString` / `CStr` conversions, which now have `no_std` replacement functions in `gleam`

The goal is to get webrender / azul running on a LinuxFb framebuffer or get it working with EGL for embedded Linux hardware.

Currently blocked on:

- gl-rs: https://github.com/brendanzab/gl-rs/pull/530
- gleam: https://github.com/servo/gleam/pull/221

TODO:

- [ ] Re-export `cstring_from_str` and `cstr_from_ptr` in gleam
- [ ] Make `gleam::ffi::__gl_imports` or expose the types
- [ ] Fix khronos API generation build error in gl-rs
- [ ] Version bump & dependency management