### PR TITLE
chore: fix animation example

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -132,15 +132,39 @@ impl Example for App {
 
         let bounds = (150, 150).to(250, 250);
         let key0 = self.property_key0;
-        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, pipeline_id, key0, Some(opacity_key), SpatialTreeItemKey::new(0, 0));
+        self.add_rounded_rect(
+            bounds,
+            ColorF::new(1.0, 0.0, 0.0, 0.5),
+            builder,
+            pipeline_id,
+            key0,
+            Some(opacity_key),
+            SpatialTreeItemKey::new(0, 0)
+        );
 
         let bounds = (400, 400).to(600, 600);
         let key1 = self.property_key1;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, pipeline_id, key1, None, SpatialTreeItemKey::new(0, 1));
+        self.add_rounded_rect(
+            bounds,
+            ColorF::new(0.0, 1.0, 0.0, 0.5),
+            builder,
+            pipeline_id,
+            key1,
+            None,
+            SpatialTreeItemKey::new(0, 1)
+        );
 
         let bounds = (200, 500).to(350, 580);
         let key2 = self.property_key2;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, pipeline_id, key2, None, SpatialTreeItemKey::new(0, 2));
+        self.add_rounded_rect(
+            bounds,
+            ColorF::new(0.0, 0.0, 1.0, 0.5),
+            builder,
+            pipeline_id,
+            key2,
+            None,
+            SpatialTreeItemKey::new(0, 2)
+        );
     }
 
     fn on_event(

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -46,6 +46,7 @@ impl App {
         pipeline_id: PipelineId,
         property_key: PropertyBindingKey<LayoutTransform>,
         opacity_key: Option<PropertyBindingKey<f32>>,
+        spatial_tree_item_key: SpatialTreeItemKey,
     ) {
         let filters = match opacity_key {
             Some(opacity_key) => {
@@ -68,7 +69,7 @@ impl App {
                 should_snap: false,
                 paired_with_perspective: false,
             },
-            SpatialTreeItemKey::new(0, 0),
+            spatial_tree_item_key,
         );
 
         builder.push_simple_stacking_context_with_filters(
@@ -131,15 +132,15 @@ impl Example for App {
 
         let bounds = (150, 150).to(250, 250);
         let key0 = self.property_key0;
-        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, pipeline_id, key0, Some(opacity_key));
+        self.add_rounded_rect(bounds, ColorF::new(1.0, 0.0, 0.0, 0.5), builder, pipeline_id, key0, Some(opacity_key), SpatialTreeItemKey::new(0, 0));
 
         let bounds = (400, 400).to(600, 600);
         let key1 = self.property_key1;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, pipeline_id, key1, None);
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 1.0, 0.0, 0.5), builder, pipeline_id, key1, None, SpatialTreeItemKey::new(0, 1));
 
         let bounds = (200, 500).to(350, 580);
         let key2 = self.property_key2;
-        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, pipeline_id, key2, None);
+        self.add_rounded_rect(bounds, ColorF::new(0.0, 0.0, 1.0, 0.5), builder, pipeline_id, key2, None, SpatialTreeItemKey::new(0, 2));
     }
 
     fn on_event(


### PR DESCRIPTION
The animation example was not working because of `duplicate key SpatialNodeUid`.