### PR TITLE
Better handle incomplete display lists during hit testing

### DIFF
--- a/webrender/src/hit_test.rs
+++ b/webrender/src/hit_test.rs
@@ -445,8 +445,9 @@ impl HitTester {
         result
     }
 
-    fn get_pipeline_root(&self, pipeline_id: PipelineId) -> &HitTestSpatialNode {
-        &self.spatial_nodes[&self.pipeline_root_nodes[&pipeline_id]]
+    fn get_pipeline_root(&self, pipeline_id: PipelineId) -> Option<&HitTestSpatialNode> {
+        let root_node = &self.pipeline_root_nodes.get(&pipeline_id)?;
+        self.spatial_nodes.get(root_node)
     }
 
 }
@@ -481,7 +482,7 @@ impl HitTest {
         self.pipeline_id
             .and_then(|id|
                 hit_tester
-                    .get_pipeline_root(id)
+                    .get_pipeline_root(id)?
                     .world_viewport_transform
                     .transform_point2d(point)
             )


### PR DESCRIPTION
Our custom hit testing code tries to find the root node of a pipeline. There can be references to non-existant pipelines if hit testing is performed at a time when not all display lists have arrived to WebRender yet. This changes handles that situation more gracefully instead of panicking.