### PR TITLE
Prepare WebRender for crates.io release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install freetype
-        run: sudo apt install libfreetype-dev
+        run: sudo apt update && sudo apt install -y libfreetype-dev
       - name: Build wrench
         run: |
           cd wrench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
  "log",
  "once_cell",
  "whatsys",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.2.2",
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ dependencies = [
  "thiserror 2.0.15",
  "uniffi",
  "uuid",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.2.2",
  "zeitstempel",
 ]
 
@@ -2625,7 +2625,7 @@ dependencies = [
  "thiserror 2.0.15",
  "url",
  "uuid",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.2.2",
 ]
 
 [[package]]
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.66.0"
+version = "0.68.0"
 dependencies = [
  "allocator-api2",
  "base64",
@@ -3536,7 +3536,7 @@ dependencies = [
  "webrender_api",
  "webrender_build",
  "wr_glyph_rasterizer",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.68.0",
  "zeitstempel",
 ]
 
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "webrender_api"
-version = "0.66.0"
+version = "0.68.0"
 dependencies = [
  "app_units",
  "bitflags 2.4.2",
@@ -3569,13 +3569,13 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.68.0",
  "zeitstempel",
 ]
 
 [[package]]
 name = "webrender_build"
-version = "0.0.2"
+version = "0.68.0"
 dependencies = [
  "bitflags 2.4.2",
  "lazy_static",
@@ -3861,7 +3861,7 @@ dependencies = [
 
 [[package]]
 name = "wr_glyph_rasterizer"
-version = "0.1.0"
+version = "0.68.0"
 dependencies = [
  "core-foundation 0.9.2",
  "core-graphics 0.23.1",
@@ -3886,12 +3886,21 @@ dependencies = [
  "tracy-rs",
  "webrender_api",
  "winit",
- "wr_malloc_size_of",
+ "wr_malloc_size_of 0.68.0",
 ]
 
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "wr_malloc_size_of"
+version = "0.68.0"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "glsl-to-cxx"
-version = "0.1.0"
+version = "0.68.0"
 dependencies = [
  "glsl",
 ]
@@ -2936,7 +2936,7 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "swgl"
-version = "0.1.0"
+version = "0.68.0"
 dependencies = [
  "cc",
  "gleam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ api = { version = "0.68", path = "./webrender_api", package = "webrender_api" }
 webrender_build = { version = "0.68", path = "./webrender_build", package = "webrender_build" }
 glyph_rasterizer = { version = "0.68", path = "./wr_glyph_rasterizer", package = "wr_glyph_rasterizer" }
 malloc_size_of = { version = "0.68", path = "./wr_malloc_size_of", package = "wr_malloc_size_of" }
-peek-poke = { version = "0.3", path = "./peek-poke" }
+swgl = { version = "0.68", path = "./swgl", package = "swgl" }
+glsl-to-cxx = { version = "0.68", path = "./glsl-to-cxx", package = "glsl-to-cxx" }
+peek-poke = { version = "0.3", path = "./peek-poke", package = "peek-poke" }
 
 gleam = "0.15.1"
 glean = "=65.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,18 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.68.0"
+
 [workspace.dependencies]
+# Local repo dependencies
+webrender = { version = "0.68", path = "./webrender", package = "webrender" }
+api = { version = "0.68", path = "./webrender_api", package = "webrender_api" }
+webrender_build = { version = "0.68", path = "./webrender_build", package = "webrender_build" }
+glyph_rasterizer = { version = "0.68", path = "./wr_glyph_rasterizer", package = "wr_glyph_rasterizer" }
+malloc_size_of = { version = "0.68", path = "./wr_malloc_size_of", package = "wr_malloc_size_of" }
+peek-poke = { version = "0.3", path = "./peek-poke" }
+
 gleam = "0.15.1"
 glean = "=65.2.1"
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 WebRender is a GPU-based 2D rendering engine written in [Rust](https://www.rust-lang.org/). [Firefox](https://www.mozilla.org/firefox), the research web browser [Servo](https://github.com/servo/servo), and other GUI frameworks draw with it. It currently uses the OpenGL API internally.
 
-Note that the canonical home for this code is in gfx/wr folder of the
-mozilla-central repository at https://hg.mozilla.org/mozilla-central. The
+Note that the canonical home for this code is in [gfx/wr folder[(https://github.com/mozilla-firefox/firefox/tree/main/gfx/wr)] of the
+mozilla-central repository at https://github.com/mozilla-firefox/firefox. The
 Github repository at https://github.com/servo/webrender should be considered
 a downstream mirror, although it contains additional metadata (such as Github
 wiki pages) that do not exist in mozilla-central. Pull requests against the

--- a/glsl-to-cxx/Cargo.toml
+++ b/glsl-to-cxx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glsl-to-cxx"
-version = "0.1.0"
+version.workspace = true
 license = "MPL-2.0"
 authors = ["The Mozilla Project Developers", "Dimitri Sabadie"]
 edition = "2018"

--- a/swgl/Cargo.toml
+++ b/swgl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swgl"
-version = "0.1.0"
+version.workspace = true
 license = "MPL-2.0"
 authors = ["The Mozilla Project Developers"]
 build = "build.rs"
@@ -8,8 +8,8 @@ description = "Software OpenGL implementation for WebRender."
 
 [build-dependencies]
 cc = "1.0.46"
-glsl-to-cxx = { path = "../glsl-to-cxx" }
-webrender_build = { path = "../webrender_build" }
+glsl-to-cxx = { workspace = true}
+webrender_build = { workspace = true }
 
 [dependencies]
 gleam = { workspace = true }

--- a/webrender/Cargo.toml
+++ b/webrender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender"
-version = "0.68.0"
+version.workspace = true
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
@@ -25,7 +25,7 @@ debugger = ["tiny_http", "serde_json", "url", "sha1", "base64", "api/debugger"]
 [build-dependencies]
 build-parallel = "0.1.2"
 glslopt = "0.1.11"
-webrender_build = { version = "0.0.2", path = "../webrender_build" }
+webrender_build = { workspace = true }
 
 [dependencies]
 bincode = "1.0"
@@ -44,10 +44,10 @@ rayon = "1"
 ron = { optional = true, version = "0.10.0" }
 serde = { optional = true, version = "1.0", features = ["serde_derive"] }
 smallvec = "1"
-api = { version = "0.68.0", path = "../webrender_api", package = "webrender_api" }
-webrender_build = { version = "0.0.2", path = "../webrender_build" }
-malloc_size_of = { version = "0.2.0", path = "../wr_malloc_size_of", package = "wr_malloc_size_of" }
-glyph_rasterizer = { version = "0.1.0", path = "../wr_glyph_rasterizer", package = "wr_glyph_rasterizer", default-features = false }
+api = { workspace = true }
+webrender_build = { workspace = true }
+malloc_size_of = { workspace = true }
+glyph_rasterizer = { workspace = true }
 svg_fmt = "0.4"
 tracy-rs = "0.1.2"
 derive_more = { version = "2", features = ["add_assign"] }

--- a/webrender/src/render_backend.rs
+++ b/webrender/src/render_backend.rs
@@ -1491,8 +1491,9 @@ impl RenderBackend {
                 .cloned()
                 .filter(|key| !document_already_present(*key))
                 .collect();
-            #[allow(unused_variables)]
+            #[cfg_attr(not(feature = "capture"), allow(unused_variables))]
             let mut built_frame = false;
+            #[cfg_attr(not(feature = "capture"), allow(unused_assignments))]
             for &document_id in &nop_documents {
                 built_frame |= self.update_document(
                     document_id,

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -23,7 +23,7 @@ malloc_size_of_derive = "0.1"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_bytes = "0.11"
-malloc_size_of = { version = "0.2.0", path = "../wr_malloc_size_of", package = "wr_malloc_size_of" }
-peek-poke = { version = "0.3", path = "../peek-poke", features = ["extras"] }
+malloc_size_of = { workspace = true }
+peek-poke = { workspace = true, features = ["extras"] }
 crossbeam-channel = "0.5"
 zeitstempel = "0.1.2"

--- a/webrender_build/Cargo.toml
+++ b/webrender_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "webrender_build"
 authors = ["The Servo Project Developers"]
-version = "0.0.2"
+version.workspace = true
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"
 description = "Code shared between precompilation (build.rs) and the rest of WebRender"

--- a/wr_glyph_rasterizer/Cargo.toml
+++ b/wr_glyph_rasterizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wr_glyph_rasterizer"
-version = "0.1.0"
+version.workspace = true
 authors = ["The Mozilla Project Developers"]
 description = "A glyph rasterizer for WebRender"
 license = "MPL-2.0"
@@ -15,9 +15,9 @@ replay = ["api/deserialize", "serde", "smallvec/serde"]
 gecko = ["firefox-on-glean", "glean"]
 
 [dependencies]
-api = { version = "0.68.0", path = "../webrender_api", package = "webrender_api" }
+api = { workspace = true }
 euclid = { version = "0.22.0", features = ["serde"] }
-malloc_size_of = { version = "0.2.0", path = "../wr_malloc_size_of", package = "wr_malloc_size_of" }
+malloc_size_of = { workspace = true }
 malloc_size_of_derive = "0.1"
 rayon = "1"
 smallvec = "1"

--- a/wr_malloc_size_of/Cargo.toml
+++ b/wr_malloc_size_of/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["The Servo Project Developers"]
 description = "Internal utility to measure memory usage in WebRender."
 name = "wr_malloc_size_of"
-version = "0.2.2"
+version.workspace = true
 license = "MIT OR Apache-2.0"
 edition = "2018"
 

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -25,8 +25,8 @@ chrono = "0.4"
 crossbeam = "0.2"
 osmesa-sys = { version = "0.1.2", optional = true }
 osmesa-src = { version = "0.2", git = "https://github.com/servo/osmesa-src", optional = true }
-webrender = { path = "../webrender", features = ["capture", "replay", "png", "profiler", "dynamic_freetype", "leak_checks"] }
-webrender_build = { path = "../webrender_build" }
+webrender = { workspace = true, features = ["capture", "replay", "png", "profiler", "dynamic_freetype", "leak_checks"] }
+webrender_build = { workspace = true }
 winit = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0.12"


### PR DESCRIPTION
Changes made:

- Update `webrender` and in-repo crates that are dependencies of `webrender` to version 0.68
- Update these crates to use workspace depency versions similar to [stylo#249](https://github.com/servo/stylo/pull/249) (seeing as the feedback on that change was positive).

I have not bothered updating the versions of the other in-repo crates that are not dependencies of `webrender` (e.g. `wrench` and crates that are used by `wrench` like `swgl`) as we don't need to publish those and thus their version numbers don't matter, and I figured it would keep the diff a little smaller. But it would be easy to update those too if we wanted to.