### PR TITLE
Enable shader optimization on OpenHarmony

### DIFF
--- a/webrender/build.rs
+++ b/webrender/build.rs
@@ -128,9 +128,11 @@ fn write_optimized_shaders(
 
     // The full set of optimized shaders can be quite large, so only optimize
     // for the GL version we expect to be used on the target platform. If a different GL
-    // version is used we will simply fall back to the unoptimized shaders.
-    let shader_versions = match env::var("CARGO_CFG_TARGET_OS").as_ref().map(|s| &**s) {
-        Ok("android") | Ok("windows") => [ShaderVersion::Gles],
+    // version is used we will simply fall back to the unoptimized shaders. 
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("Cargo error");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("Cargo error");
+    let shader_versions = match (target_os.as_str(), target_env.as_str()) {
+        ("android", _) | ("windows", _) | ("linux", "ohos") => [ShaderVersion::Gles],
         _ => [ShaderVersion::Gl],
     };
 

--- a/wrench/src/test_shaders.rs
+++ b/wrench/src/test_shaders.rs
@@ -119,7 +119,7 @@ fn test_varying_explicit_precision(
 
 pub fn test_shaders() {
     let mut flags = ShaderFeatureFlags::all();
-    if cfg!(any(target_os = "windows", target_os = "android")) {
+    if cfg!(any(target_os = "windows", target_os = "android",  target_env = "ohos")) {
         flags.remove(ShaderFeatureFlags::GL);
     } else {
         flags.remove(ShaderFeatureFlags::GLES);


### PR DESCRIPTION
We use GLES on OpenHarmony, so the shaders should be optimizied accordingly. Cargo guarantees that the CARG_CFG variables are set. Using expect instead of matching improves the readability.

-------

This re-applies 8468e81608b00d83c62466f1c0f5ef73d44fda76, which was lost when updating from 0.65 to 0.66.