### PR TITLE
Bump the workspace version to 0.70.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "glsl-to-cxx"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "glsl",
 ]
@@ -2796,7 +2796,7 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "swgl"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "cc",
  "gleam",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "allocator-api2",
  "base64",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "webrender_api"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "webrender_build"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "bitflags 2.11.0",
  "lazy_static",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "wr_glyph_rasterizer"
-version = "0.69.0"
+version = "0.70.0"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.69.0"
+version = "0.70.0"
 
 [workspace.dependencies]
-api = { version = "0.69", path = "./webrender_api", package = "webrender_api" }
-glsl-to-cxx = { version = "0.69", path = "./glsl-to-cxx", package = "glsl-to-cxx" }
-glyph_rasterizer = { version = "0.69", path = "./wr_glyph_rasterizer", package = "wr_glyph_rasterizer", default-features = false }
+api = { version = "0.70", path = "./webrender_api", package = "webrender_api" }
+glsl-to-cxx = { version = "0.70", path = "./glsl-to-cxx", package = "glsl-to-cxx" }
+glyph_rasterizer = { version = "0.70", path = "./wr_glyph_rasterizer", package = "wr_glyph_rasterizer", default-features = false }
 malloc_size_of = { version = "0.2.2", path = "./wr_malloc_size_of", package = "wr_malloc_size_of" }
 peek-poke = { version = "0.3", path = "./peek-poke", package = "peek-poke" }
-swgl = { version = "0.69", path = "./swgl", package = "swgl" }
-webrender = { version = "0.69", path = "./webrender", package = "webrender" }
-webrender_build = { version = "0.69", path = "./webrender_build", package = "webrender_build" }
+swgl = { version = "0.70", path = "./swgl", package = "swgl" }
+webrender = { version = "0.70", path = "./webrender", package = "webrender" }
+webrender_build = { version = "0.70", path = "./webrender_build", package = "webrender_build" }
 
 gleam = "0.15.1"
 glean = "=67.3.2"

--- a/webrender_api/Cargo.toml
+++ b/webrender_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrender_api"
-version = "0.69.0"
+version = "0.70.0"
 authors = ["Glenn Watson <gw@intuitionlibrary.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/webrender"

--- a/wrench/Cargo.toml
+++ b/wrench/Cargo.toml
@@ -28,12 +28,12 @@ chrono = "0.4"
 crossbeam = "0.2"
 osmesa-sys = { version = "0.1.2", optional = true }
 osmesa-src = { version = "0.2", git = "https://github.com/servo/osmesa-src", optional = true }
-webrender = { version = "0.69", path = "../webrender", default-features = false, features = ["capture", "replay", "png", "profiler", "dynamic_freetype", "leak_checks"] }
-webrender_build = { version = "0.69", path = "../webrender_build" }
+webrender = { version = "0.70", path = "../webrender", default-features = false, features = ["capture", "replay", "png", "profiler", "dynamic_freetype", "leak_checks"] }
+webrender_build = { version = "0.70", path = "../webrender_build" }
 winit = "0.30"
 serde = { version = "1.0", features = ["derive"] }
 semver = "1.0.12"
-swgl = { version = "0.69", path = "../swgl", optional = true }
+swgl = { version = "0.70", path = "../swgl", optional = true }
 tracy-rs = "0.1.2"
 
 [dependencies.image]


### PR DESCRIPTION
In preperation for the freetype-sys release.
This is technically a breaking change, since one can only link one freetype-sys version. We'd be fine in servoshell, but it could break third-party embedder builds, so better to be explicit and bump the version accordingly.

This PR should not be merged, and instead after approval pushed as the new 0.70 branch. 
We could also decide to publish as 0.69.1 and accept the potential downstream breackage, but I'd personally prefer to play it safe.
`webrender_api` wouldn't need a bump since it is unchanged, so we could revert that, but if we do a major bump i thought it would make things more consistent to stick with the same number.